### PR TITLE
Ensure panic safety for all FFI methods

### DIFF
--- a/examples/arithmetic/src/arithmetic.idl
+++ b/examples/arithmetic/src/arithmetic.idl
@@ -10,5 +10,7 @@ namespace arithmetic {
   [Throws=ArithmeticError]
   u64 sub(u64 a, u64 b);
 
+  u64 div(u64 dividend, u64 divisor);
+
   boolean equal(u64 a, u64 b);
 };

--- a/examples/arithmetic/src/lib.rs
+++ b/examples/arithmetic/src/lib.rs
@@ -18,6 +18,13 @@ fn sub(a: u64, b: u64) -> Result<u64> {
         .ok_or(ArithmeticError::IntegerOverflow { a, b })
 }
 
+fn div(dividend: u64, divisor: u64) -> u64 {
+    if divisor == 0 {
+        panic!("Can't divide by zero");
+    }
+    dividend / divisor
+}
+
 fn equal(a: u64, b: u64) -> bool {
     a == b
 }

--- a/examples/arithmetic/tests/bindings/test_arithmetic.kts
+++ b/examples/arithmetic/tests/bindings/test_arithmetic.kts
@@ -13,6 +13,15 @@ try {
 assert(sub(4u, 2u) == 2uL)
 assert(sub(8u, 4u) == 4uL)
 
+assert(div(8u, 4u) == 2uL)
+
+try {
+    div(8u, 0u)
+    throw RuntimeException("Should have panicked when dividing by zero")
+} catch (e: InternalException) {
+    // It's okay!
+}
+
 assert(equal(2u, 2uL))
 assert(equal(4u, 4uL))
 

--- a/examples/arithmetic/tests/bindings/test_arithmetic.py
+++ b/examples/arithmetic/tests/bindings/test_arithmetic.py
@@ -20,6 +20,16 @@ except ArithmeticError.IntegerOverflow:
 assert sub(4, 2) == 2
 assert sub(8, 4) == 4
 
+assert div(8, 4) == 2
+
+try:
+    div(8, 0)
+except InternalError:
+    # It's okay!
+    pass
+else:
+    assert(not("Should have panicked when dividing by zero"))
+
 assert equal(2, 2)
 assert equal(4, 4)
 

--- a/examples/arithmetic/tests/bindings/test_arithmetic.swift
+++ b/examples/arithmetic/tests/bindings/test_arithmetic.swift
@@ -20,6 +20,11 @@ do {
 assert(try! sub(a: 4, b: 2) == 2, "sub work")
 assert(try! sub(a: 8, b: 4) == 4, "sub work")
 
+assert(div(dividend: 8, divisor: 4) == 2, "div works")
+
+// We can't test panicking in Swift because we force unwrap the error in
+// `div`, which we can't catch.
+
 assert(equal(a: 2, b: 2), "equal works")
 assert(equal(a: 4, b: 4), "equal works")
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
@@ -78,6 +78,23 @@ internal open class RustError : Structure() {
     }
 }
 
+internal open class InternalError : RustError() {
+    class ByReference: InternalError(), RustErrorReference
+
+    @Suppress("ReturnCount", "TooGenericExceptionThrown", "UNCHECKED_CAST")
+    override fun<E: Exception> intoException(): E {
+        if (!isFailure()) {
+            // It's probably a bad idea to throw here! We're probably leaking something if this is
+            // ever hit! (But we shouldn't ever hit it?)
+            throw RuntimeException("[Bug] intoException called on non-failure!")
+        }
+        val message = this.consumeErrorMessage()
+        return InternalException(message) as E
+    }
+}
+
+class InternalException(message: String) : Exception(message)
+
 {%- for e in ci.iter_error_definitions() %}
 internal open class {{e.name()}} : RustError() {
     class ByReference: {{e.name()}}(), RustErrorReference

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -5,27 +5,30 @@
 #}
 
 {%- macro to_ffi_call(func) -%}
-{%- match func.throws() %}
-{%- when Some with (e) -%}
-    rustCall({{e}}.ByReference()) { e -> 
-        _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call _arg_list_ffi_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %}e)
-    }
-{%- else -%}
-    _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call _arg_list_ffi_call(func) -%})
-{%- endmatch %}
+rustCall(
+    {% match func.throws() %}
+    {% when Some with (e) %}
+    {{e}}.ByReference()
+    {% else %}
+    InternalError.ByReference()
+    {% endmatch %}
+) { err ->
+    _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call _arg_list_ffi_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %}err)
+}
 {%- endmacro -%}
 
 {%- macro to_ffi_call_with_prefix(prefix, func) %}
-{%- match func.throws() %}
-{%- when Some with (e) -%}
-    rustCall({{e}}.ByReference()) { e -> 
-        _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}(
-            {{- prefix }}, {% call _arg_list_ffi_call(func) %}{% if func.arguments().len() > 0 %}, {% endif %}e)
-    }
-{%- else -%}
+rustCall(
+    {% match func.throws() %}
+    {% when Some with (e) %}
+    {{e}}.ByReference()
+    {% else %}
+    InternalError.ByReference()
+    {% endmatch %}
+) { err ->
     _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}(
-        {{- prefix }}{% if func.arguments().len() > 0 %}, {% endif %}{% call _arg_list_ffi_call(func) %})
-{%- endmatch %}
+        {{- prefix }}, {% call _arg_list_ffi_call(func) %}{% if func.arguments().len() > 0 %}, {% endif %}err)
+}
 {%- endmacro %}
 
 
@@ -57,5 +60,5 @@
         {{- arg.name() }}: {{ arg.type_()|type_ffi -}}
         {%- if loop.last %}{% else %},{% endif %}
     {%- endfor %}
-    {% if func.has_out_err() %}{% if func.arguments().len() > 0 %},{% endif %} e: Structure.ByReference{% endif %}
+    {% if func.has_out_err() %}{% if func.arguments().len() > 0 %},{% endif %} err: Structure.ByReference{% endif %}
 {%- endmacro -%}

--- a/uniffi_bindgen/src/bindings/python/templates/ErrorTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ErrorTemplate.py
@@ -13,6 +13,11 @@ class RustError(ctypes.Structure):
             str(ctypes.cast(self.message, ctypes.c_char_p).value, "utf-8"),
         )
 
+class InternalError(Exception):
+    @staticmethod
+    def raise_err(code, message):
+        raise InternalError(message)
+
 {% for e in ci.iter_error_definitions() %}
 class {{ e.name()|class_name_py }}:
     {%- for value in e.values() %}

--- a/uniffi_bindgen/src/bindings/python/templates/macros.py
+++ b/uniffi_bindgen/src/bindings/python/templates/macros.py
@@ -5,21 +5,28 @@
 #}
 
 {%- macro to_ffi_call(func) -%}
-{%- match func.throws() -%}
-{%- when Some with (e) -%}
-rust_call_with_error({{ e|class_name_py }},_UniFFILib.{{ func.ffi_func().name() }}{% if func.arguments().len() > 0 %},{% endif %}{% call _arg_list_ffi_call(func) -%})
-{%- else -%}
-_UniFFILib.{{ func.ffi_func().name() }}({% call _arg_list_ffi_call(func) -%})
-{%- endmatch -%}
+
+rust_call_with_error(
+    {%- match func.throws() -%}
+    {%- when Some with (e) -%}
+    {{ e|class_name_py }}
+    {%- else -%}
+    InternalError
+    {%- endmatch -%},
+    _UniFFILib.{{ func.ffi_func().name() }}{% if func.arguments().len() > 0 %},{% endif %}{% call _arg_list_ffi_call(func) -%}
+)
 {%- endmacro -%}
 
 {%- macro to_ffi_call_with_prefix(prefix, func) -%}
-{%- match func.throws() -%}
-{%- when Some with (e) -%}
-rust_call_with_error({{ e|class_name_py }},_UniFFILib.{{ func.ffi_func().name() }},{{- prefix }}{% if func.arguments().len() > 0 %},{% endif %}{% call _arg_list_ffi_call(func) %}))
-{%- else -%}
-_UniFFILib.{{ func.ffi_func().name() }}({{- prefix }}{% if func.arguments().len() > 0 %},{% endif %}{% call _arg_list_ffi_call(func) %}))
-{%- endmatch -%}
+rust_call_with_error(
+    {%- match func.throws() -%}
+    {%- when Some with (e) -%}
+    {{ e|class_name_py }}
+    {%- else -%}
+    InternalError
+    {%- endmatch -%},
+    _UniFFILib.{{ func.ffi_func().name() }},{{- prefix }}{% if func.arguments().len() > 0 %},{% endif %}{% call _arg_list_ffi_call(func) %})
+)
 {%- endmacro -%}
 
 {%- macro _arg_list_ffi_call(func) %}

--- a/uniffi_bindgen/src/bindings/python/templates/wrapper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/wrapper.py
@@ -47,6 +47,7 @@ import contextlib
 {% endfor %}
 
 __all__ = [
+    "InternalError",
     {%- for e in ci.iter_enum_definitions() %}
     "{{ e.name()|class_name_py }}",
     {%- endfor %}

--- a/uniffi_bindgen/src/bindings/swift/templates/RustBufferHelper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RustBufferHelper.swift
@@ -1,20 +1,6 @@
 // Helper classes/extensions that don't change.
 // Someday, this will be in a libray of its own.
 
-// Serialization and deserialization errors.
-enum InternalError: Error {
-    // Reading the requested value would read past the end of the buffer.
-    case bufferOverflow
-    // The buffer still has data after lifting its containing value.
-    case incompleteData
-    // Unexpected tag byte for `Optional`; should be 0 or 1.
-    case unexpectedOptionalTag
-    // Unexpected integer that doesn't correspond to an enum case.
-    case unexpectedEnumCase
-    // Empty Result returned across the FFI
-    case emptyResult
-}
-
 extension Data {
     init(rustBuffer: RustBuffer) {
         // TODO: This copies the buffer. Can we read directly from a
@@ -51,7 +37,7 @@ class Reader {
         offset = range.upperBound
         return value.bigEndian
     }
-    
+
     // Reads an arbitrary number of bytes, to be used to read
     // raw bytes, this is useful when lifting strings
     func readBytes(count: Int) throws -> Array<UInt8> {

--- a/uniffi_bindgen/src/bindings/swift/templates/macros.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/macros.swift
@@ -5,29 +5,31 @@
 #}
 
 {%- macro to_ffi_call(func) -%}
-{%- match func.throws() %}
-{%- when Some with (e) %}
-    try rustCall({{e}}.NoError) { err  in
-        {{ func.ffi_func().name() }}({% call _arg_list_ffi_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %}err)
-    }
-{%- else -%}
-    {{ func.ffi_func().name() }}({% call _arg_list_ffi_call(func) -%})
-{%- endmatch %}
+{% call try(func) %} rustCall(
+    {% match func.throws() %}
+    {% when Some with (e) %}
+    {{e}}.NoError
+    {% else %}
+    InternalError.unknown()
+    {% endmatch %}
+) { err in
+    {{ func.ffi_func().name() }}({% call _arg_list_ffi_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %}err)
+}
 {%- endmacro -%}
 
 {%- macro to_ffi_call_with_prefix(prefix, func) -%}
-{%- match func.throws() %}
-{%- when Some with (e) %}
-    try rustCall({{e}}.NoError) { err  in
-        {{ func.ffi_func().name() }}(
-            {{- prefix }}, {% call _arg_list_ffi_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %}err
-        )
-    }
-{%- else -%}
+{% call try(func) %} rustCall(
+    {% match func.throws() %}
+    {% when Some with (e) %}
+    {{e}}.NoError
+    {% else %}
+    InternalError.unknown()
+    {% endmatch %}
+) { err in
     {{ func.ffi_func().name() }}(
-        {{- prefix }}{% if func.arguments().len() > 0 %},{% endif %}{% call _arg_list_ffi_call(func) -%}
+        {{- prefix }}, {% call _arg_list_ffi_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %}err
     )
-{%- endmatch %}
+}
 {%- endmacro %}
 
 {%- macro _arg_list_ffi_call(func) %}

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -427,9 +427,7 @@ impl Function {
         self.ffi_func.name.push_str(&self.name);
         self.ffi_func.arguments = self.arguments.iter().map(FFIArgument::from).collect();
         self.ffi_func.return_type = self.return_type.as_ref().map(FFIType::from);
-        // Theoretically this should always be true
-        // but it's this way until we implement handling for panics
-        self.ffi_func.has_out_err = self.throws().is_some();
+        self.ffi_func.has_out_err = true;
         Ok(())
     }
 }
@@ -695,9 +693,7 @@ impl Constructor {
         self.ffi_func.name.push_str(&self.name);
         self.ffi_func.arguments = self.arguments.iter().map(FFIArgument::from).collect();
         self.ffi_func.return_type = Some(FFIType::UInt64);
-        // Theoretically this should always be true
-        // but it's this way until we implement handling for panics
-        self.ffi_func.has_out_err = self.throws().is_some();
+        self.ffi_func.has_out_err = true;
         Ok(())
     }
 }
@@ -784,9 +780,7 @@ impl Method {
             .map(FFIArgument::from)
             .collect();
         self.ffi_func.return_type = self.return_type.as_ref().map(FFIType::from);
-        // Theoritically this should always be true
-        // but it's this way until we implement handling for panics
-        self.ffi_func.has_out_err = self.throws().is_some();
+        self.ffi_func.has_out_err = true;
         Ok(())
     }
 }

--- a/uniffi_bindgen/src/templates/macros.rs
+++ b/uniffi_bindgen/src/templates/macros.rs
@@ -45,7 +45,6 @@ UNIFFI_HANDLE_MAP_{{ obj.name()|upper }}.insert_with_result(err, || -> Result<{{
     Ok(_retval)
 })
 {% else %}
-{% call default_err() %}
 UNIFFI_HANDLE_MAP_{{ obj.name()|upper }}.insert_with_output(err, || {
     {{ obj.name() }}::{% call to_rs_call(cons) %}
 })
@@ -60,7 +59,6 @@ UNIFFI_HANDLE_MAP_{{ obj.name()|upper }}.call_with_result_mut(err, {{ meth.first
     Ok({% call ret(meth) %})
 })
 {% else %}
-{% call default_err() %}
 UNIFFI_HANDLE_MAP_{{ obj.name()|upper }}.call_with_output_mut(err, {{ meth.first_argument().name() }}, |obj| {
     let _retval = {{ obj.name() }}::{%- call to_rs_call_with_prefix("obj", meth) -%};
     {% call ret(meth) %}
@@ -76,15 +74,9 @@ uniffi::deps::ffi_support::call_with_result(err, || -> Result<{% call return_typ
     Ok({% call ret(func) %})
 })
 {% else %}
-{% call default_err() %}
 uniffi::deps::ffi_support::call_with_output(err, || {
     let _retval = {% call to_rs_call(func) %};
     {% call ret(func) %}
 })
 {% endmatch %}
-{% endmacro %}
-
-{% macro default_err() %}
-let mut err: uniffi::deps::ffi_support::ExternError = Default::default();
-let err = &mut err;
 {% endmacro %}


### PR DESCRIPTION
This commit changes all FFI functions to take an `out_err` param, so
that they're called using `call_with_result`. Any functions that don't
have a `[Throws]` annotation in the IDL will throw a generic
`InternalError` instead.

Closes #32.