### PR TITLE
Update version requirement for ffi-support.

### DIFF
--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 # Re-exported dependencies used in generated Rust scaffolding files.
 anyhow = "1"
 bytes = "0.5"
-ffi-support = "0.4"
+ffi-support = "~0.4.2"
 lazy_static = "1.4"
 log = "0.4"
 # Regular dependencies


### PR DESCRIPTION
As of https://github.com/mozilla/uniffi-rs/pull/210, we depend on `ByteBuffer.destroy_into_vec` which is first available in the 0.4.2 release of `ffi_support`. This uses the tilde syntax to say "any semvar-compatible version that is at least 0.4.2" (which frankly, nothing about `~` makes me think "at least", but ok...)