### PR TITLE
Clarify type conversions by differentiating between API-level and FFI-level types.

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
@@ -1,6 +1,6 @@
 enum class {{ e.name()|class_name_kt }} {
-    {% for value in e.values() %}
-    {{ value|enum_variant_kt }}{% if loop.last %};{% else %},{% endif %}
+    {% for variant in e.variants() %}
+    {{ variant|enum_variant_kt }}{% if loop.last %};{% else %},{% endif %}
     {% endfor %}
 
     companion object {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
@@ -22,7 +22,7 @@ internal interface _UniFFILib : Library {
     {% for func in ci.iter_ffi_function_definitions() -%}
     fun {{ func.name() }}(
         {%- call kt::arg_list_rs_decl(func) %}
-    ){%- match func.return_type() -%}{%- when Some with (type_) %}: {{ type_|ret_type_c }}{% when None %}: Unit{% endmatch %}
+    ){%- match func.return_type() -%}{%- when Some with (type_) %}: {{ type_|type_ffi }}{% when None %}: Unit{% endmatch %}
 
     {% endfor %}
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -4,7 +4,7 @@ class {{ obj.name()|class_name_kt }}(
 
     {%- for cons in obj.constructors() %}
     constructor({% call kt::arg_list_decl(cons) -%}) :
-        this({% call kt::to_rs_call(cons) %})
+        this({% call kt::to_ffi_call(cons) %})
     {%- endfor %}
 
     /**
@@ -32,7 +32,7 @@ class {{ obj.name()|class_name_kt }}(
     {%- when Some with (return_type) -%}
     fun {{ meth.name()|fn_name_kt }}({% call kt::arg_list_decl(meth) %}): {{ return_type|type_kt }} =
         callWithHandle {
-            {% call kt::to_rs_call_with_prefix("it", meth) %} 
+            {% call kt::to_ffi_call_with_prefix("it", meth) %}
         }.let {
             {{ "it"|lift_kt(return_type) }}
         }
@@ -40,7 +40,7 @@ class {{ obj.name()|class_name_kt }}(
     {%- when None -%}
     fun {{ meth.name()|fn_name_kt }}({% call kt::arg_list_decl(meth) %}) =
         callWithHandle {
-            {% call kt::to_rs_call_with_prefix("it", meth) %} 
+            {% call kt::to_ffi_call_with_prefix("it", meth) %} 
         }
     {% endmatch %}
     {% endfor %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
@@ -164,8 +164,13 @@ fun Double.lowerInto(buf: ByteBuffer) {
     buf.putDouble(this)
 }
 
-fun String.lower(): String {
-    return this
+fun String.lower(): Pointer {
+    val rustErr = RustError.ByReference()
+    val rustStr = _UniFFILib.INSTANCE.{{ ci.ffi_string_alloc_from().name() }}(this, rustErr)
+    if (rustErr.code != 0) {
+         throw RuntimeException("caught a panic while passing a string across the ffi")
+    }
+    return rustStr
 }
 
 fun String.lowerInto(buf: ByteBuffer) {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
@@ -2,12 +2,12 @@
 {%- when Some with (return_type) %}
 
 fun {{ func.name()|fn_name_kt }}({%- call kt::arg_list_decl(func) -%}): {{ return_type|type_kt }} {
-    val _retval = {% call kt::to_rs_call(func) %}
+    val _retval = {% call kt::to_ffi_call(func) %}
     return {{ "_retval"|lift_kt(return_type) }}
 }
 
 {% when None -%}
 
 fun {{ func.name()|fn_name_kt }}({% call kt::arg_list_decl(func) %}) =
-    {% call kt::to_rs_call(func) %}
+    {% call kt::to_ffi_call(func) %}
 {% endmatch %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -1,35 +1,35 @@
 {# 
 // Template to call into rust. Used in several places.
 // Variable names in `arg_list_decl` should match up with arg lists
-// passed to rust via `_arg_list_rs_call` (we use  `var_name_kt` in `lower_kt`)
+// passed to rust via `_arg_list_ffi_call` (we use  `var_name_kt` in `lower_kt`)
 #}
 
-{%- macro to_rs_call(func) -%}
+{%- macro to_ffi_call(func) -%}
 {%- match func.throws() %}
 {%- when Some with (e) -%}
     rustCall({{e}}.ByReference()) { e -> 
-        _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call _arg_list_rs_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %}e)
+        _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call _arg_list_ffi_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %}e)
     }
 {%- else -%}
-    _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call _arg_list_rs_call(func) -%})
+    _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call _arg_list_ffi_call(func) -%})
 {%- endmatch %}
 {%- endmacro -%}
 
-{%- macro to_rs_call_with_prefix(prefix, func) %}
+{%- macro to_ffi_call_with_prefix(prefix, func) %}
 {%- match func.throws() %}
 {%- when Some with (e) -%}
     rustCall({{e}}.ByReference()) { e -> 
         _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}(
-            {{- prefix }}, {% call _arg_list_rs_call(func) %}{% if func.arguments().len() > 0 %}, {% endif %}e)
+            {{- prefix }}, {% call _arg_list_ffi_call(func) %}{% if func.arguments().len() > 0 %}, {% endif %}e)
     }
 {%- else -%}
     _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}(
-        {{- prefix }}{% if func.arguments().len() > 0 %}, {% endif %}{% call _arg_list_rs_call(func) %})
+        {{- prefix }}{% if func.arguments().len() > 0 %}, {% endif %}{% call _arg_list_ffi_call(func) %})
 {%- endmatch %}
 {%- endmacro %}
 
 
-{%- macro _arg_list_rs_call(func) %}
+{%- macro _arg_list_ffi_call(func) %}
     {%- for arg in func.arguments() %}
         {{- arg.name()|lower_kt(arg.type_()) }}
         {%- if !loop.last %}, {% endif %}
@@ -50,11 +50,11 @@
 
 {#-
 // Arglist as used in the _UniFFILib function declations.
-// Note unfiltered name but type_c filters.
+// Note unfiltered name but type_ffi filters.
 -#}
 {%- macro arg_list_rs_decl(func) %}
     {%- for arg in func.arguments() %}
-        {{- arg.name() }}: {{ arg.type_()|type_c -}}
+        {{- arg.name() }}: {{ arg.type_()|type_ffi -}}
         {%- if loop.last %}{% else %},{% endif %}
     {%- endfor %}
     {% if func.has_out_err() %}{% if func.arguments().len() > 0 %},{% endif %} e: Structure.ByReference{% endif %}

--- a/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
@@ -1,4 +1,4 @@
 class {{ e.name() }}(enum.Enum):
-    {% for value in e.values() -%}
-    {{ value|enum_name_py }} = {{ loop.index }}
+    {% for variant in e.variants() -%}
+    {{ variant|enum_name_py }} = {{ loop.index }}
     {% endfor -%}

--- a/uniffi_bindgen/src/bindings/python/templates/NamespaceLibraryTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/NamespaceLibraryTemplate.py
@@ -20,7 +20,7 @@ def loadIndirect(componentName):
 _UniFFILib = loadIndirect(componentName="{{ ci.namespace() }}")
 {%- for func in ci.iter_ffi_function_definitions() %}
 _UniFFILib.{{ func.name() }}.argtypes = (
-    {%- call py::arg_list_rs_decl(func.arguments()) -%}
+    {%- call py::arg_list_ffi_decl(func.arguments()) -%}
 )
-_UniFFILib.{{ func.name() }}.restype = {% match func.return_type() %}{% when Some with (type_) %}{{ type_|type_c }}{% when None %}None{% endmatch %}
+_UniFFILib.{{ func.name() }}.restype = {% match func.return_type() %}{% when Some with (type_) %}{{ type_|type_ffi }}{% when None %}None{% endmatch %}
 {%- endfor %}

--- a/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
@@ -3,7 +3,7 @@ class {{ obj.name()|class_name_py }}(object):
     {%- for cons in obj.constructors() %}
     def __init__(self, {% call py::arg_list_decl(cons.arguments()) -%}):
         {%- call py::coerce_args_extra_indent(cons.arguments()) %}
-        self._handle = {% call py::to_rs_call(cons) %}
+        self._handle = {% call py::to_ffi_call(cons) %}
     {%- endfor %}
 
     def __del__(self):
@@ -15,12 +15,12 @@ class {{ obj.name()|class_name_py }}(object):
     {%- when Some with (return_type) -%}
     def {{ meth.name()|fn_name_py }}(self, {% call py::arg_list_decl(meth.arguments()) %}):
         {%- call py::coerce_args_extra_indent(meth.arguments()) %}
-        _retval = {% call py::to_rs_call_with_prefix("self._handle", meth) %}
+        _retval = {% call py::to_ffi_call_with_prefix("self._handle", meth) %}
         return {{ "_retval"|lift_py(return_type) }}
     
     {%- when None -%}
     def {{ meth.name()|fn_name_py }}(self, {% call py::arg_list_decl(meth.arguments()) %}):
         {%- call py::coerce_args_extra_indent(meth.arguments()) %}
-        {% call py::to_rs_call_with_prefix("self._handle", meth) %}
+        {% call py::to_ffi_call_with_prefix("self._handle", meth) %}
     {% endmatch %}
     {% endfor %}

--- a/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
@@ -3,12 +3,12 @@
 
 def {{ func.name()|fn_name_py }}({%- call py::arg_list_decl(func.arguments()) -%}):
     {%- call py::coerce_args(func.arguments()) %}
-    _retval = {% call py::to_rs_call(func) %}
+    _retval = {% call py::to_ffi_call(func) %}
     return {{ "_retval"|lift_py(return_type) }}
 
 {% when None -%}
 
 def {{ func.name()|fn_name_py }}({%- call py::arg_list_decl(func.arguments()) -%}):
     {%- call py::coerce_args(func.arguments()) %}
-    {% call py::to_rs_call(func) %}
+    {% call py::to_ffi_call(func) %}
 {% endmatch %}

--- a/uniffi_bindgen/src/bindings/python/templates/macros.py
+++ b/uniffi_bindgen/src/bindings/python/templates/macros.py
@@ -1,20 +1,20 @@
-{# 
+{#
 // Template to call into rust. Used in several places.
 // Variable names in `arg_list_decl` should match up with arg lists
-// passed to rust via `_arg_list_rs_call` (we use  `var_name_py` in `lower_py`)
+// passed to rust via `_arg_list_ffi_call` (we use  `var_name_py` in `lower_py`)
 #}
 
-{%- macro to_rs_call(func) -%}
-_UniFFILib.{{ func.ffi_func().name() }}({% call _arg_list_rs_call(func.ffi_func().arguments()) -%})
+{%- macro to_ffi_call(func) -%}
+_UniFFILib.{{ func.ffi_func().name() }}({% call _arg_list_ffi_call(func.arguments()) -%})
 {%- endmacro -%}
 
-{%- macro to_rs_call_with_prefix(prefix, func) -%}
+{%- macro to_ffi_call_with_prefix(prefix, func) -%}
 _UniFFILib.{{ func.ffi_func().name() }}(
-    {{- prefix }}{% if func.arguments().len() > 0 %}, {% call _arg_list_rs_call(func.arguments()) -%}{% endif -%}
+    {{- prefix }}{% if func.arguments().len() > 0 %}, {% call _arg_list_ffi_call(func.arguments()) -%}{% endif -%}
 )
 {%- endmacro -%}
 
-{%- macro _arg_list_rs_call(args) %}
+{%- macro _arg_list_ffi_call(args) %}
     {%- for arg in args %}
         {{- arg.name()|lower_py(arg.type_()) }}
         {%- if !loop.last %}, {% endif %}
@@ -35,11 +35,11 @@ _UniFFILib.{{ func.ffi_func().name() }}(
 
 {#-
 // Arglist as used in the _UniFFILib function declations.
-// Note unfiltered name but type_c filters.
+// Note unfiltered name but type_ffi filters.
 -#}
-{%- macro arg_list_rs_decl(args) %}
+{%- macro arg_list_ffi_decl(args) %}
     {%- for arg in args -%}
-        {{ arg.type_()|type_c }}, {##}
+        {{ arg.type_()|type_ffi }}, {##}
     {%- endfor %}
 {%- endmacro -%}
 

--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -1,6 +1,6 @@
 public enum {{ e.name()|class_name_swift }}: Lowerable, Liftable {
-    {% for value in e.values() %}
-    case {{ value|enum_variant_swift }}
+    {% for variant in e.variants() %}
+    case {{ variant|enum_variant_swift }}
     {% endfor %}
 
     static func lift(from buf: Reader) throws -> {{ e.name() }} {
@@ -9,8 +9,8 @@ public enum {{ e.name()|class_name_swift }}: Lowerable, Liftable {
 
     static func fromFFIValue(_ number: UInt32) throws -> {{ e.name() }} {
         switch number {
-        {% for value in e.values() %}
-        case {{ loop.index }}: return .{{ value|enum_variant_swift }}
+        {% for variant in e.variants() %}
+        case {{ loop.index }}: return .{{ variant|enum_variant_swift }}
         {% endfor %}
         default: throw InternalError.unexpectedEnumCase
         }
@@ -22,8 +22,8 @@ public enum {{ e.name()|class_name_swift }}: Lowerable, Liftable {
 
     func toFFIValue() -> UInt32 {
         switch self {
-        {% for value in e.values() %}
-        case .{{ value|enum_variant_swift }}: return {{ loop.index }}
+        {% for variant in e.variants() %}
+        case .{{ variant|enum_variant_swift }}: return {{ loop.index }}
         {% endfor %}
         }
     }

--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -3,7 +3,7 @@ public class {{ obj.name() }} {
 
     {%- for cons in obj.constructors() %}
     public init({% call swift::arg_list_decl(cons) -%}) {% call swift::throws(cons) %} {
-        self.handle = {% call swift::to_rs_call(cons) %}
+        self.handle = {% call swift::to_ffi_call(cons) %}
     }
     {%- endfor %}
 
@@ -16,14 +16,14 @@ public class {{ obj.name() }} {
     {%- match meth.return_type() -%}
 
     {%- when Some with (return_type) -%}
-    public func {{ meth.name()|fn_name_swift }}({% call swift::arg_list_decl(meth) %}) {% call swift::throws(meth) %} -> {{ return_type|decl_swift }} {
-        let _retval = {% call swift::to_rs_call_with_prefix("self.handle", meth) %}
+    public func {{ meth.name()|fn_name_swift }}({% call swift::arg_list_decl(meth) %}) {% call swift::throws(meth) %} -> {{ return_type|type_swift }} {
+        let _retval = {% call swift::to_ffi_call_with_prefix("self.handle", meth) %}
         return {% call swift::try(meth) %} {{ "_retval"|lift_swift(return_type) }}
     }
 
     {%- when None -%}
     public func {{ meth.name()|fn_name_swift }}({% call swift::arg_list_decl(meth) %}) {% call swift::throws(meth) %} {
-        {% call swift::to_rs_call_with_prefix("self.handle", meth) %}
+        {% call swift::to_ffi_call_with_prefix("self.handle", meth) %}
     }
     {%- endmatch %}
     {% endfor %}

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -1,13 +1,13 @@
 public struct {{ rec.name()|class_name_swift }}: Lowerable, Liftable, Serializable, Equatable {
     {%- for field in rec.fields() %}
-    let {{ field.name()|var_name_swift }}: {{ field.type_()|decl_swift }}
+    let {{ field.name()|var_name_swift }}: {{ field.type_()|type_swift }}
     {%- endfor %}
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
     public init(
         {%- for field in rec.fields() %}
-        {{ field.name()|var_name_swift }}: {{ field.type_()|decl_swift }}{% if loop.last %}{% else %},{% endif %}
+        {{ field.name()|var_name_swift }}: {{ field.type_()|type_swift }}{% if loop.last %}{% else %},{% endif %}
         {%- endfor %}
     ) {
         {%- for field in rec.fields() %}

--- a/uniffi_bindgen/src/bindings/swift/templates/RustBufferHelper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RustBufferHelper.swift
@@ -60,7 +60,7 @@ class Reader {
             throw InternalError.bufferOverflow
         }
         var value = [UInt8](repeating: 0, count: count)
-        value.withUnsafeMutableBufferPointer({ buffer in 
+        value.withUnsafeMutableBufferPointer({ buffer in
             data.copyBytes(to: buffer, from: range)
         })
         offset = range.upperBound
@@ -140,8 +140,13 @@ extension String: Liftable, Lowerable {
         }
         return String(cString: v)
     }
-    func toFFIValue() -> Self {
-        self
+    func toFFIValue() -> UnsafeMutablePointer<CChar> {
+        var rustErr = NativeRustError(code: 0, message: nil)
+        let rustStr = {{ ci.ffi_string_alloc_from().name() }}(self, &rustErr)
+        if rustErr.code != 0 {
+            fatalError("caught a panic while passing a string across the ffi")
+        }
+        return rustStr
     }
 
     static func lift(from buf: Reader) throws -> Self {

--- a/uniffi_bindgen/src/bindings/swift/templates/Template-Bridging-Header.h
+++ b/uniffi_bindgen/src/bindings/swift/templates/Template-Bridging-Header.h
@@ -20,8 +20,8 @@ typedef struct NativeRustError {
 
   
 {% for func in ci.iter_ffi_function_definitions() -%}
-    {%- match func.return_type() -%}{%- when Some with (type_) %}{{ type_|ret_c }}{% when None %}void{% endmatch %} {{ func.name() }}(
-      {% call swift::arg_list_rs_decl(func) %}
+    {%- match func.return_type() -%}{%- when Some with (type_) %}{{ type_|type_ffi }}{% when None %}void{% endmatch %} {{ func.name() }}(
+      {% call swift::arg_list_ffi_decl(func) %}
     );
 {% endfor -%}
 

--- a/uniffi_bindgen/src/bindings/swift/templates/TopLevelFunctionTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/TopLevelFunctionTemplate.swift
@@ -1,14 +1,14 @@
 {%- match func.return_type() -%}
 {%- when Some with (return_type) %}
 
-public func {{ func.name()|fn_name_swift }}({%- call swift::arg_list_decl(func) -%}) {% call swift::throws(func) %} -> {{ return_type|decl_swift }} {
-    let _retval = {% call swift::to_rs_call(func) %}
+public func {{ func.name()|fn_name_swift }}({%- call swift::arg_list_decl(func) -%}) {% call swift::throws(func) %} -> {{ return_type|type_swift }} {
+    let _retval = {% call swift::to_ffi_call(func) %}
     return {% call swift::try(func) %} {{ "_retval"|lift_swift(return_type) }}
 }
 
 {% when None -%}
 
 public func {{ func.name()|fn_name_swift }}({% call swift::arg_list_decl(func) %}) {% call swift::throws(func) %} {
-    {% call swift::to_rs_call(func) %}
+    {% call swift::to_ffi_call(func) %}
 }
 {% endmatch %}

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -8,21 +8,20 @@
 
 //! # Component Interface Definition and Types
 //!
-//! This crate provides an abstract representation of the interface provided by a "rust component",
+//! This crate provides an abstract representation of the interface provided by a uniffi rust component,
 //! in high-level terms suitable for translation into target consumer languages such as Kotlin
-//! and swift. It also provides facilities for parsing a WebIDL interface definition file into such a
+//! and Swift. It also provides facilities for parsing a WebIDL interface definition file into such a
 //! representation.
 //!
 //! The entrypoint to this crate is the `ComponentInterface` struct, which holds a complete definition
 //! of the interface provided by a component, in two parts:
 //!
-//!    * The high-level consumer API, interms of objects and records and methods and so-on
-//!    * The low-level FFI contract through which the host language can call into Rust.
+//!    * The high-level consumer API, in terms of objects and records and methods and so-on
+//!    * The low-level FFI contract through which the foreign language code can call into Rust.
 //!
 //! That's really the key concept of this crate so it's worth repeating: a `ComponentInterface` completely
 //! defines the shape and semantics of an interface between the rust-based implementation of a component
-//! and the foreign language consumers, including
-//! details like:
+//! and its foreign language consumers, including details like:
 //!
 //!    * The names of all symbols in the compiled object file
 //!    * The type and arity of all exported functions
@@ -30,14 +29,15 @@
 //!
 //! If you have a dynamic library compiled from a rust component using this crate, and a foreign
 //! language binding generated from the same `ComponentInterface` using the same version of this
-//! crate, then there should be no opportunities for them to disagree on how they should interact.
+//! crate, then there should be no opportunities for them to disagree on how the two sides should
+//! interact.
 //!
 //! General and incomplete TODO list for this thing:
 //!
 //!   * It should prevent user error and the possibility of generating bad code by doing (at least)
 //!     the following checks:
 //!       * No duplicate names (types, methods, args, etc)
-//!       * No Shadowing of builtin names, or names we use in code generation
+//!       * No shadowing of builtin names, or names we use in code generation
 //!     We expect that if the user actually does one of these things, then they *should* get a compile
 //!     error when trying to build the component, because the codegen will be invalid. But we can't
 //!     guarantee that there's not some edge-case where it produces valid-but-incorrect code.
@@ -46,8 +46,7 @@
 //!     a good opportunity here for e.g. interned strings, but we're nowhere near the point were we need
 //!     that kind of optimization just yet.
 //!
-//!   * Error messages leave a lot to be desired (and we currently panc on errors parsing the WebIDL).
-//!     If this were to be a real thing we'd need to invest in more empathetic error messages.
+//!   * Error messages and general developer experience leave a lot to be desired.
 
 use std::{collections::hash_map::Entry, collections::HashMap, convert::TryFrom, str::FromStr};
 
@@ -56,8 +55,8 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 pub mod types;
-pub use types::TypeReference;
 use types::TypeResolver;
+pub use types::{FFIType, Type};
 
 /// The main public interface for this module, representing the complete details of an interface exposed
 /// by a rust component and the details of consuming it via an extern-C FFI layer.
@@ -69,7 +68,7 @@ pub struct ComponentInterface {
     /// using a different version, which might introduce unsafety.
     uniffi_version: String,
     /// A map of all the nameable types used in the interface (including type aliases)
-    types: HashMap<String, TypeReference>,
+    types: HashMap<String, Type>,
     namespace: String,
     /// The high-level API provided by the component.
     enums: Vec<Enum>,
@@ -85,7 +84,7 @@ impl<'ci> ComponentInterface {
         let mut ci = Self::default();
         ci.uniffi_version = env!("CARGO_PKG_VERSION").to_string();
         // There's some lifetime thing with the errors returned from weedle::parse
-        // that life is too short to figure out; unwrap and move on.
+        // that my own lifetime is too short to worry about figuring out; unwrap and move on.
         let defns = weedle::parse(idl.trim()).unwrap();
         // We process the WebIDL definitions in two passes.
         // First, go through and look for all the named types.
@@ -124,45 +123,61 @@ impl<'ci> ComponentInterface {
         self.errors.to_vec()
     }
 
+    /// Builtin FFI function for allocating a new `RustBuffer`.
+    /// This is needed so that the foreign language bindings can create buffers in which to pass
+    /// complex data types across the FFI.
     pub fn ffi_bytebuffer_alloc(&self) -> FFIFunction {
         FFIFunction {
             name: format!("ffi_{}_bytebuffer_alloc", self.namespace()),
-            arguments: vec![Argument {
+            arguments: vec![FFIArgument {
                 name: "size".to_string(),
-                type_: TypeReference::U32,
-                by_ref: false,
-                optional: false,
-                default: None,
+                type_: FFIType::UInt32,
             }],
-            return_type: Some(TypeReference::Bytes),
+            return_type: Some(FFIType::RustBuffer),
             has_out_err: false,
         }
     }
 
+    /// Builtin FFI function for freeing a `RustBuffer`.
+    /// This is needed so that the foreign language bindings can free buffers in which they received
+    /// complex data types returned across the FFI.
     pub fn ffi_bytebuffer_free(&self) -> FFIFunction {
         FFIFunction {
             name: format!("ffi_{}_bytebuffer_free", self.namespace()),
-            arguments: vec![Argument {
+            arguments: vec![FFIArgument {
                 name: "buf".to_string(),
-                type_: TypeReference::Bytes,
-                by_ref: false,
-                optional: false,
-                default: None,
+                type_: FFIType::RustBuffer,
             }],
             return_type: None,
             has_out_err: false,
         }
     }
 
+    /// Builtin FFI function for creating a `RustString`.
+    /// This is needed so that the foreign language bindings can create strings to pass as arguments
+    /// across the FFI.
+    pub fn ffi_string_alloc_from(&self) -> FFIFunction {
+        FFIFunction {
+            name: format!("ffi_{}_string_alloc_from", self.namespace()),
+            arguments: vec![FFIArgument {
+                name: "str".to_string(),
+                type_: FFIType::ForeignStringRef,
+            }],
+            return_type: Some(FFIType::RustString),
+            // Unlike other builtin helpers, this one can panic, so takes an out err.
+            has_out_err: true,
+        }
+    }
+
+    /// Builtin FFI function for freeing a `RustString`.
+    /// This is needed so that the foreign language bindings can free strings that were returned
+    /// from rust code across the FFI.
     pub fn ffi_string_free(&self) -> FFIFunction {
         FFIFunction {
             name: format!("ffi_{}_string_free", self.namespace()),
-            arguments: vec![Argument {
+            arguments: vec![FFIArgument {
                 name: "str".to_string(),
-                type_: TypeReference::RawStringPointer,
-                by_ref: false,
-                optional: false,
-                default: None,
+                type_: FFIType::RustString,
             }],
             return_type: None,
             has_out_err: false,
@@ -184,6 +199,7 @@ impl<'ci> ComponentInterface {
                 vec![
                     self.ffi_bytebuffer_alloc(),
                     self.ffi_bytebuffer_free(),
+                    self.ffi_string_alloc_from(),
                     self.ffi_string_free(),
                 ]
                 .iter()
@@ -196,11 +212,20 @@ impl<'ci> ComponentInterface {
     // Private methods for building a ComponentInterface.
     //
 
-    fn get_type_definition(&self, name: &str) -> Option<TypeReference> {
+    /// Get the high-level type corresponding to a given name, if any.
+    fn get_type_definition(&self, name: &str) -> Option<Type> {
         self.types.get(name).cloned()
     }
 
-    fn add_type_definition(&mut self, name: &str, type_: TypeReference) -> Result<()> {
+    /// Get the high-level type corresponding to a given WebIDL type node.
+    fn resolve_type_definition<T: TypeResolver>(&self, type_: T) -> Result<Type> {
+        TypeResolver::resolve_type_definition(&type_, self)
+    }
+
+    /// Add the definition of a named high-level type.
+    ///
+    /// This will fail if you try to add a name for which an existing type definition exists.
+    fn add_type_definition(&mut self, name: &str, type_: Type) -> Result<()> {
         match self.types.entry(name.to_string()) {
             Entry::Occupied(_) => bail!("Conflicting type definition for {}", name),
             Entry::Vacant(e) => {
@@ -219,21 +244,25 @@ impl<'ci> ComponentInterface {
     }
 
     fn add_enum_definition(&mut self, defn: Enum) -> Result<()> {
+        // Note that there will be no duplicates thanks to the previous type-finding pass.
         self.enums.push(defn);
         Ok(())
     }
 
     fn add_record_definition(&mut self, defn: Record) -> Result<()> {
+        // Note that there will be no duplicates thanks to the previous type-finding pass.
         self.records.push(defn);
         Ok(())
     }
 
     fn add_function_definition(&mut self, defn: Function) -> Result<()> {
+        // XXX TODO: reject duplicates; the type-finding pass won't help us here.
         self.functions.push(defn);
         Ok(())
     }
 
     fn add_object_definition(&mut self, defn: Object) -> Result<()> {
+        // Note that there will be no duplicates thanks to the previous type-finding pass.
         self.objects.push(defn);
         Ok(())
     }
@@ -262,12 +291,13 @@ impl FromStr for ComponentInterface {
     }
 }
 
+/// Trait to help build a `ComponentInterface` from WedIDL syntax nodes.
+///
+/// This trait does structural matching on the various weedle AST nodes and
+/// uses them to build up the records, enums, objects etc in the provided
+/// `ComponentInterface`.
 trait APIBuilder {
     fn process(&self, ci: &mut ComponentInterface) -> Result<()>;
-}
-
-trait APIConverter<T> {
-    fn convert(&self, ci: &ComponentInterface) -> Result<T>;
 }
 
 impl<T: APIBuilder> APIBuilder for Vec<T> {
@@ -279,25 +309,23 @@ impl<T: APIBuilder> APIBuilder for Vec<T> {
     }
 }
 
-impl<U, T: APIConverter<U>> APIConverter<Vec<U>> for Vec<T> {
-    fn convert(&self, ci: &ComponentInterface) -> Result<Vec<U>> {
-        self.iter().map(|v| v.convert(ci)).collect::<Result<_>>()
-    }
-}
-
 impl APIBuilder for weedle::Definition<'_> {
     fn process(&self, ci: &mut ComponentInterface) -> Result<()> {
         match self {
             weedle::Definition::Namespace(d) => d.process(ci),
             weedle::Definition::Enum(d) => {
                 // We check if the enum represents an error...
-                if let Some(attrs) = &d.attributes {
+                let is_error = if let Some(attrs) = &d.attributes {
                     let attributes = Attributes::try_from(attrs)?;
-                    if attributes.contains_error_attr() {
-                        return ci.add_error_definition(d.convert(ci)?);
-                    }
+                    attributes.contains_error_attr()
+                } else {
+                    false
+                };
+                if is_error {
+                    ci.add_error_definition(d.convert(ci)?)
+                } else {
+                    ci.add_enum_definition(d.convert(ci)?)
                 }
-                ci.add_enum_definition(d.convert(ci)?)
             }
             weedle::Definition::Dictionary(d) => ci.add_record_definition(d.convert(ci)?),
             weedle::Definition::Interface(d) => ci.add_object_definition(d.convert(ci)?),
@@ -309,7 +337,7 @@ impl APIBuilder for weedle::Definition<'_> {
 /// A namespace is currently just a name, but might hold more metadata about
 /// the component in future.
 ///
-/// In WebIDL, each `namespace` declares a set of functions and attriutes that
+/// In WebIDL, each `namespace` declares a set of functions and attributes that
 /// are exposed as a global object, and there can be any number of such definitions.
 ///
 /// For our purposes, we expect just a single `namespace` declaration, which defines
@@ -339,14 +367,38 @@ impl APIBuilder for weedle::NamespaceDefinition<'_> {
     }
 }
 
-// Represents a standalone function.
-//
-// The in FFI, this will be a standalone function.
+/// Trait to help convert WedIDL syntax nodes into `ComponentInterface` objects.
+///
+/// This trait does structural matching on the various weedle AST nodes and converts
+/// them into appropriate structs that we can use to build up the contents of a
+/// `ComponentInterface`. It is basically the `TryFrom` trait except that the conversion
+/// always happens in the context of a given `ComponentInterface`, which is used for
+/// resolving e.g. type definitions.
+///
+/// The difference between this trait and `APIBuilder` is that `APIConverter` treats the
+/// `ComponentInterface` as a read-only data source for resolving types, while `APIBuilder`
+/// actually mutates the `ComponentInterface` to add new definitions.
+trait APIConverter<T> {
+    fn convert(&self, ci: &ComponentInterface) -> Result<T>;
+}
+
+impl<U, T: APIConverter<U>> APIConverter<Vec<U>> for Vec<T> {
+    fn convert(&self, ci: &ComponentInterface) -> Result<Vec<U>> {
+        self.iter().map(|v| v.convert(ci)).collect::<Result<_>>()
+    }
+}
+
+/// Represents a standalone function.
+///
+/// Each `Function` corresponds to a standalone function in the rust module,
+/// and has a corresponding standalone function in the foreign language bindings.
+///
+/// In the FFI, this will be a standalone function with appropriately lowered types.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Function {
     name: String,
     arguments: Vec<Argument>,
-    return_type: Option<TypeReference>,
+    return_type: Option<Type>,
     ffi_func: FFIFunction,
     attributes: Attributes,
 }
@@ -358,7 +410,7 @@ impl Function {
     pub fn arguments(&self) -> Vec<&Argument> {
         self.arguments.iter().collect()
     }
-    pub fn return_type(&self) -> Option<&TypeReference> {
+    pub fn return_type(&self) -> Option<&Type> {
         self.return_type.as_ref()
     }
     pub fn ffi_func(&self) -> &FFIFunction {
@@ -373,64 +425,12 @@ impl Function {
         self.ffi_func.name.push_str(ci_prefix);
         self.ffi_func.name.push_str("_");
         self.ffi_func.name.push_str(&self.name);
-        self.ffi_func.arguments = self.arguments.clone();
-        self.ffi_func.return_type = self.return_type.clone();
+        self.ffi_func.arguments = self.arguments.iter().map(FFIArgument::from).collect();
+        self.ffi_func.return_type = self.return_type.as_ref().map(FFIType::from);
         // Theoretically this should always be true
         // but it's this way until we implement handling for panics
         self.ffi_func.has_out_err = self.throws().is_some();
         Ok(())
-    }
-}
-
-// Represents an argument to a function/constructor/method call.
-//
-// Each argument has a name and a type, along with some optional metadata.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Argument {
-    name: String,
-    type_: TypeReference,
-    by_ref: bool,
-    optional: bool,
-    default: Option<Literal>,
-}
-
-impl Argument {
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-    pub fn type_(&self) -> TypeReference {
-        self.type_.clone()
-    }
-    pub fn by_ref(&self) -> bool {
-        self.by_ref
-    }
-}
-
-// Represents an "extern C"-style function that will be part of the FFI.
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
-pub struct FFIFunction {
-    name: String,
-    arguments: Vec<Argument>,
-    return_type: Option<TypeReference>,
-    // We use this to determine if the C binding will require
-    // an `out error` parameter. All functions should require it,
-    // However, the buffer_alloc, buffer_free and string_free do not.
-    has_out_err: bool,
-}
-
-impl FFIFunction {
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-    pub fn arguments(&self) -> Vec<&Argument> {
-        self.arguments.iter().collect()
-    }
-    pub fn return_type(&self) -> Option<&TypeReference> {
-        self.return_type.as_ref()
-    }
-    pub fn has_out_err(&self) -> bool {
-        self.has_out_err
     }
 }
 
@@ -445,15 +445,19 @@ impl APIConverter<Function> for weedle::namespace::NamespaceMember<'_> {
 
 impl APIConverter<Function> for weedle::namespace::OperationNamespaceMember<'_> {
     fn convert(&self, ci: &ComponentInterface) -> Result<Function> {
+        let return_type = match &self.return_type {
+            weedle::types::ReturnType::Void(_) => None,
+            weedle::types::ReturnType::Type(t) => Some(ci.resolve_type_definition(t)?),
+        };
+        if let Some(Type::Object(_)) = return_type {
+            bail!("Objects cannot currently be returned from functions");
+        }
         Ok(Function {
             name: match self.identifier {
                 None => bail!("anonymous functions are not supported {:?}", self),
                 Some(id) => id.0.to_string(),
             },
-            return_type: match &self.return_type {
-                weedle::types::ReturnType::Void(_) => None,
-                weedle::types::ReturnType::Type(t) => Some(t.resolve_type_definition(ci)?),
-            },
+            return_type,
             arguments: self.args.body.list.convert(ci)?,
             ffi_func: Default::default(),
             attributes: match &self.attributes {
@@ -461,6 +465,30 @@ impl APIConverter<Function> for weedle::namespace::OperationNamespaceMember<'_> 
                 None => Attributes(Vec::new()),
             },
         })
+    }
+}
+
+/// Represents an argument to a function/constructor/method call.
+///
+/// Each argument has a name and a type, along with some optional metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Argument {
+    name: String,
+    type_: Type,
+    by_ref: bool,
+    optional: bool,
+    default: Option<Literal>,
+}
+
+impl Argument {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    pub fn type_(&self) -> Type {
+        self.type_.clone()
+    }
+    pub fn by_ref(&self) -> bool {
+        self.by_ref
     }
 }
 
@@ -475,9 +503,13 @@ impl APIConverter<Argument> for weedle::argument::Argument<'_> {
 
 impl APIConverter<Argument> for weedle::argument::SingleArgument<'_> {
     fn convert(&self, ci: &ComponentInterface) -> Result<Argument> {
+        let type_ = (&self.type_).resolve_type_definition(ci)?;
+        if let Type::Object(_) = type_ {
+            bail!("Objects cannot currently be passed as arguments");
+        }
         Ok(Argument {
             name: self.identifier.0.to_string(),
-            type_: (&self.type_).resolve_type_definition(ci)?,
+            type_,
             by_ref: match &self.attributes {
                 None => false,
                 Some(attrs) => Attributes::try_from(attrs)?
@@ -497,35 +529,21 @@ impl APIConverter<Argument> for weedle::argument::SingleArgument<'_> {
     }
 }
 
-impl APIConverter<Error> for weedle::EnumDefinition<'_> {
-    fn convert(&self, _ci: &ComponentInterface) -> Result<Error> {
-        Ok(Error {
-            name: self.identifier.0.to_string(),
-            values: self
-                .values
-                .body
-                .list
-                .iter()
-                .map(|v| v.0.to_string())
-                .collect(),
-        })
-    }
-}
-
-// Represents a simple C-style enum.
-// In the FFI these are turned into a simple u32.
+/// Represents a simple C-style enum, with named variants.
+///
+/// In the FFI these are turned into a simple u32.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Enum {
     name: String,
-    values: Vec<String>,
+    variants: Vec<String>,
 }
 
 impl Enum {
     pub fn name(&self) -> &str {
         &self.name
     }
-    pub fn values(&self) -> Vec<&str> {
-        self.values.iter().map(|v| v.as_str()).collect()
+    pub fn variants(&self) -> Vec<&str> {
+        self.variants.iter().map(|v| v.as_str()).collect()
     }
 }
 
@@ -533,7 +551,7 @@ impl APIConverter<Enum> for weedle::EnumDefinition<'_> {
     fn convert(&self, _ci: &ComponentInterface) -> Result<Enum> {
         Ok(Enum {
             name: self.identifier.0.to_string(),
-            values: self
+            variants: self
                 .values
                 .body
                 .list
@@ -591,12 +609,9 @@ impl Object {
     pub fn ffi_object_free(&self) -> FFIFunction {
         FFIFunction {
             name: format!("ffi_{}_{}_object_free", self.namespace, self.name),
-            arguments: vec![Argument {
+            arguments: vec![FFIArgument {
                 name: "handle".to_string(),
-                type_: TypeReference::Object(self.name.clone()),
-                by_ref: false,
-                optional: false,
-                default: None,
+                type_: FFIType::UInt64,
             }],
             return_type: None,
             has_out_err: false,
@@ -611,6 +626,32 @@ impl Object {
             meth.derive_ffi_func(ci_prefix, &self.name)?
         }
         Ok(())
+    }
+}
+
+impl APIConverter<Object> for weedle::InterfaceDefinition<'_> {
+    fn convert(&self, ci: &ComponentInterface) -> Result<Object> {
+        if self.attributes.is_some() {
+            bail!("interface attributes are not supported yet");
+        }
+        if self.inheritance.is_some() {
+            bail!("interface inheritence is not supported");
+        }
+        let mut object = Object::new(self.identifier.0.to_string(), ci.namespace().to_string());
+        for member in &self.members.body {
+            match member {
+                weedle::interface::InterfaceMember::Constructor(t) => {
+                    object.constructors.push(t.convert(ci)?);
+                }
+                weedle::interface::InterfaceMember::Operation(t) => {
+                    let mut method = t.convert(ci)?;
+                    method.object_name.push_str(object.name.as_str());
+                    object.methods.push(method);
+                }
+                _ => bail!("no support for interface member type {:?} yet", member),
+            }
+        }
+        Ok(object)
     }
 }
 
@@ -649,12 +690,123 @@ impl Constructor {
         self.ffi_func.name.push_str(obj_prefix);
         self.ffi_func.name.push_str("_");
         self.ffi_func.name.push_str(&self.name);
-        self.ffi_func.arguments = self.arguments.clone();
-        self.ffi_func.return_type = Some(TypeReference::Object(obj_prefix.to_string()));
+        self.ffi_func.arguments = self.arguments.iter().map(FFIArgument::from).collect();
+        self.ffi_func.return_type = Some(FFIType::UInt64);
         // Theoretically this should always be true
         // but it's this way until we implement handling for panics
         self.ffi_func.has_out_err = self.throws().is_some();
         Ok(())
+    }
+}
+
+impl APIConverter<Constructor> for weedle::interface::ConstructorInterfaceMember<'_> {
+    fn convert(&self, ci: &ComponentInterface) -> Result<Constructor> {
+        Ok(Constructor {
+            name: String::from("new"), // TODO: get the name from an attribute maybe?
+            arguments: self.args.body.list.convert(ci)?,
+            ffi_func: Default::default(),
+            attributes: match &self.attributes {
+                Some(attr) => Attributes::try_from(attr)?,
+                None => Attributes(Vec::new()),
+            },
+        })
+    }
+}
+
+// Represents an instance method for an object type.
+//
+// The in FFI, this will be a function whose first argument is a handle for an
+// instance of the corresponding object type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Method {
+    name: String,
+    object_name: String,
+    return_type: Option<Type>,
+    arguments: Vec<Argument>,
+    ffi_func: FFIFunction,
+    attributes: Attributes,
+}
+
+impl Method {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn arguments(&self) -> Vec<&Argument> {
+        self.arguments.iter().collect()
+    }
+
+    pub fn return_type(&self) -> Option<&Type> {
+        self.return_type.as_ref()
+    }
+
+    pub fn ffi_func(&self) -> &FFIFunction {
+        &self.ffi_func
+    }
+
+    pub fn first_argument(&self) -> Argument {
+        Argument {
+            name: "handle".to_string(),
+            type_: Type::Object(self.object_name.clone()),
+            by_ref: false,
+            optional: false,
+            default: None,
+        }
+    }
+
+    pub fn throws(&self) -> Option<&str> {
+        self.attributes.get_throws_err()
+    }
+
+    fn derive_ffi_func(&mut self, ci_prefix: &str, obj_prefix: &str) -> Result<()> {
+        self.ffi_func.name.push_str(ci_prefix);
+        self.ffi_func.name.push_str("_");
+        self.ffi_func.name.push_str(obj_prefix);
+        self.ffi_func.name.push_str("_");
+        self.ffi_func.name.push_str(&self.name);
+        self.ffi_func.arguments = vec![self.first_argument()]
+            .iter()
+            .chain(self.arguments.iter())
+            .map(FFIArgument::from)
+            .collect();
+        self.ffi_func.return_type = self.return_type.as_ref().map(FFIType::from);
+        // Theoritically this should always be true
+        // but it's this way until we implement handling for panics
+        self.ffi_func.has_out_err = self.throws().is_some();
+        Ok(())
+    }
+}
+
+impl APIConverter<Method> for weedle::interface::OperationInterfaceMember<'_> {
+    fn convert(&self, ci: &ComponentInterface) -> Result<Method> {
+        if self.special.is_some() {
+            bail!("special operations not supported");
+        }
+        if let Some(weedle::interface::StringifierOrStatic::Stringifier(_)) = self.modifier {
+            bail!("stringifiers are not supported");
+        }
+        let return_type = match &self.return_type {
+            weedle::types::ReturnType::Void(_) => None,
+            weedle::types::ReturnType::Type(t) => Some(ci.resolve_type_definition(t)?),
+        };
+        if let Some(Type::Object(_)) = return_type {
+            bail!("Objects cannot currently be returned from functions");
+        }
+        Ok(Method {
+            name: match self.identifier {
+                None => bail!("anonymous methods are not supported {:?}", self),
+                Some(id) => id.0.to_string(),
+            },
+            // We don't know the name of the containing `Object` at this point, fill it in later.
+            object_name: Default::default(),
+            arguments: self.args.body.list.convert(ci)?,
+            return_type,
+            ffi_func: Default::default(),
+            attributes: match &self.attributes {
+                Some(attr) => Attributes::try_from(attr)?,
+                None => Attributes(Vec::new()),
+            },
+        })
     }
 }
 
@@ -678,141 +830,26 @@ impl Error {
     }
 }
 
-// Represents an instance method for an object type.
-//
-// The in FFI, this will be a function whose first argument is a handle for an
-// instance of the corresponding object type.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Method {
-    name: String,
-    return_type: Option<TypeReference>,
-    arguments: Vec<Argument>,
-    ffi_func: FFIFunction,
-    attributes: Attributes,
-}
-
-impl Method {
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    pub fn arguments(&self) -> Vec<&Argument> {
-        self.arguments.iter().collect()
-    }
-
-    pub fn return_type(&self) -> Option<&TypeReference> {
-        self.return_type.as_ref()
-    }
-
-    pub fn ffi_func(&self) -> &FFIFunction {
-        &self.ffi_func
-    }
-
-    pub fn first_argument(&self) -> Argument {
-        Argument {
-            name: "handle".to_string(),
-            type_: TypeReference::Object(self.name.clone()),
-            by_ref: false,
-            optional: false,
-            default: None,
-        }
-    }
-
-    pub fn throws(&self) -> Option<&str> {
-        self.attributes.get_throws_err()
-    }
-
-    fn derive_ffi_func(&mut self, ci_prefix: &str, obj_prefix: &str) -> Result<()> {
-        self.ffi_func.name.push_str(ci_prefix);
-        self.ffi_func.name.push_str("_");
-        self.ffi_func.name.push_str(obj_prefix);
-        self.ffi_func.name.push_str("_");
-        self.ffi_func.name.push_str(&self.name);
-        self.ffi_func.arguments = vec![self.first_argument()]
-            .iter()
-            .cloned()
-            .chain(self.arguments.iter().cloned())
-            .collect();
-        self.ffi_func.return_type = self.return_type.clone();
-        // Theoritically this should always be true
-        // but it's this way until we implement handling for panics
-        self.ffi_func.has_out_err = self.throws().is_some();
-        Ok(())
-    }
-}
-
-impl APIConverter<Object> for weedle::InterfaceDefinition<'_> {
-    fn convert(&self, ci: &ComponentInterface) -> Result<Object> {
-        if self.attributes.is_some() {
-            bail!("interface attributes are not supported yet");
-        }
-        if self.inheritance.is_some() {
-            bail!("interface inheritence is not supported");
-        }
-        let mut object = Object::new(self.identifier.0.to_string(), ci.namespace().to_string());
-        for member in &self.members.body {
-            match member {
-                weedle::interface::InterfaceMember::Constructor(t) => {
-                    object.constructors.push(t.convert(ci)?);
-                }
-                weedle::interface::InterfaceMember::Operation(t) => {
-                    object.methods.push(t.convert(ci)?);
-                }
-                _ => bail!("no support for interface member type {:?} yet", member),
-            }
-        }
-        Ok(object)
-    }
-}
-
-impl APIConverter<Constructor> for weedle::interface::ConstructorInterfaceMember<'_> {
-    fn convert(&self, ci: &ComponentInterface) -> Result<Constructor> {
-        if self.attributes.is_some() {
-            bail!("constructor attributes are not supported yet");
-        }
-        Ok(Constructor {
-            name: String::from("new"), // TODO: get the name from an attribute maybe?
-            arguments: self.args.body.list.convert(ci)?,
-            ffi_func: Default::default(),
-            attributes: match &self.attributes {
-                Some(attr) => Attributes::try_from(attr)?,
-                None => Attributes(Vec::new()),
-            },
+impl APIConverter<Error> for weedle::EnumDefinition<'_> {
+    fn convert(&self, _ci: &ComponentInterface) -> Result<Error> {
+        Ok(Error {
+            name: self.identifier.0.to_string(),
+            values: self
+                .values
+                .body
+                .list
+                .iter()
+                .map(|v| v.0.to_string())
+                .collect(),
         })
     }
 }
 
-impl APIConverter<Method> for weedle::interface::OperationInterfaceMember<'_> {
-    fn convert(&self, ci: &ComponentInterface) -> Result<Method> {
-        if self.special.is_some() {
-            bail!("special operations not supported");
-        }
-        if let Some(weedle::interface::StringifierOrStatic::Stringifier(_)) = self.modifier {
-            bail!("stringifiers are not supported");
-        }
-        Ok(Method {
-            name: match self.identifier {
-                None => bail!("anonymous methods are not supported {:?}", self),
-                Some(id) => id.0.to_string(),
-            },
-            arguments: self.args.body.list.convert(ci)?,
-            return_type: match &self.return_type {
-                weedle::types::ReturnType::Void(_) => None,
-                weedle::types::ReturnType::Type(t) => Some(t.resolve_type_definition(ci)?),
-            },
-            ffi_func: Default::default(),
-            attributes: match &self.attributes {
-                Some(attr) => Attributes::try_from(attr)?,
-                None => Attributes(Vec::new()),
-            },
-        })
-    }
-}
-
-// Represents a "data class" style object, for passing around complex values.
-// In the FFI these are represented as a ByteBuffer, which one side explicitly
-// serializes the data into and the other serializes it out of. So I guess they're
-// kind of like "pass by clone" values.
+/// Represents a "data class" style object, for passing around complex values.
+///
+/// In the FFI these are represented as a ByteBuffer, which one side explicitly
+/// serializes the data into and the other serializes it out of. So I guess they're
+/// kind of like "pass by clone" values.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Record {
     name: String,
@@ -825,22 +862,6 @@ impl Record {
     }
     pub fn fields(&self) -> Vec<&Field> {
         self.fields.iter().collect()
-    }
-}
-// Represents an individual field on a Record.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Field {
-    name: String,
-    type_: TypeReference,
-    required: bool,
-    default: Option<Literal>,
-}
-impl Field {
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-    pub fn type_(&self) -> TypeReference {
-        self.type_.clone()
     }
 }
 
@@ -859,14 +880,36 @@ impl APIConverter<Record> for weedle::DictionaryDefinition<'_> {
     }
 }
 
+// Represents an individual field on a Record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Field {
+    name: String,
+    type_: Type,
+    required: bool,
+    default: Option<Literal>,
+}
+
+impl Field {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    pub fn type_(&self) -> Type {
+        self.type_.clone()
+    }
+}
+
 impl APIConverter<Field> for weedle::dictionary::DictionaryMember<'_> {
     fn convert(&self, ci: &ComponentInterface) -> Result<Field> {
         if self.attributes.is_some() {
             bail!("dictionary member attributes are not supported yet");
         }
+        let type_ = ci.resolve_type_definition(&self.type_)?;
+        if let Type::Object(_) = type_ {
+            bail!("Objects cannot currently appear in record fields");
+        }
         Ok(Field {
             name: self.identifier.0.to_string(),
-            type_: (&self.type_).resolve_type_definition(ci)?,
+            type_,
             required: self.required.is_some(),
             default: match self.default {
                 None => None,
@@ -895,6 +938,11 @@ impl APIConverter<Literal> for weedle::literal::DefaultValue<'_> {
     }
 }
 
+/// Represents an attribute parsed from WebIDL, like [ByRef] or [Throws].
+///
+/// This is a convenience enum for parsing WebIDL attributes and erroring out if we encounter
+/// any unsupported ones. These don't convert directly into parts of a `ComponentInterface`, but
+/// may influence the properties of things like functions and arguments.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Attribute {
     ByRef,
@@ -941,8 +989,9 @@ impl TryFrom<&weedle::attribute::ExtendedAttribute<'_>> for Attribute {
     }
 }
 
-/// Abstraction around a Vec<Attribute>. Used to define conversions between a
-/// weedle list of attributes and itself.
+/// Abstraction around a Vec<Attribute>.
+///
+/// This is a convenience for parsing a weedle list of attributes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Attributes(Vec<Attribute>);
 
@@ -980,5 +1029,64 @@ impl TryFrom<&weedle::attribute::ExtendedAttributeList<'_>> for Attributes {
             .map(|attr| Attribute::try_from(attr))
             .collect::<Result<Vec<_>, _>>()
             .map(|attrs| Attributes(attrs))
+    }
+}
+
+/// Represents an "extern C"-style function that will be part of the FFI.
+///
+/// These can't be declared explicitly in the IDL, but rather, are derived automatically
+/// from the high-level interface. Each callable thing in the component API will have a
+/// corresponding `FFIFunction` through which it can be invoked, and uniffi also provides
+/// some built-in `FFIFunction` helpers for use in the foreign language bindings.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct FFIFunction {
+    name: String,
+    arguments: Vec<FFIArgument>,
+    return_type: Option<FFIType>,
+    // We use this to determine if the C binding will require
+    // an `out error` parameter. All functions should require it,
+    // However, the buffer/string management helpers do not.
+    has_out_err: bool,
+}
+
+impl FFIFunction {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    pub fn arguments(&self) -> Vec<&FFIArgument> {
+        self.arguments.iter().collect()
+    }
+    pub fn return_type(&self) -> Option<&FFIType> {
+        self.return_type.as_ref()
+    }
+    pub fn has_out_err(&self) -> bool {
+        self.has_out_err
+    }
+}
+
+/// Represents an argument to an FFI function.
+///
+/// Each argument has a name and a type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FFIArgument {
+    name: String,
+    type_: FFIType,
+}
+
+impl FFIArgument {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    pub fn type_(&self) -> FFIType {
+        self.type_.clone()
+    }
+}
+
+impl From<&Argument> for FFIArgument {
+    fn from(arg: &Argument) -> Self {
+        FFIArgument {
+            name: arg.name.clone(),
+            type_: FFIType::from(&arg.type_),
+        }
     }
 }

--- a/uniffi_bindgen/src/interface/types.rs
+++ b/uniffi_bindgen/src/interface/types.rs
@@ -6,7 +6,22 @@
 #![allow(unknown_lints)]
 #![warn(rust_2018_idioms)]
 
-//! # Our basic typesystem for defining a component interface.
+//! # Basic typesystem for defining a component interface.
+//!
+//! Our typesystem operates at two distinct levels: "API-level types" and "FFI-level types".
+//!
+//! The [`Type`](Type) enum represents high-level types that would appear in the public API
+//! of a component, such as enums and records as well as primitives like ints and strings.
+//! The rust code that implements a component, and the foreign language bindings that consume it,
+//! will both typically deal with such types as their core concern.
+//!
+//! The [`FFIType`](FFIType) enum represents low-level types that are used internally by our
+//! generated code for passing data back and forth across the C-style FFI between rust and the
+//! foreign language. These cover a much more restricted set of possible types. Consumers of a
+//! uniffi component should not need to care about FFI-level types at all.
+//!
+//! As a developer working on uniffi itself, you're likely to spend a fair bit of time thinking
+//! about how the API-level types map into FFI-level types and back again.
 
 use anyhow::bail;
 use anyhow::Result;
@@ -15,61 +30,114 @@ use std::convert::TryFrom;
 
 use super::{Attributes, ComponentInterface};
 
-/// Represents all the different types that can be used in a component interface.
+/// Represents the restricted set of low-level types that can be used to construct
+/// the C-style FFI layer between a rust component and its foreign language bindings.
+///
+/// For the types that involve memory allocation, we make a distinction between
+/// "owned" types (the recipient must free it, or pass it to someone else) and
+/// "borrowed" types (the sender must keep it alive for the duration of the call).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FFIType {
+    // N.B. there are no booleans at this layer, since they cause problems for JNA.
+    UInt8,
+    Int8,
+    UInt16,
+    Int16,
+    UInt32,
+    Int32,
+    UInt64,
+    Int64,
+    Float32,
+    Float64,
+    /// A byte buffer allocated by rust, and owned by whoever currently holds it.
+    /// If you've got one of these, you must either call the appropriate rust function to free it
+    /// or pass it to someone that will.
+    RustBuffer,
+    /// A UTF-8 string buffer allocated by rust, and owned by whoever currently holds it.
+    /// If you've got one of these, you must either call the appropriate rust function to free it
+    /// or pass it to someone that will.
+    RustString,
+    /// A borrowed reference to a UTF-8 string buffer owned by foreign language code.
+    /// The provider of this reference must keep it alive for the duration of the receiving call.
+    ForeignStringRef,
+    /// An error struct, containing a numberic error code and char* pointer to error string.
+    /// The string is owned by rust and allocated on the rust heap, and must be freed by
+    /// passing it to the appropriate `string_free` FFI function.
+    RustError,
+    // TODO: you can imagine a richer structural typesystem here, e.g. `Ref<String>` or something.
+    // We don't need that yet and it's possible we never will, so it isn't here for now.
+}
+
+/// Represents all the different high-level types that can be used in a component interface.
 /// At this level we identify user-defined types by name, without knowing any details
 /// of their internal structure apart from what type of thing they are (record, enum, etc).
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum TypeReference {
+pub enum Type {
+    // Primitive types.
+    UInt8,
+    Int8,
+    UInt16,
+    Int16,
+    UInt32,
+    Int32,
+    UInt64,
+    Int64,
+    Float32,
+    Float64,
     Boolean,
-    U8,
-    S8,
-    U16,
-    S16,
-    U32,
-    S32,
-    U64,
-    S64,
-    Float,
-    Double,
     String,
-    // I don't like this too much since it's not a part of the IDL, and hopefully I can get rid of it
-    // But keeping it for the draft until I have a better idea
-    // on how to model the freeing. Normal Kotlin functions that take
-    // strings take a "String" across the ffi, but the "free" function
-    // takes a "Pointer".
-    RawStringPointer,
-    Bytes,
+    // Types defined in the component API, each of which has a string name.
     Object(String),
     Record(String),
     Enum(String),
     Error(String),
-    Optional(Box<TypeReference>),
-    Sequence(Box<TypeReference>),
+    // Structurally recursive types.
+    Optional(Box<Type>),
+    Sequence(Box<Type>),
 }
 
-fn resolve_builtin_type(id: &weedle::common::Identifier<'_>) -> Option<TypeReference> {
-    match id.0 {
-        "string" => Some(TypeReference::String),
-        "u8" => Some(TypeReference::U8),
-        "s8" => Some(TypeReference::S8),
-        "u16" => Some(TypeReference::U16),
-        "s16" => Some(TypeReference::S16),
-        "u32" => Some(TypeReference::U32),
-        "s32" => Some(TypeReference::S32),
-        "u64" => Some(TypeReference::U64),
-        "s64" => Some(TypeReference::S64),
-        _ => None,
+/// When passing data across the FFI, each `Type` value will be lowered into a corresponding
+/// `FFIType` value. This conversion tells you which one.
+impl From<&Type> for FFIType {
+    fn from(v: &Type) -> FFIType {
+        match v {
+            // Types that are the same map to themselves, naturally.
+            Type::UInt8 => FFIType::UInt8,
+            Type::Int8 => FFIType::Int8,
+            Type::UInt16 => FFIType::UInt16,
+            Type::Int16 => FFIType::Int16,
+            Type::UInt32 => FFIType::UInt32,
+            Type::Int32 => FFIType::Int32,
+            Type::UInt64 => FFIType::UInt64,
+            Type::Int64 => FFIType::Int64,
+            Type::Float32 => FFIType::Float32,
+            Type::Float64 => FFIType::Float64,
+            // Booleans lower into a byte, to work around a bug in JNA.
+            Type::Boolean => FFIType::UInt8,
+            // Strings are always owned rust values.
+            // We might add a separate type for borrowed strings in future.
+            Type::String => FFIType::RustString,
+            // Objects are passed as opaque integer handles.
+            Type::Object(_) => FFIType::UInt64,
+            // Enums are passed as integers.
+            Type::Enum(_) => FFIType::UInt32,
+            // Errors have their own special type.
+            Type::Error(_) => FFIType::RustError,
+            // Other types are serialized into a bytebuffer and deserialized on the other side.
+            Type::Record(_) | Type::Optional(_) | Type::Sequence(_) => FFIType::RustBuffer,
+        }
     }
 }
 
+/// Trait to help with an early "type discovery" phase when processing the IDL.
+///
+/// Ths trait does structural matching against weedle AST nodes from a parsed
+/// IDL file, looking for all the named types defined in the file and accumulating
+/// them in the `ComponentInterface`. Doing this in a preliminary pass means that
+/// we know how to resolve names to types when building up the full interface
+/// definition.
 pub(crate) trait TypeFinder {
     fn find_type_definitions(&self, ci: &mut ComponentInterface) -> Result<()>;
-}
-
-// Hrm, maybe this should be just a normal method on the ComponentInterface
-// rather than  fancy trait? We'll see how it goes...
-pub(crate) trait TypeResolver {
-    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<TypeReference>;
 }
 
 impl<T: TypeFinder> TypeFinder for Vec<T> {
@@ -96,14 +164,20 @@ impl TypeFinder for weedle::Definition<'_> {
 impl TypeFinder for weedle::InterfaceDefinition<'_> {
     fn find_type_definitions(&self, ci: &mut ComponentInterface) -> Result<()> {
         let name = self.identifier.0.to_string();
-        ci.add_type_definition(self.identifier.0, TypeReference::Object(name))
+        if resolve_builtin_type(&self.identifier).is_some() {
+            bail!("please don't shadow builtin types (interface {})", name);
+        }
+        ci.add_type_definition(self.identifier.0, Type::Object(name))
     }
 }
 
 impl TypeFinder for weedle::DictionaryDefinition<'_> {
     fn find_type_definitions(&self, ci: &mut ComponentInterface) -> Result<()> {
         let name = self.identifier.0.to_string();
-        ci.add_type_definition(self.identifier.0, TypeReference::Record(name))
+        if resolve_builtin_type(&self.identifier).is_some() {
+            bail!("please don't shadow builtin types (dictionary {})", name);
+        }
+        ci.add_type_definition(self.identifier.0, Type::Record(name))
     }
 }
 
@@ -113,11 +187,14 @@ impl TypeFinder for weedle::EnumDefinition<'_> {
             let attrs = Attributes::try_from(attrs)?;
             if attrs.contains_error_attr() {
                 let name = self.identifier.0.to_string();
-                return ci.add_type_definition(self.identifier.0, TypeReference::Error(name));
+                return ci.add_type_definition(self.identifier.0, Type::Error(name));
             }
         }
         let name = self.identifier.0.to_string();
-        ci.add_type_definition(self.identifier.0, TypeReference::Enum(name))
+        if resolve_builtin_type(&self.identifier).is_some() {
+            bail!("please don't shadow builtin types (enum {})", name);
+        }
+        ci.add_type_definition(self.identifier.0, Type::Enum(name))
     }
 }
 
@@ -134,15 +211,34 @@ impl TypeFinder for weedle::TypedefDefinition<'_> {
             None => {
                 // For now, we assume that the typedef must refer to an already-defined type, which means
                 // we can look it up in the ComponentInterface. This should suffice for our needs for
-                // a good long while before we consider implementing a more complex resolution strategy.
+                // a good long while before we consider implementing a more complex delayed resolution strategy.
                 ci.add_type_definition(self.identifier.0, self.type_.resolve_type_definition(ci)?)
             }
         }
     }
 }
 
+/// Trait to help resolving an IDL type node to a `HighLevelType`.
+///
+/// Ths trait does structural matching against type-related weedle AST nodes from
+/// a parsed IDL file, turning them into a corresponding `HighLevelType`. It uses the
+/// mapping from names to types previous built by the `TypeFinder` trait in order to
+/// resolve types by name.
+///
+/// (And to be honest, a big part of its job is to error out if we encounter any of the
+/// many, many WebIDL type definitions that are not supported by uniffi.)
+pub(crate) trait TypeResolver {
+    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<Type>;
+}
+
+impl TypeResolver for &weedle::types::Type<'_> {
+    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<Type> {
+        (*self).resolve_type_definition(ci)
+    }
+}
+
 impl TypeResolver for weedle::types::Type<'_> {
-    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<TypeReference> {
+    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<Type> {
         match self {
             weedle::types::Type::Single(t) => match t {
                 weedle::types::SingleType::Any(_) => bail!("no support for `any` types"),
@@ -154,7 +250,7 @@ impl TypeResolver for weedle::types::Type<'_> {
 }
 
 impl TypeResolver for weedle::types::NonAnyType<'_> {
-    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<TypeReference> {
+    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<Type> {
         match self {
             weedle::types::NonAnyType::Boolean(t) => t.resolve_type_definition(ci),
             weedle::types::NonAnyType::Identifier(t) => t.resolve_type_definition(ci),
@@ -167,7 +263,7 @@ impl TypeResolver for weedle::types::NonAnyType<'_> {
 }
 
 impl TypeResolver for weedle::types::AttributedNonAnyType<'_> {
-    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<TypeReference> {
+    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<Type> {
         if self.attributes.is_some() {
             bail!("type attributes are not supported yet");
         }
@@ -176,7 +272,7 @@ impl TypeResolver for weedle::types::AttributedNonAnyType<'_> {
 }
 
 impl TypeResolver for weedle::types::AttributedType<'_> {
-    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<TypeReference> {
+    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<Type> {
         if self.attributes.is_some() {
             bail!("type attributes are not supported yet");
         }
@@ -185,17 +281,17 @@ impl TypeResolver for weedle::types::AttributedType<'_> {
 }
 
 impl<T: TypeResolver> TypeResolver for weedle::types::MayBeNull<T> {
-    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<TypeReference> {
+    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<Type> {
         let type_ = self.type_.resolve_type_definition(ci)?;
         Ok(match self.q_mark {
             None => type_,
-            Some(_) => TypeReference::Optional(Box::new(type_)),
+            Some(_) => Type::Optional(Box::new(type_)),
         })
     }
 }
 
 impl TypeResolver for weedle::types::IntegerType {
-    fn resolve_type_definition(&self, _ci: &ComponentInterface) -> Result<TypeReference> {
+    fn resolve_type_definition(&self, _ci: &ComponentInterface) -> Result<Type> {
         bail!(
             "integer types not implemented ({:?}); consider using u8, u16, u32 or u64",
             self
@@ -204,7 +300,7 @@ impl TypeResolver for weedle::types::IntegerType {
 }
 
 impl TypeResolver for weedle::types::FloatingPointType {
-    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<TypeReference> {
+    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<Type> {
         match self {
             weedle::types::FloatingPointType::Float(t) => t.resolve_type_definition(ci),
             weedle::types::FloatingPointType::Double(t) => t.resolve_type_definition(ci),
@@ -213,15 +309,15 @@ impl TypeResolver for weedle::types::FloatingPointType {
 }
 
 impl TypeResolver for weedle::types::SequenceType<'_> {
-    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<TypeReference> {
-        Ok(TypeReference::Sequence(Box::new(
+    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<Type> {
+        Ok(Type::Sequence(Box::new(
             self.generics.body.as_ref().resolve_type_definition(ci)?,
         )))
     }
 }
 
 impl TypeResolver for weedle::common::Identifier<'_> {
-    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<TypeReference> {
+    fn resolve_type_definition(&self, ci: &ComponentInterface) -> Result<Type> {
         match resolve_builtin_type(self) {
             Some(type_) => Ok(type_),
             None => match ci.get_type_definition(self.0) {
@@ -233,25 +329,45 @@ impl TypeResolver for weedle::common::Identifier<'_> {
 }
 
 impl TypeResolver for weedle::term::Boolean {
-    fn resolve_type_definition(&self, _ci: &ComponentInterface) -> Result<TypeReference> {
-        Ok(TypeReference::Boolean)
+    fn resolve_type_definition(&self, _ci: &ComponentInterface) -> Result<Type> {
+        Ok(Type::Boolean)
     }
 }
 
 impl TypeResolver for weedle::types::FloatType {
-    fn resolve_type_definition(&self, _ci: &ComponentInterface) -> Result<TypeReference> {
+    fn resolve_type_definition(&self, _ci: &ComponentInterface) -> Result<Type> {
         if self.unrestricted.is_some() {
             bail!("we don't support `unrestricted float`");
         }
-        Ok(TypeReference::Float)
+        Ok(Type::Float32)
     }
 }
 
 impl TypeResolver for weedle::types::DoubleType {
-    fn resolve_type_definition(&self, _ci: &ComponentInterface) -> Result<TypeReference> {
+    fn resolve_type_definition(&self, _ci: &ComponentInterface) -> Result<Type> {
         if self.unrestricted.is_some() {
             bail!("we don't support `unrestricted double`");
         }
-        Ok(TypeReference::Double)
+        Ok(Type::Float64)
+    }
+}
+
+/// Resolve built-in API types by name.
+/// Given an identifier from the IDL, this will return `Some(Type)` if it names one of the
+/// built-in primitive types or `None` if it names something else.
+fn resolve_builtin_type(id: &weedle::common::Identifier<'_>) -> Option<Type> {
+    match id.0 {
+        "string" => Some(Type::String),
+        "u8" => Some(Type::UInt8),
+        "i8" => Some(Type::Int8),
+        "u16" => Some(Type::UInt16),
+        "i16" => Some(Type::Int16),
+        "u32" => Some(Type::UInt32),
+        "i32" => Some(Type::Int32),
+        "u64" => Some(Type::UInt64),
+        "i64" => Some(Type::Int64),
+        "f32" => Some(Type::Float32),
+        "f64" => Some(Type::Float64),
+        _ => None,
     }
 }

--- a/uniffi_bindgen/src/templates/EnumTemplate.rs
+++ b/uniffi_bindgen/src/templates/EnumTemplate.rs
@@ -9,19 +9,19 @@
 #}
 unsafe impl uniffi::ViaFfi for {{ e.name() }} {
     type Value = u32;
-    fn into_ffi_value(&self) -> Self::Value {
+    fn into_ffi_value(self) -> Self::Value {
         match self {
             // If the provided enum doesn't match the options defined in the IDL then
             // this match will fail to compile, with a type error to guide the way.
-            {%- for value in e.values() %}
-            {{ e.name() }}::{{ value }} => {{ loop.index }},
+            {%- for variant in e.variants() %}
+            {{ e.name() }}::{{ variant }} => {{ loop.index }},
             {%- endfor %}
         }
     }
     fn try_from_ffi_value(v: Self::Value) -> uniffi::deps::anyhow::Result<Self> {
         Ok(match v {
-            {%- for value in e.values() %}
-            {{ loop.index }} => {{ e.name() }}::{{ value }},
+            {%- for variant in e.variants() %}
+            {{ loop.index }} => {{ e.name() }}::{{ variant }},
             {%- endfor %}
             _ => uniffi::deps::anyhow::bail!("Invalid {{ e.name() }} enum value: {}", v),
         })
@@ -30,8 +30,11 @@ unsafe impl uniffi::ViaFfi for {{ e.name() }} {
 
 impl uniffi::Lowerable for {{ e.name() }} {
     fn lower_into<B: uniffi::deps::bytes::BufMut>(&self, buf: &mut B) {
-        use uniffi::ViaFfi;
-        buf.put_u32(self.into_ffi_value());
+        buf.put_u32(match self {
+            {%- for variant in e.variants() %}
+            {{ e.name() }}::{{ variant }} => {{ loop.index }},
+            {%- endfor %}
+        });
     }
 }
 

--- a/uniffi_bindgen/src/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/templates/ObjectTemplate.rs
@@ -18,7 +18,7 @@ uniffi::deps::lazy_static::lazy_static! {
 
     #[no_mangle]
     pub extern "C" fn {{ cons.ffi_func().name() }}(
-        {%- call rs::arg_list_rs_decl(cons.ffi_func()) %}) -> u64 {
+        {%- call rs::arg_list_ffi_decl(cons.ffi_func()) %}) -> u64 {
         uniffi::deps::log::debug!("{{ cons.ffi_func().name() }}");
         // If the constructor does not have the same signature as declared in the IDL, then
         // this attempt to call it will fail with a (somewhat) helpful compiler error.
@@ -29,7 +29,7 @@ uniffi::deps::lazy_static::lazy_static! {
 {%- for meth in obj.methods() %}
     #[no_mangle]
     pub extern "C" fn {{ meth.ffi_func().name() }}(
-        {%- call rs::arg_list_rs_decl(meth.ffi_func()) %}
+        {%- call rs::arg_list_ffi_decl(meth.ffi_func()) %}
     ) -> {% call rs::return_type_func(meth) %} {
         uniffi::deps::log::debug!("{{ meth.ffi_func().name() }}");
         // If the method does not have the same signature as declared in the IDL, then

--- a/uniffi_bindgen/src/templates/RecordTemplate.rs
+++ b/uniffi_bindgen/src/templates/RecordTemplate.rs
@@ -18,7 +18,7 @@ impl uniffi::Liftable for {{ rec.name() }} {
     fn try_lift_from<B: uniffi::deps::bytes::Buf>(buf: &mut B) -> uniffi::deps::anyhow::Result<Self> {
       Ok(Self {
         {%- for field in rec.fields() %}
-            {{ field.name() }}: <{{ field.type_()|ret_type_rs }} as uniffi::Liftable>::try_lift_from(buf)?,
+            {{ field.name() }}: <{{ field.type_()|type_rs }} as uniffi::Liftable>::try_lift_from(buf)?,
         {%- endfor %}
       })
     }

--- a/uniffi_bindgen/src/templates/RustString.rs
+++ b/uniffi_bindgen/src/templates/RustString.rs
@@ -1,0 +1,41 @@
+// Everybody gets basic string support, since they're such a common data type.
+
+/// This helper receives a borrowed foreign language string and
+/// copies it into an owned rust string. It is naturally tremendously unsafe,
+/// because pointers. The main things to remember as a consumer are:
+///
+///   * You must keep the argument buffer alive for the duration of the call,
+///     and avoid mutating it e.g. from other threads.
+///   * You must eventually free the return value by passing it to the string
+///     destructor defined below. Not just "a string destructor like the one
+///     defined below", the very one defined below for this component!
+///
+/// This function will report a panic via its `ExternError` out arg if given
+/// a null or invalid pointer, or a buffer containing non-utf8 bytes.
+#[no_mangle]
+pub unsafe extern "C" fn {{ ci.ffi_string_alloc_from().name() }}(cstr: *const std::os::raw::c_char, err: &mut uniffi::deps::ffi_support::ExternError) -> *mut std::os::raw::c_char {
+    uniffi::deps::ffi_support::call_with_output(err, || {
+        // This logic was copied from ffi_support::FfiStr, changed to panic on invalid data.
+        // We should figure out whether/how to move this back into ffi_support.
+        if cstr.is_null() {
+            panic!("null pointer provided to string_alloc_from");
+        }
+        // This copies the data into a rust-allocated string.
+        let cstr = std::ffi::CStr::from_ptr(cstr);
+        let s = cstr.to_str().expect("Invalid utf8 in foreign string buffer");
+        // And this lowers it back into a rust-owned pointer to return over the FFI.
+        <String as uniffi::ViaFfi>::into_ffi_value(s.to_string())
+    })
+}
+
+/// Free a String that had previously been passed to the foreign language code.
+/// The argument *must* be a uniquely-owned pointer previously obtained from a call
+/// into the rust code that returned a string.
+///
+#[no_mangle]
+pub unsafe extern "C" fn {{ ci.ffi_string_free().name() }}(cstr: *mut std::os::raw::c_char) {
+    // We deliberately don't check the `Result` here, so that callers don't need to pass an out `err`.
+    // There was nothing for us to free in the failure case anyway, so no point in propagating the error.
+    let s = <String as uniffi::ViaFfi>::try_from_ffi_value(cstr);
+    drop(s)
+}

--- a/uniffi_bindgen/src/templates/TopLevelFunctionTemplate.rs
+++ b/uniffi_bindgen/src/templates/TopLevelFunctionTemplate.rs
@@ -7,7 +7,7 @@
 
 #[no_mangle]
 pub extern "C" fn {{ func.ffi_func().name() }}(
-    {% call rs::arg_list_rs_decl(func.ffi_func()) %}
+    {% call rs::arg_list_ffi_decl(func.ffi_func()) %}
 ) -> {% call rs::return_type_func(func) %} {
     // If the provided function does not match the signature specified in the IDL
     // then this attempt to call it will not compile, and will give guidance as to why.

--- a/uniffi_bindgen/src/templates/macros.rs
+++ b/uniffi_bindgen/src/templates/macros.rs
@@ -22,18 +22,18 @@
 
 {#-
 // Arglist as used in the _UniFFILib function declations.
-// Note unfiltered name but type_c filters.
+// Note unfiltered name but type_ffi filters.
 -#}
-{%- macro arg_list_rs_decl(func) %}
+{%- macro arg_list_ffi_decl(func) %}
     {%- for arg in func.arguments() %}
-        {{- arg.name() }}: {{ arg.type_()|type_c -}}{% if loop.last %}{% else %},{% endif %}
+        {{- arg.name() }}: {{ arg.type_()|type_ffi -}}{% if loop.last %}{% else %},{% endif %}
     {%- endfor %}
     {% if func.has_out_err() %}
     {% if func.arguments().len() > 0 %},{% endif %} err: &mut uniffi::deps::ffi_support::ExternError,
     {% endif %}
 {%- endmacro -%}
 
-{% macro return_type_func(func) %}{% match func.ffi_func().return_type() %}{% when Some with (return_type) %}{{ return_type|ret_type_c }}{%- else -%}(){%- endmatch -%}{%- endmacro -%}
+{% macro return_type_func(func) %}{% match func.ffi_func().return_type() %}{% when Some with (return_type) %}{{ return_type|type_ffi }}{%- else -%}(){%- endmatch -%}{%- endmacro -%}
 
 {% macro ret(func) %}{% match func.return_type() %}{% when Some with (return_type) %}{{ "_retval"|lower_rs(return_type) }}{% else %}_retval{% endmatch %}{% endmacro %}
 

--- a/uniffi_bindgen/src/templates/scaffolding_template.rs
+++ b/uniffi_bindgen/src/templates/scaffolding_template.rs
@@ -3,10 +3,7 @@
 {% import "macros.rs" as rs %}
 
 {% include "RustBuffer.rs" %}
-
-// We add support for freeing strings, some crates won't need this, but it seems safe
-// enough to include anyways since strings are such a common use case.
-uniffi::deps::ffi_support::define_string_destructor!({{ ci.ffi_string_free().name() }});
+{% include "RustString.rs" %}
 
 // We generate error mappings into ffi_support::ExternErrors
 // so that the errors can propagate through the FFI


### PR DESCRIPTION
Fixes #182, kind of. This is a big PR but a lot of it is mechanical.

I spent a bit of time noodling on the difficulty we had in handling strings, with an asymmetry between how they appear in arguments, return values, and records. I think the root of the problem was the way that we were smooshing together different types of types.

Previously, we had a single set of types (the `TypeReference` enum) which were used both in API function signatures, and in the signatures of internal FFI functions. This was nice and simple to get started but involved a lot of duplication and mental tracking of the implicit conversions that happen when sending data across the FFI.

This commit splits the types into two different...um...types. We have the `Type` enum to represent the rich high-level types that appear in the component API, and a separate `FFIType` enum to represent the much more constrained set of types that
are used to pass data back-and-forth across the FFI.

To prove out the approach, this commit also removes the asymmetry in how strings are handled in argument position vs return position. The API-level `Type::String` always corresponds to an owned Rust string, and is passed across the FFI as a pointer
represented by the low-level `FFIType::RustString`. Foreign language code can create a `FFIType::RustString` using a new helper function that takes a `FFI::ForeignStringRef` and copies it into the rust world.

The result is a smaller number of moving part in the foreign language binding generation, which I think is a nice little win.