### PR TITLE
Use our own bindgen when building our crates, rather than system bindgen

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,6 @@
 
 version: 2.1
 
-commands:
-  make_install_uniffi_bindgen:
-    steps:
-      - run:
-          name: Build and install uniffi-bindgen
-          command: cargo install --path uniffi_bindgen
 jobs:
   Check Rust formatting:
     docker:
@@ -25,7 +19,6 @@ jobs:
     steps:
       - checkout
       - run: rustup component add clippy
-      - make_install_uniffi_bindgen
       - run: cargo clippy --version
       - run: cargo clippy --all --all-targets
   Rust and Foreign Language tests:
@@ -35,7 +28,6 @@ jobs:
     steps:
       - run: cat ~/.profile >> $BASH_ENV
       - checkout
-      - make_install_uniffi_bindgen
       - run: cargo test
 
 workflows:

--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -11,7 +11,7 @@ name = "uniffi_arithmetic"
 
 [dependencies]
 uniffi_macros = {path = "../../uniffi_macros"}
-uniffi = {path = "../../uniffi"}
+uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
 
 [build-dependencies]
-uniffi_build = {path = "../../uniffi_build"}
+uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/examples/geometry/Cargo.toml
+++ b/examples/geometry/Cargo.toml
@@ -11,7 +11,7 @@ name = "uniffi_geometry"
 
 [dependencies]
 uniffi_macros = {path = "../../uniffi_macros"}
-uniffi = {path = "../../uniffi"}
+uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
 
 [build-dependencies]
-uniffi_build = {path = "../../uniffi_build"}
+uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/examples/rondpoint/Cargo.toml
+++ b/examples/rondpoint/Cargo.toml
@@ -11,7 +11,7 @@ name = "uniffi_rondpoint"
 
 [dependencies]
 uniffi_macros = {path = "../../uniffi_macros"}
-uniffi = {path = "../../uniffi"}
+uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
 
 [build-dependencies]
-uniffi_build = {path = "../../uniffi_build"}
+uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/examples/sprites/Cargo.toml
+++ b/examples/sprites/Cargo.toml
@@ -11,7 +11,7 @@ name = "uniffi_sprites"
 
 [dependencies]
 uniffi_macros = {path = "../../uniffi_macros"}
-uniffi = {path = "../../uniffi"}
+uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
 
 [build-dependencies]
-uniffi_build = {path = "../../uniffi_build"}
+uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/examples/todolist/Cargo.toml
+++ b/examples/todolist/Cargo.toml
@@ -11,8 +11,8 @@ name = "uniffi_todolist"
 
 [dependencies]
 uniffi_macros = {path = "../../uniffi_macros"}
-uniffi = {path = "../../uniffi"}
+uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi_build = {path = "../../uniffi_build"}
+uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -14,3 +14,8 @@ lazy_static = "1.4"
 log = "0.4"
 # Regular dependencies
 cargo_metadata = "0.11"
+uniffi_bindgen = { path = "../uniffi_bindgen", optional = true }
+
+[features]
+default = []
+builtin-bindgen = ["uniffi_bindgen"]

--- a/uniffi_build/Cargo.toml
+++ b/uniffi_build/Cargo.toml
@@ -6,4 +6,10 @@ license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]
+cargo_metadata = "0.11"
 anyhow = "1"
+uniffi_bindgen = { path = "../uniffi_bindgen", optional = true }
+
+[features]
+default = []
+builtin-bindgen = ["uniffi_bindgen"]

--- a/uniffi_build/src/lib.rs
+++ b/uniffi_build/src/lib.rs
@@ -2,23 +2,51 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use anyhow::{bail, Result};
-use std::{env, process::Command};
+use anyhow::Result;
+use std::env;
 
+#[cfg(not(feature = "builtin-bindgen"))]
+use anyhow::{bail, Context};
+#[cfg(not(feature = "builtin-bindgen"))]
+use std::process::Command;
+
+/// Generate the rust "scaffolding" required to build a uniffi component.
+///
+/// Given the path to an IDL file, this function will call the `uniffi-bindgen`
+/// command-line tool to generate the `pub extern "C"` functions and other supporting
+/// code required to expose the defined interface from Rust. The expectation is that
+/// this will be called from a crate's build script, and the resulting file will
+/// be `include!()`ed into the build.
+///
+/// Given an IDL file named `example.idl`, the generated scaffolding will be written
+/// into a file named `example.uniffi.rs` in the `$OUT_DIR` directory.
+///
+/// If the "builtin-bindgen" feature is enabled then this will take a dependency on
+/// the `uniffi_bindgen` crate and call its methods directly, rather than using the
+/// command-line tool. This is mostly useful for developers who are working on uniffi
+/// itself and need to test out their changes to the bindings generator.
 pub fn generate_scaffolding(idl_file: &str) -> Result<()> {
     println!("cargo:rerun-if-changed={}", idl_file);
     // Why don't we just depend on uniffi-bindgen and call the public functions?
     // Calling the command line helps making sure that the generated swift/Kotlin/whatever
     // bindings were generated with the same version of uniffi as the Rust scaffolding code.
     let out_dir = env::var("OUT_DIR").map_err(|_| anyhow::anyhow!("$OUT_DIR missing?!"))?;
-    if Command::new("uniffi-bindgen").output().is_err() {
-        bail!("It looks like uniffi-bindgen is not installed. You can do so by running `cargo install uniffi-bindgen`")
-    }
+    run_uniffi_bindgen_scaffolding(&out_dir, idl_file)
+}
+
+#[cfg(not(feature = "builtin-bindgen"))]
+fn run_uniffi_bindgen_scaffolding(out_dir: &str, idl_file: &str) -> Result<()> {
     let status = Command::new("uniffi-bindgen")
-        .args(&["scaffolding", "--out-dir", &out_dir, idl_file])
-        .status()?;
+        .args(&["scaffolding", "--out-dir", out_dir, idl_file])
+        .status()
+        .context("failed to run `uniffi-bindgen`")?;
     if !status.success() {
         bail!("Error while generating scaffolding code");
     }
     Ok(())
+}
+
+#[cfg(feature = "builtin-bindgen")]
+fn run_uniffi_bindgen_scaffolding(out_dir: &str, idl_file: &str) -> Result<()> {
+    uniffi_bindgen::generate_component_scaffolding(idl_file, Some(out_dir), None, true)
 }


### PR DESCRIPTION
When working on uniffi itself, it's very inconvenient to have to rely
on an externally-installed `uniffi-bindgen` command in order to run the
tests for the in-tree example crates. You basically need to remember to
manually `cargo build -p uniffi_bindgen` anytime you make a change to the
bindings genertor, or the tests won't test what you think they should.

This commit adds a feature-flag to the `uniffi` and `uniffi_build` crates
so that they will use the builtin `unifi_bindgen` module from this workspace
rather than whatever one they find on the system. I think this gives a much
better development experience when working on this repo itself, in particular
by allow `cargo test` to Just Work (tm) and always reflect your latest changes.

On the other hand, it means the examples in this repo are doing a thing that
we might not expect actual consuming crates to do.

I'm not thrilled about this solution, but I think it's a decent tradeoff on balance.

(I spent a few hours working on something more elaborate, that would actually
build the `uniffi-bindgen` command in this workspace when needed, but I got
caught up by cargo's build locking which prevented me from doing the required
`cargo build -p uniffi_bindgen` on-demand).

Fixes https://github.com/mozilla/uniffi-rs/issues/208.