### PR TITLE
Special-case "optionals with a default value" and fix compilation errors in Gecko JS

### DIFF
--- a/uniffi_bindgen/src/bindings/gecko_js/templates/InterfaceTemplate.cpp
+++ b/uniffi_bindgen/src/bindings/gecko_js/templates/InterfaceTemplate.cpp
@@ -51,7 +51,7 @@ already_AddRefed<{{ obj.name()|class_name_cpp(context) }}> {{ obj.name()|class_n
   if (err.mCode) {
     {%- match cons.cpp_throw_by() %}
     {%- when ThrowBy::ErrorResult with (rv) %}
-    {{ rv }}.ThrowOperationError(err.mMessage);
+    {{ rv }}.ThrowOperationError(nsDependentCString(err.mMessage));
     {%- when ThrowBy::Assert %}
     MOZ_ASSERT(false);
     {%- endmatch %}

--- a/uniffi_bindgen/src/bindings/gecko_js/templates/RustBufferHelper.h
+++ b/uniffi_bindgen/src/bindings/gecko_js/templates/RustBufferHelper.h
@@ -737,4 +737,45 @@ struct ViaFfi<nsAString, {{ context.ffi_rustbuffer_type() }}, true> {
   }
 };
 
+/// Partial specialization for all non-null types on the C++ side that should be
+/// serialized as if they were nullable. This is analogous to a blanket
+/// implementation of `ViaFfiUsingByteBuffer` for `Option<T>` in Rust.
+
+template <typename T>
+struct ViaFfi<T, {{ context.ffi_rustbuffer_type() }}, true> {
+  [[nodiscard]] static bool Lift(const {{ context.ffi_rustbuffer_type() }}& aLowered,
+                                 T& aLifted) {
+    auto reader = Reader(aLowered);
+    auto hasValue = reader.ReadInt8();
+    if (hasValue != 0 && hasValue != 1) {
+      MOZ_ASSERT(false);
+      return false;
+    }
+    if (!hasValue) {
+      return true;
+    }
+    if (!Serializable<T>::ReadFrom(reader, aLifted)) {
+      return false;
+    }
+    if (reader.HasRemaining()) {
+      MOZ_ASSERT(false);
+      return false;
+    }
+    {{ context.ffi_rusterror_type() }} err = {0, nullptr};
+    {{ ci.ffi_rustbuffer_free().name() }}(aLowered, &err);
+    if (err.mCode) {
+      MOZ_ASSERT(false, "Failed to free Rust buffer after lifting contents");
+      return false;
+    }
+    return true;
+  }
+
+  [[nodiscard]] static {{ context.ffi_rustbuffer_type() }} Lower(const T& aLifted) {
+    auto writer = Writer();
+    writer.WriteInt8(1);
+    Serializable<T>::WriteInto(writer, aLifted);
+    return writer.Buffer();
+  }
+};
+
 }  // namespace {{ context.detail_name() }}

--- a/uniffi_bindgen/src/bindings/gecko_js/templates/RustBufferHelper.h
+++ b/uniffi_bindgen/src/bindings/gecko_js/templates/RustBufferHelper.h
@@ -547,14 +547,13 @@ struct Serializable<dom::Optional<T>> {
       return false;
     }
     if (!hasValue) {
-      aValue = dom::Optional<T>();
       return true;
     }
     T value;
     if (!Serializable<T>::ReadFrom(aReader, value)) {
       return false;
     }
-    aValue = dom::Optional<T>(std::move(value));
+    aValue.Construct(std::move(value));
     return true;
   };
 

--- a/uniffi_bindgen/src/bindings/gecko_js/templates/macros.cpp
+++ b/uniffi_bindgen/src/bindings/gecko_js/templates/macros.cpp
@@ -40,7 +40,7 @@
     {%- when ThrowBy::ErrorResult with (rv) %}
     {# /* TODO: Improve error throwing. See https://github.com/mozilla/uniffi-rs/issues/295
           for details. */ -#}
-    {{ rv }}.ThrowOperationError({{ err }}.mMessage);
+    {{ rv }}.ThrowOperationError(nsDependentCString({{ err }}.mMessage));
     {%- when ThrowBy::Assert %}
     MOZ_ASSERT(false);
     {%- endmatch %}


### PR DESCRIPTION
Optional arguments and members with a default value are a bag of special cases.

On the C++ side, `optional` arguments with default values are passed as `const T&`, and optional dictionary members are type `T` (for optional arguments, they're `const dom::Optional<T>&` and `dom::Optional<T>`, respectively). But the Rust side is expecting them to be serialized as `Option<T>`. It's basically the same problem as strings, where null and non-null strings have the same `const nsAString&`/`nsString` type—the Rust side is expecting to read `1`/`0` followed by the serialization of the type, but the C++ side isn't passing that `1`/`0`.

So the first commit adds a special `WebIDLType::OptionalWithDefaultValue` that's emitted as `T`, except when we call `ViaFfi`, where it passes `Nullable = true`. It also adds a helper for serializing non-null things on the C++ side as if they were `Some<T>` for Rust.

The second commit fixes some errors in the generated Nimbus bindings. `dom::Optional<T>` can't be constructed directly, and `ThrowOperationError` takes a `const ACString&`, not a raw `char*`, so we have to wrap it in an `nsDependentCString`.

@dmose and I paired on this yesterday, and got the Nimbus SDK building with these changes. We haven't written an xpcshell test for it yet—it's crashing because it's trying to use Viaduct to make a network request from the main thread, [which is forbidden](https://searchfox.org/mozilla-central/rev/7ef5cefd0468b8f509efe38e0212de2398f4c8b3/toolkit/components/viaduct/Viaduct.cpp#45)—but it compiles and runs.