### PR TITLE
Don't use i32 helpers in generated Enum code.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,6 @@ members = [
   "examples/geometry",
   "examples/rondpoint",
   "examples/sprites",
-  "examples/todolist"
+  "examples/todolist",
+  "fixtures/regressions/enum-without-i32-helpers",
 ]

--- a/fixtures/regressions/README.md
+++ b/fixtures/regressions/README.md
@@ -1,0 +1,7 @@
+# Regression tests for uniffi components
+
+This directory contains standalone uniffi component crates designed
+as regression tests for specific historical bugs. They're written
+for automated execution and *not* for being easily understandable
+by users; if you're trying to get your head around uniffo then the
+"examples" directory will be a much better bet.

--- a/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
+++ b/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "i356-enum-without-int-helpers"
+edition = "2018"
+version = "0.5.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+name = "uniffi_regression_test_i356"
+
+[dependencies]
+uniffi_macros = {path = "../../../uniffi_macros"}
+uniffi = {path = "../../../uniffi", features=["builtin-bindgen"]}
+
+[build-dependencies]
+uniffi_build = {path = "../../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/regressions/enum-without-i32-helpers/README.md
+++ b/fixtures/regressions/enum-without-i32-helpers/README.md
@@ -1,0 +1,10 @@
+# Regression test for issue #356
+
+In issue [#356](https://github.com/mozilla/uniffi-rs/issues/356)
+we discovered that the generated bindings for Enum classes were
+using helper functions from the i32 data type, but we would only
+generate those functions if the component interface was also
+using that type directly.
+
+This crate is a minimal reproduction of the issue, and its Kotlin
+bindings would fail to compile in the presence of the bug.

--- a/fixtures/regressions/enum-without-i32-helpers/build.rs
+++ b/fixtures/regressions/enum-without-i32-helpers/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/test.udl").unwrap();
+}

--- a/fixtures/regressions/enum-without-i32-helpers/src/lib.rs
+++ b/fixtures/regressions/enum-without-i32-helpers/src/lib.rs
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pub enum Which {
+    Yeah,
+    Nah,
+}
+
+pub fn which(arg: bool) -> Which {
+    if arg {
+        Which::Yeah
+    } else {
+        Which::Nah
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/test.uniffi.rs"));

--- a/fixtures/regressions/enum-without-i32-helpers/src/test.udl
+++ b/fixtures/regressions/enum-without-i32-helpers/src/test.udl
@@ -1,0 +1,15 @@
+// We define an enum, and do not use the i32 datatype.
+// This should compile and run fine, but in https://github.com/mozilla/uniffi-rs/issues/356
+// we were accidentally assuming the presence of i32 datatype helpers in the generated code.
+//
+// Note that one of the important properties of this file is what it *doesn't* do,
+// i.e. that it doesn't directly use any integer types.
+
+enum Which {
+  "Yeah",
+  "Nah"
+};
+
+namespace regression_test_i356 {
+  Which which(boolean arg);
+};

--- a/fixtures/regressions/enum-without-i32-helpers/tests/bindings/test.kts
+++ b/fixtures/regressions/enum-without-i32-helpers/tests/bindings/test.kts
@@ -1,0 +1,8 @@
+// This is just a basic "it compiled and ran" test.
+// What we're really guarding against is failure to
+// compile the bindings as a result of buggy codegen.
+
+import uniffi.regression_test_i356.*;
+
+assert(which(true) == Which.YEAH)
+assert(which(false) == Which.NAH)

--- a/fixtures/regressions/enum-without-i32-helpers/tests/bindings/test.py
+++ b/fixtures/regressions/enum-without-i32-helpers/tests/bindings/test.py
@@ -1,0 +1,8 @@
+# This is just a basic "it loaded and ran" test.
+# What we're really guarding against is failure to
+# load the bindings as a result of buggy codegen.
+
+from regression_test_i356 import *
+
+assert which(True) == Which.YEAH
+assert which(False) == Which.NAH

--- a/fixtures/regressions/enum-without-i32-helpers/tests/bindings/test.swift
+++ b/fixtures/regressions/enum-without-i32-helpers/tests/bindings/test.swift
@@ -1,0 +1,8 @@
+// This is just a basic "it compiled and run" test.
+// What we're really guarding against is failure to
+// compile the bindings as a result of buggy codegen.
+
+import regression_test_i356
+
+assert(which(arg: true) == .yeah)
+assert(which(arg: false) == .nah)

--- a/fixtures/regressions/enum-without-i32-helpers/tests/test_generated_bindings.rs
+++ b/fixtures/regressions/enum-without-i32-helpers/tests/test_generated_bindings.rs
@@ -1,0 +1,8 @@
+uniffi_macros::build_foreign_language_testcases!(
+    "src/test.udl",
+    [
+        "tests/bindings/test.py",
+        "tests/bindings/test.kts",
+        "tests/bindings/test.swift",
+    ]
+);

--- a/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
@@ -10,10 +10,10 @@ enum class {{ e.name()|class_name_kt }} {
                 throw RuntimeException("invalid enum value, something is very wrong!!", e)
             }
 
-        internal fun read(buf: ByteBuffer) = lift(Int.read(buf))
+        internal fun read(buf: ByteBuffer) = lift(buf.getInt())
     }
 
     internal fun lower() = this.ordinal + 1
 
-    internal fun write(buf: RustBufferBuilder) = this.lower().write(buf)
+    internal fun write(buf: RustBufferBuilder) = buf.putInt(this.lower())
 }


### PR DESCRIPTION
Previously, the generated Kotlin code for enums would try to use
helpers from the `Int` companion class, but we would only emit the
code for those helpers if the interface was also using the integer
type.

Now, the generated Kotlin code for enums directly uses lower-level
methods for reading and writing integers, so that it doesn't depend
on other generated code.

Fixes #356.