### PR TITLE
Tweak generated Kotlin for compatibility with Android API 21.

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
@@ -377,7 +377,10 @@ internal fun lower{{ canonical_type_name }}(m: Map<String, {{ inner_type_name }}
 
 internal fun write{{ canonical_type_name }}(v: Map<String, {{ inner_type_name }}>, buf: RustBufferBuilder) {
     buf.putInt(v.size)
-    v.forEach { k, v ->
+    // The parens on `(k, v)` here ensure we're calling the right method,
+    // which is important for compatibility with older android devices.
+    // Ref https://blog.danlew.net/2017/03/16/kotlin-puzzler-whose-line-is-it-anyways/
+    v.forEach { (k, v) ->
         k.write(buf)
         {{ "v"|write_kt("buf", inner_type) }}
     }


### PR DESCRIPTION
While trying to uniffi the fxa-client crate, I discovered some linter errors in the generated Kotlin saying "`Error: Call requires API level 24 (current min is 21)`". A bit of ducking-and-going led me to the tweaks here which silence the warnings. For good measure, I've also avoided generating helper code when it won't be used by the bindings.