### PR TITLE
No bug - fixup warnings in cargo test

### DIFF
--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -6,7 +6,6 @@ homepage = "https://mozilla.github.io/uniffi-rs"
 repository = "https://github.com/mozilla/uniffi-rs"
 version = "0.1.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
-license = "MPL-2.0"
 license-file = "../LICENSE"
 edition = "2018"
 keywords = ["ffi", "bindgen"]

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -6,7 +6,6 @@ description = "a multi-language bindings generator for rust (codegen and cli too
 documentation = "https://mozilla.github.io/uniffi-rs"
 homepage = "https://mozilla.github.io/uniffi-rs"
 repository = "https://github.com/mozilla/uniffi-rs"
-license = "MPL-2.0"
 license-file = "../LICENSE"
 edition = "2018"
 keywords = ["ffi", "bindgen"]

--- a/uniffi_bindgen/src/bindings/swift/templates/RustBufferHelper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RustBufferHelper.swift
@@ -92,7 +92,7 @@ class Writer {
     // is in the correct type!
     func writeInt<T: FixedWidthInteger>(_ value: T) {
         var value = value.bigEndian
-        let _ = withUnsafeBytes(of: &value, { bytes.append(contentsOf: $0) })
+        withUnsafeBytes(of: &value) { bytes.append(contentsOf: $0) }
     }
 
     @inlinable

--- a/uniffi_build/Cargo.toml
+++ b/uniffi_build/Cargo.toml
@@ -6,7 +6,6 @@ description = "a multi-language bindings generator for rust (build script helper
 documentation = "https://mozilla.github.io/uniffi-rs"
 homepage = "https://mozilla.github.io/uniffi-rs"
 repository = "https://github.com/mozilla/uniffi-rs"
-license = "MPL-2.0"
 license-file = "../LICENSE"
 edition = "2018"
 keywords = ["ffi", "bindgen"]

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -6,7 +6,6 @@ description = "a multi-language bindings generator for rust (convenience macros)
 documentation = "https://mozilla.github.io/uniffi-rs"
 homepage = "https://mozilla.github.io/uniffi-rs"
 repository = "https://github.com/mozilla/uniffi-rs"
-license = "MPL-2.0"
 license-file = "../LICENSE"
 edition = "2018"
 keywords = ["ffi", "bindgen"]


### PR DESCRIPTION
This PR fixes two sets of annoying warnings seen a lot in the `cargo test`:

```
warning: /Users/jhugman/workspaces/mozilla/uniffi-rs/uniffi_bindgen/Cargo.toml: only one of `license` or `license-file` is necessary
warning: /Users/jhugman/workspaces/mozilla/uniffi-rs/uniffi_macros/Cargo.toml: only one of `license` or `license-file` is necessary
warning: /Users/jhugman/workspaces/mozilla/uniffi-rs/uniffi_build/Cargo.toml: only one of `license` or `license-file` is necessary
warning: /Users/jhugman/workspaces/mozilla/uniffi-rs/uniffi/Cargo.toml: only one of `license` or `license-file` is necessary
```

and 

```
/Users/jhugman/workspaces/mozilla/uniffi-rs/target/debug/rondpoint.swift:127:9: warning: using '_' to ignore the result of a Void-returning function is redundant
        _ = withUnsafeBytes(of: &value) { bytes.append(contentsOf: $0) }
```

This should not change any other behaviour.