### PR TITLE
Fix generation of kotlin module path on Windows.

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/mod.rs
@@ -46,7 +46,7 @@ pub fn write_bindings(
 }
 
 fn full_bindings_path(config: &Config, out_dir: &Path) -> Result<PathBuf> {
-    let package_path = config.package_name().replace(".", "/");
+    let package_path: PathBuf = config.package_name().split(".").collect();
     Ok(PathBuf::from(out_dir).join(package_path))
 }
 


### PR DESCRIPTION
Thanks to `ankhers` for pointing out the buggy behavior here in Matrix.