### PR TITLE
Add support for factory functions and static methods.

### DIFF
--- a/docs/manual/src/udl/interfaces.md
+++ b/docs/manual/src/udl/interfaces.md
@@ -74,6 +74,25 @@ func display(list: TodoListProtocol) {
 }
 ```
 
+## Static Methods
+
+Interface methods can be marked with the `static` keyword to mark them as belonging to the interface
+itself rather than to a particular instance. Static methods are commonly used to make named alternatives to
+the default constructor, like this:
+
+```idl
+interface TodoList {
+    // The default constructor makes an empty list.
+    constructor();
+    // This static method is a shortcut for making a new TodoList from a list of items.
+    static TodoList new_from_items(sequence<string>)
+    ...
+```
+
+UniFFI will expose an appropriate static-method, class-method or similar in the foreign language binding,
+and will connect it to the Rust method of the same name on the underlying Rust struct.
+
+
 ## Concurrent Access
 
 Since interfaces represent mutable data, uniffi has to take extra care

--- a/examples/sprites/src/lib.rs
+++ b/examples/sprites/src/lib.rs
@@ -39,6 +39,12 @@ impl Sprite {
         }
     }
 
+    fn new_relative_to(reference: Point, direction: Vector) -> Sprite {
+        Sprite {
+            current_position: translate(&reference, direction),
+        }
+    }
+
     fn get_position(&self) -> Point {
         self.current_position.clone()
     }

--- a/examples/sprites/src/sprites.udl
+++ b/examples/sprites/src/sprites.udl
@@ -14,8 +14,8 @@ dictionary Vector {
 };
 
 interface Sprite {
-  // Should be an optional, but I had to test nullable args :)
   constructor(Point? initial_position);
+  static Sprite new_relative_to(Point reference, Vector direction);
   Point get_position();
   void move_to(Point position);
   void move_by(Vector direction);

--- a/examples/sprites/tests/bindings/test_sprites.kts
+++ b/examples/sprites/tests/bindings/test_sprites.kts
@@ -13,9 +13,13 @@ s.moveBy(Vector(-4.0, 2.0))
 assert( s.getPosition() == Point(-3.0, 4.0) )
 
 s.destroy()
-try { 
+try {
     s.moveBy(Vector(0.0, 0.0))
     assert(false) { "Should not be able to call anything after `destroy`" }
 } catch(e: IllegalStateException) {
     assert(true)
 }
+
+val srel = Sprite.newRelativeTo(Point(0.0, 1.0), Vector(1.0, 1.5))
+assert( srel.getPosition() == Point(1.0, 2.5) )
+

--- a/examples/sprites/tests/bindings/test_sprites.py
+++ b/examples/sprites/tests/bindings/test_sprites.py
@@ -11,3 +11,7 @@ assert s.get_position() == Point(1, 2)
 
 s.move_by(Vector(-4, 2))
 assert s.get_position() == Point(-3, 4)
+
+srel = Sprite.new_relative_to(Point(0, 1), Vector(1, 1.5))
+assert srel.get_position() == Point(1, 2.5)
+

--- a/examples/sprites/tests/bindings/test_sprites.swift
+++ b/examples/sprites/tests/bindings/test_sprites.swift
@@ -12,4 +12,5 @@ assert( s.getPosition() == Point(x: 1, y: 2))
 s.moveBy(direction: Vector(dx: -4, dy: 2))
 assert( s.getPosition() == Point(x: -3, y: 4))
 
-
+let srel = Sprite.newRelativeTo(reference: Point(x: 0.0, y: 1.0), direction: Vector(dx: 1, dy: 1.5))
+assert( srel.getPosition() == Point(x: 1.0, y: 2.5) )

--- a/examples/sprites/tests/test_generated_bindings.rs
+++ b/examples/sprites/tests/test_generated_bindings.rs
@@ -1,7 +1,7 @@
 uniffi_macros::build_foreign_language_testcases!(
     "src/sprites.udl",
     [
-        // "tests/bindings/test_sprites.py",
+        "tests/bindings/test_sprites.py",
         "tests/bindings/test_sprites.kts",
         "tests/bindings/test_sprites.swift",
     ]

--- a/uniffi_bindgen/src/bindings/gecko_js/templates/InterfaceTemplate.cpp
+++ b/uniffi_bindgen/src/bindings/gecko_js/templates/InterfaceTemplate.cpp
@@ -64,6 +64,9 @@ already_AddRefed<{{ obj.name()|class_name_cpp(context) }}> {{ obj.name()|class_n
 {%- endfor %}
 
 {%- for meth in obj.methods() %}
+{% if meth.is_static() %}
+MOZ_STATIC_ASSERT(false, "Sorry the gecko-js backend does not yet support static methods");
+{% endif %}
 
 {% match meth.cpp_return_type() %}{% when Some with (type_) %}{{ type_|ret_type_cpp(context) }}{% else %}void{% endmatch %} {{ obj.name()|class_name_cpp(context) }}::{{ meth.name()|fn_name_cpp }}(
   {%- for arg in meth.cpp_arguments() %}

--- a/uniffi_bindgen/src/bindings/gecko_js/templates/WebIDLTemplate.webidl
+++ b/uniffi_bindgen/src/bindings/gecko_js/templates/WebIDLTemplate.webidl
@@ -66,7 +66,7 @@ interface {{ obj.name()|class_name_webidl(context)  }} {
   {%- if meth.throws().is_some() %}
   [Throws]
   {% endif %}
-  {%- match meth.webidl_return_type() -%}{%- when Some with (type_) %}{{ type_|type_webidl(context) }}{% when None %}void{% endmatch %} {{ meth.name()|fn_name_webidl }}(
+  {%- match meth.webidl_return_type() -%}{%- when Some with (type_) %}{{ type_|type_webidl(context) }}{% when None %}void{% endmatch %} {% if meth.is_static() %}static {% endif -%} {{ meth.name()|fn_name_webidl }}(
       {%- for arg in meth.arguments() %}
       {% if arg.optional() -%}optional{%- else -%}{%- endif %} {{ arg.webidl_type()|type_webidl(context) }} {{ arg.name() }}
       {%- match arg.webidl_default_value() %}

--- a/uniffi_bindgen/src/bindings/python/gen_python.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python.rs
@@ -181,7 +181,7 @@ mod filters {
             Type::Boolean => format!("(True if {} else False)", nm),
             Type::String => format!("{}.consumeIntoString()", nm),
             Type::Enum(name) => format!("{}({})", class_name_py(name)?, nm),
-            Type::Object(_) => panic!("No support for lifting objects, yet"),
+            Type::Object(name) => format!("liftObject({}, {})", class_name_py(name)?, nm),
             Type::CallbackInterface(_) => panic!("No support for lifting callback interfaces, yet"),
             Type::Error(_) => panic!("No support for lowering errors, yet"),
             Type::Record(_) | Type::Optional(_) | Type::Sequence(_) | Type::Map(_) => format!(

--- a/uniffi_bindgen/src/bindings/python/templates/Helpers.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Helpers.py
@@ -1,0 +1,19 @@
+# Miscellaneous "private" helpers.
+#
+# These are things that we need to have available for internal use,
+# but that we don't want to expose as part of the public API classes,
+# even as "hidden" methods.
+
+{% if ci.iter_object_definitions().len() > 0 %}
+def liftObject(cls, handle):
+    """Helper to create an object instace from a handle.
+
+    This bypasses the usual __init__() logic for the given class
+    and just directly creates an instance with the given handle.
+    It's used to support factory functions and methods, which need
+    to return instances without invoking a (Python-level) constructor.
+    """
+    obj = cls.__new__(cls)
+    obj._handle = handle
+    return obj
+{% endif %}

--- a/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
@@ -14,6 +14,24 @@ class {{ obj.name()|class_name_py }}(object):
         )
 
     {% for meth in obj.methods() -%}
+    {%- if meth.is_static() -%}
+    {%- match meth.return_type() -%}
+
+    {%- when Some with (return_type) -%}
+    @staticmethod
+    def {{ meth.name()|fn_name_py }}({% call py::arg_list_decl(meth) %}):
+        {%- call py::coerce_args_extra_indent(meth) %}
+        _retval = {% call py::to_ffi_call(meth) %}
+        return {{ "_retval"|lift_py(return_type) }}
+
+    {%- when None -%}
+    @staticmethod
+    def {{ meth.name()|fn_name_py }}({% call py::arg_list_decl(meth) %}):
+        {%- call py::coerce_args_extra_indent(meth) %}
+        {% call py::to_ffi_call(meth) %}
+    {% endmatch %}
+
+    {%- else -%}
     {%- match meth.return_type() -%}
 
     {%- when Some with (return_type) -%}
@@ -27,4 +45,5 @@ class {{ obj.name()|class_name_py }}(object):
         {%- call py::coerce_args_extra_indent(meth) %}
         {% call py::to_ffi_call_with_prefix("self._handle", meth) %}
     {% endmatch %}
+    {% endif %}
     {% endfor %}

--- a/uniffi_bindgen/src/bindings/python/templates/wrapper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/wrapper.py
@@ -22,6 +22,7 @@ import contextlib
 {% include "RustBufferTemplate.py" %}
 {% include "RustBufferStream.py" %}
 {% include "RustBufferBuilder.py" %}
+{% include "Helpers.py" %}
 
 # Error definitions
 {% include "ErrorTemplate.py" %}

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -112,9 +112,6 @@ impl APIConverter<Function> for weedle::namespace::NamespaceMember<'_> {
 impl APIConverter<Function> for weedle::namespace::OperationNamespaceMember<'_> {
     fn convert(&self, ci: &mut ComponentInterface) -> Result<Function> {
         let return_type = ci.resolve_return_type_expression(&self.return_type)?;
-        if let Some(Type::Object(_)) = return_type {
-            bail!("Objects cannot currently be returned from functions");
-        }
         Ok(Function {
             name: match self.identifier {
                 None => bail!("anonymous functions are not supported {:?}", self),

--- a/uniffi_bindgen/src/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/templates/ObjectTemplate.rs
@@ -48,6 +48,42 @@ uniffi::deps::lazy_static::lazy_static! {
         uniffi::deps::log::debug!("{{ meth.ffi_func().name() }}");
         // If the method does not have the same signature as declared in the UDL, then
         // this attempt to call it will fail with a (somewhat) helpful compiler error.
+        {% if meth.is_static() %}
+        {% call rs::to_rs_static_method_call(obj, meth) %}
+        {% else %}
         {% call rs::to_rs_method_call(obj, meth) %}
+        {% endif %}
     }
 {% endfor %}
+
+// We proide a `ViaFfi` impl for each object, but the only thing it can currently
+// do is lower an owned instance into a handle. This is useful for returning new
+// instances of the object from static methods, and we know it is safe and sound
+// because Rust's ownership system ensures that:
+//  * the thing we're operating on is an owned instance (not a reference) and
+//    so we know that nothing else in the program is looking at it.
+//  * the ownership is irrevokably transferred to the handlemap, and hence to
+//    the foreign language code, which takes responsibility for it from there.
+//
+// Other operations are not yet supported, since they would involve much more
+// complicated semantics around references.
+unsafe impl uniffi::ViaFfi for {{ obj.name() }} {
+    type FfiType = u64;
+
+    fn lower(self) -> Self::FfiType {
+        // Note that this consumes `self`, transferring ownership to the handlemap.
+        {{ handle_map }}.insert(self).into_u64()
+    }
+
+    fn try_lift(_v: Self::FfiType) -> uniffi::deps::anyhow::Result<Self> {
+        uniffi::deps::anyhow::bail!("Lifting object types is not yet supported");
+    }
+
+    fn write<B: uniffi::deps::bytes::BufMut>(&self, _buf: &mut B) {
+        panic!("Writing object types is not yet supported");
+    }
+
+    fn try_read<B: uniffi::deps::bytes::Buf>(_buf: &mut B) -> uniffi::deps::anyhow::Result<Self> {
+        uniffi::deps::anyhow::bail!("Reading object types is not yet supported");
+    }
+}


### PR DESCRIPTION
It's a fairly common pattern for object-oriented interfaces to have
named functions or static methods that act as named "factories" for
producing object instances in ways that differ from the default
constructor. This commit adds basic support for such factories
by:

* Allowing owned object instances to be returned from functions
  and methods.
* Allowing interface methods to be marked as `static`.

The "owned object instances" part here is really key, since it
allows us to bypass a lot of the general concerns about returning
*references* to object instances that are outlined in #197 (and
that this commit does not at all attempt to tackle).