### PR TITLE
Add some narrative docs about important internal implementation details.

### DIFF
--- a/docs/manual/src/SUMMARY.md
+++ b/docs/manual/src/SUMMARY.md
@@ -24,3 +24,8 @@ Hello everyone
 # Swift
 
 - [Integrating with XCode](./swift/xcode.md)
+
+# Internals
+
+- [Lifting, Lowering, and Serialization](./internals/lifting_and_lowering.md)
+- [Managing object references](./internals/object_references.md)

--- a/docs/manual/src/internals/lifting_and_lowering.md
+++ b/docs/manual/src/internals/lifting_and_lowering.md
@@ -1,0 +1,94 @@
+# Lifting, Lowering and Serialization
+
+Uniffi is able to transfer rich data types back-and-forth between the Rust
+code and the foreign-language code via a process we refer to as "lowering"
+and "lifting".
+
+Recall that uniffi interoperates between different languages by defining
+a C-style FFI layer which operates in terms of primitive data types and
+plain functions. To transfer data from one side of this layer to the other,
+the sending side "***lowers***" the data from a language-specific data type
+into one of the primitive types supported by the FFI-layer functions, and the
+receiving side "***lifts***" that primitive type into its own language-specific
+data type.
+
+Lifting and lowering simple types such as integers is done by directly casting the
+value to and from an appropriate type. For complex types such as optionals and
+records we currently implement lifting and lowering by serializing into a byte
+buffer, but this is an implementation detail that may change in future. (See
+[ADR-0002](/docs/adr/0002-serialize-complex-datatypes.md) for the reasoning
+behind this choice).
+
+As a concrete example, consider this interface for accumulating a list of integers:
+
+```idl
+namespace example {
+  sequence<i32> add_to_list(i32 item);
+}
+```
+
+Calling this function from foreign language code involves the following steps:
+
+1. The user-provided calling code invokes the `add_to_list` function that is expoed by the
+   uniffi-generated foreign language bindings, passing `item` as an appropriate language-native
+   integer.
+2. The foreign language bindings ***lower*** each argument to a function call into
+   something that can be passed over the C-style FFI. Since the `item` argument is a plain integer,
+   it is lowered by casting to an `int32_t`.
+3. The foreign language bindings pass the lowered arguments to a C FFI function named
+   like `example_XYZ_add_to_list` that is exposed by the uniffi-generated Rust scaffolding.
+4. The Rust scaffolding ***lifts*** each argument received over the FFI into a native
+   Rust type. Since `item` is a plain integer it is lifted by casting to a Rust `i32`.
+5. The Rust scaffolding passes the lifted arguments to the user-provided Rust code for
+   the `add_to_list` function, which returns a `Vec<i32>`.
+6. The Rust scaffolding now needs to ***lower*** the return value in order to pass it back
+   to the foreign language code. Since this is a complex data type, it is lowered by serializing
+   the values into a byte buffer and returning the buffer pointer and length from the
+   FFI function.
+7. The foreign language bindings receive the return value and need to ***lift*** it into an
+   appropriate native data type. Since it is a complex data type, it is lifted by deserializing
+   from the returned byte buffer into a language-native list of integers.
+
+## Lowered Types
+
+| UDL Type | Representation in the C FFI |
+|----------|-----------------------------|
+| `i8`/`i16`/`i32`/`i64` | `int8_t`/`int16_t`/`int32_t`/`int64_t` |
+| `u8`/`u16`/`u32`/`u64` | `uint8_t`/`uint16_t`/`uint32_t`/`uint64_t` |
+| `f32`/`float` | `float` |
+| `f64`/`double` | `double` |
+| `boolean` | `int8_t`, either `0` or `1` |
+| `string` | `RustBuffer` struct pointing to utf8 bytes |
+| `T?` | `RustBuffer` struct pointing to serialized bytes |
+| `sequence<T>` | `RustBuffer` struct pointing to serialized bytes |
+| `record<string, T>` | `RustBuffer` struct pointing to serialized bytes |
+| `enum` | `uint32_t` indicating variant, numbered in declaration order starting from 1  |
+| `dictionary` | `RustBuffer` struct pointing to serialized bytes |
+| `interface` | `uint64_t` opaque integer handle |
+
+
+## Serialization Format
+
+When serializing complex data types into a byte buffer, uniffi uses an
+ad-hoc fixed-width format which is designed mainly for simplicity.
+The details of this format are internal only and may change between versions of uniffi.
+
+| UDL Type | Representation in serialized bytes |
+|----------|-----------------------------|
+| `i8`/`i16`/`i32`/`i64` | Fixed-width 1/2/4/8-byte signed integer, big-endian|
+| `u8`/`u16`/`u32`/`u64` | Fixed-width 1/2/4/8-byte unsigned integer, big-endian |
+| `f32`/`float` | Fixed-width 4-byte float, big-endian |
+| `f64`/`double` | Fixed-width 8-byte double, big-endian |
+| `boolean` | Fixed-width 1-byte signed integer, either `0` or `1` |
+| `string` | Serialized `i32` length followed by utf-8 string bytes; no trailing null |
+| `T?` | If null, serialized `boolean` false; if non-null, serialized `boolean` true followed by serialized `T` |
+| `sequence<T>` | Serialized `i32` item count followed by serialized items; each item is a serialized `T` |
+| `record<string, T>` | Serialized `i32` item count followed by serialized items; each item is a serialized `string` followed by a serialized `T` |
+| `enum` | Serialized `u32` indicating variant, numbered in declaration order starting from 1 |
+| `dictionary` | The serialized value of each field, in declaration order |
+| `interface` | *Cannot currently be serialized* |
+
+Note that length fields in this format are serialized as *signed* integers
+despite the fact that they will always be non-negative. This is to help
+ease compatibility with JVM-based languages since the JVM uses signed 32-bit
+integers for its size fields internally.

--- a/docs/manual/src/internals/object_references.md
+++ b/docs/manual/src/internals/object_references.md
@@ -1,0 +1,86 @@
+# Managing Object References
+
+Uniffi [interfaces](../udl/interfaces.md) represent instances of objects
+that have methods and contain shared mutable state. One of Rust's core innovations
+is its ability to provide compile-time guarantees about working with such instances,
+including:
+
+* Ensuring that each instance has a unique owner responsible for disposing of it.
+* Ensuring that there is only a single writer *or* multiple readers of an object
+  active at any point in the program.
+* Guarding against data races.
+
+Uniffi aims to maintain these guarantees even when the Rust code is being invoked
+from a foreign language, at the cost of turning them into run-time checks rather
+than compile-time guarantees.
+
+We achieve this by indirecting all object access through a
+[handle map](https://docs.rs/ffi-support/0.4.0/ffi_support/handle_map/index.html),
+a mapping from opaque integer handles to object instances. This indirection
+imposes a small runtime cost but helps us guard against errors or oversights
+in the generated bindings.
+
+For each interface declared in the UDL, the uniffi-generated Rust scaffolding
+will create a global [ffi_support::ConcurrentHandleMap](https://docs.rs/ffi-support/0.4.0/ffi_support/handle_map/struct.ConcurrentHandleMap.html) that is responsible for owning all instances
+of that interface, and handing out references to them when methods are called.
+
+For example, given a interface definition like this:
+
+```idl
+interface TodoList {
+    constructor();
+    void add_item(string todo);
+    sequence<string> get_items();
+};
+```
+
+The Rust scaffolding would define a lazyily-initialized global static like:
+
+```rust
+lazy_static! {
+    static ref UNIFFI_HANDLE_MAP_TODOLIST: ConcurrentHandleMap<TodoList> = ConcurrentHandleMap::new();
+}
+```
+
+On the Rust side of the generated bindings, the instance constructor will create an instance of the
+corresponding `TodoList` Rust struct, insert it into the handlemap, and return the resulting integer
+handle to the foreign language code:
+
+```rust
+pub extern "C" fn todolist_TodoList_new(err: &mut ExternError) -> u64 {
+    // Give ownership of the new instance to the handlemap.
+    // We will only ever operate on borrowed references to it.
+    UNIFFI_HANDLE_MAP_TODOLIST.insert_with_output(err, || TodoList::new())
+}
+```
+
+When invoking a method on the instance, the foreign-language code passes the integer handle back
+to the Rust code, which borrows a reference to the instance from the handlemap for the duration
+of the method call:
+
+```rust
+pub extern "C" fn todolist_TodoList_add_item(handle: u64, todo: RustBuffer, err: &mut ExternError) -> () {
+    let todo = <String as uniffi::ViaFfi>::try_lift(todo).unwrap()
+    // Borrow a reference to the instance so that we can call a method on it.
+    UNIFFI_HANDLE_MAP_TODOLIST.call_with_result_mut(err, handle, |obj| -> Result<(), TodoError> {
+        TodoList::add_item(obj, todo)
+    })
+}
+```
+
+Finally, when the foreign-language code frees the instance, it passes the integer handle to
+a special destructor function so that the Rust code can delete it from the handlemap:
+
+```rust
+pub extern "C" fn ffi_todolist_TodoList_object_free(handle: u64) {
+    UNIFFI_HANDLE_MAP_TODOLIST.delete_u64(handle);
+}
+```
+
+This indirection gives us some important safety properties:
+
+* If the generated bindings incorrectly pass an invalid handle, or a handle for a different type of object,
+  then the handlemap will throw an error with high probability, providing some amount of run-time typechecking
+  for correctness of the generated bindings.
+* The `ConcurrentHandleMap` class wraps each instance with a `Mutex`, which serializes access to the instance
+  and upholds Rust's guarantees against shared mutable access.

--- a/docs/manual/src/udl/interfaces.md
+++ b/docs/manual/src/udl/interfaces.md
@@ -72,3 +72,21 @@ func display(list: TodoListProtocol) {
     }
 }
 ```
+
+## Concurrent Access
+
+Since interfaces represent mutable data, uniffi has to take extra care
+to uphold Rust's safety guarantees around shared and mutable references.
+The foreign-language code may attempt to operate on an interface instance
+from multiple threads, and it's important that this not violate Rust's
+assumption that there is at most a single mutable reference to a struct
+at any point in time.
+
+Uniffi enforces this using runtime locking. Each interface instance
+has an associated lock which is transparently acquired at the beginning of each
+call to a method of that instance, and released once the method returns. This
+approach is simple and safe, but it means that all method calls on an instance
+are run in a strictly sequential fashion, limiting concurrency.
+
+You can read more about the technical details in the docs on the
+[internal details of managing object references](../internals/object_references.md).


### PR DESCRIPTION
Specifically:

* What "lifting" and "lowering" are and how they're done.
* The serialization format we use for lowering complex data types.
* How and why we use handlemaps for managing object references.

(These describe the *current* state of the world, but I want to get them into the repo so that I can propose *diffs* to that state of the world in order to resolve the current threading/concurrency issues).

Fixes #297.