### PR TITLE
Check for specific error subclasses in the kotlin "todolist" tests.

### DIFF
--- a/examples/todolist/tests/bindings/test_todolist.kts
+++ b/examples/todolist/tests/bindings/test_todolist.kts
@@ -6,7 +6,7 @@ val todo = TodoList()
 try {
     todo.getLast()
     throw RuntimeException("Should have thrown a TodoError!")
-} catch (e: TodoErrorException) {
+} catch (e: TodoErrorException.EmptyTodoList) {
     // It's okay, we don't have any items yet!
 }
 
@@ -15,6 +15,8 @@ try {
     throw RuntimeException("Should have thrown a TodoError!")
 } catch (e: TodoErrorException) {
     // It's okay, the string was empty!
+    assert(e is TodoErrorException.EmptyString)
+    assert(e !is TodoErrorException.EmptyTodoList)
 }
 
 todo.addItem("Write strings support")


### PR DESCRIPTION
I noticed that the kotlin tests for the "todolist" example were only
checking that the correct *type* of error is thrown, whereas the
swift tests check for the correct error code/case. This adjusts the
kotlin tests to match.