### PR TITLE
Start generating async gecko_js bindings rather than sync one - WIP

### DIFF
--- a/uniffi_bindgen/src/bindings/gecko_js/templates/InterfaceHeaderTemplate.h
+++ b/uniffi_bindgen/src/bindings/gecko_js/templates/InterfaceHeaderTemplate.h
@@ -9,6 +9,7 @@
 #include "jsapi.h"
 #include "nsCOMPtr.h"
 #include "nsIGlobalObject.h"
+#include "nsISerialEventTarget.h"
 #include "nsWrapperCache.h"
 
 #include "mozilla/RefPtr.h"
@@ -41,7 +42,7 @@ class {{ obj.name()|class_name_cpp(context) }} final : public nsISupports, publi
 
   {%- for meth in obj.methods() %}
 
-  {% match meth.cpp_return_type() %}{% when Some with (type_) %}{{ type_|ret_type_cpp(context) }}{% else %}void{% endmatch %} {{ meth.name()|fn_name_cpp }}(
+  already_AddRefed<Promise> {{ meth.name()|fn_name_cpp }}(
     {%- for arg in meth.cpp_arguments() %}
     {{ arg|arg_type_cpp(context) }} {{ arg.name() }}{%- if !loop.last %},{% endif %}
     {%- endfor %}
@@ -52,6 +53,8 @@ class {{ obj.name()|class_name_cpp(context) }} final : public nsISupports, publi
   ~{{ obj.name()|class_name_cpp(context) }}();
 
   nsCOMPtr<nsIGlobalObject> mGlobal;
+  RefPtr<nsISerialEventTarget> GetBackgroundTarget();
+  RefPtr<nsISerialEventTarget> mBackgroundET;
   uint64_t mHandle;
 };
 

--- a/uniffi_bindgen/src/bindings/gecko_js/templates/InterfaceTemplate.cpp
+++ b/uniffi_bindgen/src/bindings/gecko_js/templates/InterfaceTemplate.cpp
@@ -46,11 +46,6 @@ JSObject* {{ obj.name()|class_name_cpp(context) }}::WrapObject(
   return dom::{{ obj.name()|class_name_cpp(context) }}_Binding::Wrap(aCx, this, aGivenProto);
 }
 
-using nimbus_1725_MozPromise = MozPromise < {{context.ffi_rustbuffer_type()}}, {{context.ffi_rusterror_type()}}, false >;
-
-using nimbus_1725_MozPromiseVoid = MozPromise < void, {{context.ffi_rusterror_type()}}, false >;
-
-
 RefPtr<nsISerialEventTarget> {{ obj.name()|class_name_cpp(context) }}::GetBackgroundTarget() {
   if (!mBackgroundET) {
     MOZ_ALWAYS_SUCCEEDS(NS_CreateBackgroundTaskQueue(

--- a/uniffi_bindgen/src/bindings/gecko_js/templates/InterfaceTemplate.cpp
+++ b/uniffi_bindgen/src/bindings/gecko_js/templates/InterfaceTemplate.cpp
@@ -48,6 +48,9 @@ JSObject* {{ obj.name()|class_name_cpp(context) }}::WrapObject(
 
 using nimbus_1725_MozPromise = MozPromise < {{context.ffi_rustbuffer_type()}}, {{context.ffi_rusterror_type()}}, false >;
 
+using nimbus_1725_MozPromiseVoid = MozPromise < void, {{context.ffi_rusterror_type()}}, false >;
+
+
 RefPtr<nsISerialEventTarget> {{ obj.name()|class_name_cpp(context) }}::GetBackgroundTarget() {
   if (!mBackgroundET) {
     MOZ_ALWAYS_SUCCEEDS(NS_CreateBackgroundTaskQueue(

--- a/uniffi_bindgen/src/bindings/gecko_js/templates/WebIDLTemplate.webidl
+++ b/uniffi_bindgen/src/bindings/gecko_js/templates/WebIDLTemplate.webidl
@@ -29,7 +29,7 @@ namespace {{ context.namespace()|class_name_webidl(context) }} {
   {%- if func.throws().is_some() %}
   [Throws]
   {% endif %}
-  {%- match func.webidl_return_type() -%}{%- when Some with (type_) %}{{ type_|type_webidl(context) }}{% when None %}void{% endmatch %} {{ func.name()|fn_name_webidl }}(
+  {%- match func.webidl_return_type() -%}{%- when Some with (type_) %}{{ type_|type_webidl(context) }}{% when None %}void{% endmatch %}> {{ func.name()|fn_name_webidl }}(
     {%- for arg in func.arguments() %}
     {% if arg.optional() -%}optional{%- else -%}{%- endif %} {{ arg.webidl_type()|type_webidl(context) }} {{ arg.name() }}
     {%- match arg.webidl_default_value() %}
@@ -66,7 +66,7 @@ interface {{ obj.name()|class_name_webidl(context)  }} {
   {%- if meth.throws().is_some() %}
   [Throws]
   {% endif %}
-  {%- match meth.webidl_return_type() -%}{%- when Some with (type_) %}{{ type_|type_webidl(context) }}{% when None %}void{% endmatch %} {{ meth.name()|fn_name_webidl }}(
+  Promise<{%- match meth.webidl_return_type() -%}{%- when Some with (type_) %}{{ type_|type_webidl(context) }}{% when None %}void{% endmatch %}> {{ meth.name()|fn_name_webidl }}(
       {%- for arg in meth.arguments() %}
       {% if arg.optional() -%}optional{%- else -%}{%- endif %} {{ arg.webidl_type()|type_webidl(context) }} {{ arg.name() }}
       {%- match arg.webidl_default_value() %}

--- a/uniffi_bindgen/src/bindings/gecko_js/templates/macros.cpp
+++ b/uniffi_bindgen/src/bindings/gecko_js/templates/macros.cpp
@@ -1,13 +1,34 @@
-{# /* Calls an FFI function. */ #}
+{#/* Calls an FFI function. */ #}
 {%- macro to_ffi_call(context, func) -%}
   {%- call to_ffi_call_head(context, func, "err", "loweredRetVal_") -%}
   {%- call _to_ffi_call_tail(context, func, "err", "loweredRetVal_") -%}
 {%- endmacro -%}
 
-{# /* Calls an FFI function with an initial argument. */ #}
+{#/* Calls an FFI function with an initial argument. */ #}
 {%- macro to_ffi_call_with_prefix(context, prefix, func) %}
-  {{ context.ffi_rusterror_type() }} err = {0, nullptr};
-  {% match func.ffi_func().return_type() %}{% when Some with (type_) %}const {{ type_|type_ffi(context) }} loweredRetVal_ ={% else %}{% endmatch %}{{ func.ffi_func().name() }}(
+
+  if (!XRE_IsParentProcess() && !NS_IsMainThread()) {
+    aRv.Throw(NS_ERROR_UNEXPECTED);
+    return nullptr;
+  }
+
+  RefPtr<Promise> promise = Promise::Create(GetParentObject(), aRv);
+  if (aRv.Failed()) {
+    return nullptr;
+  }
+
+  RefPtr<nsISerialEventTarget> backgroundET = GetBackgroundTarget();
+  mozilla::InvokeAsync(
+      backgroundET, __func__,
+      [mHandle=mHandle]() { // XXX should be templ vars, not literal
+        if (XRE_IsParentProcess() && NS_IsMainThread()) {
+          MOZ_CRASH("lambda called outside of parent process main thread");
+      }
+
+      {{ context.ffi_rusterror_type() }} err = {0, nullptr};
+
+      {% match func.ffi_func().return_type() %}
+      {% when Some with(type_) %}const {{ type_|type_ffi(context) }} loweredRetVal_ = {% else %}{% endmatch %}{{ func.ffi_func().name() }}(
     {{ prefix }}
     {%- let args = func.arguments() -%}
     {%- if !args.is_empty() %},{% endif -%}
@@ -41,19 +62,34 @@
     {# /* TODO: Improve error throwing. See https://github.com/mozilla/uniffi-rs/issues/295
           for details. */ -#}
     {{ rv }}.ThrowOperationError(nsDependentCString({{ err }}.mMessage));
+    return nimbus_1725_MozPromise::CreateAndReject(std::move(err), __func__);
     {%- when ThrowBy::Assert %}
     MOZ_ASSERT(false);
     {%- endmatch %}
-    return {% match func.cpp_return_type() %}{% when Some with (type_) %}{{ type_|dummy_ret_value_cpp(context) }}{% else %}{% endmatch %};
-  }
-  {%- match func.cpp_return_by() %}
-  {%- when ReturnBy::OutParam with (name, type_) %}
-  DebugOnly<bool> ok_ = {{ type_|lift_cpp(result, name, context) }};
-  MOZ_ASSERT(ok_);
-  {%- when ReturnBy::Value with (type_) %}
-  {{ type_|type_cpp(context) }} retVal_;
-  DebugOnly<bool> ok_ = {{ type_|lift_cpp(result, "retVal_", context) }};
-  MOZ_ASSERT(ok_);
-  return retVal_;
-  {%- when ReturnBy::Void %}{%- endmatch %}
-{%- endmacro -%}
+
+    return nimbus_1725_MozPromise::CreateAndResolve(std::move(loweredRetVal_), __func__);
+  })->Then(GetCurrentSerialEventTarget(), __func__,
+    [promise]({{ context.ffi_rustbuffer_type() }} rustBuf) {
+      /* resolve DOM promise */
+
+      {%- match func.cpp_return_by() %}
+      {%- when ReturnBy::OutParam with (name, type_) %}
+      DebugOnly<bool> ok_ = {{ type_|lift_cpp(result, name, context) }};
+      MOZ_ASSERT(ok_);
+      {%- when ReturnBy::Value with (type_) %}
+
+      { type_ | type_cpp(context) }} retVal_;
+      DebugOnly<bool> ok_ = {{ type_|lift_cpp(result, "retVal_", context) }};
+      MOZ_ASSERT(ok_);
+      promise->MaybeResolve(retVal_);
+      {%- when ReturnBy::Void %}
+      promise->MaybeResolve(void);
+      {%- endmatch %}
+    },
+    [promise]({{ context.ffi_rusterror_type() }} err) {
+      // XXX put the message into the error
+      // (a la aRv.ThrowOperationError(nsDependentCString(err.mMessage))
+      promise->MaybeReject(NS_ERROR_FAILURE);
+    });
+  return promise.forget(); // XXX i assume .forget is needed, check on this
+  {%- endmacro -%}

--- a/uniffi_bindgen/src/bindings/gecko_js/templates/macros.cpp
+++ b/uniffi_bindgen/src/bindings/gecko_js/templates/macros.cpp
@@ -20,23 +20,25 @@
   RefPtr<nsISerialEventTarget> backgroundET = GetBackgroundTarget();
   mozilla::InvokeAsync(
       backgroundET, __func__,
-      [mHandle=mHandle]() { // XXX should be templ vars, not literal
+      [mHandle=mHandle
+        {%- let args = func.arguments() -%}
+        {%- if !args.is_empty() %},{% endif -%}
+        {%- for arg in args %}
+        {{ arg.name() }}={{ arg.name()}}{%- if !loop.last %},{% endif -%}
+        {%- endfor %}]() {
         if (XRE_IsParentProcess() && NS_IsMainThread()) {
           MOZ_CRASH("lambda called outside of parent process main thread");
-      }
+        }
 
       {{ context.ffi_rusterror_type() }} err = {0, nullptr};
-
       {% match func.ffi_func().return_type() %}
-      {% when Some with(type_) %}const {{ type_|type_ffi(context) }} loweredRetVal_ = {% else %}{% endmatch %}{{ func.ffi_func().name() }}(
+      {% when Some with(type_) %}const {{ type_|type_ffi(context) }} loweredRetVal_ =  {% else %}
+      {% endmatch %}{{ func.ffi_func().name() }}(
     {{ prefix }}
-    {%- let args = func.arguments() -%}
     {%- if !args.is_empty() %},{% endif -%}
     {%- for arg in args %}
     {{ arg.webidl_type()|lower_cpp(arg.name(), context) }}{%- if !loop.last %},{% endif -%}
-    {%- endfor %}
-    , &err
-  );
+    {%- endfor %}, &err);
   {%- call _to_ffi_call_tail(context, func, "err", "loweredRetVal_") -%}
 {%- endmacro -%}
 
@@ -56,20 +58,19 @@
 
 {# /* Handles errors and lifts the return value from an FFI function. */ #}
 {%- macro _to_ffi_call_tail(context, func, err, result) %}
-  if ({{ err }}.mCode) {
-    {%- match func.cpp_throw_by() %}
-    {%- when ThrowBy::ErrorResult with (rv) %}
-    {# /* TODO: Improve error throwing. See https://github.com/mozilla/uniffi-rs/issues/295
-          for details. */ -#}
-    {{ rv }}.ThrowOperationError(nsDependentCString({{ err }}.mMessage));
-    return nimbus_1725_MozPromise::CreateAndReject(std::move(err), __func__);
-    {%- when ThrowBy::Assert %}
-    MOZ_ASSERT(false);
-    {%- endmatch %}
+    if ({{ err }}.mCode) {
+      {%- match func.cpp_throw_by() %}
+      {%- when ThrowBy::ErrorResult with (rv) %}
+      {# /* TODO: Improve error throwing. See https://github.com/mozilla/uniffi-rs/issues/295
+          for details. XXXdmose code below is different now that we're async */ -#}
+      return nimbus_1725_MozPromise::CreateAndReject(std::move({{ err }}), __func__);
+      {%- when ThrowBy::Assert %}
+      {%- endmatch %}
+    }
 
-    return nimbus_1725_MozPromise::CreateAndResolve(std::move(loweredRetVal_), __func__);
+    return nimbus_1725_MozPromise::CreateAndResolve(std::move({{ result }}), __func__);
   })->Then(GetCurrentSerialEventTarget(), __func__,
-    [promise]({{ context.ffi_rustbuffer_type() }} rustBuf) {
+    [promise]({% match func.ffi_func().return_type() %}{% when Some with (type_) %}const {{ type_|type_ffi(context) }} {% else %}{% endmatch %} {{result}}) {
       /* resolve DOM promise */
 
       {%- match func.cpp_return_by() %}
@@ -77,8 +78,7 @@
       DebugOnly<bool> ok_ = {{ type_|lift_cpp(result, name, context) }};
       MOZ_ASSERT(ok_);
       {%- when ReturnBy::Value with (type_) %}
-
-      { type_ | type_cpp(context) }} retVal_;
+      {{ type_|type_cpp(context) }} retVal_;
       DebugOnly<bool> ok_ = {{ type_|lift_cpp(result, "retVal_", context) }};
       MOZ_ASSERT(ok_);
       promise->MaybeResolve(retVal_);

--- a/uniffi_bindgen/src/bindings/gecko_js/templates/macros.cpp
+++ b/uniffi_bindgen/src/bindings/gecko_js/templates/macros.cpp
@@ -21,11 +21,13 @@
   mozilla::InvokeAsync(
       backgroundET, __func__,
       [mHandle=mHandle
-        {%- let args = func.arguments() -%}
-        {%- if !args.is_empty() %},{% endif -%}
-        {%- for arg in args %}
-        {{ arg.name() }}={{ arg.name()}}{%- if !loop.last %},{% endif -%}
-        {%- endfor %}]() {
+       {%- let args = func.arguments() -%}{%- if !args.is_empty() %},{% endif -%}
+
+       {%- for arg in args %}
+       {{ arg.name() }}={% match arg.type_() %}{% when Type::String %}PromiseFlatString({{ arg.name() }}){% else %}{{ arg.name() }}{% endmatch %}
+
+      {%- if !loop.last %},{% endif -%}
+      {%- endfor %}]() {
         if (XRE_IsParentProcess() && NS_IsMainThread()) {
           MOZ_CRASH("lambda called outside of parent process main thread");
         }

--- a/uniffi_bindgen/src/bindings/gecko_js/webidl.rs
+++ b/uniffi_bindgen/src/bindings/gecko_js/webidl.rs
@@ -279,7 +279,7 @@ impl MethodExt for Method {
             .filter(|type_| type_.needs_out_param())
         {
             // ...But they can take out params, since they return values.
-            result.push(CPPArgument::Out(type_));
+            //result.push(CPPArgument::Out(type_));
         }
         if self.throws().is_some() {
             // ...And they can throw.
@@ -403,11 +403,13 @@ pub enum ReturnBy {
 
 impl ReturnBy {
     fn from_return_type(type_: WebIDLType) -> Self {
-        if type_.needs_out_param() {
-            ReturnBy::OutParam("aRetVal", type_)
-        } else {
-            ReturnBy::Value(type_)
-        }
+        // if type_.needs_out_param() {
+        //     ReturnBy::OutParam("aRetVal", type_)
+        // } else {
+        //     ReturnBy::Value(type_)
+        // }
+        ReturnBy::Value(type_)
+
     }
 }
 


### PR DESCRIPTION
Here's a PR that makes the gecko_js bindings more or less entirely async.  Excitingly, it makes the 'hot garbage' that Lena's comments refer to even hotter _and_ garbagier! A bunch of cleanup will be needed here, post-demo...

I've checked in the WebIDL and C++ generated by this branch into the `io-work` branch.

Each time I change one of the uniffi templates, I've been using this shell command from the uniffi_bindgen directory of my own uniffi_rs repo on this branch:

```
cargo run -- generate ../../mozilla-central/third_party/rust/nimbus-sdk/src/nimbus.idl -l gecko_js \
 -o ../../mozilla-central/toolkit/components/nimbus && (cd ../mozilla-central && ./mach build)
```

to generate new C++ code into the right place in my mozilla-central tree and compile it.

