### PR TITLE
Mark record fields as `public` in Swift bindings.

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -1,6 +1,6 @@
 public struct {{ rec.name()|class_name_swift }}:  ViaFfiUsingByteBuffer, ViaFfi, Equatable, Hashable {
     {%- for field in rec.fields() %}
-    let {{ field.name()|var_name_swift }}: {{ field.type_()|type_swift }}
+    public let {{ field.name()|var_name_swift }}: {{ field.type_()|type_swift }}
     {%- endfor %}
 
     // Default memberwise initializers are never public by default, so we


### PR DESCRIPTION
Swift struct fields default to `internal` visibility, loosly
analogous to Rust's `pub(crate)`. That's clearly enough for them
to work fine in our tests, but when I tried out using these
across Swift module boundaries, I got errors about being able
to access to fields.

Since the whole point of record types is to make structured
data available, I think it makes sense for their fields to be
marked public.