### PR TITLE
Roundtrip and stringify testing for primitives

### DIFF
--- a/examples/rondpoint/src/lib.rs
+++ b/examples/rondpoint/src/lib.rs
@@ -50,4 +50,97 @@ fn switcheroo(b: bool) -> bool {
     !b
 }
 
+// Test that values can traverse both ways across the FFI.
+// Even if roundtripping works, it's possible we have
+// symmetrical errors that cancel each other out.
+#[derive(Debug, Clone)]
+struct Retourneur;
+impl Retourneur {
+    fn new() -> Self {
+        Retourneur
+    }
+    fn identique_i8(&self, value: i8) -> i8 {
+        value
+    }
+    fn identique_u8(&self, value: u8) -> u8 {
+        value
+    }
+    fn identique_i16(&self, value: i16) -> i16 {
+        value
+    }
+    fn identique_u16(&self, value: u16) -> u16 {
+        value
+    }
+    fn identique_i32(&self, value: i32) -> i32 {
+        value
+    }
+    fn identique_u32(&self, value: u32) -> u32 {
+        value
+    }
+    fn identique_i64(&self, value: i64) -> i64 {
+        value
+    }
+    fn identique_u64(&self, value: u64) -> u64 {
+        value
+    }
+    fn identique_float(&self, value: f32) -> f32 {
+        value
+    }
+    fn identique_double(&self, value: f64) -> f64 {
+        value
+    }
+    fn identique_boolean(&self, value: bool) -> bool {
+        value
+    }
+    fn identique_string(&self, value: String) -> String {
+        value
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Stringifier;
+
+#[allow(dead_code)]
+impl Stringifier {
+    fn new() -> Self {
+        Stringifier
+    }
+    fn to_string_i8(&self, value: i8) -> String {
+        value.to_string()
+    }
+    fn to_string_u8(&self, value: u8) -> String {
+        value.to_string()
+    }
+    fn to_string_i16(&self, value: i16) -> String {
+        value.to_string()
+    }
+    fn to_string_u16(&self, value: u16) -> String {
+        value.to_string()
+    }
+    fn to_string_i32(&self, value: i32) -> String {
+        value.to_string()
+    }
+    fn to_string_u32(&self, value: u32) -> String {
+        value.to_string()
+    }
+    fn to_string_i64(&self, value: i64) -> String {
+        value.to_string()
+    }
+    fn to_string_u64(&self, value: u64) -> String {
+        value.to_string()
+    }
+    fn to_string_float(&self, value: f32) -> String {
+        value.to_string()
+    }
+    fn to_string_double(&self, value: f64) -> String {
+        value.to_string()
+    }
+    fn to_string_boolean(&self, value: bool) -> String {
+        value.to_string()
+    }
+    fn well_known_string(&self, value: String) -> String {
+        format!("uniffi 💚 {}!", value)
+    }
+}
+
 include!(concat!(env!("OUT_DIR"), "/rondpoint.uniffi.rs"));

--- a/examples/rondpoint/src/rondpoint.idl
+++ b/examples/rondpoint/src/rondpoint.idl
@@ -26,3 +26,39 @@ dictionary Dictionnaire {
     u8 petit_nombre;
     u64 gros_nombre;
 };
+
+interface Retourneur {
+  // A constructor is mandatory
+  // See https://github.com/mozilla/uniffi-rs/issues/246
+  constructor();
+
+  i8 identique_i8(i8 value);
+  u8 identique_u8(u8 value);
+  i16 identique_i16(i16 value);
+  u16 identique_u16(u16 value);
+  i32 identique_i32(i32 value);
+  u32 identique_u32(u32 value);
+  i64 identique_i64(i64 value);
+  u64 identique_u64(u64 value);
+  float identique_float(float value);
+  double identique_double(double value);
+  boolean identique_boolean(boolean value);
+  string identique_string(string value);
+};
+
+interface Stringifier {
+  constructor();
+  string well_known_string(string value);
+
+  string to_string_i8(i8 value);
+  string to_string_u8(u8 value);
+  string to_string_i16(i16 value);
+  string to_string_u16(u16 value);
+  string to_string_i32(i32 value);
+  string to_string_u32(u32 value);
+  string to_string_i64(i64 value);
+  string to_string_u64(u64 value);
+  string to_string_float(float value);
+  string to_string_double(double value);
+  string to_string_boolean(boolean value);
+};

--- a/examples/rondpoint/tests/bindings/test_rondpoint.kts
+++ b/examples/rondpoint/tests/bindings/test_rondpoint.kts
@@ -9,3 +9,107 @@ assert(copieEnumerations(listOf(Enumeration.UN, Enumeration.DEUX)) == listOf(Enu
 assert(copieCarte(mapOf("1" to Enumeration.UN, "2" to Enumeration.DEUX)) == mapOf("1" to Enumeration.UN, "2" to Enumeration.DEUX))
 
 assert(switcheroo(false))
+
+// Test the roundtrip across the FFI.
+// This shows that the values we send come back in exactly the same state as we sent them.
+// i.e. it shows that lowering from kotlin and lifting into rust is symmetrical with 
+//      lowering from rust and lifting into kotlin.
+val rt = Retourneur()
+
+fun <T> List<T>.affirmAllerRetour(fn: (T) -> T) {
+    this.forEach { v ->
+        assert(fn.invoke(v) == v) { "$fn($v)" }
+    }
+}
+
+// Booleans
+listOf(true, false).affirmAllerRetour(rt::identiqueBoolean)
+
+// Bytes.
+listOf(Byte.MIN_VALUE, Byte.MAX_VALUE).affirmAllerRetour(rt::identiqueI8)
+listOf(0x00, 0xFF).map { it.toByte() }.affirmAllerRetour(rt::identiqueU8)
+
+// Shorts
+listOf(Short.MIN_VALUE, Short.MAX_VALUE).affirmAllerRetour(rt::identiqueI16)
+listOf(0x0000, 0xFFFF).map { it.toShort() }.affirmAllerRetour(rt::identiqueU16)
+
+// Ints
+listOf(0, 1, -1, Int.MIN_VALUE, Int.MAX_VALUE).affirmAllerRetour(rt::identiqueI32)
+listOf(0x00000000, 0xFFFFFFFF).map { it.toInt() }.affirmAllerRetour(rt::identiqueU32)
+
+// Longs
+listOf(0L, 1L, -1L, Long.MIN_VALUE, Long.MAX_VALUE).affirmAllerRetour(rt::identiqueI64)
+listOf(0L, 1L, -1L, Long.MIN_VALUE, Long.MAX_VALUE).affirmAllerRetour(rt::identiqueU64)
+
+// Floats
+listOf(0.0F, 0.5F, 0.25F, Float.MIN_VALUE, Float.MAX_VALUE).affirmAllerRetour(rt::identiqueFloat)
+
+// Doubles
+listOf(0.0, 1.0, Double.MIN_VALUE, Double.MAX_VALUE).affirmAllerRetour(rt::identiqueDouble)
+
+// Strings
+listOf("", "abc", "été", "ښي لاس ته لوستلو لوستل", "😻emoji 👨‍👧‍👦multi-emoji, 🇨🇭a flag, a canal, panama")
+    .affirmAllerRetour(rt::identiqueString)
+
+// Test one way across the FFI.
+//
+// We send one representation of a value to lib.rs, and it transforms it into another, a string.
+// lib.rs sends the string back, and then we compare here in kotlin.
+//
+// This shows that the values are transformed into strings the same way in both kotlin and rust.
+// i.e. if we assume that the string return works (we test this assumption elsewhere)
+//      we show that lowering from kotlin and lifting into rust has values that both kotlin and rust
+//      both stringify in the same way. i.e. the same values.
+//
+// If we roundtripping proves the symmetry of our lowering/lifting from here to rust, and lowering/lifting from rust t here,
+// and this convinces us that lowering/lifting from here to rust is correct, then 
+// together, we've shown the correctness of the return leg.
+val st = Stringifier()
+
+typealias StringyEquals<T> = (observed: String, expected: T) -> Boolean
+fun <T> List<T>.affirmEnchaine(
+    fn: (T) -> String,
+    equals: StringyEquals<T> = { obs, exp -> obs == exp.toString() }
+) {
+    this.forEach { exp ->
+        val obs = fn.invoke(exp)
+        assert(equals(obs, exp)) { "$fn($exp): observed=$obs, expected=$exp" }
+    }
+}
+
+// Test the effigacy of the string transport from rust. If this fails, but everything else 
+// works, then things are very weird.
+val wellKnown = st.wellKnownString("kotlin")
+assert("uniffi 💚 kotlin!" == wellKnown) { "wellKnownString 'uniffi 💚 kotlin!' == '$wellKnown'" }
+
+// NB. Numbers are all signed in kotlin. This makes roundtripping of unsigned numbers tricky to show. 
+// Uniffi does not generate unsigned types for kotlin, but the work tracked is 
+// in https://github.com/mozilla/uniffi-rs/issues/249. Tests using unsigned types are 
+// commented out for now.
+
+// Booleans
+listOf(true, false).affirmEnchaine(st::toStringBoolean)
+
+// Bytes.
+listOf(Byte.MIN_VALUE, Byte.MAX_VALUE).affirmEnchaine(st::toStringI8)
+// listOf(0x00, 0xFF).map { it.toByte() }.affirmEnchaine(st::toStringU8)
+
+// Shorts
+listOf(Short.MIN_VALUE, Short.MAX_VALUE).affirmEnchaine(st::toStringI16)
+// listOf(0x0000, 0xFFFF).map { it.toShort() }.affirmEnchaine(st::toStringU16)
+
+// Ints
+listOf(0, 1, -1, Int.MIN_VALUE, Int.MAX_VALUE).affirmEnchaine(st::toStringI32)
+// listOf(0x00000000, 0xFFFFFFFF).map { it.toInt() }.affirmEnchaine(st::toStringU32)
+
+// Longs
+listOf(0L, 1L, -1L, Long.MIN_VALUE, Long.MAX_VALUE).affirmEnchaine(st::toStringI64)
+// listOf(0L, 1L, -1L, Long.MIN_VALUE, Long.MAX_VALUE).affirmEnchaine(st::toStringU64)
+
+// Floats
+// MIN_VAUE is 1.4E-45. Accuracy and formatting get weird at small sizes.
+listOf(0.0F, 1.0F, -1.0F, Float.MIN_VALUE, Float.MAX_VALUE).affirmEnchaine(st::toStringFloat) { s, n -> s.toFloat() == n }
+
+// Doubles
+// MIN_VALUE is 4.9E-324. Accuracy and formatting get weird at small sizes.
+listOf(0.0, 1.0, -1.0, Double.MIN_VALUE, Double.MAX_VALUE).affirmEnchaine(st::toStringDouble)  { s, n -> s.toDouble() == n }

--- a/examples/rondpoint/tests/bindings/test_rondpoint.swift
+++ b/examples/rondpoint/tests/bindings/test_rondpoint.swift
@@ -9,3 +9,104 @@ assert(copieEnumerations(e: [.un, .deux]) == [.un, .deux])
 assert(copieCarte(c: ["1": .un, "2": .deux]) == ["1": .un, "2": .deux])
 
 assert(switcheroo(b: false))
+
+// Test the roundtrip across the FFI.
+// This shows that the values we send come back in exactly the same state as we sent them.
+// i.e. it shows that lowering from swift and lifting into rust is symmetrical with 
+//      lowering from rust and lifting into swift.
+let rt = Retourneur()
+
+// Booleans
+[true, false].affirmAllerRetour(rt.identiqueBoolean)
+
+// Bytes.
+[.min, .max].affirmAllerRetour(rt.identiqueI8)
+[0x00, 0xFF].map { $0 as UInt8 }.affirmAllerRetour(rt.identiqueU8)
+
+// Shorts
+[.min, .max].affirmAllerRetour(rt.identiqueI16)
+[0x0000, 0xFFFF].map { $0 as UInt16 }.affirmAllerRetour(rt.identiqueU16)
+
+// Ints
+[0, 1, -1, .min, .max].affirmAllerRetour(rt.identiqueI32)
+[0x00000000, 0xFFFFFFFF].map { $0 as UInt32 }.affirmAllerRetour(rt.identiqueU32)
+
+// Longs
+[.zero, 1, -1, .min, .max].affirmAllerRetour(rt.identiqueI64)
+[.zero, 1, .min, .max].affirmAllerRetour(rt.identiqueU64)
+
+// Floats
+[.zero, 1, 0.25, .leastNonzeroMagnitude, .greatestFiniteMagnitude].affirmAllerRetour(rt.identiqueFloat)
+
+// Doubles
+[0.0, 1.0, .leastNonzeroMagnitude, .greatestFiniteMagnitude].affirmAllerRetour(rt.identiqueDouble)
+
+// Strings
+["", "abc", "été", "ښي لاس ته لوستلو لوستل", "😻emoji 👨‍👧‍👦multi-emoji, 🇨🇭a flag, a canal, panama"]
+    .affirmAllerRetour(rt.identiqueString)
+
+// Test one way across the FFI.
+//
+// We send one representation of a value to lib.rs, and it transforms it into another, a string.
+// lib.rs sends the string back, and then we compare here in swift.
+//
+// This shows that the values are transformed into strings the same way in both swift and rust.
+// i.e. if we assume that the string return works (we test this assumption elsewhere)
+//      we show that lowering from swift and lifting into rust has values that both swift and rust
+//      both stringify in the same way. i.e. the same values.
+//
+// If we roundtripping proves the symmetry of our lowering/lifting from here to rust, and lowering/lifting from rust t here,
+// and this convinces us that lowering/lifting from here to rust is correct, then 
+// together, we've shown the correctness of the return leg.
+let st = Stringifier()
+
+// Test the effigacy of the string transport from rust. If this fails, but everything else 
+// works, then things are very weird.
+let wellKnown = st.wellKnownString(value: "swift")
+assert("uniffi 💚 swift!" == wellKnown, "wellKnownString 'uniffi 💚 swift!' == '\(wellKnown)'")
+
+// Booleans
+[true, false].affirmEnchaine(st.toStringBoolean)
+
+// Bytes.
+[.min, .max].affirmEnchaine(st.toStringI8)
+[.min, .max].affirmEnchaine(st.toStringU8)
+
+// Shorts
+[.min, .max].affirmEnchaine(st.toStringI16)
+[.min, .max].affirmEnchaine(st.toStringU16)
+
+// Ints
+[0, 1, -1, .min, .max].affirmEnchaine(st.toStringI32)
+[0, 1, .min, .max].affirmEnchaine(st.toStringU32)
+
+// Longs
+[.zero, 1, -1, .min, .max].affirmEnchaine(st.toStringI64)
+[.zero, 1, .min, .max].affirmEnchaine(st.toStringU64)
+
+// Floats
+[.zero, 1, -1, .leastNonzeroMagnitude, .greatestFiniteMagnitude].affirmEnchaine(st.toStringFloat) { Float.init($0) == $1 }
+
+// Doubles
+[.zero, 1, -1, .leastNonzeroMagnitude, .greatestFiniteMagnitude].affirmEnchaine(st.toStringDouble) { Double.init($0) == $1 }
+
+// Some extension functions for testing the results of roundtripping and stringifying
+extension Array where Element: Equatable {
+    static func defaultEquals(_ observed: String, expected: Element) -> Bool {
+        let exp = "\(expected)"
+        return observed == exp
+    }
+
+    func affirmEnchaine(_ fn: (Element) -> String, equals: (String, Element) -> Bool = defaultEquals) {
+        self.forEach { v in
+            let obs = fn(v)
+            assert(equals(obs, v), "toString_\(type(of:v))(\(v)): observed=\(obs), expected=\(v)")
+        }
+    }
+
+    func affirmAllerRetour(_ fn: (Element) -> Element) {
+        self.forEach { v in
+            assert(fn(v) == v, "identique_\(type(of:v))(\(v))")
+        }
+    }
+}


### PR DESCRIPTION
Fixes #175 

This PR adds a good deal of certainty around the lowering and lifting code for primitives. 

The idea is that roundtripping gives us some confidence that two rounds of lowering/lifting works, but not that the value that rust gets is the value sent by the foreign language.

e.g. 
1. calling round: lower from swift to C then lift from C to rust.
2. returning round: lower from rust to C, then lift from C to swift.

i.e. if we only test by roundtripping, we only verify that the two lowering/lifting rounds are symmetrical, not that they are both correct.

If we can convince ourselves that one round is correct, and that both rounds are symmetrical, then we can say that both are correct.

To do this, we ask rust to transform the received value into a different, but well known representation, and send _that_ back to be compared in swift.

In this way, we can exercise and test the FFI, without having to get oracle data into rust in another way (e.g. hard coding into rust, or loading a file).