### PR TITLE
Use destroy_into_vec

### DIFF
--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -91,7 +91,7 @@ pub trait Liftable: Sized {
 }
 
 pub fn try_lift<T: Liftable>(buf: ByteBuffer) -> Result<T> {
-    let vec = buf.into_vec();
+    let vec = buf.destroy_into_vec();
     let mut buf = vec.as_slice();
     let value = <T as Liftable>::try_lift_from(&mut buf)?;
     if buf.remaining() != 0 {


### PR DESCRIPTION
`into_vec` throws a warning at compile time

```sh
warning: use of deprecated item 'ffi_support::ByteBuffer::into_vec': Name is confusing, please use `destroy_into_vec` instead
```
