### PR TITLE
A strawfox for #417 to allow an interface to have a method which take…

### DIFF
--- a/examples/threadsafe/src/lib.rs
+++ b/examples/threadsafe/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::sync::Arc;
 
 /// Simulation of a task doing something to keep a thread busy.
 /// Up until now, everything has been synchronous and blocking, so
@@ -53,6 +54,7 @@ impl Counter {
 // It relies on its own locking mechanisms, and uses the `Threadsafe`
 // attribute to tell uniffi to use the `ArcHandleMap`, so avoid the default
 // locking strategy.
+#[derive(Debug)]
 struct ThreadsafeCounter {
     is_busy: AtomicBool,
     count: AtomicI32,
@@ -61,6 +63,7 @@ struct ThreadsafeCounter {
 // Interface structs labelled `Threadsafe` should (safely) implement
 // `Send` and `Sync`.
 static_assertions::assert_impl_all!(ThreadsafeCounter: Send, Sync);
+
 
 impl ThreadsafeCounter {
     fn new() -> Self {
@@ -82,6 +85,11 @@ impl ThreadsafeCounter {
         } else {
             self.count.load(Ordering::SeqCst)
         }
+    }
+
+    fn cloneable(self: Arc<Self>) {
+        // `self` is already an Arc::clone() so can be used directly.
+        println!("Got {:?}", self)
     }
 }
 

--- a/examples/threadsafe/src/threadsafe.udl
+++ b/examples/threadsafe/src/threadsafe.udl
@@ -12,5 +12,9 @@ interface Counter {
 interface ThreadsafeCounter {
   void busy_wait(i32 ms);
   i32 increment_if_busy();
+  // A function that wants a signature of `fn cloneable(self: Arc<Self>)`
+  // so that it's capable of sending an Arc::clone somewhere else.
+  [SomethingSomethingArc] // probably want a better attribute? ;)
+  void cloneable();
 };
 

--- a/uniffi/src/ffi/handle_maps.rs
+++ b/uniffi/src/ffi/handle_maps.rs
@@ -161,7 +161,7 @@ impl<T: Sync + Send> ArcHandleMap<T> {
         callback: F,
     ) -> R::Value
     where
-        F: std::panic::UnwindSafe + FnOnce(&T) -> Result<R, E>,
+        F: std::panic::UnwindSafe + FnOnce(Arc<T>) -> Result<R, E>,
         ExternError: From<E>,
         R: IntoFfi,
     {
@@ -175,7 +175,7 @@ impl<T: Sync + Send> ArcHandleMap<T> {
                 let obj = map.get(h)?;
                 Arc::clone(&obj)
             };
-            Ok(callback(&*obj)?)
+            Ok(callback(obj)?)
         })
     }
 
@@ -187,7 +187,7 @@ impl<T: Sync + Send> ArcHandleMap<T> {
         callback: F,
     ) -> R::Value
     where
-        F: std::panic::UnwindSafe + FnOnce(&T) -> R,
+        F: std::panic::UnwindSafe + FnOnce(Arc<T>) -> R,
         R: IntoFfi,
     {
         self.call_with_result(out_error, h, |r| -> Result<_, HandleError> {
@@ -313,7 +313,7 @@ impl<T: Sync + Send> ArcHandleMap<T> {
         callback: F,
     ) -> R::Value
     where
-        F: std::panic::UnwindSafe + FnOnce(&T) -> Result<R, E>,
+        F: std::panic::UnwindSafe + FnOnce(Arc<T>) -> Result<R, E>,
         ExternError: From<E>,
         R: IntoFfi,
     {
@@ -327,7 +327,7 @@ impl<T: Sync + Send> ArcHandleMap<T> {
         callback: F,
     ) -> R::Value
     where
-        F: std::panic::UnwindSafe + FnOnce(&T) -> R,
+        F: std::panic::UnwindSafe + FnOnce(Arc<T>) -> R,
         R: IntoFfi,
     {
         self.call_with_output(out_error, h, callback)

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -300,6 +300,10 @@ impl Method {
         self.attributes.get_throws_err()
     }
 
+    pub fn something_something_arc(&self) -> bool {
+        self.attributes.get_something_something_arc()
+    }
+
     pub fn derive_ffi_func(&mut self, ci_prefix: &str, obj_prefix: &str) -> Result<()> {
         self.ffi_func.name.push_str(ci_prefix);
         self.ffi_func.name.push_str("_");

--- a/uniffi_bindgen/src/templates/macros.rs
+++ b/uniffi_bindgen/src/templates/macros.rs
@@ -66,12 +66,20 @@ use uniffi::UniffiMethodCall;
 {% match meth.throws() -%}
 {% when Some with (e) -%}
 {{ this_handle_map }}.method_call_with_result(err, {{ meth.first_argument().name() }}, |obj| -> Result<{% call return_type_func(meth) %}, {{e}}> {
+    {%- if meth.something_something_arc() -%}
     let _retval = {{ obj.name() }}::{%- call to_rs_call_with_prefix("obj", meth) -%}?;
+    {%- else -%}
+    let _retval = {{ obj.name() }}::{%- call to_rs_call_with_prefix("&*obj", meth) -%}?;
+    {%- endif -%}
     Ok({% call ret(meth) %})
 })
 {% else -%}
 {{ this_handle_map }}.method_call_with_output(err, {{ meth.first_argument().name() }}, |obj| {
+    {%- if meth.something_something_arc() -%}
     let _retval = {{ obj.name() }}::{%- call to_rs_call_with_prefix("obj", meth) -%};
+    {%- else -%}
+    let _retval = {{ obj.name() }}::{%- call to_rs_call_with_prefix("&*obj", meth) -%};
+    {%- endif -%}
     {% call ret(meth) %}
 })
 {% endmatch -%}


### PR DESCRIPTION
…s an `Arc::clone(self)`

[Had to do a last-minute rebase based on James's recent improvements and hope I didn't do anything even dumber there :]

Intent is a new attribute is added to such methods (and the method must be on
a `[ThreadSafe]` interface). I've chosen `[SomethingSomethingArc]` as the
attribute name :)

I attempted to change things so handle_map.rs no longer does the
ref-deref `&*` magic but instead delegates that to the macros, which
only does it if the new attribute exists. This *nearly* works, but
has unintended consequences I don't yet understand (ie, the
non-threadsafe generated code is using `&*obj` which makes no sense
at this hour).