### PR TITLE
Output Kotlin bindings into package path

### DIFF
--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -244,9 +244,12 @@ pub fn run_tests<P: AsRef<Path>>(
 
 fn get_out_dir(idl_file: &Path, out_dir_override: Option<&Path>) -> Result<PathBuf> {
     Ok(match out_dir_override {
-        Some(s) => PathBuf::from(s)
-            .canonicalize()
-            .map_err(|e| anyhow!("Unable to find out-dir: {:?}", e))?,
+        Some(s) => {
+            // Create the directory if it doesn't exist yet.
+            std::fs::create_dir_all(&s)?;
+            s.canonicalize()
+                .map_err(|e| anyhow!("Unable to find out-dir: {:?}", e))?
+        }
         None => idl_file
             .parent()
             .ok_or_else(|| anyhow!("File has no parent directory"))?


### PR DESCRIPTION
Java loves folders, and so when running `uniffi-bindgen generate MYPROJECT --language kotlin --out-dir MY_OUT_DIR`, you will have to create `MY_OUT_DIR/uniffi/MYPROJECT` beforehand for it to make sense and point `--out-dir` to `MY_OUT_DIR/uniffi/MYPROJECT`

Note that I'd be cool to be able to specify the package name with an idl directive (kinda like protobufs)