### PR TITLE
Compatibility tweaks for Rust v1.43.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,9 @@ jobs:
     steps:
       - run: cat ~/.profile >> $BASH_ENV
       - run:
+          name: "Print the Rust version, to help with debugging"
+          command: rustc --version
+      - run:
           name: "Set RUSTFLAGS to fail the build if there are warnings"
           command: echo 'export RUSTFLAGS="-D warnings"' >> $BASH_ENV
       - checkout

--- a/docker/Dockerfile-build
+++ b/docker/Dockerfile-build
@@ -35,7 +35,9 @@ RUN sudo apt-get update -qq \
     && sudo apt-get clean
 
 RUN rustup update \
-    && rustup default stable
+    # This specific version of Rust is required for compatibility with mozilla-central
+    && rustup install 1.43.0 \
+    && rustup default 1.43.0
 
 RUN mkdir -p /tmp/setup-swift \
     && cd /tmp/setup-swift \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,11 @@
+This directory contains a Dockerfile for building the
+`uniffi-ci` docker image that we use for running tests
+in CI. To build a new version of this docker image, use:
+
+```
+docker build -t rfkelly/uniffi-ci -f Dockerfile-build .
+docker push rfkelly/uniffi-ci
+```
+
+That only works if you're `rfkelly`; we need to figure out
+a better strategy for maintainership of said docker image.

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -18,7 +18,7 @@ ffi-support = "~0.4.2"
 lazy_static = "1.4"
 log = "0.4"
 # Regular dependencies
-cargo_metadata = "0.12"
+cargo_metadata = "0.11"
 paste = "1.0"
 uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "0.4.0" }
 

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -15,7 +15,7 @@ name = "uniffi-bindgen"
 path = "src/main.rs"
 
 [dependencies]
-cargo_metadata = "0.12"
+cargo_metadata = "0.11"
 weedle = "0.11"
 anyhow = "1"
 askama = { version = "0.10", default-features = false, features = ["config"] }

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -1170,11 +1170,14 @@ fn convert_default_value(
             radix
         };
 
+        // Using `strip_prefix` would be better here, but that's not available in the version
+        // of Rust that is currently used in mozilla-central. Using `trim_start_matches` will
+        // *repeatedly* strip the given prefix, but that's fine because legit literals can't
+        // contain multiple instances of it anyway.
         let string = if string.starts_with('-') {
-            ("-".to_string() + string[1..].strip_prefix("0x").unwrap_or(&string[1..]))
-                .to_lowercase()
+            ("-".to_string() + string[1..].trim_start_matches("0x")).to_lowercase()
         } else {
-            string.strip_prefix("0x").unwrap_or(&string).to_lowercase()
+            string.trim_start_matches("0x").to_lowercase()
         };
 
         Ok(match type_ {


### PR DESCRIPTION
The version of Rust in mozilla-central is currently pinned to v1.43.0,
so we need to make sure we're compatible with it as well.