### PR TITLE
Removes throws from non-throwing swift functions

### DIFF
--- a/examples/arithmetic/tests/bindings/test_arithmetic.swift
+++ b/examples/arithmetic/tests/bindings/test_arithmetic.swift
@@ -1,6 +1,6 @@
 import arithmetic
 
-assert(try! add(a: 2, b: 3, overflow: .saturating) == 5, "addition works")
+assert(add(a: 2, b: 3, overflow: .saturating) == 5, "addition works")
 
-assert(try! equal(a: 4, b: 4), "equality works")
-assert(try! !equal(a: 4, b: 5), "non-equality works")
+assert(equal(a: 4, b: 4), "equality works")
+assert(!equal(a: 4, b: 5), "non-equality works")

--- a/examples/geometry/tests/bindings/test_geometry.swift
+++ b/examples/geometry/tests/bindings/test_geometry.swift
@@ -3,8 +3,8 @@ import geometry
 let ln1 = Line(start: Point(coordX: 0, coordY: 0), end: Point(coordX: 1, coordY: 2))
 let ln2 = Line(start: Point(coordX: 1, coordY: 1), end: Point(coordX: 2, coordY: 2))
 
-assert(try! gradient(ln: ln1) == 2.0)
-assert(try! gradient(ln: ln2) == 1.0)
+assert(gradient(ln: ln1) == 2.0)
+assert(gradient(ln: ln2) == 1.0)
 
-assert(try! intersection(ln1: ln1, ln2: ln2) == Point(coordX: 0, coordY: 0))
-assert(try! intersection(ln1: ln1, ln2: ln1) == nil)
+assert(intersection(ln1: ln1, ln2: ln2) == Point(coordX: 0, coordY: 0))
+assert(intersection(ln1: ln1, ln2: ln1) == nil)

--- a/examples/rondpoint/tests/bindings/test_rondpoint.swift
+++ b/examples/rondpoint/tests/bindings/test_rondpoint.swift
@@ -1,10 +1,10 @@
 import rondpoint
 
 let dico = Dictionnaire(un: .deux, deux: false)
-let copyDico = try! copieDictionnaire(d: dico)
+let copyDico = copieDictionnaire(d: dico)
 assert(dico == copyDico)
 
-assert(try! copieEnumeration(e: .deux) == .deux)
-assert(try! copieEnumerations(e: [.un, .deux]) == [.un, .deux])
+assert(copieEnumeration(e: .deux) == .deux)
+assert(copieEnumerations(e: [.un, .deux]) == [.un, .deux])
 
-assert(try! switcheroo(b: false))
+assert(switcheroo(b: false))

--- a/examples/sprites/tests/bindings/test_sprites.swift
+++ b/examples/sprites/tests/bindings/test_sprites.swift
@@ -1,15 +1,15 @@
 import sprites
 
-let sempty = try! Sprite(initialPosition: nil)
-assert( try! sempty.getPosition() == Point(x: 0, y: 0))
+let sempty = Sprite(initialPosition: nil)
+assert( sempty.getPosition() == Point(x: 0, y: 0))
 
-let s = try! Sprite(initialPosition: Point(x: 0, y: 1))
-assert( try! s.getPosition() == Point(x: 0, y: 1))
+let s = Sprite(initialPosition: Point(x: 0, y: 1))
+assert( s.getPosition() == Point(x: 0, y: 1))
 
-try! s.moveTo(position: Point(x: 1.0, y: 2.0))
-assert( try! s.getPosition() == Point(x: 1, y: 2))
+s.moveTo(position: Point(x: 1.0, y: 2.0))
+assert( s.getPosition() == Point(x: 1, y: 2))
 
-try! s.moveBy(direction: Vector(dx: -4, dy: 2))
-assert( try! s.getPosition() == Point(x: -3, y: 4))
+s.moveBy(direction: Vector(dx: -4, dy: 2))
+assert( s.getPosition() == Point(x: -3, y: 4))
 
 

--- a/examples/todolist/tests/bindings/test_todolist.swift
+++ b/examples/todolist/tests/bindings/test_todolist.swift
@@ -1,7 +1,7 @@
 import todolist
 
 
-let todo = try! TodoList()
+let todo = TodoList()
 do {
     let _ = try todo.getLast()
     fatalError("Should have thrown an EmptyTodoList error!")
@@ -32,13 +32,13 @@ let entry2 = TodoEntry(text: "Test Ünicode hàndling in an entry can't believe 
 try! todo.addEntry(entry: entry2)
 assert(try! todo.getLastEntry() == entry2)
 
-assert(try! todo.getEntries().count == 5)
+assert(todo.getEntries().count == 5)
 
-try! todo.addEntries(entries: [TodoEntry(text: "foo"), TodoEntry(text: "bar")])
-assert(try! todo.getEntries().count == 7)
-assert(try! todo.getItems().count == 7)
+todo.addEntries(entries: [TodoEntry(text: "foo"), TodoEntry(text: "bar")])
+assert(todo.getEntries().count == 7)
+assert(todo.getItems().count == 7)
 assert(try! todo.getLast() == "bar")
 
-try! todo.addItems(items: ["bobo", "fofo"])
-assert(try! todo.getItems().count == 9)
-assert(try! todo.getItems()[7] == "bobo")
+todo.addItems(items: ["bobo", "fofo"])
+assert(todo.getItems().count == 9)
+assert(todo.getItems()[7] == "bobo")

--- a/uniffi/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi/src/bindings/swift/templates/ObjectTemplate.swift
@@ -2,7 +2,7 @@ public class {{ obj.name() }} {
     private let handle: UInt64
 
     {%- for cons in obj.constructors() %}
-    public init({% call swift::arg_list_decl(cons) -%}) throws {
+    public init({% call swift::arg_list_decl(cons) -%}) {% call swift::throws(cons) %} {
         self.handle = {% call swift::to_rs_call(cons) %}
     }
     {%- endfor %}
@@ -15,13 +15,13 @@ public class {{ obj.name() }} {
     {%- match meth.return_type() -%}
 
     {%- when Some with (return_type) -%}
-    public func {{ meth.name()|fn_name_swift }}({% call swift::arg_list_decl(meth) %}) throws -> {{ return_type|decl_swift }} {
+    public func {{ meth.name()|fn_name_swift }}({% call swift::arg_list_decl(meth) %}) {% call swift::throws(meth) %} -> {{ return_type|decl_swift }} {
         let _retval = {% call swift::to_rs_call_with_prefix("self.handle", meth) %}
-        return try! {{ "_retval"|lift_swift(return_type) }}
+        return {%- call swift::try(meth) %} {{ "_retval"|lift_swift(return_type) }}
     }
 
     {%- when None -%}
-    public func {{ meth.name()|fn_name_swift }}({% call swift::arg_list_decl(meth) %}) throws {
+    public func {{ meth.name()|fn_name_swift }}({% call swift::arg_list_decl(meth) %}) {% call swift::throws(meth) %} {
         {% call swift::to_rs_call_with_prefix("self.handle", meth) %}
     }
     {%- endmatch %}

--- a/uniffi/src/bindings/swift/templates/TopLevelFunctionTemplate.swift
+++ b/uniffi/src/bindings/swift/templates/TopLevelFunctionTemplate.swift
@@ -1,14 +1,14 @@
 {%- match func.return_type() -%}
 {%- when Some with (return_type) %}
 
-public func {{ func.name()|fn_name_swift }}({%- call swift::arg_list_decl(func) -%}) throws -> {{ return_type|decl_swift }} {
+public func {{ func.name()|fn_name_swift }}({%- call swift::arg_list_decl(func) -%}) {% call swift::throws(func) %} -> {{ return_type|decl_swift }} {
     let _retval = {% call swift::to_rs_call(func) %}
-    return try {{ "_retval"|lift_swift(return_type) }}
+    return {%- call swift::try(func) %} {{ "_retval"|lift_swift(return_type) }}
 }
 
 {% when None -%}
 
-public func {{ func.name()|fn_name_swift }}({% call swift::arg_list_decl(func) %}) throws {
+public func {{ func.name()|fn_name_swift }}({% call swift::arg_list_decl(func) %}) {% call swift::throws(func) %} {
     {% call swift::to_rs_call(func) %}
 }
 {% endmatch %}

--- a/uniffi/src/bindings/swift/templates/macros.swift
+++ b/uniffi/src/bindings/swift/templates/macros.swift
@@ -61,3 +61,11 @@ try rustCall({{e}}.NoError) { err  in
     {% if func.has_out_err() %}{% if func.arguments().len() > 0 %},{% endif %}NativeRustError *_Nonnull out_err{% endif %}
 
 {%- endmacro -%}
+
+{%- macro throws(func) %}
+{% match func.throws() %}{% when Some with (e) %}throws{% else %}{% endmatch %}
+{%- endmacro -%}
+
+{%- macro try(func) %}
+{% match func.throws() %}{% when Some with (e) %}try{% else %}try!{% endmatch %}
+{%- endmacro -%}


### PR DESCRIPTION
Clean up after #31.

Removes `throws` from swift functions that don't throw. 