### PR TITLE
Use static assertions to check uniffi/uniffi-bindgen version compatibility.

### DIFF
--- a/docker/Dockerfile-build
+++ b/docker/Dockerfile-build
@@ -36,8 +36,8 @@ RUN sudo apt-get update -qq \
 
 RUN rustup update \
     # This specific version of Rust is required for compatibility with mozilla-central
-    && rustup install 1.43.0 \
-    && rustup default 1.43.0
+    && rustup install 1.50.0 \
+    && rustup default 1.50.0
 
 RUN mkdir -p /tmp/setup-swift \
     && cd /tmp/setup-swift \

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -28,3 +28,6 @@ default = []
 # Use the `uniffi_bindgen` from this workspace instead of the one installed on your system.
 # You probably only want to enable this feature if you're working on uniffi itself.
 builtin-bindgen = ["uniffi_bindgen"]
+
+[dev-dependencies]
+trybuild = "1"

--- a/uniffi/src/testing.rs
+++ b/uniffi/src/testing.rs
@@ -120,9 +120,11 @@ pub fn ensure_compiled_cdylib(pkg_dir: &str) -> Result<String> {
     let cdylib_files: Vec<_> = cdylib
         .filenames
         .iter()
-        .filter(|nm| match nm.extension().unwrap_or_default().to_str() {
-            Some(std::env::consts::DLL_EXTENSION) => true,
-            _ => false,
+        .filter(|nm| {
+            matches!(
+                nm.extension().unwrap_or_default().to_str(),
+                Some(std::env::consts::DLL_EXTENSION)
+            )
         })
         .collect();
     if cdylib_files.len() != 1 {

--- a/uniffi/tests/ui/version_mismatch.rs
+++ b/uniffi/tests/ui/version_mismatch.rs
@@ -1,0 +1,4 @@
+// This should fail with a version mismatch.
+uniffi::assert_compatible_version!("0.0.1"); // An error message would go here.
+
+fn main() {}

--- a/uniffi/tests/ui/version_mismatch.stderr
+++ b/uniffi/tests/ui/version_mismatch.stderr
@@ -1,0 +1,7 @@
+error[E0080]: evaluation of constant value failed
+ --> $DIR/version_mismatch.rs:2:1
+  |
+2 | uniffi::assert_compatible_version!("0.0.1"); // An error message would go here.
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/uniffi_bindgen/src/scaffolding.rs
+++ b/uniffi_bindgen/src/scaffolding.rs
@@ -11,10 +11,14 @@ use super::interface::*;
 #[template(syntax = "rs", escape = "none", path = "scaffolding_template.rs")]
 pub struct RustScaffolding<'a> {
     ci: &'a ComponentInterface,
+    uniffi_version: &'static str,
 }
 impl<'a> RustScaffolding<'a> {
     pub fn new(ci: &'a ComponentInterface) -> Self {
-        Self { ci }
+        Self {
+            ci,
+            uniffi_version: crate::BINDGEN_VERSION,
+        }
     }
 }
 

--- a/uniffi_bindgen/src/templates/scaffolding_template.rs
+++ b/uniffi_bindgen/src/templates/scaffolding_template.rs
@@ -2,6 +2,12 @@
 // Trust me, you don't want to mess with it!
 {% import "macros.rs" as rs %}
 
+// Check for compatibility between `uniffi` and `uniffi_bindgen` versions.
+// Note that we have an error message on the same line as the assertion.
+// This is important, because if the assertion fails, the compiler only
+// seems to show that single line as context for the user.
+uniffi::assert_compatible_version!("{{ uniffi_version }}"); // Please check that you depend on version {{ uniffi_version }} of the `uniffi` crate.
+
 {% include "RustBuffer.rs" %}
 
 // We generate error mappings into ffi_support::ExternErrors

--- a/uniffi_build/src/lib.rs
+++ b/uniffi_build/src/lib.rs
@@ -48,5 +48,5 @@ fn run_uniffi_bindgen_scaffolding(out_dir: &str, udl_file: &str) -> Result<()> {
 
 #[cfg(feature = "builtin-bindgen")]
 fn run_uniffi_bindgen_scaffolding(out_dir: &str, udl_file: &str) -> Result<()> {
-    uniffi_bindgen::generate_component_scaffolding(udl_file, None, Some(out_dir), None, true)
+    uniffi_bindgen::generate_component_scaffolding(udl_file, None, Some(out_dir), true)
 }


### PR DESCRIPTION
(I know I said over in https://github.com/mozilla/uniffi-rs/issues/413#issuecomment-790259989 that this may not be too much of a problem
in practice, but I suddenly realised what a good fix would look like and decided to
try it out).

Fixes #413.

Prior to this commit, the `uniffi-bindgen` command would use `cargo metadata`
to discover the version of uniffi being used by the target crate, and would
error out if did not match the version of uniffi-bindgen itself.

Unfortunately, this approach is not reliable when the target crate is being
compiled as a dependency rather than as the primary crate. The build process
may pick a version of uniffi based on the `Cargo.lock` of the primary crate
or based on resolving compatible versions with other dependencies, while
while `cargo metadata` will report the verison of uniffi that would be used
if you built the target crate in isolation.

To avoid these potential sources of error, this commit switches to an approach
based on static assertions, in two halves:

* When generating the Rust scaffolding, we emit a call to a new
  macro `uniffi::assert_compatible_version!(v)` and pass it a static
  string constant representing the version of uniffi_bindgen that
  generated the code.

* When compiling the resulting code as part of a uniffied crate, the
  `assert_compatible_version!` macro will check the static string against
  the version of uniffi being used in the build, producing a compile-time
  failure if they do not match.

This is a slightly worse consumer experience because the error message
isn't as good, but it's more reliable, so I think it's a win overall.

Be warned, I had to do some terrible things to perform this check in
a compile-time const context on stable Rust :-/

I've also taken the opportunity to try out the `trybuild` crate to
write a testcase for the actual compiler error message generated
by the macro. As we come to iterate more on the developer experience,
I expect `trybuild` or something like it will become pretty important.