### PR TITLE
Mark example crates as `publish = false`.

### DIFF
--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2018"
 version = "0.1.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/geometry/Cargo.toml
+++ b/examples/geometry/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2018"
 version = "0.1.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/rondpoint/Cargo.toml
+++ b/examples/rondpoint/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2018"
 version = "0.1.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/sprites/Cargo.toml
+++ b/examples/sprites/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2018"
 version = "0.1.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/todolist/Cargo.toml
+++ b/examples/todolist/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2018"
 version = "0.1.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
We don't want to accidentally publish these to crates.io.