### PR TITLE
Fix a clippy lint in the generated scaffolding for enums with associated data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
   Rust and Foreign Language tests:
     docker:
       - image: rfkelly/uniffi-ci:latest
-    resource_class: medium
+    resource_class: large
     steps:
       - run: cat ~/.profile >> $BASH_ENV
       - run:

--- a/uniffi_bindgen/src/templates/EnumTemplate.rs
+++ b/uniffi_bindgen/src/templates/EnumTemplate.rs
@@ -38,7 +38,7 @@ unsafe impl uniffi::ViaFfi for {{ e.name() }} {
                 {%- endfor %}
             }{% endif %},
             {%- endfor %}
-            v @ _ => uniffi::deps::anyhow::bail!("Invalid {{ e.name() }} enum value: {}", v),
+            v => uniffi::deps::anyhow::bail!("Invalid {{ e.name() }} enum value: {}", v),
         })
     }
 }


### PR DESCRIPTION
Otherwise clippy yells at me when trying to use this feature in the fxa-client crate:

```
error: the `v @ _` pattern can be written as just `v`
```