### PR TITLE
A little experiment with macros instead of build scripts.

### DIFF
--- a/examples/geometry/Cargo.toml
+++ b/examples/geometry/Cargo.toml
@@ -11,8 +11,5 @@ crate-type = ["cdylib"]
 name = "uniffi_geometry"
 
 [dependencies]
-uniffi_macros = {path = "../../uniffi_macros"}
+uniffi_macros = {path = "../../uniffi_macros", features=["builtin-bindgen"]}
 uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
-
-[build-dependencies]
-uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/examples/geometry/build.rs
+++ b/examples/geometry/build.rs
@@ -1,7 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-fn main() {
-    uniffi_build::generate_scaffolding("./src/geometry.udl").unwrap();
-}

--- a/examples/geometry/src/lib.rs
+++ b/examples/geometry/src/lib.rs
@@ -6,42 +6,43 @@
 // Silence, clippy!
 const EPSILON: f64 = 0.0001f64;
 
-#[derive(Debug, Clone)]
-pub struct Point {
-    coord_x: f64,
-    coord_y: f64,
-}
-
-#[derive(Debug, Clone)]
-pub struct Line {
-    start: Point,
-    end: Point,
-}
-
-pub fn gradient(ln: Line) -> f64 {
-    let rise = ln.end.coord_y - ln.start.coord_y;
-    let run = ln.end.coord_x - ln.start.coord_x;
-    rise / run
-}
-
-pub fn intersection(ln1: Line, ln2: Line) -> Option<Point> {
-    // TODO: yuck, should be able to take &Line as argument here
-    // and have rust figure it out with a bunch of annotations...
-    let g1 = gradient(ln1.clone());
-    let z1 = ln1.start.coord_y - g1 * ln1.start.coord_x;
-    let g2 = gradient(ln2.clone());
-    let z2 = ln2.start.coord_y - g2 * ln2.start.coord_x;
-    // Parallel lines do not intersect.
-    if (g1 - g2).abs() < EPSILON {
-        return None;
+#[uniffi_macros::declare_interface]
+pub mod geometry {
+    #[derive(Debug, Clone)]
+    pub struct Point {
+        coord_x: f64,
+        coord_y: f64,
     }
-    // Otherwise, they intersect at this fancy calculation that
-    // I found on wikipedia.
-    let x = (z2 - z1) / (g1 - g2);
-    Some(Point {
-        coord_x: x,
-        coord_y: g1 * x + z1,
-    })
-}
 
-include!(concat!(env!("OUT_DIR"), "/geometry.uniffi.rs"));
+    #[derive(Debug, Clone)]
+    pub struct Line {
+        start: Point,
+        end: Point,
+    }
+
+    pub fn gradient(ln: Line) -> f64 {
+        let rise = ln.end.coord_y - ln.start.coord_y;
+        let run = ln.end.coord_x - ln.start.coord_x;
+        rise / run
+    }
+
+    pub fn intersection(ln1: Line, ln2: Line) -> Option<Point> {
+        // TODO: yuck, should be able to take &Line as argument here
+        // and have rust figure it out with a bunch of annotations...
+        let g1 = gradient(ln1.clone());
+        let z1 = ln1.start.coord_y - g1 * ln1.start.coord_x;
+        let g2 = gradient(ln2.clone());
+        let z2 = ln2.start.coord_y - g2 * ln2.start.coord_x;
+        // Parallel lines do not intersect.
+        if (g1 - g2).abs() < EPSILON {
+            return None;
+        }
+        // Otherwise, they intersect at this fancy calculation that
+        // I found on wikipedia.
+        let x = (z2 - z1) / (g1 - g2);
+        Some(Point {
+            coord_x: x,
+            coord_y: g1 * x + z1,
+        })
+    }
+}

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -16,5 +16,13 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["extra-traits"] }
+syn = { version = "1.0", features = ["extra-traits", "full"] }
 glob = "0.3"
+tempfile = "3"
+uniffi_bindgen = { path = "../uniffi_bindgen", version = "= 0.7.0", optional = true }
+
+[features]
+default = []
+# Use the `uniffi_bindgen` from this workspace instead of the one installed on your system.
+# You probably only want to enable this feature if you're working on uniffi itself.
+builtin-bindgen = ["uniffi_bindgen"]

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -9,6 +9,9 @@
 
 use quote::{format_ident, quote};
 use std::env;
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::prelude::*;
 use std::path::PathBuf;
 use syn::{bracketed, punctuated::Punctuated, LitStr, Token};
 
@@ -83,4 +86,138 @@ impl syn::parse::Parse for FilePaths {
             test_scripts,
         })
     }
+}
+
+/// A helper macro to include generated component scaffolding.
+///
+/// This is a simple convenience macro to include the UniFFI component
+/// scaffolding as built by `uniffi_build::generate_scaffolding`.
+/// Use it like so:
+///
+/// ```rs
+/// uniffi_macros::include_scaffolding!("my_component_name");
+/// ```
+///
+/// This will expand to the appropriate `include!` invocation to include
+/// the generated `my_component_name.uniffi.rs` (which it assumes has
+/// been successfully built by your crate's `build.rs` script).
+//
+#[proc_macro]
+pub fn include_scaffolding(component_name: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let name = syn::parse_macro_input!(component_name as syn::LitStr);
+    if std::env::var("OUT_DIR").is_err() {
+        quote! {
+            compile_error!("This macro assumes the crate has a build.rs script, but $OUT_DIR is not present");
+        }
+    } else {
+        quote! {
+            include!(concat!(env!("OUT_DIR"), "/", #name, ".uniffi.rs"));
+        }
+    }.into()
+}
+
+/// A (very naughty) macro to generate and include UniFFI component scaffolding.
+///
+/// This is a (very naughty) macro that can be used by UniFFI component crates to
+/// automatically generate the UniFFI component scaffolding and include it into their
+/// Rust code. It's intended as a simpler alternative to a build script that runs
+/// `uniffi-bindgen`, and can be used like this:
+///
+/// ```rs
+///
+/// #[uniffi_macros::declare_interface]
+/// mod my_example {
+///     // The Rust code to implement the component goes here.
+///     pub struct Example {
+///         pub fn hello(&self) -> String {
+///             String::new("world")
+///         }
+///     }
+/// }
+/// ```
+///
+/// This macro call would read a UniFFI component interface definition from `my_example.udl`,
+/// generate the corresponding Rust scaffolding code, combine it with the Rust code from the
+/// inline module, and make the result available as top-level items in the containing file.
+///
+/// What's so naughty about this, you ask? Well, the ideal macro is supposed to be a pure
+/// function of its input tokens to its output tokens, but this one does some very
+/// frowned-upon things behind the scenes:
+///
+///  * it accesses a separate file in order to find the component interface definition.
+///  * it runs `uniffi-bindgen` and writes its output to disk.
+///  * it parses the resulting file back into memory to include in its return value.
+///
+/// All in all, some pretty weird behaviours for a macro. However, you can imagine it
+/// evolving to do fewer of these things in the future.
+///
+/// A future version could do the scaffolding generation in-process rather than
+/// shelling out to `uniffi-bindgen`. A future version could directly generate a Rust
+/// tokenstream rather than re-parsing the scaffolding from a string. And a far, far
+/// future version could conceivably even parse the attributed Rust code in order to
+/// determine the interface of the component, rather than depending on a separate `.udl`
+/// file at all...
+///
+/// For now, consider this an experiment to see whether we like the macro syntax
+/// from a developer-experience perspective.
+///
+#[proc_macro_attribute]
+pub fn declare_interface(
+    _attrs: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    // We expect to be applied to an inline module declaration, whose name
+    // is the name of the `.udl` file to load.
+    let module = syn::parse_macro_input!(item as syn::ItemMod);
+    let component_name = module.ident.to_string();
+    // Locate file relative to `src` directory of current crate.
+    let file_name = format!("{}.udl", component_name);
+    let pkg_dir = env::var("CARGO_MANIFEST_DIR")
+        .expect("Missing $CARGO_MANIFEST_DIR, cannot generate scaffolding for current crate");
+    let file_path: PathBuf = [&pkg_dir, "src", &file_name].iter().collect();
+    // Shell out to the uniffi-bindgen build process.
+    // Note that `uniffi_bindgen` expects to be writing into $OUT_DIR, but we can't assume that exists
+    // (it only seems to be present when the crate has a build script) and so need to create a tempdir.
+    let out_dir = tempfile::tempdir()
+        .expect("Could not generate temporary directly in which to run uniffi-bindgen");
+    run_uniffi_bindgen_scaffolding(out_dir.path().as_os_str(), file_path.as_os_str());
+    // Slurp the resulting code back in, so we can include it in our output.
+    let mut scaffolding = String::new();
+    let mut f = File::open(out_dir.path().join(format!("{}.uniffi.rs", component_name)))
+        .expect("Failed to open uniffi-bindgen output file");
+    f.read_to_string(&mut scaffolding)
+        .expect("Failed to read uniffi-bindgen output file");
+    let scaffolding: syn::File =
+        syn::parse_str(scaffolding.as_str()).expect("Failed to parse uniffi-bindgen output file");
+    // Lift the contents of the inline module up to the top level.
+    let mut module_items = match module.content {
+        None => vec![],
+        Some((_, items)) => items,
+    };
+    // Include the generated scaffolding.
+    module_items.extend(scaffolding.items);
+    // And we're done!
+    proc_macro::TokenStream::from(quote! {
+        #(#module_items)*
+    })
+}
+
+#[cfg(not(feature = "builtin-bindgen"))]
+fn run_uniffi_bindgen_scaffolding(out_dir: &OsStr, udl_file: &OsStr) -> () {
+    let status = std::process::Command::new("uniffi-bindgen")
+        .arg("scaffolding")
+        .arg("--out-dir")
+        .arg(out_dir)
+        .arg(udl_file)
+        .status()
+        .expect("failed to run `uniffi-bindgen` - have you installed it via `cargo install uniffi_bindgen`?");
+    if !status.success() {
+        panic!("Eror while generating scaffolding code with uniffi-bindgen");
+    }
+}
+
+#[cfg(feature = "builtin-bindgen")]
+fn run_uniffi_bindgen_scaffolding(out_dir: &OsStr, udl_file: &OsStr) -> () {
+    uniffi_bindgen::generate_component_scaffolding(udl_file, None, Some(out_dir), None, false)
+        .expect("Failed to generate scaffolding code");
 }


### PR DESCRIPTION
This commit is basically me messing around with procedural macros,
to try them out as a potential future iteration of the UniFFI
developer experience.

As a crate author, I think it would be amazing not to have to
worry about .udl files and built scripts and what-not, but
instead be able to declare my API with a macro and have Rust
just take care of the details. This commit is a tiny experiment
in that direction, based on existing features of UniFFI.

The idea is that I can wrap my Rust code in a little macro
like this:

```
[uniffi_macros::declare_interface]
pub mod my_component {
  ...my rust code goes here...
}
```

And I can provide a corresponding `my_component.udl` file that
declares the interface, and all the Rust scaffolding code just
gets taken care of automagically.

I still have to provide a `.udl` file, but I hope you can imagine
one day the possibility of generating the interface definition
directly from the Rust code that is decorated by the macro.
Not any time soon! But one day...

Curious to hear any early impressions on these shenanigans :-)