### PR TITLE
Adds first pass of nimbus api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,6 @@ members = [
   "examples/geometry",
   "examples/rondpoint",
   "examples/sprites",
-  "examples/todolist"
+  "examples/todolist",
+  "examples/nimbus"
 ]

--- a/examples/nimbus/Cargo.toml
+++ b/examples/nimbus/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "uniffi-example-nimbus"
+edition = "2018"
+version = "0.1.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+license = "MPL-2.0"
+
+[lib]
+crate-type = ["cdylib"]
+name = "uniffi_nimbus"
+
+[dependencies]
+uniffi_macros = {path = "../../uniffi_macros"}
+uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
+thiserror = "1.0"
+
+[build-dependencies]
+uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/examples/nimbus/build.rs
+++ b/examples/nimbus/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/nimbus.idl").unwrap();
+}

--- a/examples/nimbus/src/lib.rs
+++ b/examples/nimbus/src/lib.rs
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#[derive(Debug, Clone)]
+pub struct ApplicationContext {
+    app_id: Option<String>,
+    app_version: Option<String>,
+    locale: Option<String>,
+    device_manufacturer: Option<String>,
+    device_model: Option<String>,
+    region: Option<String>,
+    debug_tag: Option<String>,
+}
+
+pub struct Experiment {
+    slug: String,
+    user_facing_name: String,
+    user_facing_description: String,
+}
+
+pub struct Config {
+    server_url: Option<String>,
+    uuid: Option<String>,
+    collection_name: Option<String>,
+    bucket_name: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExperimentError {
+    #[error("Error from the network")]
+    NetworkError,
+    #[error("Error retrieving from the database")]
+    DbError,
+}
+
+type Result<T, E = ExperimentError> = std::result::Result<T, E>;
+pub struct Experiments {}
+
+impl Experiments {
+    pub fn new(_: ApplicationContext, _: String, _: Option<Config>) -> Result<Self> {
+        unimplemented!()
+    }
+
+    pub fn get_experiment_branch(&self, _: String) -> Option<String> {
+        unimplemented!()
+    }
+
+    pub fn get_active_experiments(&self) -> Vec<Experiment> {
+        unimplemented!()
+    }
+
+    pub fn opt_in_with_branch(&self, _: String, _: String) {
+        unimplemented!()
+    }
+
+    pub fn opt_out(&self, _: String) {
+        unimplemented!()
+    }
+
+    pub fn opt_out_all(&self) {
+        unimplemented!()
+    }
+
+    pub fn update_experiments(&self) -> Result<()> {
+        unimplemented!()
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/nimbus.uniffi.rs"));

--- a/examples/nimbus/src/nimbus.idl
+++ b/examples/nimbus/src/nimbus.idl
@@ -1,0 +1,45 @@
+namespace nimbus {};
+dictionary ApplicationContext {
+    string? app_id;
+    string? app_version;
+    string? locale;
+    string? device_manufacturer;
+    string? device_model;
+    string? region;
+    string? debug_tag;
+};
+
+dictionary Experiment {
+    string slug;
+    string user_facing_name;
+    string user_facing_description;
+};
+
+dictionary Config {
+    string? server_url;
+    string? uuid;
+    string? collection_name;
+    string? bucket_name;
+};
+
+[Error]
+enum ExperimentError {
+   "NetworkError", "DbError"
+};
+
+interface Experiments {
+    [Throws=ExperimentError]
+    constructor(ApplicationContext app_ctx, string dbpath, Config? config);
+
+
+    string? get_experiment_branch(string experiment_slug);
+
+    sequence<Experiment> get_active_experiments();
+
+    void opt_in_with_branch(string experiment_slug, string branch);
+    void opt_out(string experiment_slug);
+    void opt_out_all();
+
+    [Throws=ExperimentError]
+    void update_experiments();
+};


### PR DESCRIPTION
fixes #178, relates to https://github.com/mozilla/application-services/issues/3440

Adds the proposed nimbus API as an example here. 

compiles ✅ 
bindings can be generated ✅ 
tested ❌ 

I intentionally left out the README we usually add in examples, created #219 to consolidate the README's (since they all say the same thing 😆)