### PR TITLE
Experiment with using raw pointers for objects.

### DIFF
--- a/docs/manual/book.toml
+++ b/docs/manual/book.toml
@@ -1,5 +1,5 @@
 [book]
-authors = ["Edouard Oger"]
+authors = ["Edouard Oger", "Ryan Kelly"]
 language = "en"
 multilingual = false
 src = "src"

--- a/docs/manual/src/SUMMARY.md
+++ b/docs/manual/src/SUMMARY.md
@@ -24,3 +24,9 @@ Hello everyone
 # Swift
 
 - [Integrating with XCode](./swift/xcode.md)
+
+# Internals
+
+- [Lifting, Lowering, and Serialization](./internals/lifting_and_lowering.md)
+  - [Serialization format](./internals/serialization_format.md)
+- [Managing object references](./internals/object_references.md)

--- a/docs/manual/src/internals/lifting_and_lowering.md
+++ b/docs/manual/src/internals/lifting_and_lowering.md
@@ -1,0 +1,3 @@
+# Lifting, Lowering and Serialization
+
+Here is where I will write about lifting and lowering.

--- a/docs/manual/src/internals/object_references.md
+++ b/docs/manual/src/internals/object_references.md
@@ -1,0 +1,3 @@
+# Managing Object References
+
+Here is where I'll talk about handlemaps, and about the upcoming "threadsafe" mode.

--- a/docs/manual/src/internals/serialization_format.md
+++ b/docs/manual/src/internals/serialization_format.md
@@ -1,0 +1,3 @@
+# Serialization Format
+
+Here is where I will describe our incredibly basic serialization format.

--- a/docs/manual/src/udl/interfaces.md
+++ b/docs/manual/src/udl/interfaces.md
@@ -156,7 +156,7 @@ impl Counter {
 }
 ```
 
-This version uses the `AtomicU64` struct for interior mutability, which is both `Sync` and
+This version uses an `AtomicU64` for interior mutability, which is both `Sync` and
 `Send` and hence will compile successfully:
 
 ```rust
@@ -178,6 +178,3 @@ impl Counter {
     }
 }
 ```
-
-Uniffi aims to uphold Rust's safety guarantees at all times, without requiring the
-foreign-language code to know or care about them.

--- a/examples/rondpoint/src/lib.rs
+++ b/examples/rondpoint/src/lib.rs
@@ -70,7 +70,7 @@ fn switcheroo(b: bool) -> bool {
 // Even if roundtripping works, it's possible we have
 // symmetrical errors that cancel each other out.
 #[derive(Debug, Clone)]
-struct Retourneur;
+pub struct Retourneur;
 impl Retourneur {
     fn new() -> Self {
         Retourneur
@@ -129,7 +129,7 @@ impl Retourneur {
 }
 
 #[derive(Debug, Clone)]
-struct Stringifier;
+pub struct Stringifier;
 
 #[allow(dead_code)]
 impl Stringifier {
@@ -175,7 +175,7 @@ impl Stringifier {
 }
 
 #[derive(Debug, Clone)]
-struct Optionneur;
+pub struct Optionneur;
 impl Optionneur {
     fn new() -> Self {
         Optionneur

--- a/examples/sprites/tests/test_generated_bindings.rs
+++ b/examples/sprites/tests/test_generated_bindings.rs
@@ -1,7 +1,7 @@
 uniffi_macros::build_foreign_language_testcases!(
     "src/sprites.udl",
     [
-        // "tests/bindings/test_sprites.py",
+        "tests/bindings/test_sprites.py",
         "tests/bindings/test_sprites.kts",
         "tests/bindings/test_sprites.swift",
     ]

--- a/examples/todolist/tests/test_generated_bindings.rs
+++ b/examples/todolist/tests/test_generated_bindings.rs
@@ -3,6 +3,6 @@ uniffi_macros::build_foreign_language_testcases!(
     [
         "tests/bindings/test_todolist.kts",
         "tests/bindings/test_todolist.swift",
-        // "tests/bindings/test_todolist.py"
+        "tests/bindings/test_todolist.py"
     ]
 );

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -17,6 +17,7 @@ bytes = "0.5"
 ffi-support = "~0.4.2"
 lazy_static = "1.4"
 log = "0.4"
+static_assertions = "1"
 # Regular dependencies
 cargo_metadata = "0.11"
 paste = "1.0"

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -47,6 +47,7 @@ pub mod deps {
     pub use ffi_support;
     pub use lazy_static;
     pub use log;
+    pub use static_assertions;
 }
 
 /// Trait defining how to transfer values via the FFI layer.

--- a/uniffi_bindgen/src/bindings/gecko_js/gen_gecko_js.rs
+++ b/uniffi_bindgen/src/bindings/gecko_js/gen_gecko_js.rs
@@ -331,6 +331,7 @@ mod filters {
             FFIType::UInt64 => "uint64_t".into(),
             FFIType::Float32 => "float".into(),
             FFIType::Float64 => "double".into(),
+            FFIType::Pointer(_) => "void*".into(), // TODO: name the type
             FFIType::RustCString => "const char*".into(),
             FFIType::RustBuffer => context.ffi_rustbuffer_type(),
             FFIType::RustError => context.ffi_rusterror_type(),

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin.rs
@@ -102,6 +102,7 @@ mod filters {
             FFIType::Int64 | FFIType::UInt64 => "Long".to_string(),
             FFIType::Float32 => "Float".to_string(),
             FFIType::Float64 => "Double".to_string(),
+            FFIType::Pointer(_) => "Pointer".to_string(), // TODO: name the type?
             FFIType::RustCString => "Pointer".to_string(),
             FFIType::RustBuffer => "RustBuffer.ByValue".to_string(),
             FFIType::RustError => "RustError".to_string(),

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
@@ -2,16 +2,16 @@
 // This would be a good candidate for isolating in its own ffi-support lib.
 
 abstract class FFIObject(
-    private val handle: AtomicLong
+    private val pointer: AtomicReference<Pointer?>
 ) {
     open fun destroy() {
-        this.handle.set(0L)
+        this.pointer.set(null)
     }
 
-    internal inline fun <R> callWithHandle(block: (handle: Long) -> R) =
-        this.handle.get().let { handle -> 
-            if (handle != 0L) {
-                block(handle)
+    internal inline fun <R> callWithPointer(block: (pointer: Pointer) -> R) =
+        this.pointer.get().let { pointer ->
+            if (pointer != null) {
+                block(pointer)
             } else {
                 throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
             }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -9,8 +9,8 @@ public interface {{ obj.name()|class_name_kt }}Interface {
 }
 
 class {{ obj.name()|class_name_kt }}(
-    handle: Long
-) : FFIObject(AtomicLong(handle)), {{ obj.name()|class_name_kt }}Interface {
+    ptr: Pointer
+) : FFIObject(AtomicReference(ptr)), {{ obj.name()|class_name_kt }}Interface {
 
     {%- for cons in obj.constructors() %}
     constructor({% call kt::arg_list_decl(cons) -%}) :
@@ -19,16 +19,16 @@ class {{ obj.name()|class_name_kt }}(
 
     /**
      * Disconnect the object from the underlying Rust object.
-     * 
+     *
      * It can be called more than once, but once called, interacting with the object 
      * causes an `IllegalStateException`.
-     * 
+     *
      * Clients **must** call this method once done with the object, or cause a memory leak.
      */
     override fun destroy() {
         try {
-            callWithHandle {
-                super.destroy() // poison the handle so no-one else can use it before we tell rust.
+            callWithPointer {
+                super.destroy() // poison the pointer so no-one else can use it before we tell rust.
                 rustCall(InternalError.ByReference()) { err ->
                     _UniFFILib.INSTANCE.{{ obj.ffi_object_free().name() }}(it, err)
                 }
@@ -43,7 +43,7 @@ class {{ obj.name()|class_name_kt }}(
 
     {%- when Some with (return_type) -%}
     override fun {{ meth.name()|fn_name_kt }}({% call kt::arg_list_protocol(meth) %}): {{ return_type|type_kt }} =
-        callWithHandle {
+        callWithPointer {
             {%- call kt::to_ffi_call_with_prefix("it", meth) %}
         }.let {
             {{ "it"|lift_kt(return_type) }}
@@ -51,7 +51,7 @@ class {{ obj.name()|class_name_kt }}(
     
     {%- when None -%}
     override fun {{ meth.name()|fn_name_kt }}({% call kt::arg_list_protocol(meth) %}) =
-        callWithHandle {
+        callWithPointer {
             {%- call kt::to_ffi_call_with_prefix("it", meth) %} 
         }
     {% endmatch %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/wrapper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/wrapper.kt
@@ -23,7 +23,7 @@ import com.sun.jna.Pointer
 import com.sun.jna.Structure
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 {% include "RustBufferTemplate.kt" %}
 

--- a/uniffi_bindgen/src/bindings/python/gen_python.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python.rs
@@ -58,6 +58,7 @@ mod filters {
             FFIType::UInt64 => "ctypes.c_uint64".to_string(),
             FFIType::Float32 => "ctypes.c_float".to_string(),
             FFIType::Float64 => "ctypes.c_double".to_string(),
+            FFIType::Pointer(_) => "ctypes.c_voidp".to_string(), // TODO: name the type?
             FFIType::RustCString => "ctypes.c_voidp".to_string(),
             FFIType::RustBuffer => "RustBuffer".to_string(),
             FFIType::RustError => "ctypes.POINTER(RustError)".to_string(),

--- a/uniffi_bindgen/src/bindings/swift/gen_swift.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift.rs
@@ -151,6 +151,7 @@ mod filters {
             FFIType::UInt64 => "uint64_t".into(),
             FFIType::Float32 => "float".into(),
             FFIType::Float64 => "double".into(),
+            FFIType::Pointer(_) => "void*_Nonnull".into(), // TODO: name the type?
             FFIType::RustCString => "const char*_Nonnull".into(),
             FFIType::RustBuffer => "RustBuffer".into(),
             FFIType::RustError => "NativeRustError".into(),

--- a/uniffi_bindgen/src/interface/types.rs
+++ b/uniffi_bindgen/src/interface/types.rs
@@ -49,6 +49,8 @@ pub enum FFIType {
     Int64,
     Float32,
     Float64,
+    /// A pointer to a named struct type.
+    Pointer(String),
     /// A `char*` pointer belonging to a rust-owned CString.
     /// If you've got one of these, you must call the appropriate rust function to free it.
     /// This is currently only used for error messages, and may go away in future.
@@ -124,8 +126,8 @@ impl From<&Type> for FFIType {
             // Strings are always owned rust values.
             // We might add a separate type for borrowed strings in future.
             Type::String => FFIType::RustBuffer,
-            // Objects are passed as opaque integer handles.
-            Type::Object(_) => FFIType::UInt64,
+            // Objects are passed as raw pointers.
+            Type::Object(name) => FFIType::Pointer(name.into()),
             // Enums are passed as integers.
             Type::Enum(_) => FFIType::UInt32,
             // Errors have their own special type.

--- a/uniffi_bindgen/src/scaffolding.rs
+++ b/uniffi_bindgen/src/scaffolding.rs
@@ -57,6 +57,7 @@ mod filters {
             FFIType::UInt64 => "u64".into(),
             FFIType::Float32 => "f32".into(),
             FFIType::Float64 => "f64".into(),
+            FFIType::Pointer(name) => format!("Option<Box<{}>>", name),
             FFIType::RustCString => "*mut std::os::raw::c_char".into(),
             FFIType::RustBuffer => "uniffi::RustBuffer".into(),
             FFIType::RustError => "uniffi::deps::ffi_support::ExternError".into(),

--- a/uniffi_bindgen/src/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/templates/ObjectTemplate.rs
@@ -1,28 +1,39 @@
 // For each Object definition, we assume the caller has provided an appropriately-shaped `struct`
-// with an `impl` for each method on the object. We create a `ConcurrentHandleMap` for safely handing
-// out references to these structs to foreign language code, and we provide a `pub extern "C"` function
-// corresponding to each method.
+// with an `impl` for each method on the object. We generate some boxing code in order to represent
+// instances of this struct as raw pointers in the FFI, and some static assertions to ensure this
+// is safe (well...TBD exactly the circumstances under which this is safe, but it's a start).
+// We provide a `pub extern "C"` function corresponding to each method on the object, which takes
+// an instance pointer as first argument.
 //
 // If the caller's implementation of the struct does not match with the methods or types specified
 // in the UDL, then the rust compiler will complain with a (hopefully at least somewhat helpful!)
 // error message when processing this generated code.
-{% let handle_map = format!("UNIFFI_HANDLE_MAP_{}", obj.name().to_uppercase()) %}
-uniffi::deps::lazy_static::lazy_static! {
-    static ref {{ handle_map }}: uniffi::deps::ffi_support::ConcurrentHandleMap<{{ obj.name() }}> = uniffi::deps::ffi_support::ConcurrentHandleMap::new();
+
+// Pass objects across the FFI as pointers, in using a box.
+//
+// Per the `Box` docs:
+// "So long as T: Sized, a Box<T> is guaranteed to be represented as a single pointer and is also ABI-compatible with C pointers".
+//
+// Note that implementing `IntoFfi` for `T` asserts that `T: Sized`.
+
+unsafe impl uniffi::deps::ffi_support::IntoFfi for {{ obj.name() }} {
+    type Value = Option<Box<{{ obj.name() }}>>;
+    fn ffi_default() -> Self::Value { None }
+    fn into_ffi_value(self) -> Self::Value { Some(Box::new(self)) }
 }
 
-    {% let ffi_free = obj.ffi_object_free() -%}
-    #[no_mangle]
-    pub extern "C" fn {{ ffi_free.name() }}(handle: u64) {
-        let _ = {{ handle_map }}.delete_u64(handle);
-    }
+#[no_mangle]
+pub extern "C" fn {{ obj.ffi_object_free().name() }}(obj : Option<Box<{{ obj.name() }}>>) {
+    drop(obj);
+}
 
 {%- for cons in obj.constructors() %}
     #[allow(clippy::all)]
     #[no_mangle]
     pub extern "C" fn {{ cons.ffi_func().name() }}(
-        {%- call rs::arg_list_ffi_decl(cons.ffi_func()) %}) -> u64 {
-        uniffi::deps::log::debug!("{{ cons.ffi_func().name() }}");
+        {%- call rs::arg_list_ffi_decl(cons.ffi_func()) %}
+    ) -> Option<Box<{{ obj.name() }}>> {
+        uniffi::deps::log::debug!("{{ cons.ffi_func().name() }} - raw pointer version");
         // If the constructor does not have the same signature as declared in the UDL, then
         // this attempt to call it will fail with a (somewhat) helpful compiler error.
         {% call rs::to_rs_constructor_call(obj, cons) %}
@@ -35,7 +46,7 @@ uniffi::deps::lazy_static::lazy_static! {
     pub extern "C" fn {{ meth.ffi_func().name() }}(
         {%- call rs::arg_list_ffi_decl(meth.ffi_func()) %}
     ) -> {% call rs::return_type_func(meth) %} {
-        uniffi::deps::log::debug!("{{ meth.ffi_func().name() }}");
+        uniffi::deps::log::debug!("{{ meth.ffi_func().name() }} - raw pointer version");
         // If the method does not have the same signature as declared in the UDL, then
         // this attempt to call it will fail with a (somewhat) helpful compiler error.
         {% call rs::to_rs_method_call(obj, meth) %}

--- a/uniffi_bindgen/src/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/templates/ObjectTemplate.rs
@@ -22,6 +22,9 @@ unsafe impl uniffi::deps::ffi_support::IntoFfi for {{ obj.name() }} {
     fn into_ffi_value(self) -> Self::Value { Some(Box::new(self)) }
 }
 
+// For thread-safety, we only support raw pointers on things that are Sync and Send.
+uniffi::deps::static_assertions::assert_impl_all!({{ obj.name() }}: Sync, Send);
+
 #[no_mangle]
 pub extern "C" fn {{ obj.ffi_object_free().name() }}(obj : Option<Box<{{ obj.name() }}>>) {
     drop(obj);

--- a/uniffi_bindgen/src/templates/macros.rs
+++ b/uniffi_bindgen/src/templates/macros.rs
@@ -38,12 +38,12 @@
 {% macro to_rs_constructor_call(obj, cons) %}
 {% match cons.throws() %}
 {% when Some with (e) %}
-UNIFFI_HANDLE_MAP_{{ obj.name()|upper }}.insert_with_result(err, || -> Result<{{obj.name()}}, {{e}}> {
+uniffi::deps::ffi_support::call_with_result(err, || -> Result<{{ obj.name() }}, {{e}}> {
     let _retval = {{ obj.name() }}::{% call to_rs_call(cons) %}?;
     Ok(_retval)
 })
 {% else %}
-UNIFFI_HANDLE_MAP_{{ obj.name()|upper }}.insert_with_output(err, || {
+uniffi::deps::ffi_support::call_with_output(err, || {
     {{ obj.name() }}::{% call to_rs_call(cons) %}
 })
 {% endmatch %}
@@ -52,12 +52,22 @@ UNIFFI_HANDLE_MAP_{{ obj.name()|upper }}.insert_with_output(err, || {
 {% macro to_rs_method_call(obj, meth) %}
 {% match meth.throws() %}
 {% when Some with (e) %}
-UNIFFI_HANDLE_MAP_{{ obj.name()|upper }}.call_with_result_mut(err, {{ meth.first_argument().name() }}, |obj| -> Result<{% call return_type_func(meth) %}, {{e}}> {
+uniffi::deps::ffi_support::call_with_result(err, || -> Result<{% call return_type_func(meth) %}, {{e}}> {
+    // We're declaring the argument type as an `Option<Box<T>>` but the value is owned by the foreign code,
+    // we so don't want to drop the Box. Probably it would be better to encode this as a reference type.
+    let mut obj_box = std::mem::ManuallyDrop::new(obj.expect("Must receive a non-null object pointer"));
+    // TODO: terrifically unsafe to assume we can take a mutable reference here! Needs locks etc.
+    let obj = obj_box.as_mut();
     let _retval = {{ obj.name() }}::{%- call to_rs_call_with_prefix("obj", meth) -%}?;
     Ok({% call ret(meth) %})
 })
 {% else %}
-UNIFFI_HANDLE_MAP_{{ obj.name()|upper }}.call_with_output_mut(err, {{ meth.first_argument().name() }}, |obj| {
+uniffi::deps::ffi_support::call_with_output(err, || {
+    // We're declaring the argument type as an `Option<Box<T>>` but the value is owned by the foreign code,
+    // we so don't want to drop the Box. Probably it would be better to encode this as a reference type.
+    let mut obj_box = std::mem::ManuallyDrop::new(obj.expect("Must receive a non-null object pointer"));
+    // TODO: terrifically unsafe to assume we can take a mutable reference here! Needs locks etc.
+    let obj = obj_box.as_mut();
     let _retval = {{ obj.name() }}::{%- call to_rs_call_with_prefix("obj", meth) -%};
     {% call ret(meth) %}
 })

--- a/uniffi_bindgen/src/templates/macros.rs
+++ b/uniffi_bindgen/src/templates/macros.rs
@@ -55,9 +55,9 @@ uniffi::deps::ffi_support::call_with_output(err, || {
 uniffi::deps::ffi_support::call_with_result(err, || -> Result<{% call return_type_func(meth) %}, {{e}}> {
     // We're declaring the argument type as an `Option<Box<T>>` but the value is owned by the foreign code,
     // we so don't want to drop the Box. Probably it would be better to encode this as a reference type.
-    let mut obj_box = std::mem::ManuallyDrop::new(obj.expect("Must receive a non-null object pointer"));
+    let obj_box = std::mem::ManuallyDrop::new(obj.expect("Must receive a non-null object pointer"));
     // TODO: terrifically unsafe to assume we can take a mutable reference here! Needs locks etc.
-    let obj = obj_box.as_mut();
+    let obj = obj_box.as_ref();
     let _retval = {{ obj.name() }}::{%- call to_rs_call_with_prefix("obj", meth) -%}?;
     Ok({% call ret(meth) %})
 })
@@ -65,9 +65,9 @@ uniffi::deps::ffi_support::call_with_result(err, || -> Result<{% call return_typ
 uniffi::deps::ffi_support::call_with_output(err, || {
     // We're declaring the argument type as an `Option<Box<T>>` but the value is owned by the foreign code,
     // we so don't want to drop the Box. Probably it would be better to encode this as a reference type.
-    let mut obj_box = std::mem::ManuallyDrop::new(obj.expect("Must receive a non-null object pointer"));
+    let obj_box = std::mem::ManuallyDrop::new(obj.expect("Must receive a non-null object pointer"));
     // TODO: terrifically unsafe to assume we can take a mutable reference here! Needs locks etc.
-    let obj = obj_box.as_mut();
+    let obj = obj_box.as_ref();
     let _retval = {{ obj.name() }}::{%- call to_rs_call_with_prefix("obj", meth) -%};
     {% call ret(meth) %}
 })

--- a/uniffi_bindgen/src/templates/scaffolding_template.rs
+++ b/uniffi_bindgen/src/templates/scaffolding_template.rs
@@ -38,9 +38,11 @@
 {% endfor -%}
 
 // For each Object definition, we assume the caller has provided an appropriately-shaped `struct`
-// with an `impl` for each method on the object. We create a `ConcurrentHandleMap` for safely handing
-// out references to these structs to foreign language code, and we provide a `pub extern "C"` function
-// corresponding to each method.
+// with an `impl` for each method on the object. We generate some boxing code in order to represent
+// instances of this struct as raw pointers in the FFI, and some static assertions to ensure this
+// is safe (well...TBD exactly the circumstances under which this is safe, but it's a start).
+// We provide a `pub extern "C"` function corresponding to each method on the object, which takes
+// an instance pointer as first argument.
 //
 // If the caller's implementation of the struct does not match with the methods or types specified
 // in the UDL, then the rust compiler will complain with a (hopefully at least somewhat helpful!)


### PR DESCRIPTION
Opening for early visibility.

As noted in [SDK-157](https://jira.mozilla.com/browse/SDK-157), the way we use a `ConcurrentHandleMap` for managing objects means that we foist certain threading/locking behaviors on all API conumers. It's currently only possible for a single thread to be operating on a given Rust object at any one time, even if there are operations that could safely be performed without synchronization. This is making it awkward to create the desired API for the Nimbus SDK, where we want to offer a synchronous `getExperimentBranch` method that will return immediately, even if there is a concurrent `updateExperiments` call running on a another thread.

A little while back, @thomcc posted the excellent https://github.com/mozilla/uniffi-rs/issues/244 discussing sources of overhead in uniffi, and one thing he suggested there was that we could consider using raw pointers instead of a `HandleMap`. Many of the features of `HandleMap` are designed to guard against programmer error, so they're more useful in a manually-written FFI layer than in generated bindings.

This PR is me experimenting with using raw pointers instead of a `ConcurrentHandleMap`. I plan to use it to see whether the handlemap is indeed the source of the blocking behaviour seen in [SDK-157](https://jira.mozilla.com/browse/SDK-157).

This is emphatically *not* suitable for merging, and in fact it contains known very-dangerous-completely-unsafe behaviours (such as just assuming we can get an `&mut T` from a pointer interpreted as a `Box<T>` without worrying about a little thing called *locking*). I need to get my head around what would be required to make this safe, but the unsafe version is suitable for my investigations in the meantime.