### PR TITLE
Remove version pin of `funty`, which is no longer required.

### DIFF
--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -23,11 +23,3 @@ heck = "0.3"
 clap = { version = "2", default-features = false }
 serde = "1"
 toml = "0.5"
-
-# Workaround for an issue with `bitvec` on newer rusts, which we get via `nom`.
-# Hopefully we'll be able to remove this after a new release of `nom`.
-# Ref https://github.com/Geal/nom/pull/1286/.
-[dependencies.funty]
-version = ">1.0, <=1.1"
-optional = true
-default-features = false


### PR DESCRIPTION
The latest release of `nom` seems to have fixed the dependency issue so this is no longer required.

This basically reverts the version pin from https://github.com/mozilla/uniffi-rs/pull/382, and I'm counting on CI to confirm my "no longer required" hypothesis with a clean build...