### PR TITLE
Mention how to install uniffi-bindgen if we fail to execute it.

### DIFF
--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -58,7 +58,7 @@
 //!
 //! ### 3) Generate and include component scaffolding from the IDL file
 //!
-//! First you will need to install `uniffi-bindgen` on your system using `cargo install uniffi-bindgen`.
+//! First you will need to install `uniffi-bindgen` on your system using `cargo install uniffi_bindgen`.
 //! Then add to your crate `uniffi_build` under `[build-dependencies]`.
 //! Finally, add a `build.rs` script to your crate and have it call [uniffi_build::generate_scaffolding](uniffi_build::generate_scaffolding)
 //! to process your `.idl` file. This will generate some Rust code to be included in the top-level source

--- a/uniffi_build/src/lib.rs
+++ b/uniffi_build/src/lib.rs
@@ -39,7 +39,7 @@ fn run_uniffi_bindgen_scaffolding(out_dir: &str, idl_file: &str) -> Result<()> {
     let status = Command::new("uniffi-bindgen")
         .args(&["scaffolding", "--out-dir", out_dir, idl_file])
         .status()
-        .context("failed to run `uniffi-bindgen`")?;
+        .context("failed to run `uniffi-bindgen` - have you installed it via `cargo install uniffi_bindgen`?")?;
     if !status.success() {
         bail!("Error while generating scaffolding code");
     }


### PR DESCRIPTION
Also updates other instructions to reflect the name is `uniffi_bindgen`
rather than `uniffi-bindgen`.