### PR TITLE
Get `cargo test py` passing on Window.

### DIFF
--- a/uniffi/src/testing.rs
+++ b/uniffi/src/testing.rs
@@ -121,7 +121,7 @@ pub fn ensure_compiled_cdylib(pkg_dir: &str) -> Result<String> {
         .filenames
         .iter()
         .filter(|nm| match nm.extension().unwrap_or_default().to_str() {
-            Some("dylib") | Some("so") => true,
+            Some(std::env::consts::DLL_EXTENSION) => true,
             _ => false,
         })
         .collect();

--- a/uniffi_bindgen/src/bindings/python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/mod.rs
@@ -57,12 +57,13 @@ pub fn generate_python_bindings(config: &Config, ci: &ComponentInterface) -> Res
 /// Execute the specifed python script, with environment based on the generated
 /// artifacts in the given output directory.
 pub fn run_script(out_dir: &Path, script_file: &Path) -> Result<()> {
-    let mut pythonpath = env::var_os("PYTHONPATH").unwrap_or_else(|| OsString::from(""));
-    // This lets python find the compiled library for the rust component.
-    pythonpath.push(":");
-    pythonpath.push(out_dir);
     let mut cmd = Command::new("python3");
+    // This helps python find the generated .py wrapper for rust component.
+    let pythonpath = env::var_os("PYTHONPATH").unwrap_or_else(|| OsString::from(""));
+    let pythonpath =
+        env::join_paths(env::split_paths(&pythonpath).chain(vec![out_dir.to_path_buf()]))?;
     cmd.env("PYTHONPATH", pythonpath);
+    // We should now be able to execute the tests successfully.
     cmd.arg(script_file);
     let status = cmd
         .spawn()

--- a/uniffi_bindgen/src/bindings/python/templates/NamespaceLibraryTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/NamespaceLibraryTemplate.py
@@ -11,7 +11,14 @@ def loadIndirect():
     elif sys.platform == "darwin":
         libname = "lib{}.dylib"
     elif sys.platform.startswith("win"):
-        libname = "lib_{}.dll"
+        # As of python3.8, ctypes does not seem to search $PATH when loading DLLs.
+        # We could use `os.add_dll_directory` to configure the search path, but
+        # it doesn't feel right to mess with application-wide settings. Let's
+        # assume that the `.dll` is next to the `.py` file and load by full path.
+        libname = os.path.join(
+            os.path.dirname(__file__),
+            "{}.dll",
+        )
     return getattr(ctypes.cdll, libname.format("{{ config.cdylib_name() }}"))
 
 # A ctypes library to expose the extern-C FFI definitions.

--- a/uniffi_bindgen/src/bindings/python/templates/wrapper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/wrapper.py
@@ -13,6 +13,7 @@
 # compile the rust component. The easiest way to ensure this is to bundle the Python
 # helpers directly inline like we're doing here.
 
+import os
 import sys
 import ctypes
 import enum


### PR DESCRIPTION
Fixes https://github.com/mozilla/uniffi-rs/issues/391.

I have no intention of messing around with Swift or Kotlin on Windows, but this at least makes `cargo test py` run successfully.