### PR TITLE
Add config option to set the cdylib name for backends that use it.

### DIFF
--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [lib]
 crate-type = ["cdylib", "lib"]
-name = "uniffi_arithmetic"
+name = "arithmetical"
 
 [dependencies]
 uniffi_macros = {path = "../../uniffi_macros"}

--- a/examples/arithmetic/uniffi.toml
+++ b/examples/arithmetic/uniffi.toml
@@ -1,2 +1,9 @@
 [bindings.kotlin]
 package_name = "org.mozilla.uniffi.example.arithmetic"
+cdylib_name = "arithmetical"
+
+[bindings.python]
+cdylib_name = "arithmetical"
+
+[bindings.swift]
+cdylib_name = "arithmetical"

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin.rs
@@ -16,18 +16,23 @@ use crate::MergeWith;
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Config {
     package_name: Option<String>,
+    cdylib_name: Option<String>,
 }
 
 impl Config {
-    fn default_package_name() -> String {
-        "uniffi".into()
-    }
-
     pub fn package_name(&self) -> String {
         if let Some(package_name) = &self.package_name {
             package_name.clone()
         } else {
-            Config::default_package_name()
+            "uniffi".into()
+        }
+    }
+
+    pub fn cdylib_name(&self) -> String {
+        if let Some(cdylib_name) = &self.cdylib_name {
+            cdylib_name.clone()
+        } else {
+            "uniffi".into()
         }
     }
 }
@@ -36,6 +41,7 @@ impl From<&ComponentInterface> for Config {
     fn from(ci: &ComponentInterface) -> Self {
         Config {
             package_name: Some(format!("uniffi.{}", ci.namespace())),
+            cdylib_name: Some(format!("uniffi_{}", ci.namespace())),
         }
     }
 }
@@ -44,6 +50,7 @@ impl MergeWith for Config {
     fn merge_with(&self, other: &Self) -> Self {
         Config {
             package_name: self.package_name.merge_with(&other.package_name),
+            cdylib_name: self.cdylib_name.merge_with(&other.cdylib_name),
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
@@ -4,7 +4,7 @@ fun findLibraryName(componentName: String): String {
     if (libOverride != null) {
         return libOverride
     }
-    return "uniffi_${componentName}"
+    return "{{ config.cdylib_name() }}"
 }
 
 inline fun <reified Lib : Library> loadIndirect(

--- a/uniffi_bindgen/src/bindings/python/gen_python.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python.rs
@@ -15,30 +15,44 @@ use crate::MergeWith;
 // sine the details of the underlying component are entirely determined by the `ComponentInterface`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Config {
-    // No config options yet.
+    cdylib_name: Option<String>,
+}
+
+impl Config {
+    pub fn cdylib_name(&self) -> String {
+        if let Some(cdylib_name) = &self.cdylib_name {
+            cdylib_name.clone()
+        } else {
+            "uniffi".into()
+        }
+    }
 }
 
 impl From<&ComponentInterface> for Config {
-    fn from(_ci: &ComponentInterface) -> Self {
-        Config {}
+    fn from(ci: &ComponentInterface) -> Self {
+        Config {
+            cdylib_name: Some(format!("uniffi_{}", ci.namespace())),
+        }
     }
 }
 
 impl MergeWith for Config {
-    fn merge_with(&self, _other: &Self) -> Self {
-        self.clone()
+    fn merge_with(&self, other: &Self) -> Self {
+        Config {
+            cdylib_name: self.cdylib_name.merge_with(&other.cdylib_name),
+        }
     }
 }
 
 #[derive(Template)]
 #[template(syntax = "py", escape = "none", path = "wrapper.py")]
 pub struct PythonWrapper<'a> {
-    _config: Config,
+    config: Config,
     ci: &'a ComponentInterface,
 }
 impl<'a> PythonWrapper<'a> {
-    pub fn new(_config: Config, ci: &'a ComponentInterface) -> Self {
-        Self { _config, ci }
+    pub fn new(config: Config, ci: &'a ComponentInterface) -> Self {
+        Self { config, ci }
     }
 }
 

--- a/uniffi_bindgen/src/bindings/python/templates/NamespaceLibraryTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/NamespaceLibraryTemplate.py
@@ -5,19 +5,19 @@
 # E.g. we might start by looking for the named component in `libuniffi.so` and if
 # that fails, fall back to loading it separately from `lib${componentName}.so`.
 
-def loadIndirect(componentName):
+def loadIndirect():
     if sys.platform == "linux":
-        libname = "libuniffi_{}.so"
+        libname = "lib{}.so"
     elif sys.platform == "darwin":
-        libname = "libuniffi_{}.dylib"
+        libname = "lib{}.dylib"
     elif sys.platform.startswith("win"):
-        libname = "libuniffi_{}.dll"
-    return getattr(ctypes.cdll, libname.format(componentName))
+        libname = "lib_{}.dll"
+    return getattr(ctypes.cdll, libname.format("{{ config.cdylib_name() }}"))
 
 # A ctypes library to expose the extern-C FFI definitions.
 # This is an implementation detail which will be called internally by the public API.
 
-_UniFFILib = loadIndirect(componentName="{{ ci.namespace() }}")
+_UniFFILib = loadIndirect()
 {%- for func in ci.iter_ffi_function_definitions() %}
 _UniFFILib.{{ func.name() }}.argtypes = (
     {%- call py::arg_list_ffi_decl(func) -%}

--- a/uniffi_bindgen/src/bindings/swift/gen_swift.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift.rs
@@ -19,6 +19,7 @@ use crate::MergeWith;
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Config {
     module_name: Option<String>,
+    cdylib_name: Option<String>,
 }
 impl Config {
     pub fn module_name(&self) -> String {
@@ -33,12 +34,20 @@ impl Config {
     pub fn header_filename(&self) -> String {
         format!("{}-Bridging-Header.h", self.module_name())
     }
+    pub fn cdylib_name(&self) -> String {
+        if let Some(cdylib_name) = &self.cdylib_name {
+            cdylib_name.clone()
+        } else {
+            "uniffi".into()
+        }
+    }
 }
 
 impl From<&ComponentInterface> for Config {
     fn from(ci: &ComponentInterface) -> Self {
         Config {
             module_name: Some(format!("uniffi_{}", ci.namespace())),
+            cdylib_name: Some(format!("uniffi_{}", ci.namespace())),
         }
     }
 }
@@ -47,6 +56,7 @@ impl MergeWith for Config {
     fn merge_with(&self, other: &Self) -> Self {
         Config {
             module_name: self.module_name.merge_with(&other.module_name),
+            cdylib_name: self.cdylib_name.merge_with(&other.cdylib_name),
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -140,7 +140,7 @@ pub fn compile_bindings(config: &Config, ci: &ComponentInterface, out_dir: &Path
         .arg("-parse-as-library")
         .arg("-L")
         .arg(&out_path)
-        .arg(format!("-luniffi_{}", ci.namespace()))
+        .arg(format!("-l{}", config.cdylib_name()))
         .arg("-Xcc")
         .arg(module_map_file_option)
         .arg(source_file)


### PR DESCRIPTION
When building uniffi components in the application-services monorepo,
we know that they're all going to want to load their FFI symbols from
the combined "libmegazord.so". This adds a config option so that
the generated code can use this cdylib name by default, rather
than having to specify it as an override at runtime.

Ref https://github.com/mozilla/application-services/issues/3874