### PR TITLE
Add support for enums with associated data (aka "tagged unions", aka "sum types", aka ...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Things that are implemented so far:
 
 * Primitive numeric types, equivalents to those offered by Rust (`u32`, `f64`, etc).
 * Strings (which are always UTF-8, like Rust's `String`).
-* C-style enums (just the discriminant, no associated data).
+* Enums, including enums with associated data (aka "tagged unions" or "sum types").
 * C-style structs containing named fields (we call these *records*).
 * Sequences of all of the above (like Rust's `Vec<T>`).
 * Optional instances of all of the above (like Rust's `Option<T>`).
@@ -98,7 +98,6 @@ Things that are implemented so far:
 
 Things that are not implemented yet:
 
-* Enums with associated data.
 * Union types.
 * Efficient access to binary data (like Rust's `Vec<u8>`).
 * Passing object references to functions or methods.

--- a/docs/manual/src/internals/lifting_and_lowering.md
+++ b/docs/manual/src/internals/lifting_and_lowering.md
@@ -62,7 +62,7 @@ Calling this function from foreign language code involves the following steps:
 | `T?` | `RustBuffer` struct pointing to serialized bytes |
 | `sequence<T>` | `RustBuffer` struct pointing to serialized bytes |
 | `record<DOMString, T>` | `RustBuffer` struct pointing to serialized bytes |
-| `enum` | `uint32_t` indicating variant, numbered in declaration order starting from 1  |
+| `enum` and `[Enum] interface` | `RustBuffer` struct pointing to serialized bytes |
 | `dictionary` | `RustBuffer` struct pointing to serialized bytes |
 | `interface` | `uint64_t` opaque integer handle |
 
@@ -84,7 +84,7 @@ The details of this format are internal only and may change between versions of 
 | `T?` | If null, serialized `boolean` false; if non-null, serialized `boolean` true followed by serialized `T` |
 | `sequence<T>` | Serialized `i32` item count followed by serialized items; each item is a serialized `T` |
 | `record<DOMString, T>` | Serialized `i32` item count followed by serialized items; each item is a serialized `string` followed by a serialized `T` |
-| `enum` | Serialized `u32` indicating variant, numbered in declaration order starting from 1 |
+| `enum` and `[Enum] interface` | Serialized `i32` indicating variant, numbered in declaration order starting from 1, followed by the serialized values of the variant's fields in declaration order |
 | `dictionary` | The serialized value of each field, in declaration order |
 | `interface` | *Cannot currently be serialized* |
 

--- a/docs/manual/src/udl/enumerations.md
+++ b/docs/manual/src/udl/enumerations.md
@@ -1,6 +1,7 @@
 # Enumerations
 
 An enumeration defined in Rust code as
+
 ```rust
 enum Animal {
     Dog,
@@ -17,4 +18,25 @@ enum Animal {
 };
 ```
 
-Note that enumerations with associated data are not yet supported.
+Enumerations with associated data require a different syntax,
+due to the limitations of using WebIDL as the basis for UniFFI's interface language.
+An enum like this in Rust:
+
+```rust
+enum IpAddr {
+  V4 {q1: u8, q2: u8, q3: u8, q4: u8},
+  V6 {addr: string},
+}
+```
+
+Can be exposed in the UDL file with:
+
+```idl
+[Enum]
+interface IpAddr {
+  V4(u8 q1, u8 q2, u8 q3, u8 q4);
+  V6(string addr);
+};
+```
+
+Only enums with named fields are supported by this syntax.

--- a/examples/rondpoint/src/lib.rs
+++ b/examples/rondpoint/src/lib.rs
@@ -35,6 +35,13 @@ pub enum Enumeration {
     Trois,
 }
 
+#[derive(Debug, Clone)]
+pub enum EnumerationAvecDonnees {
+    Zero,
+    Un { premier: u32 },
+    Deux { premier: u32, second: String },
+}
+
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
 pub struct minusculeMAJUSCULEDict {
@@ -54,7 +61,9 @@ fn copie_enumerations(e: Vec<Enumeration>) -> Vec<Enumeration> {
     e
 }
 
-fn copie_carte(e: HashMap<String, Enumeration>) -> HashMap<String, Enumeration> {
+fn copie_carte(
+    e: HashMap<String, EnumerationAvecDonnees>,
+) -> HashMap<String, EnumerationAvecDonnees> {
     e
 }
 

--- a/examples/rondpoint/src/rondpoint.udl
+++ b/examples/rondpoint/src/rondpoint.udl
@@ -2,7 +2,7 @@ namespace rondpoint {
   Dictionnaire copie_dictionnaire(Dictionnaire d);
   Enumeration copie_enumeration(Enumeration e);
   sequence<Enumeration> copie_enumerations(sequence<Enumeration> e);
-  record<DOMString, Enumeration> copie_carte(record<DOMString, Enumeration> c);
+  record<DOMString, EnumerationAvecDonnees> copie_carte(record<DOMString, EnumerationAvecDonnees> c);
   boolean switcheroo(boolean b);
 };
 
@@ -18,6 +18,13 @@ enum Enumeration {
     "Un",
     "Deux",
     "Trois",
+};
+
+[Enum]
+interface EnumerationAvecDonnees {
+  Zero();
+  Un(u32 premier);
+  Deux(u32 premier, string second);
 };
 
 dictionary Dictionnaire {

--- a/examples/rondpoint/tests/bindings/test_rondpoint.kts
+++ b/examples/rondpoint/tests/bindings/test_rondpoint.kts
@@ -6,7 +6,24 @@ assert(dico == copyDico)
 
 assert(copieEnumeration(Enumeration.DEUX) == Enumeration.DEUX)
 assert(copieEnumerations(listOf(Enumeration.UN, Enumeration.DEUX)) == listOf(Enumeration.UN, Enumeration.DEUX))
-assert(copieCarte(mapOf("1" to Enumeration.UN, "2" to Enumeration.DEUX)) == mapOf("1" to Enumeration.UN, "2" to Enumeration.DEUX))
+assert(copieCarte(mapOf(
+    "0" to EnumerationAvecDonnees.Zero,
+    "1" to EnumerationAvecDonnees.Un(1u),
+    "2" to EnumerationAvecDonnees.Deux(2u, "deux")
+)) == mapOf(
+    "0" to EnumerationAvecDonnees.Zero,
+    "1" to EnumerationAvecDonnees.Un(1u),
+    "2" to EnumerationAvecDonnees.Deux(2u, "deux")
+))
+
+val var1: EnumerationAvecDonnees = EnumerationAvecDonnees.Zero
+val var2: EnumerationAvecDonnees = EnumerationAvecDonnees.Un(1u)
+val var3: EnumerationAvecDonnees = EnumerationAvecDonnees.Un(2u)
+assert(var1 != var2)
+assert(var2 != var3)
+assert(var1 == EnumerationAvecDonnees.Zero)
+assert(var1 != EnumerationAvecDonnees.Un(1u))
+assert(var2 == EnumerationAvecDonnees.Un(1u))
 
 assert(switcheroo(false))
 

--- a/examples/rondpoint/tests/bindings/test_rondpoint.py
+++ b/examples/rondpoint/tests/bindings/test_rondpoint.py
@@ -8,9 +8,21 @@ assert dico == copyDico
 
 assert copie_enumeration(Enumeration.DEUX) == Enumeration.DEUX
 assert copie_enumerations([Enumeration.UN, Enumeration.DEUX]) == [Enumeration.UN, Enumeration.DEUX]
-assert copie_carte({"1": Enumeration.UN, "2": Enumeration.DEUX}) == {"1": Enumeration.UN, "2": Enumeration.DEUX}
+assert copie_carte({
+    "0": EnumerationAvecDonnees.ZERO(),
+    "1": EnumerationAvecDonnees.UN(1),
+    "2": EnumerationAvecDonnees.DEUX(2, "deux"),
+}) == {
+    "0": EnumerationAvecDonnees.ZERO(),
+    "1": EnumerationAvecDonnees.UN(1),
+    "2": EnumerationAvecDonnees.DEUX(2, "deux"),
+}
 
 assert switcheroo(False) is True
+
+assert EnumerationAvecDonnees.ZERO() != EnumerationAvecDonnees.UN(1)
+assert EnumerationAvecDonnees.UN(1) == EnumerationAvecDonnees.UN(1)
+assert EnumerationAvecDonnees.UN(1) != EnumerationAvecDonnees.UN(2)
 
 # Test the roundtrip across the FFI.
 # This shows that the values we send come back in exactly the same state as we sent them.
@@ -19,9 +31,9 @@ assert switcheroo(False) is True
 rt = Retourneur()
 
 def affirmAllerRetour(vals, identique):
-  for v in vals:
-    id_v = identique(v)
-    assert id_v == v, f"Round-trip failure: {v} => {id_v}"
+    for v in vals:
+        id_v = identique(v)
+        assert id_v == v, f"Round-trip failure: {v} => {id_v}"
 
 MIN_I8 = -1 * 2**7
 MAX_I8 = 2**7 - 1
@@ -87,8 +99,8 @@ st = Stringifier()
 
 def affirmEnchaine(vals, toString, rustyStringify=lambda v: str(v).lower()):
     for v in vals:
-      str_v = toString(v)
-      assert rustyStringify(v) == str_v, f"String compare error {v} => {str_v}"
+        str_v = toString(v)
+        assert rustyStringify(v) == str_v, f"String compare error {v} => {str_v}"
 
 # Test the efficacy of the string transport from rust. If this fails, but everything else
 # works, then things are very weird.

--- a/examples/rondpoint/tests/bindings/test_rondpoint.swift
+++ b/examples/rondpoint/tests/bindings/test_rondpoint.swift
@@ -6,7 +6,20 @@ assert(dico == copyDico)
 
 assert(copieEnumeration(e: .deux) == .deux)
 assert(copieEnumerations(e: [.un, .deux]) == [.un, .deux])
-assert(copieCarte(c: ["1": .un, "2": .deux]) == ["1": .un, "2": .deux])
+assert(copieCarte(c:
+    ["0": .zero,
+    "1": .un(premier: 1),
+    "2": .deux(premier: 2, second: "deux")
+]) == [
+    "0": .zero,
+    "1": .un(premier: 1),
+    "2": .deux(premier: 2, second: "deux")
+])
+
+assert(EnumerationAvecDonnees.zero != EnumerationAvecDonnees.un(premier: 1))
+assert(EnumerationAvecDonnees.un(premier: 1) == EnumerationAvecDonnees.un(premier: 1))
+assert(EnumerationAvecDonnees.un(premier: 1) != EnumerationAvecDonnees.un(premier: 2))
+
 
 assert(switcheroo(b: false))
 

--- a/uniffi_bindgen/src/bindings/gecko_js/templates/WebIDLTemplate.webidl
+++ b/uniffi_bindgen/src/bindings/gecko_js/templates/WebIDLTemplate.webidl
@@ -14,9 +14,13 @@ dictionary {{ rec.name()|class_name_webidl(context)  }} {
 {% endfor %}
 
 {%- for e in ci.iter_enum_definitions() %}
+{% if ! e.is_flat() %}
+// Sorry the gecko-js backend does not yet support enums with associated data,
+// so this probably isn't going to compile just yet...
+{% endif %}
 enum {{ e.name()|class_name_webidl(context)  }} {
   {% for variant in e.variants() %}
-  "{{ variant|enum_variant_webidl }}"{%- if !loop.last %}, {% endif %}
+  "{{ variant.name()|enum_variant_webidl }}"{%- if !loop.last %}, {% endif %}
   {% endfor %}
 };
 {% endfor %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
@@ -1,19 +1,88 @@
+{#
+// Kotlin's `enum class` constuct doesn't support variants with associated data,
+// but is a little nicer for consumers than its `sealed class` enum pattern.
+// So, we switch here, using `enum class` for enums with no associated data
+// and `sealed class` for the general case.
+#}
+
+{% if e.is_flat() %}
+
 enum class {{ e.name()|class_name_kt }} {
-    {% for variant in e.variants() %}
-    {{ variant|enum_variant_kt }}{% if loop.last %};{% else %},{% endif %}
-    {% endfor %}
+    {% for variant in e.variants() -%}
+    {{ variant.name()|enum_variant_kt }}{% if loop.last %};{% else %},{% endif %}
+    {%- endfor %}
 
     companion object {
-        internal fun lift(n: Int) =
-            try { values()[n - 1] }
+        internal fun lift(rbuf: RustBuffer.ByValue): {{ e.name()|class_name_kt }} {
+            return liftFromRustBuffer(rbuf) { buf -> {{ e.name()|class_name_kt }}.read(buf) }
+        }
+
+        internal fun read(buf: ByteBuffer) =
+            try { values()[buf.getInt() - 1] }
             catch (e: IndexOutOfBoundsException) {
                 throw RuntimeException("invalid enum value, something is very wrong!!", e)
             }
-
-        internal fun read(buf: ByteBuffer) = lift(buf.getInt())
     }
 
-    internal fun lower() = this.ordinal + 1
+    internal fun lower(): RustBuffer.ByValue {
+        return lowerIntoRustBuffer(this, {v, buf -> v.write(buf)})
+    }
 
-    internal fun write(buf: RustBufferBuilder) = buf.putInt(this.lower())
+    internal fun write(buf: RustBufferBuilder) {
+        buf.putInt(this.ordinal + 1)
+    }
 }
+
+{% else %}
+
+sealed class {{ e.name()|class_name_kt }} {
+    {% for variant in e.variants() -%}
+    {% if !variant.has_fields() -%}
+    object {{ variant.name()|class_name_kt }} : {{ e.name()|class_name_kt }}()
+    {% else -%}
+    data class {{ variant.name()|class_name_kt }}(
+        {% for field in variant.fields() -%}
+        val {{ field.name()|var_name_kt }}: {{ field.type_()|type_kt}}{% if loop.last %}{% else %}, {% endif %}
+        {% endfor -%}
+    ) : {{ e.name()|class_name_kt }}()
+    {%- endif %}
+    {% endfor %}
+
+    companion object {
+        internal fun lift(rbuf: RustBuffer.ByValue): {{ e.name()|class_name_kt }} {
+            return liftFromRustBuffer(rbuf) { buf -> {{ e.name()|class_name_kt }}.read(buf) }
+        }
+
+        internal fun read(buf: ByteBuffer): {{ e.name()|class_name_kt }} {
+            return when(buf.getInt()) {
+                {%- for variant in e.variants() %}
+                {{ loop.index }} -> {{ e.name()|class_name_kt }}.{{ variant.name()|class_name_kt }}{% if variant.has_fields() %}(
+                    {% for field in variant.fields() -%}
+                    {{ "buf"|read_kt(field.type_()) }}{% if loop.last %}{% else %},{% endif %}
+                    {% endfor -%}
+                ){%- endif -%}
+                {%- endfor %}
+                else -> throw RuntimeException("invalid enum value, something is very wrong!!")
+            }
+        }
+    }
+
+    internal fun lower(): RustBuffer.ByValue {
+        return lowerIntoRustBuffer(this, {v, buf -> v.write(buf)})
+    }
+
+    internal fun write(buf: RustBufferBuilder) {
+        when(this) {
+            {%- for variant in e.variants() %}
+            is {{ e.name()|class_name_kt }}.{{ variant.name()|class_name_kt }} -> {
+                buf.putInt({{ loop.index }})
+                {% for field in variant.fields() -%}
+                {{ "(this.{})"|format(field.name())|write_kt("buf", field.type_()) }}
+                {% endfor -%}
+            }
+            {%- endfor %}
+        }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+}
+
+{% endif %}

--- a/uniffi_bindgen/src/bindings/python/gen_python.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python.rs
@@ -141,9 +141,10 @@ mod filters {
             | Type::UInt64 => format!("int({})", nm), // TODO: check max/min value
             Type::Float32 | Type::Float64 => format!("float({})", nm),
             Type::Boolean => format!("bool({})", nm),
-            Type::String | Type::Object(_) | Type::Error(_) | Type::Record(_) => nm.to_string(),
+            Type::String | Type::Object(_) | Type::Enum(_) | Type::Error(_) | Type::Record(_) => {
+                nm.to_string()
+            }
             Type::CallbackInterface(_) => panic!("No support for coercing callback interfaces yet"),
-            Type::Enum(name) => format!("{}({})", class_name_py(name)?, nm),
             Type::Optional(t) => format!("(None if {} is None else {})", nm, coerce_py(nm, t)?),
             Type::Sequence(t) => format!("list({} for x in {})", coerce_py(&"x", t)?, nm),
             Type::Map(t) => format!(
@@ -169,11 +170,14 @@ mod filters {
             | Type::Float64 => nm.to_string(),
             Type::Boolean => format!("(1 if {} else 0)", nm),
             Type::String => format!("RustBuffer.allocFromString({})", nm),
-            Type::Enum(_) => format!("({}.value)", nm),
             Type::Object(_) => format!("({}._handle)", nm),
             Type::CallbackInterface(_) => panic!("No support for lowering callback interfaces yet"),
             Type::Error(_) => panic!("No support for lowering errors, yet"),
-            Type::Record(_) | Type::Optional(_) | Type::Sequence(_) | Type::Map(_) => format!(
+            Type::Enum(_)
+            | Type::Record(_)
+            | Type::Optional(_)
+            | Type::Sequence(_)
+            | Type::Map(_) => format!(
                 "RustBuffer.allocFrom{}({})",
                 class_name_py(&type_.canonical_name())?,
                 nm
@@ -194,11 +198,14 @@ mod filters {
             Type::Float32 | Type::Float64 => format!("float({})", nm),
             Type::Boolean => format!("(True if {} else False)", nm),
             Type::String => format!("{}.consumeIntoString()", nm),
-            Type::Enum(name) => format!("{}({})", class_name_py(name)?, nm),
             Type::Object(_) => panic!("No support for lifting objects, yet"),
             Type::CallbackInterface(_) => panic!("No support for lifting callback interfaces, yet"),
-            Type::Error(_) => panic!("No support for lifting errors, yet"),
-            Type::Record(_) | Type::Optional(_) | Type::Sequence(_) | Type::Map(_) => format!(
+            Type::Error(_) => panic!("No support for lowering errors, yet"),
+            Type::Enum(_)
+            | Type::Record(_)
+            | Type::Optional(_)
+            | Type::Sequence(_)
+            | Type::Map(_) => format!(
                 "{}.consumeInto{}()",
                 nm,
                 class_name_py(&type_.canonical_name())?

--- a/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
@@ -1,4 +1,59 @@
+{#
+# Python has a built-in `enum` module which is nice to use, but doesn't support
+# variants with associated data. So, we switch here, and generate a stdlib `enum`
+# when none of the variants have associated data, or a generic nested-class
+# construct when they do.
+#}
+{% if e.is_flat() %}
+
 class {{ e.name()|class_name_py }}(enum.Enum):
     {% for variant in e.variants() -%}
-    {{ variant|enum_name_py }} = {{ loop.index }}
+    {{ variant.name()|enum_name_py }} = {{ loop.index }}
     {% endfor %}
+
+{% else %}
+
+class {{ e.name()|class_name_py }}(object):
+    def __init__(self):
+        raise RuntimeError("{{ e.name()|class_name_py }} cannot be instantiated directly")
+
+    # Each enum variant is a nested class of the enum itself.
+    {% for variant in e.variants() -%}
+    class {{ variant.name()|enum_name_py }}(object):
+        def __init__(self,{% for field in variant.fields() %}{{ field.name()|var_name_py }}{% if loop.last %}{% else %}, {% endif %}{% endfor %}):
+            {% if variant.has_fields() %}
+            {%- for field in variant.fields() %}
+            self.{{ field.name()|var_name_py }} = {{ field.name()|var_name_py }}
+            {%- endfor %}
+            {% else %}
+            pass
+            {% endif %}
+
+        def __str__(self):
+            return "{{ e.name()|class_name_py }}.{{ variant.name()|enum_name_py }}({% for field in variant.fields() %}{{ field.name() }}={}{% if loop.last %}{% else %}, {% endif %}{% endfor %})".format({% for field in variant.fields() %}self.{{ field.name() }}{% if loop.last %}{% else %}, {% endif %}{% endfor %})
+
+        def __eq__(self, other):
+            if not other.is_{{ variant.name()|var_name_py }}():
+                return False
+            {%- for field in variant.fields() %}
+            if self.{{ field.name()|var_name_py }} != other.{{ field.name()|var_name_py }}:
+                return False
+            {%- endfor %}
+            return True
+    {% endfor %}
+
+    # For each variant, we have an `is_NAME` method for easily checking
+    # whether an instance is that variant.
+    {% for variant in e.variants() -%}
+    def is_{{ variant.name()|var_name_py }}(self):
+        return isinstance(self, {{ e.name()|class_name_py }}.{{ variant.name()|enum_name_py }})
+    {% endfor %}
+
+# Now, a little trick - we make each nested variant class be a subclass of the main
+# enum class, so that method calls and instance checks etc will work intuitively.
+# We might be able to do this a little more neatly with a metaclass, but this'll do.
+{% for variant in e.variants() -%}
+{{ e.name()|class_name_py }}.{{ variant.name()|enum_name_py }} = type("{{ e.name()|class_name_py }}.{{ variant.name()|enum_name_py }}", ({{ e.name()|class_name_py }}.{{variant.name()|enum_name_py}}, {{ e.name()|class_name_py }},), {})
+{% endfor %}
+
+{% endif %}

--- a/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
@@ -11,5 +11,5 @@ class {{ rec.name()|class_name_py }}(object):
         {%- for field in rec.fields() %}
         if self.{{ field.name()|var_name_py }} != other.{{ field.name()|var_name_py }}:
             return False
-        return True
         {%- endfor %}
+        return True

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
@@ -92,6 +92,20 @@ class RustBuffer(ctypes.Structure):
         with self.consumeWithStream() as stream:
             return stream.read{{ canonical_type_name }}()
 
+    {% when Type::Enum with (enum_name) -%}
+    {%- let e = ci.get_enum_definition(enum_name).unwrap() -%}
+    # The Enum type {{ enum_name }}.
+
+    @staticmethod
+    def allocFrom{{ canonical_type_name }}(v):
+        with RustBuffer.allocWithBuilder() as builder:
+            builder.write{{ canonical_type_name }}(v)
+            return builder.finalize()
+
+    def consumeInto{{ canonical_type_name }}(self):
+        with self.consumeWithStream() as stream:
+            return stream.read{{ canonical_type_name }}()
+
     {% when Type::Optional with (inner_type) -%}
     # The Optional<T> type for {{ inner_type.canonical_name() }}.
 

--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -1,30 +1,39 @@
-public enum {{ e.name()|class_name_swift }}: ViaFfi {
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+public enum {{ e.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi, Equatable {
     {% for variant in e.variants() %}
-    case {{ variant|enum_variant_swift }}
+    case {{ variant.name()|enum_variant_swift }}{% if variant.fields().len() > 0 %}({% call swift::field_list_decl(variant) %}){% endif -%}
     {% endfor %}
 
     static func read(from buf: Reader) throws -> {{ e.name()|class_name_swift }} {
-        return try {{ e.name()|class_name_swift }}.lift(UInt32.read(from: buf))
-    }
-
-    static func lift(_ number: UInt32) throws -> {{ e.name()|class_name_swift }} {
-        switch number {
+        let variant: Int32 = try buf.readInt()
+        switch variant {
         {% for variant in e.variants() %}
-        case {{ loop.index }}: return .{{ variant|enum_variant_swift }}
+        case {{ loop.index }}: return .{{ variant.name()|enum_variant_swift }}{% if variant.has_fields() -%}(
+            {% for field in variant.fields() -%}
+            {{ field.name()|var_name_swift }}: try {{ "buf"|read_swift(field.type_()) }}{% if loop.last %}{% else %},{% endif %}
+            {% endfor -%}
+        ){% endif -%}
         {% endfor %}
         default: throw InternalError.unexpectedEnumCase
         }
     }
 
     func write(into buf: Writer) {
-        self.lower().write(into: buf)
-    }
-
-    func lower() -> UInt32 {
         switch self {
         {% for variant in e.variants() %}
-        case .{{ variant|enum_variant_swift }}: return {{ loop.index }}
-        {% endfor %}
+        {% if variant.has_fields() %}
+        case let .{{ variant.name()|enum_variant_swift }}({% for field in variant.fields() %}{{ field.name()|var_name_swift }}{%- if loop.last -%}{%- else -%},{%- endif -%}{% endfor %}):
+            buf.writeInt(Int32({{ loop.index }}))
+            {% for field in variant.fields() -%}
+            {{ field.name()|var_name_swift }}.write(into: buf)
+            {% endfor -%}
+        {% else %}
+        case .{{ variant.name()|enum_variant_swift }}:
+            buf.writeInt(Int32({{ loop.index }}))
+        {% endif %}
+        {%- endfor %}
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -5,16 +5,7 @@ public struct {{ rec.name()|class_name_swift }}:  ViaFfiUsingByteBuffer, ViaFfi,
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(
-        {%- for field in rec.fields() %}
-        {{ field.name()|var_name_swift }}: {{ field.type_()|type_swift -}}
-        {%- match field.default_value() %}
-            {%- when Some with(literal) %} = {{ literal|literal_swift }}
-            {%- else %}
-        {%- endmatch -%}
-        {% if !loop.last %}, {% endif %}
-        {%- endfor %}
-    ) {
+    public init({% call swift::field_list_decl(rec) %}) {
         {%- for field in rec.fields() %}
         self.{{ field.name()|var_name_swift }} = {{ field.name()|var_name_swift }}
         {%- endfor %}

--- a/uniffi_bindgen/src/bindings/swift/templates/macros.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/macros.swift
@@ -55,6 +55,21 @@
     {%- endfor %}
 {%- endmacro %}
 
+{#-
+// Field lists as used in Swift declarations of Records and Enums.
+// Note the var_name_swift and type_swift filters.
+-#}
+{% macro field_list_decl(item) %}
+    {%- for field in item.fields() -%}
+        {{ field.name()|var_name_swift }}: {{ field.type_()|type_swift -}}
+        {%- match field.default_value() %}
+            {%- when Some with(literal) %} = {{ literal|literal_swift }}
+            {%- else %}
+        {%- endmatch -%}
+        {% if !loop.last %}, {% endif %}
+    {%- endfor %}
+{%- endmacro %}
+
 
 {% macro arg_list_protocol(func) %}
     {%- for arg in func.arguments() -%}

--- a/uniffi_bindgen/src/interface/callbacks.rs
+++ b/uniffi_bindgen/src/interface/callbacks.rs
@@ -110,7 +110,7 @@ impl APIConverter<CallbackInterface> for weedle::CallbackInterfaceDefinition<'_>
         for member in &self.members.body {
             match member {
                 weedle::interface::InterfaceMember::Operation(t) => {
-                    let mut method = t.convert(ci)?;
+                    let mut method: Method = t.convert(ci)?;
                     method.object_name.push_str(object.name.as_str());
                     object.methods.push(method);
                 }

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -31,33 +31,85 @@
 //! let e = ci.get_enum_definition("Example").unwrap();
 //! assert_eq!(e.name(), "Example");
 //! assert_eq!(e.variants().len(), 2);
-//! assert_eq!(e.variants()[0], "one");
-//! assert_eq!(e.variants()[1], "two");
+//! assert_eq!(e.variants()[0].name(), "one");
+//! assert_eq!(e.variants()[1].name(), "two");
+//! # Ok::<(), anyhow::Error>(())
+//! ```
+//!
+//! Like in Rust, UniFFI enums can contain associated data, but this needs to be
+//! declared with a different syntax in order to work within the restrictions of
+//! WebIDL. A declaration like this:
+//!
+//! ```
+//! # let ci = uniffi_bindgen::interface::ComponentInterface::from_webidl(r##"
+//! # namespace example {};
+//! [Enum]
+//! interface Example {
+//!   Zero();
+//!   One(u32 first);
+//!   Two(u32 first, string second);
+//! };
+//! # "##)?;
+//! # Ok::<(), anyhow::Error>(())
+//! ```
+//!
+//! Will result in an [`Enum`] member whose variants have associated fields:
+//!
+//! ```
+//! # let ci = uniffi_bindgen::interface::ComponentInterface::from_webidl(r##"
+//! # namespace example {};
+//! # [Enum]
+//! # interface ExampleWithData {
+//! #   Zero();
+//! #   One(u32 first);
+//! #   Two(u32 first, string second);
+//! # };
+//! # "##)?;
+//! let e = ci.get_enum_definition("ExampleWithData").unwrap();
+//! assert_eq!(e.name(), "ExampleWithData");
+//! assert_eq!(e.variants().len(), 3);
+//! assert_eq!(e.variants()[0].name(), "Zero");
+//! assert_eq!(e.variants()[0].fields().len(), 0);
+//! assert_eq!(e.variants()[1].name(), "One");
+//! assert_eq!(e.variants()[1].fields().len(), 1);
+//! assert_eq!(e.variants()[1].fields()[0].name(), "first");
 //! # Ok::<(), anyhow::Error>(())
 //! ```
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 
+use super::record::Field;
+use super::types::Type;
 use super::{APIConverter, ComponentInterface};
 
-/// Represents a simple C-style enum, with named variants.
+/// Represents an enum with named variants, each of which may have named
+/// and typed fields.
 ///
-/// In the FFI these are turned into a plain u32, with variants numbered
-/// in the order they appear in the declaration, starting from 1.
+/// Enums are passed across the FFI by serializing to a bytebuffer, with a
+/// i32 indicating the variant followed by the serialization of each field.
 #[derive(Debug, Clone, Hash)]
 pub struct Enum {
     pub(super) name: String,
-    pub(super) variants: Vec<String>,
+    pub(super) variants: Vec<Variant>,
+    // "Flat" enums do not have, and will never have, variants with associated data.
+    pub(super) flat: bool,
 }
 
 impl Enum {
     pub fn name(&self) -> &str {
         &self.name
     }
-    pub fn variants(&self) -> Vec<&str> {
-        self.variants.iter().map(|v| v.as_str()).collect()
+    pub fn variants(&self) -> Vec<&Variant> {
+        self.variants.iter().collect()
+    }
+
+    pub fn is_flat(&self) -> bool {
+        self.flat
     }
 }
+
+// Note that we have two `APIConverter` impls here - one for the `enum` case
+// and one for the `[Enum] interface` case.
 
 impl APIConverter<Enum> for weedle::EnumDefinition<'_> {
     fn convert(&self, _ci: &mut ComponentInterface) -> Result<Enum> {
@@ -68,14 +120,138 @@ impl APIConverter<Enum> for weedle::EnumDefinition<'_> {
                 .body
                 .list
                 .iter()
-                .map(|v| v.0.to_string())
-                .collect(),
+                .map::<Result<_>, _>(|v| {
+                    Ok(Variant {
+                        name: v.0.to_string(),
+                        ..Default::default()
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?,
+            flat: true,
+        })
+    }
+}
+
+impl APIConverter<Enum> for weedle::InterfaceDefinition<'_> {
+    fn convert(&self, ci: &mut ComponentInterface) -> Result<Enum> {
+        if self.inheritance.is_some() {
+            bail!("interface inheritence is not supported for enum interfaces");
+        }
+        // We don't need to check `self.attributes` here; if calling code has dispatched
+        // to this impl then we already know there was an `[Enum]` attribute.
+        Ok(Enum {
+            name: self.identifier.0.to_string(),
+            variants: self
+                .members
+                .body
+                .iter()
+                .map::<Result<Variant>, _>(|member| match member {
+                    weedle::interface::InterfaceMember::Operation(t) => Ok(t.convert(ci)?),
+                    _ => bail!(
+                        "interface member type {:?} not supported in enum interface",
+                        member
+                    ),
+                })
+                .collect::<Result<Vec<_>>>()?,
+            flat: false,
+        })
+    }
+}
+
+/// Represents an individual variant in an Enum.
+///
+/// Each variant has a name and zero or more fields.
+#[derive(Debug, Clone, Default, Hash)]
+pub struct Variant {
+    pub(super) name: String,
+    pub(super) fields: Vec<Field>,
+}
+
+impl Variant {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    pub fn fields(&self) -> Vec<&Field> {
+        self.fields.iter().collect()
+    }
+
+    pub fn has_fields(&self) -> bool {
+        self.fields.len() > 0
+    }
+}
+
+impl APIConverter<Variant> for weedle::interface::OperationInterfaceMember<'_> {
+    fn convert(&self, ci: &mut ComponentInterface) -> Result<Variant> {
+        if self.special.is_some() {
+            bail!("special operations not supported");
+        }
+        if let Some(weedle::interface::StringifierOrStatic::Stringifier(_)) = self.modifier {
+            bail!("stringifiers are not supported");
+        }
+        // OK, so this is a little weird.
+        // The syntax we use for enum interface members is `Name(type arg, ...);`, which parses
+        // as an anonymous operation where `Name` is the return type. We re-interpret it to
+        // use `Name` as the name of the variant.
+        if self.identifier.is_some() {
+            bail!("enum interface members must not have a method name");
+        }
+        let name: String = {
+            use weedle::types::{
+                NonAnyType::Identifier, ReturnType, SingleType::NonAny, Type::Single,
+            };
+            match &self.return_type {
+                ReturnType::Type(Single(NonAny(Identifier(id)))) => id.type_.0.to_owned(),
+                _ => bail!("enum interface members must have plain identifers as names"),
+            }
+        };
+        Ok(Variant {
+            name,
+            fields: self
+                .args
+                .body
+                .list
+                .iter()
+                .map(|arg| arg.convert(ci))
+                .collect::<Result<Vec<_>>>()?,
+        })
+    }
+}
+
+impl APIConverter<Field> for weedle::argument::Argument<'_> {
+    fn convert(&self, ci: &mut ComponentInterface) -> Result<Field> {
+        match self {
+            weedle::argument::Argument::Single(t) => t.convert(ci),
+            weedle::argument::Argument::Variadic(_) => bail!("variadic arguments not supported"),
+        }
+    }
+}
+
+impl APIConverter<Field> for weedle::argument::SingleArgument<'_> {
+    fn convert(&self, ci: &mut ComponentInterface) -> Result<Field> {
+        let type_ = ci.resolve_type_expression(&self.type_)?;
+        if let Type::Object(_) = type_ {
+            bail!("Objects cannot currently be used in enum variant data");
+        }
+        if self.default.is_some() {
+            bail!("enum interface variant fields must not have default values");
+        }
+        if self.attributes.is_some() {
+            bail!("enum interface variant fields must not have attributes");
+        }
+        // TODO: maybe we should use our own `Field` type here with just name and type,
+        // rather than appropriating record::Field..?
+        Ok(Field {
+            name: self.identifier.0.to_string(),
+            type_,
+            required: false,
+            default: None,
         })
     }
 }
 
 #[cfg(test)]
 mod test {
+    use super::super::ffi::FFIType;
     use super::*;
 
     #[test]
@@ -92,6 +268,133 @@ mod test {
             ci.get_enum_definition("Testing").unwrap().variants().len(),
             3
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_associated_data() -> Result<()> {
+        const UDL: &str = r##"
+            namespace test {
+                void takes_an_enum(TestEnum e);
+                void takes_an_enum_with_data(TestEnumWithData ed);
+                TestEnum returns_an_enum();
+                TestEnumWithData returns_an_enum_with_data();
+            };
+
+            enum TestEnum { "one", "two" };
+
+            [Enum]
+            interface TestEnumWithData {
+                Zero();
+                One(u32 first);
+                Two(u32 first, string second);
+            };
+
+            [Enum]
+            interface TestEnumWithoutData {
+                One();
+                Two();
+            };
+        "##;
+        let ci = ComponentInterface::from_webidl(UDL).unwrap();
+        assert_eq!(ci.iter_enum_definitions().len(), 3);
+        assert_eq!(ci.iter_function_definitions().len(), 4);
+
+        // The "flat" enum with no associated data.
+        let e = ci.get_enum_definition("TestEnum").unwrap();
+        assert!(e.is_flat());
+        assert_eq!(e.variants().len(), 2);
+        assert_eq!(
+            e.variants().iter().map(|v| v.name()).collect::<Vec<_>>(),
+            vec!["one", "two"]
+        );
+        assert_eq!(e.variants()[0].fields().len(), 0);
+        assert_eq!(e.variants()[1].fields().len(), 0);
+
+        // The enum with associated data.
+        let ed = ci.get_enum_definition("TestEnumWithData").unwrap();
+        assert!(!ed.is_flat());
+        assert_eq!(ed.variants().len(), 3);
+        assert_eq!(
+            ed.variants().iter().map(|v| v.name()).collect::<Vec<_>>(),
+            vec!["Zero", "One", "Two"]
+        );
+        assert_eq!(ed.variants()[0].fields().len(), 0);
+        assert_eq!(
+            ed.variants()[1]
+                .fields()
+                .iter()
+                .map(|f| f.name())
+                .collect::<Vec<_>>(),
+            vec!["first"]
+        );
+        assert_eq!(
+            ed.variants()[1]
+                .fields()
+                .iter()
+                .map(|f| f.type_())
+                .collect::<Vec<_>>(),
+            vec![Type::UInt32]
+        );
+        assert_eq!(
+            ed.variants()[2]
+                .fields()
+                .iter()
+                .map(|f| f.name())
+                .collect::<Vec<_>>(),
+            vec!["first", "second"]
+        );
+        assert_eq!(
+            ed.variants()[2]
+                .fields()
+                .iter()
+                .map(|f| f.type_())
+                .collect::<Vec<_>>(),
+            vec![Type::UInt32, Type::String]
+        );
+
+        // The enum declared via interface, but with no associated data.
+        let ewd = ci.get_enum_definition("TestEnumWithoutData").unwrap();
+        assert!(!ewd.is_flat());
+        assert_eq!(ewd.variants().len(), 2);
+        assert_eq!(
+            ewd.variants().iter().map(|v| v.name()).collect::<Vec<_>>(),
+            vec!["One", "Two"]
+        );
+        assert_eq!(ewd.variants()[0].fields().len(), 0);
+        assert_eq!(ewd.variants()[1].fields().len(), 0);
+
+        // Flat enums pass over the FFI as bytebuffers.
+        // (It might be nice to optimize these to pass as plain integers, but that's
+        // difficult atop the current factoring of `ComponentInterface` and friends).
+        let farg = ci.get_function_definition("takes_an_enum").unwrap();
+        assert_eq!(farg.arguments()[0].type_(), Type::Enum("TestEnum".into()));
+        assert_eq!(farg.ffi_func().arguments()[0].type_(), FFIType::RustBuffer);
+        let fret = ci.get_function_definition("returns_an_enum").unwrap();
+        assert!(matches!(fret.return_type(), Some(Type::Enum(nm)) if nm == "TestEnum"));
+        assert!(matches!(
+            fret.ffi_func().return_type(),
+            Some(FFIType::RustBuffer)
+        ));
+
+        // Enums with associated data pass over the FFI as bytebuffers.
+        let farg = ci
+            .get_function_definition("takes_an_enum_with_data")
+            .unwrap();
+        assert_eq!(
+            farg.arguments()[0].type_(),
+            Type::Enum("TestEnumWithData".into())
+        );
+        assert_eq!(farg.ffi_func().arguments()[0].type_(), FFIType::RustBuffer);
+        let fret = ci
+            .get_function_definition("returns_an_enum_with_data")
+            .unwrap();
+        assert!(matches!(fret.return_type(), Some(Type::Enum(nm)) if nm == "TestEnumWithData"));
+        assert!(matches!(
+            fret.ffi_func().return_type(),
+            Some(FFIType::RustBuffer)
+        ));
+
         Ok(())
     }
 }

--- a/uniffi_bindgen/src/interface/ffi.rs
+++ b/uniffi_bindgen/src/interface/ffi.rs
@@ -18,7 +18,7 @@
 /// For the types that involve memory allocation, we make a distinction between
 /// "owned" types (the recipient must free it, or pass it to someone else) and
 /// "borrowed" types (the sender must keep it alive for the duration of the call).
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum FFIType {
     // N.B. there are no booleans at this layer, since they cause problems for JNA.
     UInt8,

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -123,10 +123,7 @@ impl APIConverter<Function> for weedle::namespace::OperationNamespaceMember<'_> 
             return_type,
             arguments: self.args.body.list.convert(ci)?,
             ffi_func: Default::default(),
-            attributes: match &self.attributes {
-                Some(attr) => FunctionAttributes::try_from(attr)?,
-                None => Default::default(),
-            },
+            attributes: FunctionAttributes::try_from(self.attributes.as_ref())?,
         })
     }
 }
@@ -186,10 +183,7 @@ impl APIConverter<Argument> for weedle::argument::SingleArgument<'_> {
             None => None,
             Some(v) => Some(convert_default_value(&v.value, &type_)?),
         };
-        let by_ref = match &self.attributes {
-            Some(attrs) => ArgumentAttributes::try_from(attrs)?.by_ref(),
-            None => false,
-        };
+        let by_ref = ArgumentAttributes::try_from(self.attributes.as_ref())?.by_ref();
         Ok(Argument {
             name: self.identifier.0.to_string(),
             type_,

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -171,14 +171,14 @@ impl APIConverter<Object> for weedle::InterfaceDefinition<'_> {
         for member in &self.members.body {
             match member {
                 weedle::interface::InterfaceMember::Constructor(t) => {
-                    let cons = t.convert(ci)?;
+                    let cons: Constructor = t.convert(ci)?;
                     if !member_names.insert(cons.name.clone()) {
                         bail!("Duplicate interface member name: \"{}\"", cons.name())
                     }
                     object.constructors.push(cons);
                 }
                 weedle::interface::InterfaceMember::Operation(t) => {
-                    let mut method = t.convert(ci)?;
+                    let mut method: Method = t.convert(ci)?;
                     if !member_names.insert(method.name.clone()) {
                         bail!("Duplicate interface member name: \"{}\"", method.name())
                     }
@@ -388,10 +388,7 @@ impl APIConverter<Method> for weedle::interface::OperationInterfaceMember<'_> {
             arguments: self.args.body.list.convert(ci)?,
             return_type,
             ffi_func: Default::default(),
-            attributes: match &self.attributes {
-                Some(attr) => MethodAttributes::try_from(attr)?,
-                None => Default::default(),
-            },
+            attributes: MethodAttributes::try_from(self.attributes.as_ref())?,
         })
     }
 }

--- a/uniffi_bindgen/src/interface/record.rs
+++ b/uniffi_bindgen/src/interface/record.rs
@@ -88,10 +88,10 @@ impl APIConverter<Record> for weedle::DictionaryDefinition<'_> {
 // Represents an individual field on a Record.
 #[derive(Debug, Clone, Hash)]
 pub struct Field {
-    name: String,
-    type_: Type,
-    required: bool,
-    default: Option<Literal>,
+    pub(super) name: String,
+    pub(super) type_: Type,
+    pub(super) required: bool,
+    pub(super) default: Option<Literal>,
 }
 
 impl Field {

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -133,14 +133,14 @@ impl Into<FFIType> for &Type {
             Type::Object(_) => FFIType::UInt64,
             // Callback interfaces are passed as opaque integer handles.
             Type::CallbackInterface(_) => FFIType::UInt64,
-            // Enums are passed as integers.
-            Type::Enum(_) => FFIType::UInt32,
             // Errors have their own special type.
             Type::Error(_) => FFIType::RustError,
             // Other types are serialized into a bytebuffer and deserialized on the other side.
-            Type::Record(_) | Type::Optional(_) | Type::Sequence(_) | Type::Map(_) => {
-                FFIType::RustBuffer
-            }
+            Type::Enum(_)
+            | Type::Record(_)
+            | Type::Optional(_)
+            | Type::Sequence(_)
+            | Type::Map(_) => FFIType::RustBuffer,
         }
     }
 }
@@ -184,7 +184,7 @@ impl TypeUniverse {
         }
         let type_ = self.add_known_type(type_)?;
         match self.type_definitions.entry(name.to_string()) {
-            Entry::Occupied(_) => bail!("Conflicting type definition for {}", name),
+            Entry::Occupied(_) => bail!("Conflicting type definition for \"{}\"", name),
             Entry::Vacant(e) => {
                 e.insert(type_);
                 Ok(())
@@ -193,7 +193,7 @@ impl TypeUniverse {
     }
 
     /// Get the [Type] corresponding to a given name, if any.
-    fn get_type_definition(&self, name: &str) -> Option<Type> {
+    pub(super) fn get_type_definition(&self, name: &str) -> Option<Type> {
         self.type_definitions.get(name).cloned()
     }
 

--- a/uniffi_bindgen/src/templates/EnumTemplate.rs
+++ b/uniffi_bindgen/src/templates/EnumTemplate.rs
@@ -1,45 +1,44 @@
 {#
-// For each enum declared in the UDL, we assume the caller as provided a corresponding
+// For each enum declared in the UDL, we assume the caller has provided a corresponding
 // rust `enum`. We provide the traits for sending it across the FFI, which will fail to
 // compile if the provided struct has a different shape to the one declared in the UDL.
-//
-// The enum will be sent over the FFI as a u32, with values assigned according to the
-// order of items *as declared in the UDL file*. This might be different to the order
-// of items as declared in the rust code, but no harm will come from it.
 #}
 #[doc(hidden)]
 unsafe impl uniffi::ViaFfi for {{ e.name() }} {
-    type FfiType = u32;
+    type FfiType = uniffi::RustBuffer;
 
     fn lower(self) -> Self::FfiType {
-        match self {
-            // If the provided enum doesn't match the options defined in the UDL then
-            // this match will fail to compile, with a type error to guide the way.
-            {%- for variant in e.variants() %}
-            {{ e.name() }}::{{ variant }} => {{ loop.index }},
-            {%- endfor %}
-        }
+        uniffi::lower_into_buffer(self)
     }
 
     fn try_lift(v: Self::FfiType) -> uniffi::deps::anyhow::Result<Self> {
-        Ok(match v {
-            {%- for variant in e.variants() %}
-            {{ loop.index }} => {{ e.name() }}::{{ variant }},
-            {%- endfor %}
-            _ => uniffi::deps::anyhow::bail!("Invalid {{ e.name() }} enum value: {}", v),
-        })
+        uniffi::try_lift_from_buffer(v)
     }
 
     fn write<B: uniffi::deps::bytes::BufMut>(&self, buf: &mut B) {
-        buf.put_u32(match self {
+        match self {
             {%- for variant in e.variants() %}
-            {{ e.name() }}::{{ variant }} => {{ loop.index }},
+            {{ e.name() }}::{{ variant.name() }} { {% for field in variant.fields() %}{{ field.name() }}, {%- endfor %} } => {
+                buf.put_i32({{ loop.index }});
+                {% for field in variant.fields() -%}
+                <{{ field.type_()|type_rs }} as uniffi::ViaFfi>::write({{ field.name() }}, buf);
+                {%- endfor %}
+            },
             {%- endfor %}
-        });
+        };
     }
 
     fn try_read<B: uniffi::deps::bytes::Buf>(buf: &mut B) -> uniffi::deps::anyhow::Result<Self> {
         uniffi::check_remaining(buf, 4)?;
-        <Self as uniffi::ViaFfi>::try_lift(buf.get_u32())
+        Ok(match buf.get_i32() {
+            {%- for variant in e.variants() %}
+            {{ loop.index }} => {{ e.name() }}::{{ variant.name() }}{% if variant.has_fields() %} {
+                {% for field in variant.fields() %}
+                {{ field.name() }}: <{{ field.type_()|type_rs }} as uniffi::ViaFfi>::try_read(buf)?,
+                {%- endfor %}
+            }{% endif %},
+            {%- endfor %}
+            v @ _ => uniffi::deps::anyhow::bail!("Invalid {{ e.name() }} enum value: {}", v),
+        })
     }
 }


### PR DESCRIPTION
Our fxa-client component makes use of a Rust enum with associated data to represent the different kinds of event that can happen to your account. The [Rust code](https://github.com/mozilla/application-services/blob/9ffdf88cdb269bf6f6769be67802f85983ae8d97/components/fxa-client/src/lib.rs#L276) looks like this:

```
pub enum AccountEvent {
    IncomingDeviceCommand(Box<IncomingDeviceCommand>),
    ProfileUpdated,
    DeviceConnected {
        device_name: String,
    },
    [...other cases omitted...]
}
```

In the hand-written bindings, we [reflect this to Kotlin as a sealed class](https://github.com/mozilla/application-services/blob/9ffdf88cdb269bf6f6769be67802f85983ae8d97/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/AccountEvent.kt#L11) and [reflect it to Swift as an enum with associated data](https://github.com/mozilla/application-services/blob/9ffdf88cdb269bf6f6769be67802f85983ae8d97/components/fxa-client/ios/FxAClient/FxAccountDevice.swift#L127).

UniFFI doesn't yet support this kind of data structure, which makes it awkward to use for the fxa-client component. So let's see if we can add it!

WebIDL doesn't seem to have a notion of a datatype like this or offer any ready syntax for it (It has union types, but they're like C-style unions and do not have an explicit discriminant). I messed around a bit and came up with a syntax that doesn't seem too bad, and is similar to how we're implemented errors. This PR contains just the docs and test changes that would happen *if* we chose to implement tagged unions in this manner. I'm looking for early feedback on whether this seems like a good idea.

/cc @mhammond @lougeniaC64 @jhugman @dmose 