### PR TITLE
Add destructors for objects

### DIFF
--- a/examples/sprites/tests/bindings/test_sprites.kts
+++ b/examples/sprites/tests/bindings/test_sprites.kts
@@ -11,3 +11,11 @@ assert( s.getPosition() == Point(1.0, 2.0) )
 
 s.moveBy(Vector(-4.0, 2.0))
 assert( s.getPosition() == Point(-3.0, 4.0) )
+
+s.destroy()
+try { 
+    s.moveBy(Vector(0.0, 0.0))
+    assert(false) { "Should not be able to call anything after `destroy`" }
+} catch(e: IllegalStateException) {
+    assert(true)
+}

--- a/uniffi/src/bindings/kotlin/templates/ErrorTemplate.kt
+++ b/uniffi/src/bindings/kotlin/templates/ErrorTemplate.kt
@@ -39,7 +39,7 @@ internal open class RustError : Structure() {
     @Synchronized
     fun ensureConsumed() {
         if (this.message != null) {
-            _UniFFILib.INSTANCE.{{ci.namespace()}}_string_free(this.message!!)
+            _UniFFILib.INSTANCE.{{ ci.ffi_string_free().name() }}(this.message!!)
             this.message = null
         }
     }

--- a/uniffi/src/bindings/kotlin/templates/Helpers.kt
+++ b/uniffi/src/bindings/kotlin/templates/Helpers.kt
@@ -1,0 +1,30 @@
+// A handful of classes and functions to support the generated data structures.
+// This would be a good candidate for isolating in its own ffi-support lib.
+
+abstract class FFIObject(
+    private val handle: AtomicLong
+) {
+    open fun destroy() {
+        this.handle.set(0L)
+    }
+
+    internal inline fun <R> callWithHandle(block: (handle: Long) -> R) =
+        this.handle.get().let { handle -> 
+            if (handle != 0L) {
+                block(handle)
+            } else {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+        }
+}
+
+inline fun <T : FFIObject, R> T.use(block: (T) -> R) =
+    try {
+        block(this)
+    } finally {
+        try {
+            this.destroy()
+        } catch (e: Throwable) {
+            // swallow
+        }
+    }

--- a/uniffi/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -30,19 +30,17 @@ class {{ obj.name()|class_name_kt }}(
     {%- match meth.return_type() -%}
 
     {%- when Some with (return_type) -%}
-    fun {{ meth.name()|fn_name_kt }}({% call kt::arg_list_decl(meth) %}): {{ return_type|type_kt }} {
-        val _retval = callWithHandle {
-            {# // Use it here, kotlin's anonymous argument for lambas/closures.
-            -#}
+    fun {{ meth.name()|fn_name_kt }}({% call kt::arg_list_decl(meth) %}): {{ return_type|type_kt }} =
+        callWithHandle {
             {% call kt::to_rs_call_with_prefix("it", meth) %} 
+        }.let {
+            {{ "it"|lift_kt(return_type) }}
         }
-        return {{ "_retval"|lift_kt(return_type) }}
-    }
     
     {%- when None -%}
     fun {{ meth.name()|fn_name_kt }}({% call kt::arg_list_decl(meth) %}) =
         callWithHandle {
-            {% call kt::to_rs_call_with_prefix("it", meth.ffi_func()) %} 
+            {% call kt::to_rs_call_with_prefix("it", meth) %} 
         }
     {% endmatch %}
     {% endfor %}

--- a/uniffi/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -1,25 +1,49 @@
+class {{ obj.name()|class_name_kt }}(
+    handle: Long
+) : FFIObject(AtomicLong(handle)) {
 
-class {{ obj.name()|class_name_kt }}(handle: Long) {
-    private var handle: AtomicLong = AtomicLong(handle)
     {%- for cons in obj.constructors() %}
     constructor({% call kt::arg_list_decl(cons) -%}) :
         this({% call kt::to_rs_call(cons) %})
     {%- endfor %}
 
-    // XXX TODO: destructors or equivalent.
+    /**
+     * Disconnect the object from the underlying Rust object.
+     * 
+     * It can be called more than once, but once called, interacting with the object 
+     * causes an `IllegalStateException`.
+     * 
+     * Clients **must** call this method once done with the object, or cause a memory leak.
+     */
+    override fun destroy() {
+        try {
+            callWithHandle {
+                super.destroy() // poison the handle so no-one else can use it before we tell rust.
+                _UniFFILib.INSTANCE.{{ obj.ffi_object_free().name() }}(it)
+            }
+        } catch (e: IllegalStateException) {
+            // The user called this more than once. Better than less than once.
+        }
+    }
 
     {% for meth in obj.methods() -%}
     {%- match meth.return_type() -%}
 
     {%- when Some with (return_type) -%}
     fun {{ meth.name()|fn_name_kt }}({% call kt::arg_list_decl(meth) %}): {{ return_type|type_kt }} {
-        val _retval = {% call kt::to_rs_call_with_prefix("this.handle.get()", meth) %}
+        val _retval = callWithHandle {
+            {# // Use it here, kotlin's anonymous argument for lambas/closures.
+            -#}
+            {% call kt::to_rs_call_with_prefix("it", meth) %} 
+        }
         return {{ "_retval"|lift_kt(return_type) }}
     }
     
     {%- when None -%}
     fun {{ meth.name()|fn_name_kt }}({% call kt::arg_list_decl(meth) %}) =
-        {% call kt::to_rs_call_with_prefix("this.handle.get()", meth) %}
+        callWithHandle {
+            {% call kt::to_rs_call_with_prefix("it", meth.ffi_func()) %} 
+        }
     {% endmatch %}
     {% endfor %}
 }

--- a/uniffi/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi/src/bindings/kotlin/templates/macros.kt
@@ -5,29 +5,28 @@
 #}
 
 {%- macro to_rs_call(func) -%}
-{% match func.throws() %}
-{% when Some with (e) %}
- rustCall({{e}}.ByReference()) { e -> 
-    _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call _arg_list_rs_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %}e)
- }
-{% else %}
- _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call _arg_list_rs_call(func) -%})
-
-{% endmatch %}
+{%- match func.throws() %}
+{%- when Some with (e) -%}
+    rustCall({{e}}.ByReference()) { e -> 
+        _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call _arg_list_rs_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %}e)
+    }
+{%- else -%}
+    _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call _arg_list_rs_call(func) -%})
+{%- endmatch %}
 {%- endmacro -%}
 
-{%- macro to_rs_call_with_prefix(prefix, func) -%}
-{% match func.throws() %}
-{% when Some with (e) %}
- rustCall({{e}}.ByReference()) { e -> 
+{%- macro to_rs_call_with_prefix(prefix, func) %}
+{%- match func.throws() %}
+{%- when Some with (e) -%}
+    rustCall({{e}}.ByReference()) { e -> 
+        _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}(
+            {{- prefix }}, {% call _arg_list_rs_call(func) %}{% if func.arguments().len() > 0 %}, {% endif %}e)
+    }
+{%- else -%}
     _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}(
-        {{- prefix }}, {% call _arg_list_rs_call(func) %}{% if func.arguments().len() > 0 %},{% endif %}e)
- }
- {% else %}
-_UniFFILib.INSTANCE.{{ func.ffi_func().name() }}(
-    {{- prefix }}{% if func.arguments().len() > 0 %},{% endif %}{% call _arg_list_rs_call(func) %})
-{% endmatch %}
-{%- endmacro -%}
+        {{- prefix }}{% if func.arguments().len() > 0 %}, {% endif %}{% call _arg_list_rs_call(func) %})
+{%- endmatch %}
+{%- endmacro %}
 
 
 {%- macro _arg_list_rs_call(func) %}

--- a/uniffi/src/bindings/kotlin/templates/wrapper.kt
+++ b/uniffi/src/bindings/kotlin/templates/wrapper.kt
@@ -31,6 +31,8 @@ import java.util.concurrent.atomic.AtomicLong
 
 {% include "NamespaceLibraryTemplate.kt" %}
 
+{% include "Helpers.kt" %}
+
 // Public interface members begin here.
 // Public facing enums
 {% for e in ci.iter_enum_definitions() %}

--- a/uniffi/src/bindings/python/templates/ObjectTemplate.py
+++ b/uniffi/src/bindings/python/templates/ObjectTemplate.py
@@ -3,10 +3,11 @@ class {{ obj.name()|class_name_py }}(object):
     {%- for cons in obj.constructors() %}
     def __init__(self, {% call py::arg_list_decl(cons.arguments()) -%}):
         {%- call py::coerce_args_extra_indent(cons.arguments()) %}
-        self._handle = {% call py::to_rs_call(cons) %}
+        self._handle = {% call py::to_rs_call(cons.ffi_func()) %}
     {%- endfor %}
 
-    # XXX TODO: destructors or equivalent.
+    def __del__(self):
+        _UniFFILib.{{ obj.ffi_object_free().name() }}(handle)
 
     {% for meth in obj.methods() -%}
     {%- match meth.return_type() -%}
@@ -14,12 +15,12 @@ class {{ obj.name()|class_name_py }}(object):
     {%- when Some with (return_type) -%}
     def {{ meth.name()|fn_name_py }}(self, {% call py::arg_list_decl(meth.arguments()) %}):
         {%- call py::coerce_args_extra_indent(meth.arguments()) %}
-        _retval = {% call py::to_rs_call_with_prefix("self._handle", meth) %}
+        _retval = {% call py::to_rs_call_with_prefix("self._handle", meth.ffi_func()) %}
         return {{ "_retval"|lift_py(return_type) }}
     
     {%- when None -%}
     def {{ meth.name()|fn_name_py }}(self, {% call py::arg_list_decl(meth.arguments()) %}):
         {%- call py::coerce_args_extra_indent(meth.arguments()) %}
-        {% call py::to_rs_call_with_prefix("self._handle", meth) %}
+        {% call py::to_rs_call_with_prefix("self._handle", meth.ffi_func()) %}
     {% endmatch %}
     {% endfor %}

--- a/uniffi/src/bindings/python/templates/ObjectTemplate.py
+++ b/uniffi/src/bindings/python/templates/ObjectTemplate.py
@@ -3,11 +3,11 @@ class {{ obj.name()|class_name_py }}(object):
     {%- for cons in obj.constructors() %}
     def __init__(self, {% call py::arg_list_decl(cons.arguments()) -%}):
         {%- call py::coerce_args_extra_indent(cons.arguments()) %}
-        self._handle = {% call py::to_rs_call(cons.ffi_func()) %}
+        self._handle = {% call py::to_rs_call(cons) %}
     {%- endfor %}
 
     def __del__(self):
-        _UniFFILib.{{ obj.ffi_object_free().name() }}(handle)
+        _UniFFILib.{{ obj.ffi_object_free().name() }}(self._handle)
 
     {% for meth in obj.methods() -%}
     {%- match meth.return_type() -%}
@@ -15,12 +15,12 @@ class {{ obj.name()|class_name_py }}(object):
     {%- when Some with (return_type) -%}
     def {{ meth.name()|fn_name_py }}(self, {% call py::arg_list_decl(meth.arguments()) %}):
         {%- call py::coerce_args_extra_indent(meth.arguments()) %}
-        _retval = {% call py::to_rs_call_with_prefix("self._handle", meth.ffi_func()) %}
+        _retval = {% call py::to_rs_call_with_prefix("self._handle", meth) %}
         return {{ "_retval"|lift_py(return_type) }}
     
     {%- when None -%}
     def {{ meth.name()|fn_name_py }}(self, {% call py::arg_list_decl(meth.arguments()) %}):
         {%- call py::coerce_args_extra_indent(meth.arguments()) %}
-        {% call py::to_rs_call_with_prefix("self._handle", meth.ffi_func()) %}
+        {% call py::to_rs_call_with_prefix("self._handle", meth) %}
     {% endmatch %}
     {% endfor %}

--- a/uniffi/src/bindings/python/templates/TopLevelFunctionTemplate.py
+++ b/uniffi/src/bindings/python/templates/TopLevelFunctionTemplate.py
@@ -3,12 +3,12 @@
 
 def {{ func.name()|fn_name_py }}({%- call py::arg_list_decl(func.arguments()) -%}):
     {%- call py::coerce_args(func.arguments()) %}
-    _retval = {% call py::to_rs_call(func) %}
+    _retval = {% call py::to_rs_call(func.ffi_func()) %}
     return {{ "_retval"|lift_py(return_type) }}
 
 {% when None -%}
 
 def {{ func.name()|fn_name_py }}({%- call py::arg_list_decl(func.arguments()) -%}):
     {%- call py::coerce_args(func.arguments()) %}
-    {% call py::to_rs_call(func) %}
+    {% call py::to_rs_call(func.ffi_func()) %}
 {% endmatch %}

--- a/uniffi/src/bindings/python/templates/TopLevelFunctionTemplate.py
+++ b/uniffi/src/bindings/python/templates/TopLevelFunctionTemplate.py
@@ -3,12 +3,12 @@
 
 def {{ func.name()|fn_name_py }}({%- call py::arg_list_decl(func.arguments()) -%}):
     {%- call py::coerce_args(func.arguments()) %}
-    _retval = {% call py::to_rs_call(func.ffi_func()) %}
+    _retval = {% call py::to_rs_call(func) %}
     return {{ "_retval"|lift_py(return_type) }}
 
 {% when None -%}
 
 def {{ func.name()|fn_name_py }}({%- call py::arg_list_decl(func.arguments()) -%}):
     {%- call py::coerce_args(func.arguments()) %}
-    {% call py::to_rs_call(func.ffi_func()) %}
+    {% call py::to_rs_call(func) %}
 {% endmatch %}

--- a/uniffi/src/bindings/python/templates/macros.py
+++ b/uniffi/src/bindings/python/templates/macros.py
@@ -4,13 +4,13 @@
 // passed to rust via `_arg_list_rs_call` (we use  `var_name_py` in `lower_py`)
 #}
 
-{%- macro to_rs_call(ffi_func) -%}
-_UniFFILib.{{ ffi_func.name() }}({% call _arg_list_rs_call(ffi_func.arguments()) -%})
+{%- macro to_rs_call(func) -%}
+_UniFFILib.{{ func.ffi_func().name() }}({% call _arg_list_rs_call(func.ffi_func().arguments()) -%})
 {%- endmacro -%}
 
-{%- macro to_rs_call_with_prefix(prefix, ffi_func) -%}
-_UniFFILib.{{ ffi_func.name() }}(
-    {{- prefix }}{% if ffi_func.arguments().len() > 1 %}, {% call _arg_list_rs_call(ffi_func.method_arguments()) -%}{% endif -%}
+{%- macro to_rs_call_with_prefix(prefix, func) -%}
+_UniFFILib.{{ func.ffi_func().name() }}(
+    {{- prefix }}{% if func.arguments().len() > 0 %}, {% call _arg_list_rs_call(func.arguments()) -%}{% endif -%}
 )
 {%- endmacro -%}
 

--- a/uniffi/src/bindings/python/templates/macros.py
+++ b/uniffi/src/bindings/python/templates/macros.py
@@ -4,13 +4,13 @@
 // passed to rust via `_arg_list_rs_call` (we use  `var_name_py` in `lower_py`)
 #}
 
-{%- macro to_rs_call(func) -%}
-_UniFFILib.{{ func.ffi_func().name() }}({% call _arg_list_rs_call(func.arguments()) -%})
+{%- macro to_rs_call(ffi_func) -%}
+_UniFFILib.{{ ffi_func.name() }}({% call _arg_list_rs_call(ffi_func.arguments()) -%})
 {%- endmacro -%}
 
-{%- macro to_rs_call_with_prefix(prefix, func) -%}
-_UniFFILib.{{ func.ffi_func().name() }}(
-    {{- prefix }}{% if func.arguments().len() > 0 %}, {% call _arg_list_rs_call(func.arguments()) -%}{% endif -%}
+{%- macro to_rs_call_with_prefix(prefix, ffi_func) -%}
+_UniFFILib.{{ ffi_func.name() }}(
+    {{- prefix }}{% if ffi_func.arguments().len() > 1 %}, {% call _arg_list_rs_call(ffi_func.method_arguments()) -%}{% endif -%}
 )
 {%- endmacro -%}
 

--- a/uniffi/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi/src/bindings/swift/templates/ObjectTemplate.swift
@@ -18,7 +18,7 @@ public class {{ obj.name() }} {
     {%- when Some with (return_type) -%}
     public func {{ meth.name()|fn_name_swift }}({% call swift::arg_list_decl(meth) %}) {% call swift::throws(meth) %} -> {{ return_type|decl_swift }} {
         let _retval = {% call swift::to_rs_call_with_prefix("self.handle", meth) %}
-        return {%- call swift::try(meth) %} {{ "_retval"|lift_swift(return_type) }}
+        return {% call swift::try(meth) %} {{ "_retval"|lift_swift(return_type) }}
     }
 
     {%- when None -%}

--- a/uniffi/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi/src/bindings/swift/templates/ObjectTemplate.swift
@@ -7,8 +7,9 @@ public class {{ obj.name() }} {
     }
     {%- endfor %}
 
-    // XXX TODO: destructors or equivalent.
-
+    deinit {
+        {{ obj.ffi_object_free().name() }}(handle)
+    }
 
     // TODO: Maybe merge the two templates (i.e the one with a return type and the one without)
     {% for meth in obj.methods() -%}

--- a/uniffi/src/bindings/swift/templates/TopLevelFunctionTemplate.swift
+++ b/uniffi/src/bindings/swift/templates/TopLevelFunctionTemplate.swift
@@ -3,7 +3,7 @@
 
 public func {{ func.name()|fn_name_swift }}({%- call swift::arg_list_decl(func) -%}) {% call swift::throws(func) %} -> {{ return_type|decl_swift }} {
     let _retval = {% call swift::to_rs_call(func) %}
-    return {%- call swift::try(func) %} {{ "_retval"|lift_swift(return_type) }}
+    return {% call swift::try(func) %} {{ "_retval"|lift_swift(return_type) }}
 }
 
 {% when None -%}

--- a/uniffi/src/bindings/swift/templates/macros.swift
+++ b/uniffi/src/bindings/swift/templates/macros.swift
@@ -5,30 +5,30 @@
 #}
 
 {%- macro to_rs_call(func) -%}
-{% match func.throws() %}
-{% when Some with (e) %}
-try rustCall({{e}}.NoError) { err  in
-    {{ func.ffi_func().name() }}({% call _arg_list_rs_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %}err)
-}
-{% else %}
-{{ func.ffi_func().name() }}({% call _arg_list_rs_call(func) -%})
-{% endmatch %}
+{%- match func.throws() %}
+{%- when Some with (e) %}
+    try rustCall({{e}}.NoError) { err  in
+        {{ func.ffi_func().name() }}({% call _arg_list_rs_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %}err)
+    }
+{%- else -%}
+    {{ func.ffi_func().name() }}({% call _arg_list_rs_call(func) -%})
+{%- endmatch %}
 {%- endmacro -%}
 
 {%- macro to_rs_call_with_prefix(prefix, func) -%}
-{% match func.throws() %}
-{% when Some with (e) %}
-try rustCall({{e}}.NoError) { err  in
+{%- match func.throws() %}
+{%- when Some with (e) %}
+    try rustCall({{e}}.NoError) { err  in
+        {{ func.ffi_func().name() }}(
+            {{- prefix }}, {% call _arg_list_rs_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %}err
+        )
+    }
+{%- else -%}
     {{ func.ffi_func().name() }}(
-        {{- prefix }}, {% call _arg_list_rs_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %}err
-    )
-}
-{% else %}
-{{ func.ffi_func().name() }}(
         {{- prefix }}{% if func.arguments().len() > 0 %},{% endif %}{% call _arg_list_rs_call(func) -%}
-)
-{% endmatch %}
-{%- endmacro -%}
+    )
+{%- endmatch %}
+{%- endmacro %}
 
 {%- macro _arg_list_rs_call(func) %}
     {%- for arg in func.arguments() %}
@@ -63,9 +63,9 @@ try rustCall({{e}}.NoError) { err  in
 {%- endmacro -%}
 
 {%- macro throws(func) %}
-{% match func.throws() %}{% when Some with (e) %}throws{% else %}{% endmatch %}
+{%- match func.throws() %}{% when Some with (e) %}throws{% else %}{% endmatch %}
 {%- endmacro -%}
 
 {%- macro try(func) %}
-{% match func.throws() %}{% when Some with (e) %}try{% else %}try!{% endmatch %}
+{%- match func.throws() %}{% when Some with (e) %}try{% else %}try!{% endmatch %}
 {%- endmacro -%}

--- a/uniffi/src/interface/mod.rs
+++ b/uniffi/src/interface/mod.rs
@@ -449,9 +449,6 @@ impl FFIFunction {
     pub fn has_out_err(&self) -> bool {
         self.has_out_err
     }
-    pub fn method_arguments(&self) -> &[Argument] {
-        self.arguments.get(1..self.arguments.len()).unwrap_or_default()
-    }
 }
 
 impl APIConverter<Function> for weedle::namespace::NamespaceMember<'_> {

--- a/uniffi/src/templates/ObjectTemplate.rs
+++ b/uniffi/src/templates/ObjectTemplate.rs
@@ -6,17 +6,22 @@
 // If the caller's implementation of the struct does not match with the methods or types specified
 // in the IDL, then the rust compiler will complain with a (hopefully at least somewhat helpful!)
 // error message when processing this generated code.
-
+{% let handle_map = format!("UNIFFI_HANDLE_MAP_{}", obj.name().to_uppercase()) %}
 lazy_static::lazy_static! {
-    static ref UNIFFI_HANDLE_MAP_{{ obj.name()|upper }}: ffi_support::ConcurrentHandleMap<{{ obj.name() }}> = ffi_support::ConcurrentHandleMap::new();
+    static ref {{ handle_map }}: ffi_support::ConcurrentHandleMap<{{ obj.name() }}> = ffi_support::ConcurrentHandleMap::new();
 }
 
-// XXX TODO: destructors.
-// These will need to be defined as another FFI function on the Object struct, and included automatically
-// in the set of all FFI functions for use by the bindings.
-// define_handle_map_deleter!(UNIFFI_HANDLE_MAP_{{ obj.name() }}, {{ obj.name() }}_free);
+    {% let ffi_free = obj.ffi_object_free() -%}
+    // define_handle_map_deleter!({{ handle_map }}, {{ ffi_free.name() }});
+    #[no_mangle]
+    pub extern "C" fn {{ ffi_free.name() }}(
+        {%- call rs::arg_list_rs_decl(ffi_free.arguments()) %}) {
+        log::debug!("{{ ffi_free.name() }}");
+        let _ = {{ handle_map }}.delete_u64(handle);
+    }
 
 {%- for cons in obj.constructors() %}
+
     #[no_mangle]
     pub extern "C" fn {{ cons.ffi_func().name() }}(
         {%- call rs::arg_list_rs_decl(cons.ffi_func()) %}) -> u64 {
@@ -25,10 +30,10 @@ lazy_static::lazy_static! {
         // this attempt to call it will fail with a (somewhat) helpful compiler error.
         {% call rs::to_rs_constructor_call(obj, cons) %}
     }
-{% endfor %}
+{%- endfor %}
 
 {%- for meth in obj.methods() %}
-#[no_mangle]
+    #[no_mangle]
     pub extern "C" fn {{ meth.ffi_func().name() }}(
         {%- call rs::arg_list_rs_decl(meth.ffi_func()) %}
     ) -> {% call rs::return_type_func(meth) %} {

--- a/uniffi/src/templates/ObjectTemplate.rs
+++ b/uniffi/src/templates/ObjectTemplate.rs
@@ -12,13 +12,7 @@ lazy_static::lazy_static! {
 }
 
     {% let ffi_free = obj.ffi_object_free() -%}
-    // define_handle_map_deleter!({{ handle_map }}, {{ ffi_free.name() }});
-    #[no_mangle]
-    pub extern "C" fn {{ ffi_free.name() }}(
-        {%- call rs::arg_list_rs_decl(ffi_free.arguments()) %}) {
-        log::debug!("{{ ffi_free.name() }}");
-        let _ = {{ handle_map }}.delete_u64(handle);
-    }
+    ffi_support::define_handle_map_deleter!({{ handle_map }}, {{ ffi_free.name() }});
 
 {%- for cons in obj.constructors() %}
 


### PR DESCRIPTION
Fixes #8.

This PR adds `deinit` and `__del__` calls into a reserved `object_free` method. (aside: this should be one more example for the need for #10.)

For kotlin, the JVM has a long and storied history of destructor not being the right thing.

Our _best_ hope is for `java.lang.ref.Cleaner` to be implemented in Java 9 and then adopted by Android.

Our _second best_ hope is for explicit `destroy` method. Provided here is an abstract class which checks if the object has been destroyed before each call.