### PR TITLE
WIP experiment with using procedural macros rather than an IDL

### DIFF
--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -15,6 +15,8 @@ log = "0.4"
 ffi-support = "0.4"
 uniffi = {path = "../../uniffi"}
 uniffi_macros = {path = "../../uniffi_macros"}
+lazy_static = "1.4"
+static_assertions = "1.1"
 
 [build-dependencies]
 uniffi = {path = "../../uniffi"}

--- a/examples/arithmetic/src/lib.rs
+++ b/examples/arithmetic/src/lib.rs
@@ -2,25 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Flag to let calling code specify a particular behaviour of integer overflow,
-// since rust has such nice support for these.
-enum Overflow {
+use uniffi_macros::*;
+
+#[uniffi_export_enum]
+pub enum Overflow {
     WRAPPING,
     SATURATING,
 }
 
-fn add(a: u64, b: u64, overflow: Overflow) -> u64 {
+#[uniffi_export_fn]
+pub fn add(a: u64, b: u64, overflow: Overflow) -> u64 {
     match overflow {
         Overflow::WRAPPING => a.overflowing_add(b).0,
         Overflow::SATURATING => a.saturating_add(b),
     }
 }
 
-fn sub(a: u64, b: u64, overflow: Overflow) -> u64 {
+#[uniffi_export_fn]
+pub fn sub(a: u64, b: u64, overflow: Overflow) -> u64 {
     match overflow {
         Overflow::WRAPPING => a.overflowing_sub(b).0,
         Overflow::SATURATING => a.saturating_sub(b),
     }
 }
-
-include!(concat!(env!("OUT_DIR"), "/arithmetic.uniffi.rs"));

--- a/examples/geometry/src/lib.rs
+++ b/examples/geometry/src/lib.rs
@@ -2,29 +2,35 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use uniffi_macros::*;
+
 // https://rust-lang.github.io/rust-clippy/master/index.html#float_cmp
 // Silence, clippy!
 const EPSILON: f64 = 0.0001f64;
 
+#[uniffi_export_record]
 #[derive(Debug, Clone)]
 struct Point {
     x: f64,
     y: f64,
 }
 
+#[uniffi_export_record]
 #[derive(Debug, Clone)]
 struct Line {
     start: Point,
     end: Point,
 }
 
-fn gradient(ln: Line) -> f64 {
+#[uniffi_export_fn]
+pub fn gradient(ln: Line) -> f64 {
     let rise = ln.end.y - ln.start.y;
     let run = ln.end.x - ln.start.x;
     rise / run
 }
 
-fn intersection(ln1: Line, ln2: Line) -> Option<Point> {
+#[uniffi_export_fn]
+pub fn intersection(ln1: Line, ln2: Line) -> Option<Point> {
     // TODO: yuck, should be able to take &Line as argument here
     // and have rust figure it out with a bunch of annotations...
     let g1 = gradient(ln1.clone());
@@ -40,5 +46,3 @@ fn intersection(ln1: Line, ln2: Line) -> Option<Point> {
     let x = (z2 - z1) / (g1 - g2);
     Some(Point { x, y: g1 * x + z1 })
 }
-
-include!(concat!(env!("OUT_DIR"), "/geometry.uniffi.rs"));

--- a/examples/sprites/src/lib.rs
+++ b/examples/sprites/src/lib.rs
@@ -2,22 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// A point in two-dimensional space.
+use uniffi_macros::*;
+
+/// A point in two-dimensional space.
+#[uniffi_export_record]
 #[derive(Debug, Clone)]
-struct Point {
+pub struct Point {
     x: f64,
     y: f64,
 }
 
-// A magnitude and direction in two-dimensional space.
-// For simplicity we represent this as a point relative to the origin.
+/// A magnitude and direction in two-dimensional space.
+/// For simplicity we represent this as a point relative to the origin.
+#[uniffi_export_record]
 #[derive(Debug, Clone)]
-struct Vector {
+pub struct Vector {
     dx: f64,
     dy: f64,
 }
 
-// Move from the given Point, according to the given Vector.
+/// Move from the given Point, according to the given Vector.
+#[uniffi_export_fn]
 fn translate(p: Point, v: Vector) -> Point {
     Point {
         x: p.x + v.dx,
@@ -25,31 +30,31 @@ fn translate(p: Point, v: Vector) -> Point {
     }
 }
 
-// An entity in our imaginary world, which occupies a position in space
-// and which can move about over time.
-#[derive(Debug, Clone)]
-struct Sprite {
+/// An entity in our imaginary world, which occupies a position in space
+/// and which can move about over time.
+#[uniffi_export_class]
+#[derive(Debug)]
+pub struct Sprite {
     current_position: Point,
 }
 
+#[uniffi_export_methods]
 impl Sprite {
-    fn new(initial_position: Point) -> Sprite {
+    pub fn new(initial_position: Point) -> Sprite {
         Sprite {
             current_position: initial_position,
         }
     }
 
-    fn get_position(&self) -> Point {
+    pub fn get_position(&self) -> Point {
         self.current_position.clone()
     }
 
-    fn move_to(&mut self, position: Point) {
+    pub fn move_to(&mut self, position: Point) {
         self.current_position = position;
     }
 
-    fn move_by(&mut self, direction: Vector) {
+    pub fn move_by(&mut self, direction: Vector) {
         self.current_position = translate(self.current_position.clone(), direction)
     }
 }
-
-include!(concat!(env!("OUT_DIR"), "/sprites.uniffi.rs"));

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -22,3 +22,6 @@ serde = "1.0"
 bincode = "1.3"
 cargo_metadata = "0.10.0"
 lazy_static = "1.4"
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0", features = ["extra-traits", "full"] }

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -134,6 +134,7 @@ use anyhow::Result;
 
 pub mod bindings;
 pub mod interface;
+pub mod macros;
 pub mod scaffolding;
 pub mod support;
 

--- a/uniffi/src/macros/export_class.rs
+++ b/uniffi/src/macros/export_class.rs
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use quote::{format_ident, quote};
+use serde::{Deserialize, Serialize};
+use std::convert::{Into, TryFrom};
+use syn::spanned::Spanned;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassDefinition {}
+
+impl ClassDefinition {}
+
+impl TryFrom<&syn::ItemStruct> for ClassDefinition {
+    type Error = syn::Error;
+    fn try_from(_item: &syn::ItemStruct) -> syn::Result<Self> {
+        Ok(ClassDefinition {})
+    }
+}
+
+impl Into<proc_macro2::TokenStream> for &ClassDefinition {
+    fn into(self) -> proc_macro2::TokenStream {
+        quote! {
+            // Not implemented yet...
+        }
+    }
+}
+
+impl quote::ToTokens for ClassDefinition {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let tt: proc_macro2::TokenStream = self.into();
+        tt.to_tokens(tokens);
+    }
+}

--- a/uniffi/src/macros/export_enum.rs
+++ b/uniffi/src/macros/export_enum.rs
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use quote::{format_ident, quote};
+use serde::{Deserialize, Serialize};
+use std::convert::{Into, TryFrom};
+use std::matches;
+use syn::spanned::Spanned;
+
+use crate::syn_err;
+
+// Represents a simple C-style enum.
+// In the FFI these are turned into a plain u32.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnumDefinition {
+    name: String,
+    values: Vec<String>,
+}
+
+impl EnumDefinition {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    pub fn values(&self) -> Vec<&str> {
+        self.values.iter().map(|v| v.as_str()).collect()
+    }
+}
+
+impl TryFrom<&syn::ItemEnum> for EnumDefinition {
+    type Error = syn::Error;
+    fn try_from(item: &syn::ItemEnum) -> syn::Result<Self> {
+        if !matches!(item.vis, syn::Visibility::Public(_)) {
+            return syn_err!(item, "Exported enums must be public");
+        }
+        if !item.generics.params.is_empty() || item.generics.where_clause.is_some() {
+            return syn_err!(item.generics, "Exported enums cannot have generics");
+        }
+        // XXX TODO: check valid names, reserved words etc.
+        Ok(EnumDefinition {
+            name: item.ident.to_string(),
+            values: item
+                .variants
+                .iter()
+                .map(|v| {
+                    if !matches!(v.fields, syn::Fields::Unit) {
+                        return syn_err!(v, "Exported enum variants cannot have fields");
+                    }
+                    if v.discriminant.is_some() {
+                        return syn_err!(
+                            v,
+                            "Exported enum fields cannot have explicit discriminant"
+                        );
+                    }
+                    Ok(v.ident.to_string())
+                })
+                .collect::<syn::Result<Vec<_>>>()?,
+        })
+    }
+}
+
+impl Into<proc_macro2::TokenStream> for &EnumDefinition {
+    fn into(self) -> proc_macro2::TokenStream {
+        let name = format_ident!("{}", self.name);
+        let name_str = self.name.as_str();
+        let variants = self
+            .values
+            .iter()
+            .map(|v| format_ident!("{}", v))
+            .collect::<Vec<_>>();
+        let indices = (1..self.values.len() + 1)
+            .map(|i| syn::Index::from(i))
+            .collect::<Vec<_>>();
+        let serialized_defn = super::ExportDefinition::Enum(self.clone());
+        quote! {
+            unsafe impl uniffi::support::ViaFfi for #name {
+                type Value = u32;
+                const NAME: &'static str = #name_str;
+                fn into_ffi_value(self) -> Self::Value {
+                    match self {
+                        #(#name::#variants => #indices),*
+                    }
+                }
+                fn try_from_ffi_value(v: Self::Value) -> anyhow::Result<Self> {
+                    Ok(match v {
+                        #(#indices => #name::#variants),*,
+                        _ => anyhow::bail!("Invalid {} enum value: {}", Self::NAME, v),
+                    })
+                }
+            }
+            #serialized_defn
+        }
+    }
+}
+
+impl quote::ToTokens for EnumDefinition {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let tt: proc_macro2::TokenStream = self.into();
+        tt.to_tokens(tokens);
+    }
+}

--- a/uniffi/src/macros/export_fn.rs
+++ b/uniffi/src/macros/export_fn.rs
@@ -1,0 +1,304 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use quote::{format_ident, quote};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::convert::{Into, TryFrom};
+use syn::spanned::Spanned;
+
+use crate::syn_err;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionDefinition {
+    name: String,
+    arguments: Vec<ArgumentDefinition>,
+    return_type: Option<TypeReference>,
+}
+
+impl FunctionDefinition {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    pub fn arguments(&self) -> Vec<&ArgumentDefinition> {
+        self.arguments.iter().collect()
+    }
+    pub fn return_type(&self) -> Option<&TypeReference> {
+        self.return_type.as_ref()
+    }
+}
+
+impl TryFrom<&syn::ItemFn> for FunctionDefinition {
+    type Error = syn::Error;
+    fn try_from(item: &syn::ItemFn) -> syn::Result<Self> {
+        if !matches!(item.vis, syn::Visibility::Public(_)) {
+            return syn_err!(item, "Exported functions must be public");
+        }
+        if item.sig.asyncness.is_some() {
+            return syn_err!(item, "Functions marked `async` cannot be exported");
+        }
+        if item.sig.unsafety.is_some() {
+            return syn_err!(item, "Functions marked `unsafe` cannot be exported");
+        }
+        if item.sig.abi.is_some() {
+            return syn_err!(item, "Functions marked `extern` cannot be exported");
+        }
+        if !item.sig.generics.params.is_empty() || item.sig.generics.where_clause.is_some() {
+            return syn_err!(
+                item.sig.generics,
+                "Exported functions cannot have generic parameters"
+            );
+        }
+        if item.sig.variadic.is_some() {
+            return syn_err!(item, "Functions with variadic arguments cannot be exported");
+        }
+        Ok(FunctionDefinition {
+            name: item.sig.ident.to_string(),
+            arguments: item
+                .sig
+                .inputs
+                .iter()
+                .map(|arg| match &arg {
+                    syn::FnArg::Receiver(_) => syn_err!(
+                        arg,
+                        "Exported function cannot have a method receiver argument"
+                    ),
+                    syn::FnArg::Typed(arg) => Ok(ArgumentDefinition::try_from(arg)?),
+                })
+                .collect::<syn::Result<Vec<_>>>()?,
+            return_type: match &item.sig.output {
+                syn::ReturnType::Default => None,
+                syn::ReturnType::Type(_, type_) => Some(TypeReference::try_from(type_.as_ref())?),
+            },
+        })
+    }
+}
+
+impl Into<proc_macro2::TokenStream> for &FunctionDefinition {
+    fn into(self) -> proc_macro2::TokenStream {
+        let name = format_ident!("{}", self.name);
+        // XXX TODO: get namespacing info from calling crate.
+        let extern_name = format_ident!("arithmetic_{}", self.name);
+        // Each argument is received over the FFI as the type of its `ViaFfi` impl.
+        let args_recv = self.arguments.iter().map(|arg| {
+            let nm = format_ident!("{}", arg.name);
+            let ty = &arg.type_;
+            quote! {
+              #nm: <#ty as uniffi::support::ViaFfi>::Value
+            }
+        });
+        // To forward each argument on to the rust call, convert it with `try_from_ffi_value()`.
+        let args_call = self.arguments.iter().map(|arg| {
+            let nm = format_ident!("{}", arg.name);
+            let ty = &arg.type_;
+            quote! {
+              <#ty as uniffi::support::ViaFfi>::try_from_ffi_value(#nm).unwrap()
+            }
+        });
+        // The body of the `extern "C"` fn, which depends on whether there's a return type.
+        // In the future we'll probably have more work to do here, e.g. if it returns an error.
+        let extern_fn = match &self.return_type {
+            None => quote! {
+               pub extern "C" fn #extern_name(#(#args_recv),*) {
+                   #name(#(#args_call),*);
+               }
+            },
+            Some(ret) => quote! {
+                pub extern "C" fn #extern_name(#(#args_recv),*) -> #ret {
+                    <#ret as uniffi::support::ViaFfi>::into_ffi_value(
+                      #name(#(#args_call),*)
+                    )
+                }
+            },
+        };
+        // The exported `FunctionDefinition` struct will only be valid if the argument type names
+        // we discovered from the rust code actually match the names those types use in the generated
+        // API. Let's not compile code where that isn't true.
+        let mut named_type_names: HashSet<&str> = self
+            .arguments
+            .iter()
+            .filter_map(|arg| {
+                if let TypeReference::Named(nm) = &arg.type_ {
+                    Some(nm.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if let Some(ty) = &self.return_type {
+            if let TypeReference::Named(nm) = ty {
+                named_type_names.insert(nm.as_str());
+            }
+        }
+        let named_type_names = named_type_names.iter().collect::<Vec<_>>();
+        let named_type_idents = named_type_names.iter().map(|nm| format_ident!("{}", nm));
+        // Finally, we need to include the FunctionDefinition itself in the generated lib.
+        let serialized_defn = super::ExportDefinition::Function(self.clone());
+        quote! {
+            #[no_mangle]
+            #extern_fn
+            #(uniffi_macros::uniffi_assert_type_name!(#named_type_idents, #named_type_names);)*
+            #serialized_defn
+        }
+    }
+}
+
+impl quote::ToTokens for FunctionDefinition {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let tt: proc_macro2::TokenStream = self.into();
+        tt.to_tokens(tokens);
+    }
+}
+
+// Represents an argument to a function/constructor/method call.
+//
+// Each argument has a name and a type, along with some optional metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArgumentDefinition {
+    name: String,
+    type_: TypeReference,
+}
+
+impl TryFrom<&syn::PatType> for ArgumentDefinition {
+    type Error = syn::Error;
+    fn try_from(item: &syn::PatType) -> syn::Result<Self> {
+        let name = match &*item.pat {
+            syn::Pat::Ident(pat) => {
+                if pat.by_ref.is_some() {
+                    return syn_err!(
+                        item,
+                        "Exported function arguments cannot be passed by reference (yet)"
+                    );
+                }
+                if pat.subpat.is_some() {
+                    return syn_err!(
+                        item,
+                        "Exported function arguments must have simple names, nothing fancy!"
+                    );
+                }
+                pat.ident.to_string()
+            }
+            _ => {
+                println!("UNSUPPORTED ARG PATTERN {:?}", item);
+                return syn_err!(
+                    item,
+                    "Exported function arguments must have simple names, nothing fancy!"
+                );
+            }
+        };
+        Ok(ArgumentDefinition {
+            name,
+            type_: TypeReference::try_from(item.ty.as_ref())?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TypeReference {
+    Bool,
+    U8,
+    I8,
+    U16,
+    I16,
+    U32,
+    I32,
+    U64,
+    I64,
+    F32,
+    F64,
+    String,
+    Bytes,
+    Named(String),
+    //Optional(Box<TypeReference>),
+    //Sequence(Box<TypeReference>),
+}
+
+impl TryFrom<&syn::Type> for TypeReference {
+    type Error = syn::Error;
+    fn try_from(item: &syn::Type) -> syn::Result<Self> {
+        match item {
+            syn::Type::Path(typ) => {
+                if typ.qself.is_some() {
+                    return syn_err!(
+                        item,
+                        "Exported types must have simple names, nothing fancy!"
+                    );
+                }
+                if typ.path.leading_colon.is_some() {
+                    return syn_err!(
+                        item,
+                        "Exported types must have simple names, nothing fancy!"
+                    );
+                }
+                if typ.path.segments.len() != 1 {
+                    return syn_err!(
+                        item,
+                        "Exported types must have simple names, nothing fancy!"
+                    );
+                }
+                let path = typ.path.segments.first().unwrap();
+                if !matches!(path.arguments, syn::PathArguments::None) {
+                    return syn_err!(
+                        item,
+                        "Exported types must have simple names, nothing fancy!"
+                    );
+                }
+                let nm = path.ident.to_string();
+                Ok(match nm.as_str() {
+                    "bool" => TypeReference::Bool,
+                    "u8" => TypeReference::U8,
+                    "i8" => TypeReference::I8,
+                    "u16" => TypeReference::U16,
+                    "i16" => TypeReference::I16,
+                    "u32" => TypeReference::U32,
+                    "i32" => TypeReference::I32,
+                    "u64" => TypeReference::U64,
+                    "i64" => TypeReference::I64,
+                    "f32" => TypeReference::F32,
+                    "f64" => TypeReference::F64,
+                    _ => TypeReference::Named(nm),
+                })
+            }
+            _ => {
+                println!("UNSUPPORTED TYPE: {:?}", item);
+                syn_err!(
+                    item,
+                    "Exported types must have simple names, nothing fancy!"
+                )
+            }
+        }
+    }
+}
+
+impl Into<proc_macro2::TokenStream> for &TypeReference {
+    fn into(self) -> proc_macro2::TokenStream {
+        let name = match self {
+            TypeReference::Bool => "bool",
+            TypeReference::U8 => "u8",
+            TypeReference::I8 => "i8",
+            TypeReference::U16 => "u16",
+            TypeReference::I16 => "i16",
+            TypeReference::U32 => "u32",
+            TypeReference::I32 => "i32",
+            TypeReference::U64 => "u64",
+            TypeReference::I64 => "i64",
+            TypeReference::F32 => "f32",
+            TypeReference::F64 => "f64",
+            TypeReference::String => "&str",
+            TypeReference::Bytes => "&[u8]",
+            TypeReference::Named(nm) => nm.as_str(),
+        };
+        let name = format_ident!("{}", name);
+        quote! {
+            #name
+        }
+    }
+}
+
+impl quote::ToTokens for TypeReference {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let tt: proc_macro2::TokenStream = self.into();
+        tt.to_tokens(tokens);
+    }
+}

--- a/uniffi/src/macros/export_methods.rs
+++ b/uniffi/src/macros/export_methods.rs
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use quote::{format_ident, quote};
+use serde::{Deserialize, Serialize};
+use std::convert::{Into, TryFrom};
+use syn::spanned::Spanned;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MethodDefinition {}
+
+impl MethodDefinition {}
+
+impl TryFrom<&syn::ItemImpl> for MethodDefinition {
+    type Error = syn::Error;
+    fn try_from(_item: &syn::ItemImpl) -> syn::Result<Self> {
+        Ok(MethodDefinition {})
+    }
+}
+
+impl Into<proc_macro2::TokenStream> for &MethodDefinition {
+    fn into(self) -> proc_macro2::TokenStream {
+        quote! {
+            // Not implemented yet...
+        }
+    }
+}
+
+impl quote::ToTokens for MethodDefinition {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let tt: proc_macro2::TokenStream = self.into();
+        tt.to_tokens(tokens);
+    }
+}
+
+// We expect to parse multiple method definitions from a single `ItemImpl` block.
+
+pub struct MethodDefinitions {
+    methods: Vec<MethodDefinition>,
+}
+
+impl TryFrom<&syn::ItemImpl> for MethodDefinitions {
+    type Error = syn::Error;
+    fn try_from(_item: &syn::ItemImpl) -> syn::Result<Self> {
+        Ok(MethodDefinitions { methods: vec![] })
+    }
+}
+
+impl Into<proc_macro2::TokenStream> for &MethodDefinitions {
+    fn into(self) -> proc_macro2::TokenStream {
+        quote! {
+            // Not implemented yet...
+        }
+    }
+}
+
+impl quote::ToTokens for MethodDefinitions {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let tt: proc_macro2::TokenStream = self.into();
+        tt.to_tokens(tokens);
+    }
+}

--- a/uniffi/src/macros/export_record.rs
+++ b/uniffi/src/macros/export_record.rs
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use quote::{format_ident, quote};
+use serde::{Deserialize, Serialize};
+use std::convert::{Into, TryFrom};
+use syn::spanned::Spanned;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecordDefinition {}
+
+impl RecordDefinition {}
+
+impl TryFrom<&syn::ItemStruct> for RecordDefinition {
+    type Error = syn::Error;
+    fn try_from(_item: &syn::ItemStruct) -> syn::Result<Self> {
+        Ok(RecordDefinition {})
+    }
+}
+
+impl Into<proc_macro2::TokenStream> for &RecordDefinition {
+    fn into(self) -> proc_macro2::TokenStream {
+        quote! {
+            // Not implemented yet...
+        }
+    }
+}
+
+impl quote::ToTokens for RecordDefinition {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let tt: proc_macro2::TokenStream = self.into();
+        tt.to_tokens(tokens);
+    }
+}

--- a/uniffi/src/macros/mod.rs
+++ b/uniffi/src/macros/mod.rs
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use quote::{format_ident, quote};
+use serde::{Deserialize, Serialize};
+use std::convert::Into;
+
+pub mod export_class;
+pub mod export_enum;
+pub mod export_fn;
+pub mod export_methods;
+pub mod export_record;
+
+pub use export_class::ClassDefinition;
+pub use export_enum::EnumDefinition;
+pub use export_fn::FunctionDefinition;
+pub use export_methods::{MethodDefinition, MethodDefinitions};
+pub use export_record::RecordDefinition;
+
+#[derive(Serialize, Deserialize)]
+pub enum ExportDefinition {
+    Enum(EnumDefinition),
+    Function(FunctionDefinition),
+    Record(RecordDefinition),
+    Class(ClassDefinition),
+    Method(MethodDefinition),
+}
+
+impl ExportDefinition {
+    pub fn to_bincode(&self) -> Vec<u8> {
+        // Serialization of this struct is infallible.
+        bincode::serialize(self).unwrap()
+    }
+
+    pub fn export_name(&self) -> &str {
+        match self {
+            Self::Enum(defn) => defn.name(),
+            Self::Function(defn) => defn.name(),
+            _ => panic!("not implemented yet"),
+        }
+    }
+}
+
+impl quote::ToTokens for ExportDefinition {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let tt: proc_macro2::TokenStream = self.into();
+        tt.to_tokens(tokens);
+    }
+}
+
+impl Into<proc_macro2::TokenStream> for &ExportDefinition {
+    fn into(self) -> proc_macro2::TokenStream {
+        let name = format_ident!("UNIFFI_EXPORT_{}", self.export_name());
+        let data = self.to_bincode();
+        let data_len = syn::Index::from(data.len());
+        let data_bytes = data.iter().map(|i| syn::Index::from(*i as usize));
+        quote! {
+            #[no_mangle]
+            #[cfg_attr(any(target_os="macos", target_os="ios"), link_section = "DATA,.uniffi_idl")]
+            #[cfg_attr(not(any(target_os="macos", target_os="ios")), link_section = ".uniffi_idl")]
+            pub static #name: [u8;#data_len] = [#(#data_bytes),*];
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! syn_err {
+    ($item:expr, $msg:expr) => {
+        Err(syn::Error::new($item.span(), $msg))
+    };
+}

--- a/uniffi/src/support/mod.rs
+++ b/uniffi/src/support/mod.rs
@@ -119,6 +119,7 @@ pub unsafe trait ViaFfi: Sized {
     type Value;
     fn into_ffi_value(self) -> Self::Value;
     fn try_from_ffi_value(v: Self::Value) -> Result<Self>;
+    const NAME: &'static str;
 }
 
 macro_rules! impl_via_ffi_for_primitive {
@@ -127,6 +128,7 @@ macro_rules! impl_via_ffi_for_primitive {
       type Value = Self;
       #[inline] fn into_ffi_value(self) -> Self::Value { self }
       #[inline] fn try_from_ffi_value(v: Self::Value) -> Result<Self> { Ok(v) }
+      const NAME: &'static str = "";
     }
   )+}
 }
@@ -145,6 +147,7 @@ unsafe impl<T: ViaFfiUsingByteBuffer> ViaFfi for T {
     fn try_from_ffi_value(v: Self::Value) -> anyhow::Result<Self> {
         try_lift(v)
     }
+    const NAME: &'static str = "";
 }
 
 unsafe impl<T: Liftable + Lowerable> ViaFfi for Option<T> {
@@ -157,4 +160,5 @@ unsafe impl<T: Liftable + Lowerable> ViaFfi for Option<T> {
     fn try_from_ffi_value(v: Self::Value) -> anyhow::Result<Self> {
         try_lift(v)
     }
+    const NAME: &'static str = "";
 }

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -11,5 +11,6 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["extra-traits"] }
+syn = { version = "1.0", features = ["extra-traits", "full"] }
 glob = "0.3"
+uniffi = { path = "../uniffi" }


### PR DESCRIPTION
The conversation over in https://github.com/rfk/uniffi-rs/pull/9 got me interested in messing around with procedural macros, and I finally managed to steal a bit of time to dig in. This is my *extremely* work-in-progress attempt to port the code over to using macros rather than a separate IDL file.

The code here really doesn't work, although I can see a plausible path to making it work. I'm entirely pushing it for early visibility, and the comments below are a bit of brain-dump as I finish up my current timebox.

I like it so far! It's quite fun to work with `syn` and `quote`, and the shape of much of the code here is fairly similar to how it works on top of `weedle` - rather than converting from e.g. a parsed `weedle` enum into our own definition struct, we convert from a parsed `syn` enum, but it works in broadly the same way. It's also **much** easier to produce helpful contextual error messages, as thom suggested in https://github.com/rfk/uniffi-rs/pull/9.

I've opted for a wasm-bindgen style API here, where you decorate otherwise ordinary rust code with macros to export bits of it over the FFI. I like the way this approach plays with the rest of the rust tooling, such as allowing `cargo fmt` to work as expected.

One thing that's a lot harder though, is that each macro only gets to operate on its local information - for example if I'm exporting `pub fun foo(v: Bar)` with a macro, the macro can see that it wants a type named `Bar`, but it doesn't know whether that type has been properly exported or even exists at all. This seems tractable, but annoying. I have vague recollections of wasm-binding needing to do some pretty hacky things to work around this, but I don't really remember the details.

An alternative would be to do something in the style of the [gobject macros mentioned in this recent release note](https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html#stabilizing-function-like-procedural-macros-in-expressions-patterns-and-statements), where they have a whole custom API definition inside of a `gobject_gen! { ... }` macro invocation. Taking this approach would let us see and operate on the entire interface definition at once, but honestly, I think I'd really miss `cargo fmt`.

