### PR TITLE
Add a default constructor if none is provided

### DIFF
--- a/examples/rondpoint/src/rondpoint.idl
+++ b/examples/rondpoint/src/rondpoint.idl
@@ -28,10 +28,6 @@ dictionary Dictionnaire {
 };
 
 interface Retourneur {
-  // A constructor is mandatory
-  // See https://github.com/mozilla/uniffi-rs/issues/246
-  constructor();
-
   i8 identique_i8(i8 value);
   u8 identique_u8(u8 value);
   i16 identique_i16(i16 value);
@@ -47,7 +43,6 @@ interface Retourneur {
 };
 
 interface Stringifier {
-  constructor();
   string well_known_string(string value);
 
   string to_string_i8(i8 value);

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -651,6 +651,9 @@ impl APIConverter<Object> for weedle::InterfaceDefinition<'_> {
                 _ => bail!("no support for interface member type {:?} yet", member),
             }
         }
+        if object.constructors.is_empty() {
+            object.constructors.push(Default::default());
+        }
         Ok(object)
     }
 }
@@ -696,6 +699,17 @@ impl Constructor {
         // but it's this way until we implement handling for panics
         self.ffi_func.has_out_err = self.throws().is_some();
         Ok(())
+    }
+}
+
+impl Default for Constructor {
+    fn default() -> Self {
+        Constructor {
+            name: String::from("new"),
+            arguments: Vec::new(),
+            ffi_func: Default::default(),
+            attributes: Attributes(Vec::new()),
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #246.

Implement the `Default` trait for `Constructor`, and use it when no constructors are given in the IDL.

Removed the noarg constructors in `rondpoint.idl`.