### PR TITLE
Allows dynamic error messages

### DIFF
--- a/examples/arithmetic/src/lib.rs
+++ b/examples/arithmetic/src/lib.rs
@@ -4,16 +4,18 @@
 
 #[derive(Debug, thiserror::Error)]
 enum ArithmeticError {
-    #[error("Integer overflow!")]
-    IntegerOverflow,
+    #[error("Integer overflow on an operation with {a} and {b}")]
+    IntegerOverflow { a: u64, b: u64 },
 }
 
 fn add(a: u64, b: u64) -> Result<u64> {
-    a.checked_add(b).ok_or(ArithmeticError::IntegerOverflow)
+    a.checked_add(b)
+        .ok_or(ArithmeticError::IntegerOverflow { a, b })
 }
 
 fn sub(a: u64, b: u64) -> Result<u64> {
-    a.checked_sub(b).ok_or(ArithmeticError::IntegerOverflow)
+    a.checked_sub(b)
+        .ok_or(ArithmeticError::IntegerOverflow { a, b })
 }
 
 fn equal(a: u64, b: u64) -> bool {

--- a/examples/todolist/src/todolist.idl
+++ b/examples/todolist/src/todolist.idl
@@ -9,7 +9,7 @@ dictionary TodoEntry {
 
 [Error]
 enum TodoError {
-    "TodoDoesNotExist", "EmptyTodoList", "DuplicateTodo", "EmptyString"
+    "TodoDoesNotExist", "EmptyTodoList", "DuplicateTodo", "EmptyString", "DeligatedError"
 };
 
 interface TodoList {

--- a/uniffi_bindgen/src/templates/ErrorTemplate.rs
+++ b/uniffi_bindgen/src/templates/ErrorTemplate.rs
@@ -12,7 +12,7 @@ impl From<{{e.name()}}> for uniffi::deps::ffi_support::ExternError {
         // we might find that we need to reserve some codes.
         match err {
             {%- for value in e.values() %}
-            {{ e.name()}}::{{value}} => uniffi::deps::ffi_support::ExternError::new_error(uniffi::deps::ffi_support::ErrorCode::new({{ loop.index }}), err.to_string()),
+            {{ e.name()}}::{{value}}{..} => uniffi::deps::ffi_support::ExternError::new_error(uniffi::deps::ffi_support::ErrorCode::new({{ loop.index }}), err.to_string()),
             {%- endfor %}
         }
     }


### PR DESCRIPTION
fixes #245 

Forces errors variants to have an associate type

i.e now all error variants must have some internal thing they are wrapping, example:

```rust
enum Error {
    NetworkError, // This is an invalid variant, will not compile
    ExperimentError(String), // Valid
    DbError(rusqlite::Error), // This is also valid
    OtherError {
       message: String
     } // Invalid will not compile
}
```

I don't like this too much. 

I would prefer it if we were able to let the consumer decide what each variant looks like.

In order to do that we need a way to match against an enum variant's name, regardless if it has an associated type, is a struct, or is just a variant with no other data. Seems like a reasonable thing, except I couldn't for the life of me find a way to do that. What I mean is something like this for the above struct:
```rust
match err {
  Error::OtherError => ..... // Gives a compiler error, since `OtherError` is a struct variant, and we need to do `Error::OtherError{message:_}`
}
```

We could force the consumer to annotate each variant in the `idl` but not sure if that's too much 😅 


Happy to ditch this if we can think of a nice way to do this.