### PR TITLE
Format generated bindings

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/mod.rs
@@ -17,11 +17,28 @@ pub use gen_kotlin::{Config, KotlinWrapper};
 
 use super::super::interface::ComponentInterface;
 
-pub fn write_bindings(ci: &ComponentInterface, out_dir: &Path) -> Result<()> {
+pub fn write_bindings(
+    ci: &ComponentInterface,
+    out_dir: &Path,
+    try_format_code: bool,
+) -> Result<()> {
     let mut kt_file = PathBuf::from(out_dir);
     kt_file.push(format!("{}.kt", ci.namespace()));
     let mut f = File::create(&kt_file).context("Failed to create .kt file for bindings")?;
     write!(f, "{}", generate_bindings(&ci)?)?;
+    if try_format_code {
+        if let Err(e) = Command::new("ktlint")
+            .arg("-F")
+            .arg(kt_file.to_str().unwrap())
+            .output()
+        {
+            println!(
+                "Warning: Unable to auto-format {} using ktlint: {:?}",
+                kt_file.file_name().unwrap().to_str().unwrap(),
+                e
+            )
+        }
+    }
     Ok(())
 }
 

--- a/uniffi_bindgen/src/bindings/mod.rs
+++ b/uniffi_bindgen/src/bindings/mod.rs
@@ -64,15 +64,16 @@ pub fn write_bindings<P>(
     ci: &ComponentInterface,
     out_dir: P,
     language: TargetLanguage,
+    try_format_code: bool,
 ) -> Result<()>
 where
     P: AsRef<Path>,
 {
     let out_dir = out_dir.as_ref();
     match language {
-        TargetLanguage::Kotlin => kotlin::write_bindings(&ci, out_dir)?,
-        TargetLanguage::Swift => swift::write_bindings(&ci, out_dir)?,
-        TargetLanguage::Python => python::write_bindings(&ci, out_dir)?,
+        TargetLanguage::Kotlin => kotlin::write_bindings(&ci, out_dir, try_format_code)?,
+        TargetLanguage::Swift => swift::write_bindings(&ci, out_dir, try_format_code)?,
+        TargetLanguage::Python => python::write_bindings(&ci, out_dir, try_format_code)?,
     }
     Ok(())
 }

--- a/uniffi_bindgen/src/bindings/python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/mod.rs
@@ -20,11 +20,26 @@ use super::super::interface::ComponentInterface;
 
 // Generate python bindings for the given ComponentInterface, in the given output directory.
 
-pub fn write_bindings(ci: &ComponentInterface, out_dir: &Path) -> Result<()> {
+pub fn write_bindings(
+    ci: &ComponentInterface,
+    out_dir: &Path,
+    try_format_code: bool,
+) -> Result<()> {
     let mut py_file = PathBuf::from(out_dir);
     py_file.push(format!("{}.py", ci.namespace()));
     let mut f = File::create(&py_file).context("Failed to create .py file for bindings")?;
     write!(f, "{}", generate_python_bindings(&ci)?)?;
+
+    if try_format_code {
+        if let Err(e) = Command::new("yapf").arg(py_file.to_str().unwrap()).output() {
+            println!(
+                "Warning: Unable to auto-format {} using yapf: {:?}",
+                py_file.file_name().unwrap().to_str().unwrap(),
+                e
+            )
+        }
+    }
+
     Ok(())
 }
 

--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -26,7 +26,11 @@ pub struct Bindings {
 /// Unlike other target languages, binding to rust code from swift involves more than just
 /// generating a `.swift` file. We also need to produce a `.h` file with the C-level API
 /// declarations, and a `.modulemap` file to tell swift how to use it.
-pub fn write_bindings(ci: &ComponentInterface, out_dir: &Path) -> Result<()> {
+pub fn write_bindings(
+    ci: &ComponentInterface,
+    out_dir: &Path,
+    try_format_code: bool,
+) -> Result<()> {
     let out_path = PathBuf::from(out_dir);
 
     let mut module_map_file = out_path.clone();
@@ -49,6 +53,19 @@ pub fn write_bindings(ci: &ComponentInterface, out_dir: &Path) -> Result<()> {
 
     let mut l = File::create(&source_file).context("Failed to create .swift file for bindings")?;
     write!(l, "{}", library)?;
+
+    if try_format_code {
+        if let Err(e) = Command::new("swiftformat")
+            .arg(source_file.to_str().unwrap())
+            .output()
+        {
+            println!(
+                "Warning: Unable to auto-format {} using swiftformat: {:?}",
+                source_file.file_name().unwrap().to_str().unwrap(),
+                e
+            )
+        }
+    }
 
     Ok(())
 }

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -191,6 +191,7 @@ pub fn generate_bindings<P: AsRef<Path>>(
     idl_file: P,
     target_languages: Vec<&str>,
     out_dir_override: Option<P>,
+    try_format_code: bool,
 ) -> Result<()> {
     let out_dir_override = out_dir_override.as_ref().map(|p| p.as_ref());
     let idl_file = PathBuf::from(idl_file.as_ref())
@@ -199,7 +200,7 @@ pub fn generate_bindings<P: AsRef<Path>>(
     let component = parse_idl(&idl_file)?;
     let out_dir = get_out_dir(&idl_file, out_dir_override)?;
     for language in target_languages {
-        bindings::write_bindings(&component, &out_dir, language.try_into()?)?;
+        bindings::write_bindings(&component, &out_dir, language.try_into()?, try_format_code)?;
     }
     Ok(())
 }
@@ -232,7 +233,7 @@ pub fn run_tests<P: AsRef<Path>>(
     }
 
     for (lang, test_scripts) in language_tests {
-        bindings::write_bindings(&component, &cdylib_dir, lang)?;
+        bindings::write_bindings(&component, &cdylib_dir, lang, true)?;
         bindings::compile_bindings(&component, &cdylib_dir, lang)?;
         for test_script in test_scripts {
             bindings::run_script(cdylib_dir, &test_script, lang)?;

--- a/uniffi_bindgen/src/main.rs
+++ b/uniffi_bindgen/src/main.rs
@@ -30,6 +30,11 @@ fn main() -> Result<()> {
                         .takes_value(true)
                         .help("Directory in which to write generated files. Default is same folder as .idl file."),
                 )
+                .arg(
+                    clap::Arg::with_name("no_format")
+                        .long("--no-format")
+                        .help("Do not try to format the generated bindings"),
+                )
                 .arg(clap::Arg::with_name("idl_file").required(true)),
         )
         .subcommand(
@@ -68,6 +73,7 @@ fn main() -> Result<()> {
             m.value_of_os("idl_file").unwrap(),         // Required
             m.values_of("language").unwrap().collect(), // Required
             m.value_of_os("out_dir"),
+            !m.is_present("no_format"),
         )?,
         ("scaffolding", Some(m)) => uniffi_bindgen::generate_component_scaffolding(
             m.value_of_os("idl_file").unwrap(), // Required


### PR DESCRIPTION
Fixes https://github.com/mozilla/uniffi-rs/issues/234.

We auto-format code after generation using:
- `swiftformat` for Swift
- `ktlint` for Kotlin
- `yapf` for Python

This feature is enabled by default, but does not generate a hard error if these tools are not available.