### PR TITLE
Add workaround for JNA bug when passing small structs by value.

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
@@ -113,7 +113,7 @@ internal open class {{e.name()}} : RustError() {
             {% for value in e.values() -%}
             {{loop.index}} -> return {{e.name()}}Exception.{{value}}(message) as E
             {% endfor -%}
-            else -> throw RuntimeException("Invalid error received...")
+            else -> throw RuntimeException("Invalid error received: $code, $message")
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
@@ -2,11 +2,13 @@
 // A rust-owned buffer is represented by its capacity, its current length, and a
 // pointer to the underlying data.
 
-@Structure.FieldOrder("capacity", "len", "data")
+@Structure.FieldOrder("capacity", "len", "data", "padding")
 open class RustBuffer : Structure() {
     @JvmField var capacity: Int = 0
     @JvmField var len: Int = 0
     @JvmField var data: Pointer? = null
+    // Ref https://github.com/mozilla/uniffi-rs/issues/334 for this weird "padding" field.
+    @JvmField var padding: Long = 0
 
     class ByValue : RustBuffer(), Structure.ByValue
 
@@ -37,10 +39,13 @@ open class RustBuffer : Structure() {
 // then we might as well copy it into a `RustBuffer`. But it's here for API
 // completeness.
 
-@Structure.FieldOrder("len", "data")
+@Structure.FieldOrder("len", "data", "padding", "padding2")
 open class ForeignBytes : Structure() {
     @JvmField var len: Int = 0
     @JvmField var data: Pointer? = null
+    // Ref https://github.com/mozilla/uniffi-rs/issues/334 for these weird "padding" fields.
+    @JvmField var padding: Long = 0
+    @JvmField var padding2: Int = 0
 
     class ByValue : ForeignBytes(), Structure.ByValue
 }

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
@@ -4,6 +4,8 @@ class RustBuffer(ctypes.Structure):
         ("capacity", ctypes.c_int32),
         ("len", ctypes.c_int32),
         ("data", ctypes.POINTER(ctypes.c_char)),
+        # Ref https://github.com/mozilla/uniffi-rs/issues/334 for this weird "padding" field.
+        ("padding", ctypes.c_int64),
     ]
 
     @staticmethod
@@ -139,6 +141,9 @@ class ForeignBytes(ctypes.Structure):
     _fields_ = [
         ("len", ctypes.c_int32),
         ("data", ctypes.POINTER(ctypes.c_char)),
+        # Ref https://github.com/mozilla/uniffi-rs/issues/334 for these weird "padding" fields.
+        ("padding", ctypes.c_int64),
+        ("padding2", ctypes.c_int32),
     ]
 
     def __str__(self):

--- a/uniffi_bindgen/src/bindings/swift/templates/RustBufferTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RustBufferTemplate.swift
@@ -6,7 +6,8 @@ extension RustBuffer {
                 {{ ci.ffi_rustbuffer_from_bytes().name() }}(ForeignBytes(bufferPointer: ptr), err)
             }
         }
-        self.init(capacity: rbuf.capacity, len: rbuf.len, data: rbuf.data)
+        // Ref https://github.com/mozilla/uniffi-rs/issues/334 for the extra "padding" arg.
+        self.init(capacity: rbuf.capacity, len: rbuf.len, data: rbuf.data, padding: 0)
     }
 
     // Frees the buffer in place.
@@ -20,6 +21,7 @@ extension RustBuffer {
 
 extension ForeignBytes {
     init(bufferPointer: UnsafeBufferPointer<UInt8>) {
-        self.init(len: Int32(bufferPointer.count), data: bufferPointer.baseAddress)
+        // Ref https://github.com/mozilla/uniffi-rs/issues/334 for the extra "padding" args.
+        self.init(len: Int32(bufferPointer.count), data: bufferPointer.baseAddress, padding: 0, padding2: 0)
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/Template-Bridging-Header.h
+++ b/uniffi_bindgen/src/bindings/swift/templates/Template-Bridging-Header.h
@@ -11,12 +11,17 @@ typedef struct RustBuffer
     int32_t capacity;
     int32_t len;
     uint8_t *_Nullable data;
+    // Ref https://github.com/mozilla/uniffi-rs/issues/334 for this weird "padding" field.
+    int64_t padding;
 } RustBuffer;
 
 typedef struct ForeignBytes
 {
     int32_t len;
     const uint8_t *_Nullable data;
+    // Ref https://github.com/mozilla/uniffi-rs/issues/334 for these weird "padding" fields.
+    int64_t padding;
+    int32_t padding2;
 } ForeignBytes;
 
 // Error definitions


### PR DESCRIPTION
The current version of JNA appears to have a bug when passing small structs
as arguments by value, on arm64 platforms, when the function call has too
many arguments to pass the struct in registers. It turns out that our generated
code does this a lot thanks to the way we pass around `RustBuffer` structs.

This commit adds a temporary workaround for the issue, by padding our structs
to be larger than 16 bytes, which causes them to be passed as pointers rather
than by value.

See https://github.com/mozilla/application-services/issues/3646 for investigation
of the JNA issue, and https://github.com/mozilla/uniffi-rs/issues/334 to track
the work of removing this workaround once a fix is released in upstream JNA.