### PR TITLE
Fixes clippy for consumers

### DIFF
--- a/examples/todolist/src/lib.rs
+++ b/examples/todolist/src/lib.rs
@@ -54,7 +54,7 @@ impl TodoList {
         if self.items.contains(&item) {
             return Err(TodoError::DuplicateTodo);
         }
-        self.items.push(item.into());
+        self.items.push(item);
         Ok(())
     }
 

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -2,10 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-//#![deny(missing_docs)]
-#![allow(unknown_lints)]
-#![warn(rust_2018_idioms)]
-
 //! # Component Interface Definition and Types
 //!
 //! This crate provides an abstract representation of the interface provided by a uniffi rust component,
@@ -967,7 +963,7 @@ impl Attribute {
 impl TryFrom<&weedle::attribute::ExtendedAttribute<'_>> for Attribute {
     type Error = anyhow::Error;
     fn try_from(
-        weedle_attribute: &weedle::attribute::ExtendedAttribute,
+        weedle_attribute: &weedle::attribute::ExtendedAttribute<'_>,
     ) -> Result<Self, anyhow::Error> {
         match weedle_attribute {
             weedle::attribute::ExtendedAttribute::NoArgs(attr) => match (attr.0).0 {
@@ -1005,7 +1001,7 @@ pub struct Attributes(Vec<Attribute>);
 
 impl Attributes {
     pub fn contains_error_attr(&self) -> bool {
-        self.0.iter().find(|attr| attr.is_error()).is_some()
+        self.0.iter().any(|attr| attr.is_error())
     }
 
     fn get_throws_err(&self) -> Option<&str> {
@@ -1021,7 +1017,7 @@ impl Attributes {
 impl TryFrom<&weedle::attribute::ExtendedAttributeList<'_>> for Attributes {
     type Error = anyhow::Error;
     fn try_from(
-        weedle_attributes: &weedle::attribute::ExtendedAttributeList,
+        weedle_attributes: &weedle::attribute::ExtendedAttributeList<'_>,
     ) -> Result<Self, Self::Error> {
         let attrs = &weedle_attributes.body.list;
 
@@ -1034,9 +1030,9 @@ impl TryFrom<&weedle::attribute::ExtendedAttributeList<'_>> for Attributes {
 
         attrs
             .iter()
-            .map(|attr| Attribute::try_from(attr))
+            .map(Attribute::try_from)
             .collect::<Result<Vec<_>, _>>()
-            .map(|attrs| Attributes(attrs))
+            .map(Attributes)
     }
 }
 

--- a/uniffi_bindgen/src/interface/types.rs
+++ b/uniffi_bindgen/src/interface/types.rs
@@ -2,10 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-//#![deny(missing_docs)]
-#![allow(unknown_lints)]
-#![warn(rust_2018_idioms)]
-
 //! # Basic typesystem for defining a component interface.
 //!
 //! Our typesystem operates at two distinct levels: "API-level types" and "FFI-level types".

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -89,6 +89,9 @@
 //! to load and use the compiled rust code via its C-compatible FFI.
 //!
 
+#![warn(rust_2018_idioms)]
+#![allow(unknown_lints)]
+
 const BINDGEN_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 use anyhow::{anyhow, bail, Result};

--- a/uniffi_bindgen/src/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/templates/ObjectTemplate.rs
@@ -18,7 +18,7 @@ uniffi::deps::lazy_static::lazy_static! {
     }
 
 {%- for cons in obj.constructors() %}
-
+    #[allow(clippy::all)]
     #[no_mangle]
     pub extern "C" fn {{ cons.ffi_func().name() }}(
         {%- call rs::arg_list_ffi_decl(cons.ffi_func()) %}) -> u64 {
@@ -30,6 +30,7 @@ uniffi::deps::lazy_static::lazy_static! {
 {%- endfor %}
 
 {%- for meth in obj.methods() %}
+    #[allow(clippy::all)]
     #[no_mangle]
     pub extern "C" fn {{ meth.ffi_func().name() }}(
         {%- call rs::arg_list_ffi_decl(meth.ffi_func()) %}

--- a/uniffi_bindgen/src/templates/RustString.rs
+++ b/uniffi_bindgen/src/templates/RustString.rs
@@ -1,5 +1,6 @@
 // Everybody gets basic string support, since they're such a common data type.
 
+/// # Safety
 /// This helper receives a borrowed foreign language string and
 /// copies it into an owned rust string. It is naturally tremendously unsafe,
 /// because pointers. The main things to remember as a consumer are:
@@ -29,9 +30,12 @@ pub unsafe extern "C" fn {{ ci.ffi_string_alloc_from().name() }}(cstr: *const st
 }
 
 /// Free a String that had previously been passed to the foreign language code.
+///
+/// # Safety
+/// In order to free the string, Rust takes ownership of a raw pointer
+/// which is an unsafe operation.
 /// The argument *must* be a uniquely-owned pointer previously obtained from a call
 /// into the rust code that returned a string.
-///
 #[no_mangle]
 pub unsafe extern "C" fn {{ ci.ffi_string_free().name() }}(cstr: *mut std::os::raw::c_char) {
     // We deliberately don't check the `Result` here, so that callers don't need to pass an out `err`.

--- a/uniffi_bindgen/src/templates/TopLevelFunctionTemplate.rs
+++ b/uniffi_bindgen/src/templates/TopLevelFunctionTemplate.rs
@@ -4,7 +4,7 @@
 // send data across the FFI, which will fail to compile if the provided function does not match what's
 // specified in the IDL.    
 #}
-
+#[allow(clippy::all)]
 #[no_mangle]
 pub extern "C" fn {{ func.ffi_func().name() }}(
     {% call rs::arg_list_ffi_decl(func.ffi_func()) %}


### PR DESCRIPTION
fixes #254 

Adds `#[allow(clippy::all)]` in all generated functions.

A WAY nicer way to do this is to add `#![allow(clippy::all)]` but unfortunately that doesn't work because of https://github.com/rust-lang/rfcs/issues/752, although I would be happy if there is a different way to disable clippy on the whole generated file without asking the consumer to do so.


Note: I did not add the `#[allow(clippy::all)]` for anything other than the functions purely because they didn't complain, I'd be happy to go around doing that if we need to.


I also fixed some clippy errors that popped up (not sure if it's because I updated to `1.46`)