### PR TITLE
Update cargo_metadata dependency.

### DIFF
--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -18,7 +18,7 @@ ffi-support = "~0.4.2"
 lazy_static = "1.4"
 log = "0.4"
 # Regular dependencies
-cargo_metadata = "0.11.3"
+cargo_metadata = "0.12"
 paste = "1.0"
 uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "0.4.0" }
 

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -15,11 +15,11 @@ name = "uniffi-bindgen"
 path = "src/main.rs"
 
 [dependencies]
-cargo_metadata = "0.11.3"
+cargo_metadata = "0.12"
 weedle = "0.11"
 anyhow = "1"
 askama = "0.10"
 heck = "0.3"
 clap = "2"
 serde = "1"
-toml = "0.5.6"
+toml = "0.5"

--- a/uniffi_build/Cargo.toml
+++ b/uniffi_build/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 keywords = ["ffi", "bindgen"]
 
 [dependencies]
-cargo_metadata = "0.11.3"
 anyhow = "1"
 uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "0.4.0" }
 


### PR DESCRIPTION
This will avoid us pulling in multiple versions of some of our dependencies when used in conjunction with this PR: https://github.com/mozilla/nimbus-sdk/pull/49#discussion_r517688219