### PR TITLE
Implement Lowerable/Liftable for enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "uniffi_macros",
   "examples/arithmetic",
   "examples/geometry",
+  "examples/rondpoint",
   "examples/sprites",
   "examples/todolist"
 ]

--- a/examples/rondpoint/Cargo.toml
+++ b/examples/rondpoint/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "uniffi-example-rondpoint"
+edition = "2018"
+version = "0.1.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+license = "MPL-2.0"
+
+[lib]
+crate-type = ["cdylib"]
+name = "uniffi_rondpoint"
+
+[dependencies]
+anyhow = "1.0"
+log = "0.4"
+ffi-support = "0.4"
+lazy_static = "1.4"
+uniffi = {path = "../../uniffi"}
+uniffi_macros = {path = "../../uniffi_macros"}
+
+[build-dependencies]
+uniffi = {path = "../../uniffi"}

--- a/examples/rondpoint/README.md
+++ b/examples/rondpoint/README.md
@@ -1,0 +1,38 @@
+# Example uniffi component: "Rondpoint"
+
+This example is to exercise complex data types through roundtripping.
+
+* [`./src/rondpoint.idl`](./src/rondpoint.idl), the component interface definition which defines the main object and its methods. This is processed by functions in [`./build.rs`](./build.rs)
+  to generate Rust scaffolding for the component.
+* [`./src/lib.rs`](./src/lib.rs), the core implementation of the component in Rust. This basically
+  pulls in the generated Rust scaffolding via `include!()` and fills in function implementations.
+* [`./src/main.rs`](./src/main.rs) generates a helper executable that can be used for working with
+  foreign language bindings, while guaranteeing that those bindings use the same version of `uniffi`
+  as the compiled component.
+* Some small test scripts that double as API examples in each target foreign language:
+  * Kotlin [`./tests/bindings/test_rondpoint.kts`](./tests/bindings/test_rondpoint.kts)
+  * Swift [`./tests/bindings/test_rondpoint.swift`](./tests/bindings/test_rondpoint.swift)
+  * Python [`./tests/bindings/test_rondpoint.py`](./tests/bindings/test_rondpoint.py)
+
+If you want to try it out, you will need:
+
+* The [Kotlin command-line tools](https://kotlinlang.org/docs/tutorials/command-line.html), particularly `kotlinc`.
+* The [Java Native Access](https://github.com/java-native-access/jna#download) JAR downloaded and its path
+  added to your `$CLASSPATH` environment variable.
+* Python 3
+* The [Swift command-line tools](https://swift.org/download/), particularly `swift`, `swiftc` and
+  the `Foundation` package.
+
+With that in place, try the following:
+
+* Run `cargo build`. That compiles the component implementation into a native library named `uniffi_rondpoint`
+  in `../../target/debug/`.
+* Run `cargo run -- generate`. That generates component bindings for each target language:
+    * `../../target/debug/rondpoint.kt` for Kotlin
+    * `../../target/debug/rondpoint.swift` for Swift
+    * `../../target/debug/rondpoint.py` for Python
+* Run `cargo test`. This exercises the foreign language bindings via the scripts in `./tests/bindings/`.
+* Run `cargo run -- exec tests/bindings/test_rondpoint.kts`. This will directly execute the Kotlin
+  test script. Try the same for the other languages.
+* Run `cargo. run -- exec -l python` to get a Python shell in which you can import the generated
+  module for yourself and play around with it. Try `import rondpoint` and go from there!

--- a/examples/rondpoint/build.rs
+++ b/examples/rondpoint/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::generate_component_scaffolding("./src/rondpoint.idl").unwrap();
+}

--- a/examples/rondpoint/src/lib.rs
+++ b/examples/rondpoint/src/lib.rs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#[derive(Debug, Clone)]
+pub struct Dictionnaire {
+    un: Enumeration,
+}
+
+#[derive(Debug, Clone)]
+pub enum Enumeration {
+    Un,
+    Deux,
+    Trois,
+}
+
+fn copie_enumeration(e: Enumeration) -> Enumeration {
+    e
+}
+
+fn copie_enumerations(e: Vec<Enumeration>) -> Vec<Enumeration> {
+    e
+}
+
+fn copie_dictionnaire(d: Dictionnaire) -> Dictionnaire {
+    d
+}
+
+include!(concat!(env!("OUT_DIR"), "/rondpoint.uniffi.rs"));

--- a/examples/rondpoint/src/main.rs
+++ b/examples/rondpoint/src/main.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::run_bindgen_for_component("rondpoint").unwrap();
+}

--- a/examples/rondpoint/src/rondpoint.idl
+++ b/examples/rondpoint/src/rondpoint.idl
@@ -1,0 +1,15 @@
+namespace rondpoint {
+  Dictionnaire copie_dictionnaire(Dictionnaire d);
+  Enumeration copie_enumeration(Enumeration e);
+  sequence<Enumeration> copie_enumerations(sequence<Enumeration> e);
+};
+
+enum Enumeration {
+    "Un",
+    "Deux",
+    "Trois",
+};
+
+dictionary Dictionnaire {
+    Enumeration un;
+};

--- a/examples/rondpoint/tests/bindings/test_rondpoint.kts
+++ b/examples/rondpoint/tests/bindings/test_rondpoint.kts
@@ -1,0 +1,8 @@
+import uniffi.rondpoint.*
+
+val dico = Dictionnaire(Enumeration.DEUX)
+val copyDico = copieDictionnaire(dico)
+assert(dico == copyDico)
+
+assert(copieEnumeration(Enumeration.DEUX) == Enumeration.DEUX)
+assert(copieEnumerations(listOf(Enumeration.UN, Enumeration.DEUX)) == listOf(Enumeration.UN, Enumeration.DEUX))

--- a/examples/rondpoint/tests/bindings/test_rondpoint.swift
+++ b/examples/rondpoint/tests/bindings/test_rondpoint.swift
@@ -1,0 +1,8 @@
+import rondpoint
+
+let dico = Dictionnaire(un: .deux)
+let copyDico = copieDictionnaire(d: dico)
+assert(dico == copyDico)
+
+assert(copieEnumeration(e: .deux) == .deux)
+assert(copieEnumerations(e: [.un, .deux]) == [.un, .deux])

--- a/examples/rondpoint/tests/test_generated_bindings.rs
+++ b/examples/rondpoint/tests/test_generated_bindings.rs
@@ -1,0 +1,5 @@
+uniffi_macros::build_foreign_language_testcases!(
+    "tests/bindings/test_rondpoint.kts",
+    "tests/bindings/test_rondpoint.swift",
+    // "tests/bindings/test_rondpoint.py"
+);

--- a/uniffi/src/scaffolding.rs
+++ b/uniffi/src/scaffolding.rs
@@ -77,7 +77,7 @@ mod filters {
         // By explicitly naming the type here, we help the rust compiler to type-check the user-provided
         // implementations of the functions that we're wrapping (and also to type-check our generated code).
         Ok(format!(
-            "<{} as uniffi::support::ViaFfi>::into_ffi_value({})",
+            "<{} as uniffi::support::ViaFfi>::into_ffi_value(&{})",
             ret_type_rs(type_)?,
             nm
         ))

--- a/uniffi/src/templates/EnumTemplate.rs
+++ b/uniffi/src/templates/EnumTemplate.rs
@@ -9,7 +9,7 @@
 #}
 unsafe impl uniffi::support::ViaFfi for {{ e.name() }} {
     type Value = u32;
-    fn into_ffi_value(self) -> Self::Value {
+    fn into_ffi_value(&self) -> Self::Value {
         match self {
             // If the provided enum doesn't match the options defined in the IDL then
             // this match will fail to compile, with a type error to guide the way.
@@ -25,5 +25,19 @@ unsafe impl uniffi::support::ViaFfi for {{ e.name() }} {
             {%- endfor %}
             _ => anyhow::bail!("Invalid {{ e.name() }} enum value: {}", v),
         })
+    }
+}
+
+impl uniffi::support::Lowerable for {{ e.name() }} {
+    fn lower_into<B: uniffi::support::BufMut>(&self, buf: &mut B) {
+        use uniffi::support::ViaFfi;
+        buf.put_u32(self.into_ffi_value());
+    }
+}
+
+impl uniffi::support::Liftable for {{ e.name() }} {
+    fn try_lift_from<B: uniffi::support::Buf>(buf: &mut B) -> anyhow::Result<Self> {
+        uniffi::support::check_remaining(buf, 4)?;
+        <Self as uniffi::support::ViaFfi>::try_from_ffi_value(buf.get_u32())
     }
 }


### PR DESCRIPTION
Fixes https://github.com/mozilla/uniffi-rs/issues/36.

Summary of changes:
- Impl Lowerable/Liftable for enums
- `into_ffi_value` does not consume `self` anymore, uses `&self` instead (had to do this because otherwise we would require enums to implement `Copy` or `Clone`)
- Added the `rondpoint` example, it does round-tripping testing. 