### PR TITLE
Clarify terminology around passing values across the FFI.

### DIFF
--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -2,6 +2,28 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+//! # Runtime support code for uniffi
+//!
+//! This crate provides the small amount of runtime code that is required by the generated uniffi
+//! component scaffolding in order to transfer data back and forth across the C-style FFI layer,
+//! as well as some utilities for testing the generated bindings.
+//!
+//! The key concept here is the [`ViaFfi`] trait, which must be implemented for any type that can
+//! be passed across the FFI, and which determines:
+//!
+//!  * How to [represent](ViaFfi::Value) values of that type in the low-level C-style type
+//!    system of the FFI layer.
+//!  * How to ["lower"](ViaFfi::lower) rust values of that type into an appropriate low-level
+//!    FFI value.
+//!  * How to ["lift"](ViaFfi::lift) low-level FFI values back into rust values of that type.
+//!  * How to [write](ViaFfi::write) rust values of that type into a bytebuffer, for cases
+//!    where they are part of a compount data structure that is serialized for transfer.
+//!  * How to [read](ViaFfi::read) rust values of that type from bytebuffer, for cases
+//!    where they are received as part of a compound data structure that was serialized for transfer.
+//!
+//! This logic encapsulates the rust-side handling of data transfer. Each foreign-language binding
+//! must also implement a matching set of data-handling rules for each data type.
+
 use anyhow::{bail, Result};
 use bytes::buf::{Buf, BufMut};
 use ffi_support::ByteBuffer;
@@ -23,52 +45,107 @@ pub mod deps {
     pub use log;
 }
 
-/// Any type that can be returned over the FFI must implement the `Lowerable` trait, to define how
-/// it gets lowered into bytes for transit. We provide default implementtions for primitive types,
-/// and a typical implementation for composite types would lower each member in turn.
+/// Trait defining how to transfer values via the FFI layer.
+///
+/// The `ViaFfi` trait defines how to pass values of a particular type back-and-forth over
+/// the uniffi generated FFI layer, both as standalone argument or return values, and as
+/// part of serialized compound data structures.
+///
+/// (This trait is Like the `InfoFfi` trait from `ffi_support`, but local to this crate
+/// so that we can add some alternative implementations for different builtin types,
+/// and so that we can add support for receiving as well as returning).
+///
+/// ## Safety
+///
+/// This is an unsafe trait (implementing it requires `unsafe impl`) because we can't guarantee
+/// that it's safe to pass your type out to foreign-language code and back again. Buggy
+/// implementations of this trait might violate some assumptions made by the generated code,
+/// or might not match with the corresponding code in the generated foreign-language bindings.
+///
+/// In general, you should not need to implement this trait by hand, and should instead rely on
+/// implementations generated from your component IDL via the `uniffi-bindgen scaffolding` command.
 
-pub trait Lowerable: Sized {
-    fn lower_into<B: BufMut>(&self, buf: &mut B);
+pub unsafe trait ViaFfi: Sized {
+    /// The low-level type used for passing values of this type over the FFI.
+    ///
+    /// This must be a C-compatible type (e.g. a numeric primitive, a `#[repr(C)]` struct) into
+    /// which values of the target rust type can be converted.
+    ///
+    /// For complex data types, we currently recommend using `ffi_support::ByteBuffer` and
+    /// serializing the data for transfer. In theory it could be possible to build a matching
+    /// `#[repr(C)]` struct for a complex data type and pass that instead, but explicit
+    /// serialization is simpler and safer as a starting point.
+    type Value;
+
+    /// Lower a rust value of the target type, into an FFI value of type Self::Value.
+    ///
+    /// This trait method is used for sending data from rust to the foreign language code,
+    /// by (hopefully cheaply!) converting it into someting that can be passed over the FFI
+    /// and reconstructed on the other side.
+    ///
+    /// Note that this method takes an owned `self`; this allows it to transfer ownership
+    /// in turn to the foreign language code, e.g. by boxing the value and passing a pointer.
+    fn lower(self) -> Self::Value;
+
+    /// Lift a rust value of the target type, from an FFI value of type Self::Value.
+    ///
+    /// This trait method is used for receiving data from the foreign language code in rust,
+    /// by (hopefully cheaply!) converting it from a low-level FFI value of type Self::Value
+    /// into a high-level rust value of the target type.
+    ///
+    /// Since we cannot statically guarantee that the foreign-language code will send valid
+    /// values of type Self::Value, this method is fallible.
+    fn try_lift(v: Self::Value) -> Result<Self>;
+
+    /// Write a rust value into a bytebuffer, to send over the FFI in serialized form.
+    ///
+    /// This trait method can be used for sending data from rust to the foreign language code,
+    /// in cases where we're not able to use a special-purpose FFI type and must fall back to
+    /// sending serialized bytes.
+    fn write<B: BufMut>(&self, buf: &mut B);
+
+    /// Read a rust value from a bytebuffer, received over the FFI in serialized form.
+    ///
+    /// This trait method can be used for receiving data from the foreign language code in rust,
+    /// in cases where we're not able to use a special-purpose FFI type and must fall back to
+    /// receiving serialized bytes.
+    ///
+    /// Since we cannot statically guarantee that the foreign-language code will send valid
+    /// serialized bytes for the target type, this method is fallible.
+    fn try_read<B: Buf>(buf: &mut B) -> Result<Self>;
 }
 
-pub fn lower<T: Lowerable>(value: T) -> ByteBuffer {
+/// A helper function to lower a type by serializing it into a bytebuffer.
+///
+/// For complex types were it's too fiddly or too unsafe to convert them into a special-purpose
+/// C-compatible value, you can use this helper function to implement `lower()` in terms of `write()`
+/// and pass the value as a serialzied byte buffer.
+pub fn lower_into_bytebuffer<T: ViaFfi>(value: T) -> ByteBuffer {
     let mut buf = Vec::new();
-    Lowerable::lower_into(&value, &mut buf);
+    ViaFfi::write(&value, &mut buf);
     ByteBuffer::from_vec(buf)
 }
 
-impl<T: Lowerable> Lowerable for &T {
-    fn lower_into<B: BufMut>(&self, buf: &mut B) {
-        (*self).lower_into(buf);
+/// A helper function to lift a type by deserializing it from a bytebuffer.
+///
+/// For complex types were it's too fiddly or too unsafe to convert them into a special-purpose
+/// C-compatible value, you can use this helper function to implement `lift()` in terms of `read()`
+/// and receive the value as a serialzied byte buffer.
+pub fn try_lift_from_bytebuffer<T: ViaFfi>(buf: ByteBuffer) -> Result<T> {
+    let vec = buf.destroy_into_vec();
+    let mut buf = vec.as_slice();
+    let value = <T as ViaFfi>::try_read(&mut buf)?;
+    if buf.remaining() != 0 {
+        bail!("junk data left in buffer after lifting")
     }
+    Ok(value)
 }
 
-impl<T: Lowerable> Lowerable for Option<T> {
-    fn lower_into<B: BufMut>(&self, buf: &mut B) {
-        match self {
-            None => buf.put_u8(0),
-            Some(v) => {
-                buf.put_u8(1);
-                v.lower_into(buf);
-            }
-        }
-    }
-}
-
-impl<T: Lowerable> Lowerable for Vec<T> {
-    fn lower_into<B: BufMut>(&self, buf: &mut B) {
-        let len = u32::try_from(self.len()).unwrap();
-        buf.put_u32(len); // We limit arrays to u32::MAX bytes
-        for item in self.iter() {
-            item.lower_into(buf);
-        }
-    }
-}
-
-/// Any type that can be received over the FFI must implement the `Liftable` trait, to define how
-/// it gets lifted from bytes into a useable Rust value. We provide default implementtions for
-/// primitive types, and a typical implementation for composite types would lift each member in turn.
-
+/// A helper function to ensure we don't read past the end of a buffer.
+///
+/// Rust won't actually let us read past the end of a buffer, but the `Buf` trait does not support
+/// returning an explicit error in this case, and will instead panic. This is a look-before-you-leap
+/// helper function to instead return an explicit error, to help with debugging.
 pub fn check_remaining<B: Buf>(buf: &B, num_bytes: usize) -> Result<()> {
     if buf.remaining() < num_bytes {
         bail!("not enough bytes remaining in buffer");
@@ -76,34 +153,33 @@ pub fn check_remaining<B: Buf>(buf: &B, num_bytes: usize) -> Result<()> {
     Ok(())
 }
 
-pub trait Liftable: Sized {
-    fn try_lift_from<B: Buf>(buf: &mut B) -> Result<Self>;
-}
-
-pub fn try_lift<T: Liftable>(buf: ByteBuffer) -> Result<T> {
-    let vec = buf.destroy_into_vec();
-    let mut buf = vec.as_slice();
-    let value = <T as Liftable>::try_lift_from(&mut buf)?;
-    if buf.remaining() != 0 {
-        bail!("junk data left in buffer after deserializing")
-    }
-    Ok(value)
-}
-
-macro_rules! impl_lowerable_liftable_for_num_primitive {
-    ($($T:ty,)+) => { impl_lowerable_liftable_for_num_primitive!($($T),+); };
+/// Blanket implementation of ViaFfi for numeric primitives.
+///
+/// Numeric primitives have a straightforward mapping into C-compatible numeric types,
+/// sice they are themselves a C-compatible numeric type!
+macro_rules! impl_via_ffi_for_num_primitive {
+    ($($T:ty,)+) => { impl_via_ffi_for_num_primitive!($($T),+); };
     ($($T:ty),*) => {
             $(
                 paste! {
-                    impl Liftable for $T {
-                        fn try_lift_from<B: Buf>(buf: &mut B) -> Result<Self> {
+                    unsafe impl ViaFfi for $T {
+                        type Value = Self;
+
+                        fn lower(self) -> Self::Value {
+                            self
+                        }
+
+                        fn try_lift(v: Self::Value) -> Result<Self> {
+                            Ok(v)
+                        }
+
+                        fn write<B: BufMut>(&self, buf: &mut B) {
+                            buf.[<put_ $T>](*self);
+                        }
+
+                        fn try_read<B: Buf>(buf: &mut B) -> Result<Self> {
                             check_remaining(buf, std::mem::size_of::<$T>())?;
                             Ok(buf.[<get_ $T>]())
-                        }
-                    }
-                    impl Lowerable for $T {
-                        fn lower_into<B: BufMut>(&self, buf: &mut B) {
-                            buf.[<put_ $T>](*self);
                         }
                     }
                 }
@@ -111,124 +187,149 @@ macro_rules! impl_lowerable_liftable_for_num_primitive {
     };
 }
 
-impl_lowerable_liftable_for_num_primitive! {
+impl_via_ffi_for_num_primitive! {
     i8, u8, i16, u16, i32, u32, i64, u64, f32, f64
 }
 
-impl<T: Liftable> Liftable for Option<T> {
-    fn try_lift_from<B: Buf>(buf: &mut B) -> Result<Self> {
+/// Support for passing boolean values via the FFI.
+///
+/// Booleans are passed as a `u8` in order to avoid problems with handling
+/// C-compatible boolean values on JVM-based languages.
+unsafe impl ViaFfi for bool {
+    type Value = u8;
+
+    fn lower(self) -> Self::Value {
+        if self {
+            1
+        } else {
+            0
+        }
+    }
+
+    fn try_lift(v: Self::Value) -> Result<Self> {
+        Ok(match v {
+            0 => false,
+            1 => true,
+            _ => bail!("unexpected byte for Boolean"),
+        })
+    }
+
+    fn write<B: BufMut>(&self, buf: &mut B) {
+        buf.put_u8(ViaFfi::lower(*self));
+    }
+
+    fn try_read<B: Buf>(buf: &mut B) -> Result<Self> {
+        check_remaining(buf, 1)?;
+        ViaFfi::try_lift(buf.get_u8())
+    }
+}
+
+/// Support for passing optional values via the FFI.
+///
+/// Optional values are currently always passed by serializing to a bytebuffer.
+/// We write either a zero byte for `None`, or a one byte followed by the containing
+/// item for `Some`.
+///
+/// In future we could do the same optimization as rust uses internally, where the
+/// `None` option is represented as a null pointer and the `Some` as a valid pointer,
+/// but that seems more fiddly and less safe in the short term, so it can wait.
+unsafe impl<T: ViaFfi> ViaFfi for Option<T> {
+    type Value = ffi_support::ByteBuffer;
+
+    fn lower(self) -> Self::Value {
+        lower_into_bytebuffer(self)
+    }
+
+    fn try_lift(v: Self::Value) -> Result<Self> {
+        try_lift_from_bytebuffer(v)
+    }
+
+    fn write<B: BufMut>(&self, buf: &mut B) {
+        match self {
+            None => buf.put_u8(0),
+            Some(v) => {
+                buf.put_u8(1);
+                ViaFfi::write(v, buf);
+            }
+        }
+    }
+
+    fn try_read<B: Buf>(buf: &mut B) -> Result<Self> {
         check_remaining(buf, 1)?;
         Ok(match buf.get_u8() {
             0 => None,
-            1 => Some(T::try_lift_from(buf)?),
+            1 => Some(<T as ViaFfi>::try_read(buf)?),
             _ => bail!("unexpected tag byte for Option"),
         })
     }
 }
 
-impl<T: Liftable> Liftable for Vec<T> {
-    fn try_lift_from<B: Buf>(buf: &mut B) -> Result<Self> {
+/// Support for passing vectors of values via the FFI.
+///
+/// Vectors are currently always passed by serializing to a bytebuffer.
+/// We write a `u32` item count followed by each item in turn.
+///
+/// You can imagine a world where we pass some sort of (pointer, count)
+/// pair but that seems tremendously fiddly and unsafe in the short term.
+/// Maybe one day...
+unsafe impl<T: ViaFfi> ViaFfi for Vec<T> {
+    type Value = ffi_support::ByteBuffer;
+
+    fn lower(self) -> Self::Value {
+        lower_into_bytebuffer(self)
+    }
+
+    fn try_lift(v: Self::Value) -> Result<Self> {
+        try_lift_from_bytebuffer(v)
+    }
+
+    fn write<B: BufMut>(&self, buf: &mut B) {
+        // TODO: would be nice not to panic here :-/
+        let len = u32::try_from(self.len()).unwrap();
+        buf.put_u32(len); // We limit arrays to u32::MAX bytes
+        for item in self.iter() {
+            ViaFfi::write(item, buf);
+        }
+    }
+
+    fn try_read<B: Buf>(buf: &mut B) -> Result<Self> {
         check_remaining(buf, 4)?;
         let len = buf.get_u32();
         let mut vec = Vec::with_capacity(len as usize);
         for _ in 0..len {
-            vec.push(T::try_lift_from(buf)?)
+            vec.push(<T as ViaFfi>::try_read(buf)?)
         }
         Ok(vec)
     }
 }
 
-// The `ViaFfi` trait defines how to receive a type as an argument over the FFI,
-// and how to return it from FFI functions. It allows us to implement a more efficient
-// calling strategy than always lifting/lowering all types to a byte buffer.
-//
-// Types that cannot be passed via any more clever mechanism can instead get choose to
-// `impl ViaFfiUsingByteBuffer`, which provides a default implementation that uses their
-// `Lowerable` and `Liftable` impls to pass data by serializing in a ByteBuffer.
-// Unlike the base `ViaFfi` trit, `ViaFfiUsingByteBuffer` is safe.
-//
-// (This trait is Like the `InfoFfi` trait from `ffi_support`, but local to this crate
-// so that we can add some alternative implementations for different builtin types,
-// and so that we can add support for receiving as well as returning).
-
-pub unsafe trait ViaFfi: Sized {
-    type Value;
-    fn into_ffi_value(self) -> Self::Value;
-    fn try_from_ffi_value(v: Self::Value) -> Result<Self>;
-}
-
-macro_rules! impl_via_ffi_for_primitive {
-  ($($T:ty),+) => {$(
-    unsafe impl ViaFfi for $T {
-      type Value = Self;
-      #[inline] fn into_ffi_value(self) -> Self::Value { self }
-      #[inline] fn try_from_ffi_value(v: Self::Value) -> Result<Self> { Ok(v) }
-    }
-  )+}
-}
-
-impl_via_ffi_for_primitive![(), i8, u8, i16, u16, i32, u32, i64, u64, f32, f64];
-
-pub trait ViaFfiUsingByteBuffer: Liftable + Lowerable {}
-
-unsafe impl<T: ViaFfiUsingByteBuffer> ViaFfi for T {
-    type Value = ffi_support::ByteBuffer;
-    #[inline]
-    fn into_ffi_value(self) -> Self::Value {
-        lower(&self)
-    }
-    #[inline]
-    fn try_from_ffi_value(v: Self::Value) -> anyhow::Result<Self> {
-        try_lift(v)
-    }
-}
-
-unsafe impl<T: Liftable + Lowerable> ViaFfi for Option<T> {
-    type Value = ffi_support::ByteBuffer;
-    #[inline]
-    fn into_ffi_value(self) -> Self::Value {
-        lower(&self)
-    }
-    #[inline]
-    fn try_from_ffi_value(v: Self::Value) -> anyhow::Result<Self> {
-        try_lift(v)
-    }
-}
-
-unsafe impl<T: Liftable + Lowerable> ViaFfi for Vec<T> {
-    type Value = ffi_support::ByteBuffer;
-    #[inline]
-    fn into_ffi_value(self) -> Self::Value {
-        lower(&self)
-    }
-    #[inline]
-    fn try_from_ffi_value(v: Self::Value) -> anyhow::Result<Self> {
-        try_lift(v)
-    }
-}
-
-/// Support for passing Strings back and forth across the FFI.
+/// Support for passing Strings via the FFI.
 ///
 /// Unlike many other implementations of `ViaFfi`, this passes a pointer rather
 /// than copying the data from one side to the other. This is a safety hazard,
-/// but turns out to be pretty nice for useability.
+/// but turns out to be pretty nice for useability. This pointer *must be one owned
+/// by the rust allocator and it *must* point to valid utf-8 data (in other words,
+/// it *must* be an actual rust `String`).
 ///
-/// (In practice, we do end up copying the data, the copying just happens on
-/// the foreign language side rather than here in the rust code.)
+/// When serialized in a bytebuffer, strings are represented as a u32 byte length
+/// followed by utf8-encoded bytes.
+///
+/// (In practice, we currently do end up copying the data, the copying just happens
+/// on the foreign language side rather than here in the rust code.)
 unsafe impl ViaFfi for String {
     type Value = *mut std::os::raw::c_char;
 
     // This returns a raw pointer to the underlying bytes, so it's very important
     // that it consume ownership of the String, which is relinquished to the foreign
-    // language code (and can be returned by it passing the pointer back).
-    fn into_ffi_value(self) -> Self::Value {
+    // language code (and can be restored by it passing the pointer back).
+    fn lower(self) -> Self::Value {
         ffi_support::rust_string_to_c(self)
     }
 
     // The argument here *must* be a uniquely-owned pointer previously obtained
     // from `info_ffi_value` above. It will try to panic if you give it an invalid
     // pointer, but there's no guarantee that it will.
-    fn try_from_ffi_value(v: Self::Value) -> Result<Self> {
+    fn try_lift(v: Self::Value) -> Result<Self> {
         if v.is_null() {
             bail!("null pointer passed as String")
         }
@@ -240,59 +341,22 @@ unsafe impl ViaFfi for String {
         // whether we check for valid utf8 data or not.
         Ok(unsafe { String::from_utf8_unchecked(cstr.into_bytes()) })
     }
-}
 
-impl Lowerable for String {
-    fn lower_into<B: BufMut>(&self, buf: &mut B) {
+    fn write<B: BufMut>(&self, buf: &mut B) {
+        // N.B. `len()` gives us the length in bytes, not in chars or graphemes.
+        // TODO: it would be nice not to panic here.
         let len = u32::try_from(self.len()).unwrap();
         buf.put_u32(len); // We limit strings to u32::MAX bytes
         buf.put(self.as_bytes());
     }
-}
 
-// Having this be for &str instead of String would have been nice for consistency but...
-// it seems very dangerous and only possible with some unsafe magic
-// and having a slice referencing the buffer seems like a recipie for
-// disaster... so we have a String here instead.
-impl Liftable for String {
-    fn try_lift_from<B: Buf>(buf: &mut B) -> Result<Self> {
+    fn try_read<B: Buf>(buf: &mut B) -> Result<Self> {
         check_remaining(buf, 4)?;
-        let len = buf.get_u32();
-        check_remaining(buf, len as usize)?;
-        let bytes = &buf.bytes()[..len as usize];
+        let len = buf.get_u32() as usize;
+        check_remaining(buf, len)?;
+        let bytes = &buf.bytes()[..len];
         let res = String::from_utf8(bytes.to_vec())?;
-        buf.advance(len as usize);
+        buf.advance(len);
         Ok(res)
-    }
-}
-
-unsafe impl ViaFfi for bool {
-    type Value = u8;
-    fn into_ffi_value(self) -> Self::Value {
-        if self {
-            1
-        } else {
-            0
-        }
-    }
-    fn try_from_ffi_value(v: Self::Value) -> Result<Self> {
-        Ok(match v {
-            0 => false,
-            1 => true,
-            _ => bail!("unexpected byte for Boolean"),
-        })
-    }
-}
-
-impl Lowerable for bool {
-    fn lower_into<B: BufMut>(&self, buf: &mut B) {
-        buf.put_u8(ViaFfi::into_ffi_value(*self));
-    }
-}
-
-impl Liftable for bool {
-    fn try_lift_from<B: Buf>(buf: &mut B) -> Result<Self> {
-        check_remaining(buf, 1)?;
-        ViaFfi::try_from_ffi_value(buf.get_u8())
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
@@ -10,12 +10,12 @@ enum class {{ e.name()|class_name_kt }} {
                 throw RuntimeException("invalid enum value, something is very wrong!!", e)
             }
 
-        internal fun liftFrom(buf: ByteBuffer) = lift(Int.liftFrom(buf))
+        internal fun read(buf: ByteBuffer) = lift(Int.read(buf))
     }
 
     internal fun lower() = this.ordinal + 1
 
-    internal fun lowersIntoSize() = 4
+    internal fun calculateWriteSize() = 4
 
-    internal fun lowerInto(buf: ByteBuffer) = this.lower().lowerInto(buf)
+    internal fun write(buf: ByteBuffer) = this.lower().write(buf)
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
@@ -6,32 +6,32 @@ data class {{ rec.name()|class_name_kt }} (
     companion object {
         // XXX TODO: put this in a superclass maybe?
         internal fun lift(rbuf: RustBuffer.ByValue): {{ rec.name()|class_name_kt }} {
-            return liftFromRustBuffer(rbuf) { buf -> {{ rec.name()|class_name_kt }}.liftFrom(buf) }
+            return liftFromRustBuffer(rbuf) { buf -> {{ rec.name()|class_name_kt }}.read(buf) }
         }
 
-        internal fun liftFrom(buf: ByteBuffer): {{ rec.name()|class_name_kt }} {
+        internal fun read(buf: ByteBuffer): {{ rec.name()|class_name_kt }} {
             return {{ rec.name()|class_name_kt }}(
             {%- for field in rec.fields() %}
-            {{ "buf"|lift_from_kt(field.type_()) }}{% if loop.last %}{% else %},{% endif %}
+            {{ "buf"|read_kt(field.type_()) }}{% if loop.last %}{% else %},{% endif %}
             {%- endfor %}
             )
         }
     }
 
     internal fun lower(): RustBuffer.ByValue {
-        return lowerIntoRustBuffer(this, {v -> v.lowersIntoSize()}, {v, buf -> v.lowerInto(buf)})
+        return lowerIntoRustBuffer(this, {v -> v.calculateWriteSize()}, {v, buf -> v.write(buf)})
     }
 
-    internal fun lowersIntoSize(): Int {
+    internal fun calculateWriteSize(): Int {
         return 0 +
         {%- for field in rec.fields() %}
-            {{ "(this.{})"|format(field.name())|lowers_into_size_kt(field.type_()) }}{% if loop.last %}{% else %} +{% endif %}
+            {{ "(this.{})"|format(field.name())|calculate_write_size(field.type_()) }}{% if loop.last %}{% else %} +{% endif %}
         {%- endfor %}
     }
 
-    internal fun lowerInto(buf: ByteBuffer) {
+    internal fun write(buf: ByteBuffer) {
         {%- for field in rec.fields() %}
-            {{ "(this.{})"|format(field.name())|lower_into_kt("buf", field.type_()) }}
+            {{ "(this.{})"|format(field.name())|write_kt("buf", field.type_()) }}
         {%- endfor %}
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift.rs
@@ -120,23 +120,28 @@ mod filters {
         })
     }
 
-    /// Lowers a Swift type into a C type. This is used to pass arguments over
-    /// the FFI, from Swift to Rust.
+    /// Lower a Swift type into an FFI type.
+    ///
+    /// This is used to pass arguments over the FFI, from Swift to Rust.
     pub fn lower_swift(name: &dyn fmt::Display, _type_: &Type) -> Result<String, askama::Error> {
-        Ok(format!("{}.toFFIValue()", var_name_swift(name)?))
+        Ok(format!("{}.lower()", var_name_swift(name)?))
     }
 
-    /// ...
-    pub fn lift_from_swift(name: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
-        Ok(format!("{}.lift(from: {})", type_swift(type_)?, name))
-    }
-
-    /// ...
+    /// Lift a Swift type from an FFI type.
+    ///
+    /// This is used to receive values over the FFI, from Rust to Swift.
     pub fn lift_swift(name: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
-        Ok(format!("{}.fromFFIValue({})", type_swift(type_)?, name))
+        Ok(format!("{}.lift({})", type_swift(type_)?, name))
     }
 
-    /// ...
+    /// Read a Swift type from a byte buffer.
+    ///
+    /// This is used to receive values over the FFI, when they're part of a complex type
+    /// that is passed by serializing into bytes.
+    pub fn read_swift(name: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
+        Ok(format!("{}.read(from: {})", type_swift(type_)?, name))
+    }
+
     pub fn enum_variant_swift(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
         Ok(nm.to_string().to_mixed_case())
     }
@@ -153,7 +158,6 @@ mod filters {
         Ok(nm.to_string().to_mixed_case())
     }
 
-    /// ...
     pub fn header_path(path: &Path) -> Result<String, askama::Error> {
         Ok(path.to_str().expect("Invalid bridging header path").into())
     }

--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -1,13 +1,13 @@
-public enum {{ e.name()|class_name_swift }}: Lowerable, Liftable {
+public enum {{ e.name()|class_name_swift }}: ViaFfi {
     {% for variant in e.variants() %}
     case {{ variant|enum_variant_swift }}
     {% endfor %}
 
-    static func lift(from buf: Reader) throws -> {{ e.name()|class_name_swift }} {
-        return try {{ e.name()|class_name_swift }}.fromFFIValue(UInt32.lift(from: buf))
+    static func read(from buf: Reader) throws -> {{ e.name()|class_name_swift }} {
+        return try {{ e.name()|class_name_swift }}.lift(UInt32.read(from: buf))
     }
 
-    static func fromFFIValue(_ number: UInt32) throws -> {{ e.name()|class_name_swift }} {
+    static func lift(_ number: UInt32) throws -> {{ e.name()|class_name_swift }} {
         switch number {
         {% for variant in e.variants() %}
         case {{ loop.index }}: return .{{ variant|enum_variant_swift }}
@@ -16,11 +16,11 @@ public enum {{ e.name()|class_name_swift }}: Lowerable, Liftable {
         }
     }
 
-    func lower(into buf: Writer) {
-        self.toFFIValue().lower(into: buf)
+    func write(into buf: Writer) {
+        self.lower().write(into: buf)
     }
 
-    func toFFIValue() -> UInt32 {
+    func lower() -> UInt32 {
         switch self {
         {% for variant in e.variants() %}
         case .{{ variant|enum_variant_swift }}: return {{ loop.index }}

--- a/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
@@ -1,4 +1,4 @@
-{# 
+{#
 // In here we define conversions between a native reference to Swift errors
 // We use the RustError protocol to define the requirements. Any implementers of the protocol
 // Can be generated from a NativeRustError. 
@@ -39,7 +39,7 @@ public enum {{e.name()}}: RustError {
                 return nil
             {% for value in e.values() %}
             case {{loop.index}}:
-                return .{{value}}(message: try String.fromFFIValue(message!))
+                return .{{value}}(message: try String.lift(message!))
             {% endfor %}
             default:
                 return nil

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -1,4 +1,4 @@
-public struct {{ rec.name()|class_name_swift }}: Lowerable, Liftable, Serializable, Equatable {
+public struct {{ rec.name()|class_name_swift }}:  ViaFfiUsingByteBuffer, ViaFfi, Equatable {
     {%- for field in rec.fields() %}
     let {{ field.name()|var_name_swift }}: {{ field.type_()|type_swift }}
     {%- endfor %}
@@ -24,17 +24,17 @@ public struct {{ rec.name()|class_name_swift }}: Lowerable, Liftable, Serializab
         return true
     }
 
-    static func lift(from buf: Reader) throws -> {{ rec.name()|class_name_swift }} {
+    static func read(from buf: Reader) throws -> {{ rec.name()|class_name_swift }} {
         return try {{ rec.name()|class_name_swift }}(
             {%- for field in rec.fields() %}
-            {{ field.name()|var_name_swift }}: {{ "buf"|lift_from_swift(field.type_()) }}{% if loop.last %}{% else %},{% endif %}
+            {{ field.name()|var_name_swift }}: {{ "buf"|read_swift(field.type_()) }}{% if loop.last %}{% else %},{% endif %}
             {%- endfor %}
         )
     }
 
-    func lower(into buf: Writer) {
+    func write(into buf: Writer) {
         {%- for field in rec.fields() %}
-        {{ field.name()|var_name_swift }}.lower(into: buf)
+        {{ field.name()|var_name_swift }}.write(into: buf)
         {%- endfor %}
     }
 }

--- a/uniffi_bindgen/src/scaffolding.rs
+++ b/uniffi_bindgen/src/scaffolding.rs
@@ -67,7 +67,7 @@ mod filters {
         // By explicitly naming the type here, we help the rust compiler to type-check the user-provided
         // implementations of the functions that we're wrapping (and also to type-check our generated code).
         Ok(format!(
-            "<{} as uniffi::ViaFfi>::into_ffi_value({})",
+            "<{} as uniffi::ViaFfi>::lower({})",
             type_rs(type_)?,
             nm
         ))
@@ -78,7 +78,7 @@ mod filters {
         // implementations of the functions that we're wrapping (and also to type-check our generated code).
         // This will panic if the bindings provide an invalid value over the FFI.
         Ok(format!(
-            "<{} as uniffi::ViaFfi>::try_from_ffi_value({}).unwrap()",
+            "<{} as uniffi::ViaFfi>::try_lift({}).unwrap()",
             type_rs(type_)?,
             nm
         ))

--- a/uniffi_bindgen/src/templates/RustString.rs
+++ b/uniffi_bindgen/src/templates/RustString.rs
@@ -24,7 +24,7 @@ pub unsafe extern "C" fn {{ ci.ffi_string_alloc_from().name() }}(cstr: *const st
         let cstr = std::ffi::CStr::from_ptr(cstr);
         let s = cstr.to_str().expect("Invalid utf8 in foreign string buffer");
         // And this lowers it back into a rust-owned pointer to return over the FFI.
-        <String as uniffi::ViaFfi>::into_ffi_value(s.to_string())
+        <String as uniffi::ViaFfi>::lower(s.to_string())
     })
 }
 
@@ -36,6 +36,6 @@ pub unsafe extern "C" fn {{ ci.ffi_string_alloc_from().name() }}(cstr: *const st
 pub unsafe extern "C" fn {{ ci.ffi_string_free().name() }}(cstr: *mut std::os::raw::c_char) {
     // We deliberately don't check the `Result` here, so that callers don't need to pass an out `err`.
     // There was nothing for us to free in the failure case anyway, so no point in propagating the error.
-    let s = <String as uniffi::ViaFfi>::try_from_ffi_value(cstr);
+    let s = <String as uniffi::ViaFfi>::try_lift(cstr);
     drop(s)
 }


### PR DESCRIPTION
Inspired by the conversation in https://github.com/mozilla/uniffi-rs/pull/214#discussion_r467578565,
here's a PR to try to clarify and simplify some terminology.

Previously, we used a loosely-defined mix of terms like "lower" and "lower into"
to describe passing data across the FFI in two very different ways (the former
by converting to a primitive C type, the later by serializing to a bytebuffer).
Sometimes when we said "lower" we meant the former, and sometimes we meant the
later, and this was not consistent between the different codegen backends.

This commit tries to clean up the terminology and bring the Rust, Kotlin and
Swift code generators into agreement on which activities are called what.
Broadly:

* "Lowering" is now exclusively about converting from a high-level language
  type into a low-level C-compatible type, and "lifting" is the reverse.
* Serializing into a bytebuffer is now called "writing" and deserializing
  from a bytebuffer is now called "reading".

I've also consolidated all these into a single trait/protocol/what-have-you
where possible, since we've had confusion in the past where some types implemented
e.g. lowering but not writing.

I haven't touched the python bindings, because I'm working on a bigger
refactor in a separte commit.

Fixes #29 