### PR TITLE
Hide Rust scaffolding from `cargo doc`.

### DIFF
--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -23,3 +23,11 @@ heck = "0.3"
 clap = { version = "2", default-features = false }
 serde = "1"
 toml = "0.5"
+
+# Workaround for an issue with `bitvec` on newer rusts, which we get via `nom`.
+# Hopefully we'll be able to remove this after a new release of `nom`.
+# Ref https://github.com/Geal/nom/pull/1286/.
+[dependencies.funty]
+version = ">1.0, <=1.1"
+optional = true
+default-features = false

--- a/uniffi_bindgen/src/templates/CallbackInterfaceTemplate.rs
+++ b/uniffi_bindgen/src/templates/CallbackInterfaceTemplate.rs
@@ -15,14 +15,17 @@
 {% let foreign_callback_internals = format!("foreign_callback_{}_internals", trait_name)|upper -%}
 
 // Register a foreign callback for getting across the FFI.
+#[doc(hidden)]
 static {{ foreign_callback_internals }}: uniffi::ForeignCallbackInternals = uniffi::ForeignCallbackInternals::new();
 
+#[doc(hidden)]
 #[no_mangle]
 pub extern "C" fn {{ cbi.ffi_init_callback().name() }}(callback: uniffi::ForeignCallback) {
     {{ foreign_callback_internals }}.set_callback(callback);
 }
 
 // Make an implementation which will shell out to the foreign language.
+#[doc(hidden)]
 #[derive(Debug)]
 struct {{ trait_impl }} {
   handle: u64

--- a/uniffi_bindgen/src/templates/EnumTemplate.rs
+++ b/uniffi_bindgen/src/templates/EnumTemplate.rs
@@ -7,6 +7,7 @@
 // order of items *as declared in the UDL file*. This might be different to the order
 // of items as declared in the rust code, but no harm will come from it.
 #}
+#[doc(hidden)]
 unsafe impl uniffi::ViaFfi for {{ e.name() }} {
     type FfiType = u32;
 

--- a/uniffi_bindgen/src/templates/ErrorTemplate.rs
+++ b/uniffi_bindgen/src/templates/ErrorTemplate.rs
@@ -4,6 +4,7 @@
     // compile if the provided enum has a different shape to the one declared in the UDL. 
     // Here we define the neccessary converstion to allow the error to propegate through the FFI as an error.
 #}
+#[doc(hidden)]
 impl From<{{e.name()}}> for uniffi::deps::ffi_support::ExternError {
     fn from(err: {{e.name()}}) -> uniffi::deps::ffi_support::ExternError {
         // Errno just differentiate between the errors.

--- a/uniffi_bindgen/src/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/templates/ObjectTemplate.rs
@@ -13,11 +13,13 @@ uniffi::deps::lazy_static::lazy_static! {
         "uniffi::ffi::handle_maps::ArcHandleMap",
         "uniffi::ffi::handle_maps::MutexHandleMap")
     %}
+    #[doc(hidden)]
     static ref {{ handle_map }}: {{ handle_map_type }}<{{ obj.name() }}>
         = Default::default();
 }
 
     {% let ffi_free = obj.ffi_object_free() -%}
+    #[doc(hidden)]
     #[no_mangle]
     pub extern "C" fn {{ ffi_free.name() }}(handle: u64) {
         let _ = {{ handle_map }}.delete_u64(handle);
@@ -25,6 +27,7 @@ uniffi::deps::lazy_static::lazy_static! {
 
 {%- for cons in obj.constructors() %}
     #[allow(clippy::all)]
+    #[doc(hidden)]
     #[no_mangle]
     pub extern "C" fn {{ cons.ffi_func().name() }}(
         {%- call rs::arg_list_ffi_decl(cons.ffi_func()) %}) -> u64 {
@@ -37,6 +40,7 @@ uniffi::deps::lazy_static::lazy_static! {
 
 {%- for meth in obj.methods() %}
     #[allow(clippy::all)]
+    #[doc(hidden)]
     #[no_mangle]
     pub extern "C" fn {{ meth.ffi_func().name() }}(
         {%- call rs::arg_list_ffi_decl(meth.ffi_func()) %}

--- a/uniffi_bindgen/src/templates/RecordTemplate.rs
+++ b/uniffi_bindgen/src/templates/RecordTemplate.rs
@@ -4,7 +4,7 @@
 // If the caller's struct does not match the shape and types declared in the UDL then the rust
 // compiler will complain with a type error.
 #}
-
+#[doc(hidden)]
 unsafe impl uniffi::ViaFfi for {{ rec.name() }} {
     type FfiType = uniffi::RustBuffer;
 

--- a/uniffi_bindgen/src/templates/RustBuffer.rs
+++ b/uniffi_bindgen/src/templates/RustBuffer.rs
@@ -4,6 +4,7 @@
 /// to the foreign-language code as a `RustBuffer` struct. Callers must eventually
 /// free the resulting buffer, either by explicitly calling the destructor defined below,
 /// or by passing ownership of the buffer back into Rust code.
+#[doc(hidden)]
 #[no_mangle]
 pub extern "C" fn {{ ci.ffi_rustbuffer_alloc().name() }}(size: i32, err: &mut uniffi::deps::ffi_support::ExternError) -> uniffi::RustBuffer {
     uniffi::deps::ffi_support::call_with_output(err, || {
@@ -19,6 +20,7 @@ pub extern "C" fn {{ ci.ffi_rustbuffer_alloc().name() }}(size: i32, err: &mut un
 /// # Safety
 /// This function will dereference a provided pointer in order to copy bytes from it, so
 /// make sure the `ForeignBytes` struct contains a valid pointer and length.
+#[doc(hidden)]
 #[no_mangle]
 pub unsafe extern "C" fn {{ ci.ffi_rustbuffer_from_bytes().name() }}(bytes: uniffi::ForeignBytes, err: &mut uniffi::deps::ffi_support::ExternError) -> uniffi::RustBuffer {
     uniffi::deps::ffi_support::call_with_output(err, || {
@@ -33,6 +35,7 @@ pub unsafe extern "C" fn {{ ci.ffi_rustbuffer_from_bytes().name() }}(bytes: unif
 /// The argument *must* be a uniquely-owned `RustBuffer` previously obtained from a call
 /// into the Rust code that returned a buffer, or you'll risk freeing unowned memory or
 /// corrupting the allocator state.
+#[doc(hidden)]
 #[no_mangle]
 pub unsafe extern "C" fn {{ ci.ffi_rustbuffer_free().name() }}(buf: uniffi::RustBuffer, err: &mut uniffi::deps::ffi_support::ExternError) {
     uniffi::deps::ffi_support::call_with_output(err, || {
@@ -55,6 +58,7 @@ pub unsafe extern "C" fn {{ ci.ffi_rustbuffer_free().name() }}(buf: uniffi::Rust
 /// The first argument *must* be a uniquely-owned `RustBuffer` previously obtained from a call
 /// into the Rust code that returned a buffer, or you'll risk freeing unowned memory or
 /// corrupting the allocator state.
+#[doc(hidden)]
 #[no_mangle]
 pub unsafe extern "C" fn {{ ci.ffi_rustbuffer_reserve().name() }}(buf: uniffi::RustBuffer, additional: i32, err: &mut uniffi::deps::ffi_support::ExternError) -> uniffi::RustBuffer {
     uniffi::deps::ffi_support::call_with_output(err, || {
@@ -75,6 +79,7 @@ pub unsafe extern "C" fn {{ ci.ffi_rustbuffer_reserve().name() }}(buf: uniffi::R
 /// obtained from a call into the rust code that returned a string.
 /// (In practice that means you got it from the `message` field of an `ExternError`,
 /// because that's currently the only place we use `char*` types in our API).
+#[doc(hidden)]
 #[no_mangle]
 pub unsafe extern "C" fn {{ ci.ffi_string_free().name() }}(cstr: *mut std::os::raw::c_char, err: &mut uniffi::deps::ffi_support::ExternError) {
     uniffi::deps::ffi_support::call_with_output(err, || {

--- a/uniffi_bindgen/src/templates/TopLevelFunctionTemplate.rs
+++ b/uniffi_bindgen/src/templates/TopLevelFunctionTemplate.rs
@@ -5,6 +5,7 @@
 // specified in the UDL.    
 #}
 #[allow(clippy::all)]
+#[doc(hidden)]
 #[no_mangle]
 pub extern "C" fn {{ func.ffi_func().name() }}(
     {% call rs::arg_list_ffi_decl(func.ffi_func()) %}


### PR DESCRIPTION
I've been experimenting with using `cargo doc` as the canonical source
of documentation for a UniFFI component, and I quite like it so far,
except for the way that it currently documents all the autogenerated
helper functions and traint impls. So, let's hide those using the
nice `#[doc(hidden)]` annotation.