### PR TITLE
Eliminate duplicate declarations of helper structs and extensions in Swift

### DIFF
--- a/examples/app/ios/IOSApp-Bridging-Header.h
+++ b/examples/app/ios/IOSApp-Bridging-Header.h
@@ -6,6 +6,7 @@
 #ifndef IOSApp_Bridging_Header_h
 #define IOSApp_Bridging_Header_h
 
+#import "uniffi_arithmetic-Bridging-Header.h"
 #import "uniffi_todolist-Bridging-Header.h"
 
 #endif /* IOSApp_Bridging_Header_h */

--- a/examples/app/ios/IOSApp.xcodeproj/project.pbxproj
+++ b/examples/app/ios/IOSApp.xcodeproj/project.pbxproj
@@ -7,13 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		394A808A25EED46500FAF26F /* todolist.udl in Sources */ = {isa = PBXBuildFile; fileRef = 39ADD16325E98FA5000EE485 /* todolist.udl */; };
+		394A808B25EED46500FAF26F /* arithmetic.udl in Sources */ = {isa = PBXBuildFile; fileRef = 39ADD15E25E98F92000EE485 /* arithmetic.udl */; };
 		395A8817251A062C00562F33 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395A8816251A062C00562F33 /* ExampleApp.swift */; };
 		395A8819251A062C00562F33 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395A8818251A062C00562F33 /* ContentView.swift */; };
 		395A881B251A062D00562F33 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 395A881A251A062D00562F33 /* Assets.xcassets */; };
 		395A881E251A062D00562F33 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 395A881D251A062D00562F33 /* Preview Assets.xcassets */; };
 		395A8829251A062D00562F33 /* IOSAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395A8828251A062D00562F33 /* IOSAppTests.swift */; };
 		395A8834251A062D00562F33 /* IOSAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395A8833251A062D00562F33 /* IOSAppUITests.swift */; };
-		CEEB59CB25263C7E003C87D1 /* todolist.udl in Sources */ = {isa = PBXBuildFile; fileRef = CEEB59CA25263C7E003C87D1 /* todolist.udl */; };
+		39ADC3DF25E98792000EE485 /* libarithmetical.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 39ADC3DE25E98792000EE485 /* libarithmetical.a */; };
+		39ADD16D25E990CA000EE485 /* uniffi_arithmetic-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 39ADD16925E990CA000EE485 /* uniffi_arithmetic-Bridging-Header.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		39ADD16F25E990CA000EE485 /* uniffi_todolist-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 39ADD16B25E990CA000EE485 /* uniffi_todolist-Bridging-Header.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CEEB5A0025264123003C87D1 /* libuniffi_todolist.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEEB59FF25264123003C87D1 /* libuniffi_todolist.a */; };
 /* End PBXBuildFile section */
 
@@ -27,10 +31,10 @@
 			);
 			isEditable = 1;
 			outputFiles = (
-				"$(DERIVED_FILE_DIR)/$(INPUT_FILE_BASE)-Bridging-Header.h",
-				"$(DERIVED_FILE_DIR)/$(INPUT_FILE_BASE).swift",
+				"$(SRCROOT)/Generated/uniffi_$(INPUT_FILE_BASE)-Bridging-Header.h",
+				"$(SRCROOT)/Generated/$(INPUT_FILE_BASE).swift",
 			);
-			script = "# Generate swift bindings for the todolist rust library.\n\"$SRCROOT/../../../target/debug/uniffi-bindgen\" generate \"$INPUT_FILE_PATH\" --language swift --out-dir \"$DERIVED_FILE_DIR\"\necho \"Generate files in $DERIVED_FILE_DIR\"\n";
+			script = "# Generate swift bindings for the todolist rust library.\necho \"Generating files for $INPUT_FILE_PATH\"\n\"$SRCROOT/../../../target/debug/uniffi-bindgen\" generate \"$INPUT_FILE_PATH\" --language swift --out-dir \"$SRCROOT/Generated\"\necho \"Generated files for $INPUT_FILE_BASE in $SRCROOT/Generated\"\n";
 		};
 /* End PBXBuildRule section */
 
@@ -64,8 +68,14 @@
 		395A882F251A062D00562F33 /* IOSAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IOSAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		395A8833251A062D00562F33 /* IOSAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSAppUITests.swift; sourceTree = "<group>"; };
 		395A8835251A062D00562F33 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		39ADC3DE25E98792000EE485 /* libarithmetical.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libarithmetical.a; path = ../../../target/universal/debug/libarithmetical.a; sourceTree = "<group>"; };
+		39ADD15E25E98F92000EE485 /* arithmetic.udl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = arithmetic.udl; path = ../../arithmetic/src/arithmetic.udl; sourceTree = "<group>"; };
+		39ADD16325E98FA5000EE485 /* todolist.udl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = todolist.udl; path = ../../todolist/src/todolist.udl; sourceTree = "<group>"; };
+		39ADD16925E990CA000EE485 /* uniffi_arithmetic-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "uniffi_arithmetic-Bridging-Header.h"; sourceTree = "<group>"; };
+		39ADD16A25E990CA000EE485 /* arithmetic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = arithmetic.swift; sourceTree = "<group>"; };
+		39ADD16B25E990CA000EE485 /* uniffi_todolist-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "uniffi_todolist-Bridging-Header.h"; sourceTree = "<group>"; };
+		39ADD16C25E990CA000EE485 /* todolist.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = todolist.swift; sourceTree = "<group>"; };
 		39C5D6D82524F95400BDBA8A /* IOSApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "IOSApp-Bridging-Header.h"; sourceTree = "<group>"; };
-		CEEB59CA25263C7E003C87D1 /* todolist.udl */ = {isa = PBXFileReference; lastKnownFileType = text; name = todolist.udl; path = ../../todolist/src/todolist.udl; sourceTree = "<group>"; };
 		CEEB59FF25264123003C87D1 /* libuniffi_todolist.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libuniffi_todolist.a; path = ../../../target/universal/debug/libuniffi_todolist.a; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -74,6 +84,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				39ADC3DF25E98792000EE485 /* libarithmetical.a in Frameworks */,
 				CEEB5A0025264123003C87D1 /* libuniffi_todolist.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -98,11 +109,13 @@
 		395A880A251A062C00562F33 = {
 			isa = PBXGroup;
 			children = (
-				CEEB59CA25263C7E003C87D1 /* todolist.udl */,
+				39ADD16325E98FA5000EE485 /* todolist.udl */,
+				39ADD15E25E98F92000EE485 /* arithmetic.udl */,
 				39C5D6D82524F95400BDBA8A /* IOSApp-Bridging-Header.h */,
 				395A8815251A062C00562F33 /* IOSApp */,
 				395A8827251A062D00562F33 /* IOSAppTests */,
 				395A8832251A062D00562F33 /* IOSAppUITests */,
+				39ADD16825E990CA000EE485 /* Generated */,
 				395A8814251A062C00562F33 /* Products */,
 				CEEB59FE25264123003C87D1 /* Frameworks */,
 			);
@@ -156,9 +169,21 @@
 			path = IOSAppUITests;
 			sourceTree = "<group>";
 		};
+		39ADD16825E990CA000EE485 /* Generated */ = {
+			isa = PBXGroup;
+			children = (
+				39ADD16925E990CA000EE485 /* uniffi_arithmetic-Bridging-Header.h */,
+				39ADD16A25E990CA000EE485 /* arithmetic.swift */,
+				39ADD16B25E990CA000EE485 /* uniffi_todolist-Bridging-Header.h */,
+				39ADD16C25E990CA000EE485 /* todolist.swift */,
+			);
+			path = Generated;
+			sourceTree = "<group>";
+		};
 		CEEB59FE25264123003C87D1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				39ADC3DE25E98792000EE485 /* libarithmetical.a */,
 				CEEB59FF25264123003C87D1 /* libuniffi_todolist.a */,
 			);
 			name = Frameworks;
@@ -166,14 +191,28 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		39ADC3F725E98DA6000EE485 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				39ADD16F25E990CA000EE485 /* uniffi_todolist-Bridging-Header.h in Headers */,
+				39ADD16D25E990CA000EE485 /* uniffi_arithmetic-Bridging-Header.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
 		395A8812251A062C00562F33 /* IOSApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 395A8838251A062D00562F33 /* Build configuration list for PBXNativeTarget "IOSApp" */;
 			buildPhases = (
-				CEEB59EB25263ECE003C87D1 /* ShellScript */,
+				CEEB59EB25263ECE003C87D1 /* Build Universal Binary for todolist */,
+				39ADC3D125E980F1000EE485 /* Build Universal Binary for arithmetic */,
 				395A880F251A062C00562F33 /* Sources */,
 				395A8810251A062C00562F33 /* Frameworks */,
+				39ADC3F725E98DA6000EE485 /* Headers */,
 				395A8811251A062C00562F33 /* Resources */,
 			);
 			buildRules = (
@@ -291,7 +330,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		CEEB59EB25263ECE003C87D1 /* ShellScript */ = {
+		39ADC3D125E980F1000EE485 /* Build Universal Binary for arithmetic */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -300,6 +339,25 @@
 			);
 			inputPaths = (
 			);
+			name = "Build Universal Binary for arithmetic";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "bash $SRCROOT/xc-universal-binary.sh libarithmetical.a uniffi-example-arithmetic $SRCROOT/../../.. $CONFIGURATION\n";
+		};
+		CEEB59EB25263ECE003C87D1 /* Build Universal Binary for todolist */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build Universal Binary for todolist";
 			outputFileListPaths = (
 			);
 			outputPaths = (
@@ -315,7 +373,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CEEB59CB25263C7E003C87D1 /* todolist.udl in Sources */,
+				394A808A25EED46500FAF26F /* todolist.udl in Sources */,
+				394A808B25EED46500FAF26F /* arithmetic.udl in Sources */,
 				395A8819251A062C00562F33 /* ContentView.swift in Sources */,
 				395A8817251A062C00562F33 /* ExampleApp.swift in Sources */,
 			);

--- a/examples/app/ios/IOSApp/ContentView.swift
+++ b/examples/app/ios/IOSApp/ContentView.swift
@@ -10,7 +10,8 @@ struct ContentView: View {
     }
 
     var todoList: TodoList
-    @State private var clicked = 0
+    let stride: UInt64 = UInt64(1)
+    @State private var clicked = UInt64.zero
     @State private var text = ""
     var body: some View {
         VStack {
@@ -19,7 +20,7 @@ struct ContentView: View {
                 TextField("New task", text: $text, onCommit:  {
                     try! self.todoList.addEntry(entry: TodoEntry(text: "\(clicked) \(text)"))
                     text = ""
-                    clicked = clicked + 1
+                    clicked = try! add(a: clicked,  b: stride)
                 }).padding()
             }
 
@@ -32,7 +33,7 @@ struct ContentView: View {
                         if let i = index.first {
                             let entry = todoList.getEntries()[i]
                             try! todoList.clearItem(todo: entry.text)
-                            clicked = clicked - 1
+                            clicked = try! sub(a: clicked,  b: stride)
                         }
                     }
                 }

--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["staticlib", "cdylib", "lib"]
 name = "arithmetical"
 
 [dependencies]

--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -18,7 +18,7 @@ extension {{ e.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi {
             {% endfor -%}
         ){% endif -%}
         {% endfor %}
-        default: throw InternalError.unexpectedEnumCase
+        default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 

--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -1,12 +1,14 @@
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
-public enum {{ e.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi, Equatable {
+public enum {{ e.name()|class_name_swift }}: Equatable {
     {% for variant in e.variants() %}
     case {{ variant.name()|enum_variant_swift }}{% if variant.fields().len() > 0 %}({% call swift::field_list_decl(variant) %}){% endif -%}
     {% endfor %}
+}
 
-    static func read(from buf: Reader) throws -> {{ e.name()|class_name_swift }} {
+extension {{ e.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi {
+    fileprivate static func read(from buf: Reader) throws -> {{ e.name()|class_name_swift }} {
         let variant: Int32 = try buf.readInt()
         switch variant {
         {% for variant in e.variants() %}
@@ -20,7 +22,7 @@ public enum {{ e.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi, Equa
         }
     }
 
-    func write(into buf: Writer) {
+    fileprivate func write(into buf: Writer) {
         switch self {
         {% for variant in e.variants() %}
         {% if variant.has_fields() %}

--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -25,7 +25,7 @@ public class {{ obj.name()|class_name_swift }}: {{ obj.name() }}Protocol {
     {%- endmatch %}
 
     deinit {
-        try! rustCall(InternalError.unknown()) { err in
+        try! rustCall(UniffiInternalError.unknown("deinit")) { err in
             {{ obj.ffi_object_free().name() }}(handle, err)
         }
     }

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -1,4 +1,4 @@
-public struct {{ rec.name()|class_name_swift }}:  ViaFfiUsingByteBuffer, ViaFfi, Equatable, Hashable {
+public struct {{ rec.name()|class_name_swift }}: Equatable, Hashable {
     {%- for field in rec.fields() %}
     public let {{ field.name()|var_name_swift }}: {{ field.type_()|type_swift }}
     {%- endfor %}
@@ -20,7 +20,15 @@ public struct {{ rec.name()|class_name_swift }}:  ViaFfiUsingByteBuffer, ViaFfi,
         return true
     }
 
-    static func read(from buf: Reader) throws -> {{ rec.name()|class_name_swift }} {
+    public func hash(into hasher: inout Hasher) {
+        {%- for field in rec.fields() %}
+        hasher.combine({{ field.name()|var_name_swift }})
+        {%- endfor %}
+    }
+}
+
+extension {{ rec.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi {
+    fileprivate static func read(from buf: Reader) throws -> {{ rec.name()|class_name_swift }} {
         return try {{ rec.name()|class_name_swift }}(
             {%- for field in rec.fields() %}
             {{ field.name()|var_name_swift }}: {{ "buf"|read_swift(field.type_()) }}{% if loop.last %}{% else %},{% endif %}
@@ -28,15 +36,9 @@ public struct {{ rec.name()|class_name_swift }}:  ViaFfiUsingByteBuffer, ViaFfi,
         )
     }
 
-    func write(into buf: Writer) {
+    fileprivate func write(into buf: Writer) {
         {%- for field in rec.fields() %}
         {{ field.name()|var_name_swift }}.write(into: buf)
-        {%- endfor %}
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        {%- for field in rec.fields() %}
-        hasher.combine({{ field.name()|var_name_swift }})
         {%- endfor %}
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/RustBufferHelper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RustBufferHelper.swift
@@ -1,7 +1,7 @@
 // Helper classes/extensions that don't change.
 // Someday, this will be in a libray of its own.
 
-extension Data {
+fileprivate extension Data {
     init(rustBuffer: RustBuffer) {
         // TODO: This copies the buffer. Can we read directly from a
         // Rust buffer?
@@ -10,7 +10,7 @@ extension Data {
 }
 
 // A helper class to read values out of a byte buffer.
-class Reader {
+fileprivate class Reader {
     let data: Data
     var offset: Data.Index
 
@@ -73,7 +73,7 @@ class Reader {
 }
 
 // A helper class to write values into a byte buffer.
-class Writer {
+fileprivate class Writer {
     var bytes: [UInt8]
     var offset: Array<UInt8>.Index
 
@@ -108,42 +108,42 @@ class Writer {
 
 
 // Types conforming to `Serializable` can be read and written in a bytebuffer.
-protocol Serializable {
+fileprivate protocol Serializable {
     func write(into: Writer)
     static func read(from: Reader) throws -> Self
 }
 
 // Types confirming to `ViaFfi` can be transferred back-and-for over the FFI.
 // This is analogous to the Rust trait of the same name.
-protocol ViaFfi: Serializable {
+fileprivate protocol ViaFfi: Serializable {
     associatedtype FfiType
     static func lift(_ v: FfiType) throws -> Self
     func lower() -> FfiType
 }
 
 // Types conforming to `Primitive` pass themselves directly over the FFI.
-protocol Primitive {}
+fileprivate protocol Primitive {}
 
 extension Primitive {
     typealias FfiType = Self
 
-    static func lift(_ v: Self) throws -> Self {
+    fileprivate static func lift(_ v: Self) throws -> Self {
         return v
     }
 
-    func lower() -> Self {
+    fileprivate func lower() -> Self {
         return self
     }
 }
 
 // Types conforming to `ViaFfiUsingByteBuffer` lift and lower into a bytebuffer.
 // Use this for complex types where it's hard to write a custom lift/lower.
-protocol ViaFfiUsingByteBuffer: Serializable {}
+fileprivate protocol ViaFfiUsingByteBuffer: Serializable {}
 
 extension ViaFfiUsingByteBuffer {
     typealias FfiType = RustBuffer
 
-    static func lift(_ buf: RustBuffer) throws -> Self {
+    fileprivate static func lift(_ buf: RustBuffer) throws -> Self {
       let reader = Reader(data: Data(rustBuffer: buf))
       let value = try Self.read(from: reader)
       if reader.hasRemaining() {
@@ -153,7 +153,7 @@ extension ViaFfiUsingByteBuffer {
       return value
     }
 
-    func lower() -> RustBuffer {
+    fileprivate func lower() -> RustBuffer {
       let writer = Writer()
       self.write(into: writer)
       return RustBuffer(bytes: writer.bytes)
@@ -165,7 +165,7 @@ extension ViaFfiUsingByteBuffer {
 extension String: ViaFfi {
     typealias FfiType = RustBuffer
 
-    static func lift(_ v: FfiType) throws -> Self {
+    fileprivate static func lift(_ v: FfiType) throws -> Self {
         defer {
             try! rustCall(InternalError.unknown()) { err in
                 {{ ci.ffi_rustbuffer_free().name() }}(v, err)
@@ -178,7 +178,7 @@ extension String: ViaFfi {
         return String(bytes: bytes, encoding: String.Encoding.utf8)!
     }
 
-    func lower() -> FfiType {
+    fileprivate func lower() -> FfiType {
         return self.utf8CString.withUnsafeBufferPointer { ptr in
             // The swift string gives us int8_t, we want uint8_t.
             ptr.withMemoryRebound(to: UInt8.self) { ptr in
@@ -192,12 +192,12 @@ extension String: ViaFfi {
         }
     }
 
-    static func read(from buf: Reader) throws -> Self {
+    fileprivate static func read(from buf: Reader) throws -> Self {
         let len: Int32 = try buf.readInt()
         return String(bytes: try buf.readBytes(count: Int(len)), encoding: String.Encoding.utf8)!
     }
 
-    func write(into buf: Writer) {
+    fileprivate func write(into buf: Writer) {
         let len = Int32(self.utf8.count)
         buf.writeInt(len)
         buf.writeBytes(self.utf8)
@@ -208,125 +208,125 @@ extension String: ViaFfi {
 extension Bool: ViaFfi {
     typealias FfiType = Int8
 
-    static func read(from buf: Reader) throws -> Bool {
+    fileprivate static func read(from buf: Reader) throws -> Bool {
         return try self.lift(buf.readInt())
     }
 
-    func write(into buf: Writer) {
+    fileprivate func write(into buf: Writer) {
         buf.writeInt(self.lower())
     }
 
-    static func lift(_ v: Int8) throws -> Bool {
+    fileprivate static func lift(_ v: Int8) throws -> Bool {
         return v != 0
     }
 
-    func lower() -> Int8 {
+    fileprivate func lower() -> Int8 {
         return self ? 1 : 0
     }
 }
 
 extension UInt8: Primitive, ViaFfi {
-    static func read(from buf: Reader) throws -> UInt8 {
+    fileprivate static func read(from buf: Reader) throws -> UInt8 {
         return try self.lift(buf.readInt())
     }
 
-    func write(into buf: Writer) {
+    fileprivate func write(into buf: Writer) {
         buf.writeInt(self.lower())
     }
 }
 
 extension Int8: Primitive, ViaFfi {
-    static func read(from buf: Reader) throws -> Int8 {
+    fileprivate static func read(from buf: Reader) throws -> Int8 {
         return try self.lift(buf.readInt())
     }
 
-    func write(into buf: Writer) {
+    fileprivate func write(into buf: Writer) {
         buf.writeInt(self.lower())
     }
 }
 
 extension UInt16: Primitive, ViaFfi {
-    static func read(from buf: Reader) throws -> UInt16 {
+    fileprivate static func read(from buf: Reader) throws -> UInt16 {
         return try self.lift(buf.readInt())
     }
 
-    func write(into buf: Writer) {
+    fileprivate func write(into buf: Writer) {
         buf.writeInt(self.lower())
     }
 }
 
 extension Int16: Primitive, ViaFfi {
-    static func read(from buf: Reader) throws -> Int16 {
+    fileprivate static func read(from buf: Reader) throws -> Int16 {
         return try self.lift(buf.readInt())
     }
 
-    func write(into buf: Writer) {
+    fileprivate func write(into buf: Writer) {
         buf.writeInt(self.lower())
     }
 }
 
 extension UInt32: Primitive, ViaFfi {
-    static func read(from buf: Reader) throws -> UInt32 {
+    fileprivate static func read(from buf: Reader) throws -> UInt32 {
         return try self.lift(buf.readInt())
     }
 
-    func write(into buf: Writer) {
+    fileprivate func write(into buf: Writer) {
         buf.writeInt(self.lower())
     }
 }
 
 extension Int32: Primitive, ViaFfi {
-    static func read(from buf: Reader) throws -> Int32 {
+    fileprivate static func read(from buf: Reader) throws -> Int32 {
         return try self.lift(buf.readInt())
     }
 
-    func write(into buf: Writer) {
+    fileprivate func write(into buf: Writer) {
         buf.writeInt(self.lower())
     }
 }
 
 extension UInt64: Primitive, ViaFfi {
-    static func read(from buf: Reader) throws -> UInt64 {
+    fileprivate static func read(from buf: Reader) throws -> UInt64 {
         return try self.lift(buf.readInt())
     }
 
-    func write(into buf: Writer) {
+    fileprivate func write(into buf: Writer) {
         buf.writeInt(self.lower())
     }
 }
 
 extension Int64: Primitive, ViaFfi {
-    static func read(from buf: Reader) throws -> Int64 {
+    fileprivate static func read(from buf: Reader) throws -> Int64 {
         return try self.lift(buf.readInt())
     }
 
-    func write(into buf: Writer) {
+    fileprivate func write(into buf: Writer) {
         buf.writeInt(self.lower())
     }
 }
 
 extension Float: Primitive, ViaFfi {
-    static func read(from buf: Reader) throws -> Float {
+    fileprivate static func read(from buf: Reader) throws -> Float {
         return try self.lift(buf.readFloat())
     }
 
-    func write(into buf: Writer) {
+    fileprivate func write(into buf: Writer) {
         buf.writeFloat(self.lower())
     }
 }
 
 extension Double: Primitive, ViaFfi {
-    static func read(from buf: Reader) throws -> Double {
+    fileprivate static func read(from buf: Reader) throws -> Double {
         return try self.lift(buf.readDouble())
     }
 
-    func write(into buf: Writer) {
+    fileprivate func write(into buf: Writer) {
         buf.writeDouble(self.lower())
     }
 }
 
 extension Optional: ViaFfiUsingByteBuffer, ViaFfi, Serializable where Wrapped: Serializable {
-    static func read(from buf: Reader) throws -> Self {
+    fileprivate static func read(from buf: Reader) throws -> Self {
         switch try buf.readInt() as Int8 {
         case 0: return nil
         case 1: return try Wrapped.read(from: buf)
@@ -334,7 +334,7 @@ extension Optional: ViaFfiUsingByteBuffer, ViaFfi, Serializable where Wrapped: S
         }
     }
 
-    func write(into buf: Writer) {
+    fileprivate func write(into buf: Writer) {
         guard let value = self else {
             buf.writeInt(Int8(0))
             return
@@ -345,7 +345,7 @@ extension Optional: ViaFfiUsingByteBuffer, ViaFfi, Serializable where Wrapped: S
 }
 
 extension Array: ViaFfiUsingByteBuffer, ViaFfi, Serializable where Element: Serializable {
-    static func read(from buf: Reader) throws -> Self {
+    fileprivate static func read(from buf: Reader) throws -> Self {
         let len: Int32 = try buf.readInt()
         var seq = [Element]()
         seq.reserveCapacity(Int(len))
@@ -355,7 +355,7 @@ extension Array: ViaFfiUsingByteBuffer, ViaFfi, Serializable where Element: Seri
         return seq
     }
 
-    func write(into buf: Writer) {
+    fileprivate func write(into buf: Writer) {
         let len = Int32(self.count)
         buf.writeInt(len)
         for item in self {
@@ -365,7 +365,7 @@ extension Array: ViaFfiUsingByteBuffer, ViaFfi, Serializable where Element: Seri
 }
 
 extension Dictionary: ViaFfiUsingByteBuffer, ViaFfi, Serializable where Key == String, Value: Serializable {
-    static func read(from buf: Reader) throws -> Self {
+    fileprivate static func read(from buf: Reader) throws -> Self {
         let len: Int32 = try buf.readInt()
         var dict = [String: Value]()
         dict.reserveCapacity(Int(len))
@@ -375,7 +375,7 @@ extension Dictionary: ViaFfiUsingByteBuffer, ViaFfi, Serializable where Key == S
         return dict
     }
 
-    func write(into buf: Writer) {
+    fileprivate func write(into buf: Writer) {
         let len = Int32(self.count)
         buf.writeInt(len)
         for (key, value) in self {

--- a/uniffi_bindgen/src/bindings/swift/templates/RustBufferTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RustBufferTemplate.swift
@@ -2,7 +2,7 @@ fileprivate extension RustBuffer {
     // Allocate a new buffer, copying the contents of a `UInt8` array.
     init(bytes: [UInt8]) {
         let rbuf = bytes.withUnsafeBufferPointer { ptr in
-            try! rustCall(InternalError.unknown()) { err in
+            try! rustCall(UniffiInternalError.unknown("RustBuffer.init")) { err in
                 {{ ci.ffi_rustbuffer_from_bytes().name() }}(ForeignBytes(bufferPointer: ptr), err)
             }
         }
@@ -13,7 +13,7 @@ fileprivate extension RustBuffer {
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
-        try! rustCall(InternalError.unknown()) { err in
+        try! rustCall(UniffiInternalError.unknown("RustBuffer.deallocate")) { err in
             {{ ci.ffi_rustbuffer_free().name() }}(self, err)
         }
     }

--- a/uniffi_bindgen/src/bindings/swift/templates/RustBufferTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RustBufferTemplate.swift
@@ -1,4 +1,4 @@
-extension RustBuffer {
+fileprivate extension RustBuffer {
     // Allocate a new buffer, copying the contents of a `UInt8` array.
     init(bytes: [UInt8]) {
         let rbuf = bytes.withUnsafeBufferPointer { ptr in
@@ -19,7 +19,7 @@ extension RustBuffer {
     }
 }
 
-extension ForeignBytes {
+fileprivate extension ForeignBytes {
     init(bufferPointer: UnsafeBufferPointer<UInt8>) {
         // Ref https://github.com/mozilla/uniffi-rs/issues/334 for the extra "padding" args.
         self.init(len: Int32(bufferPointer.count), data: bufferPointer.baseAddress, padding: 0, padding2: 0)

--- a/uniffi_bindgen/src/bindings/swift/templates/Template-Bridging-Header.h
+++ b/uniffi_bindgen/src/bindings/swift/templates/Template-Bridging-Header.h
@@ -6,6 +6,14 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+// The following structs are used to implement the lowest level
+// of the FFI, and thus useful to multiple uniffied crates.
+// We ensure they are declared exactly once, with a header guard, UNIFFI_SHARED_H.
+// This may become a potential footgun if multiple versions of uniffi are being used
+// in the same project.
+#ifndef UNIFFI_SHARED_H
+#define UNIFFI_SHARED_H
+
 typedef struct RustBuffer
 {
     int32_t capacity;
@@ -31,6 +39,7 @@ typedef struct NativeRustError {
     char *_Nullable message;
 } NativeRustError;
 
+#endif // ndef UNIFFI_SHARED_H
   
 {% for func in ci.iter_ffi_function_definitions() -%}
     {%- match func.return_type() -%}{%- when Some with (type_) %}{{ type_|type_ffi }}{% when None %}void{% endmatch %} {{ func.name() }}(

--- a/uniffi_bindgen/src/bindings/swift/templates/Template-Bridging-Header.h
+++ b/uniffi_bindgen/src/bindings/swift/templates/Template-Bridging-Header.h
@@ -9,10 +9,18 @@
 // The following structs are used to implement the lowest level
 // of the FFI, and thus useful to multiple uniffied crates.
 // We ensure they are declared exactly once, with a header guard, UNIFFI_SHARED_H.
-// This may become a potential footgun if multiple versions of uniffi are being used
-// in the same project.
-#ifndef UNIFFI_SHARED_H
-#define UNIFFI_SHARED_H
+#ifdef UNIFFI_SHARED_H
+    // We also try to prevent mixing versions of shared uniffi header structs
+    // If you add anything to the #else block, you must increment the version in UNIFFI_VERSION_x_y_z.
+    #ifndef UNIFFI_VERSION_0_8_0
+        #error Combining helper code from multiple versions of uniffi is not supported
+    #endif // ndef UNIFFI_VERSION_0_8_0
+#else
+    #define UNIFFI_SHARED_H
+    #define UNIFFI_VERSION_0_8_0
+    // ⚠️ Attention: If you change this #else block (ending in `#endif // def UNIFFI_SHARED_H`) ⚠️
+    // ⚠️ you must increment the version in all instance of UNIFFI_VERSION_ in this file to the ⚠️
+    // ⚠️ current uniffi version.                                                               ⚠️
 
 typedef struct RustBuffer
 {
@@ -39,7 +47,7 @@ typedef struct NativeRustError {
     char *_Nullable message;
 } NativeRustError;
 
-#endif // ndef UNIFFI_SHARED_H
+#endif // def UNIFFI_SHARED_H
   
 {% for func in ci.iter_ffi_function_definitions() -%}
     {%- match func.return_type() -%}{%- when Some with (type_) %}{{ type_|type_ffi }}{% when None %}void{% endmatch %} {{ func.name() }}(

--- a/uniffi_bindgen/src/bindings/swift/templates/Template-Bridging-Header.h
+++ b/uniffi_bindgen/src/bindings/swift/templates/Template-Bridging-Header.h
@@ -10,17 +10,16 @@
 // of the FFI, and thus useful to multiple uniffied crates.
 // We ensure they are declared exactly once, with a header guard, UNIFFI_SHARED_H.
 #ifdef UNIFFI_SHARED_H
-    // We also try to prevent mixing versions of shared uniffi header structs
-    // If you add anything to the #else block, you must increment the version in UNIFFI_VERSION_x_y_z.
-    #ifndef UNIFFI_VERSION_0_8_0
+    // We also try to prevent mixing versions of shared uniffi header structs.
+    // If you add anything to the #else block, you must increment the version in UNIFFI_SHARED_HEADER_V1
+    #ifndef UNIFFI_SHARED_HEADER_V1
         #error Combining helper code from multiple versions of uniffi is not supported
-    #endif // ndef UNIFFI_VERSION_0_8_0
+    #endif // ndef UNIFFI_SHARED_HEADER_V1
 #else
-    #define UNIFFI_SHARED_H
-    #define UNIFFI_VERSION_0_8_0
-    // ⚠️ Attention: If you change this #else block (ending in `#endif // def UNIFFI_SHARED_H`) ⚠️
-    // ⚠️ you must increment the version in all instance of UNIFFI_VERSION_ in this file to the ⚠️
-    // ⚠️ current uniffi version.                                                               ⚠️
+#define UNIFFI_SHARED_H
+#define UNIFFI_SHARED_HEADER_V1
+// ⚠️ Attention: If you change this #else block (ending in `#endif // def UNIFFI_SHARED_H`) you *must* ⚠️
+// ⚠️ increment the version in all instance of UNIFFI_SHARED_HEADER_V1 in this file.                   ⚠️
 
 typedef struct RustBuffer
 {
@@ -47,6 +46,8 @@ typedef struct NativeRustError {
     char *_Nullable message;
 } NativeRustError;
 
+// ⚠️ Attention: If you change this #else block (ending in `#endif // def UNIFFI_SHARED_H`) you *must* ⚠️
+// ⚠️ increment the version in all instance of UNIFFI_SHARED_HEADER_V1 in this file.                   ⚠️
 #endif // def UNIFFI_SHARED_H
   
 {% for func in ci.iter_ffi_function_definitions() -%}

--- a/uniffi_bindgen/src/bindings/swift/templates/macros.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/macros.swift
@@ -10,7 +10,7 @@
     {% when Some with (e) %}
     {{e}}.NoError
     {% else %}
-    InternalError.unknown()
+    UniffiInternalError.unknown("rustCall")
     {% endmatch %}
 ) { err in
     {{ func.ffi_func().name() }}({% call _arg_list_ffi_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %}err)
@@ -23,7 +23,7 @@
     {%- when Some with (e) %}
     {{e}}.NoError
     {%- else %}
-    InternalError.unknown()
+    UniffiInternalError.unknown("rustCall")
     {%- endmatch %}
 ) { err in
     {{ func.ffi_func().name() }}(


### PR DESCRIPTION
Fixes #408.

This PR:

* hides all helpers in swift protocols and extensions behind `fileprivate` access modifiers.
* protects redefinition of C structs with header guards.