### PR TITLE
POC for step 1 of #419 - replace Handlemaps with Arcs.

### DIFF
--- a/docs/manual/src/internals/object_references.md
+++ b/docs/manual/src/internals/object_references.md
@@ -1,7 +1,7 @@
 # Managing Object References
 
 Uniffi [interfaces](../udl/interfaces.md) represent instances of objects
-that have methods and contain shared mutable state. One of Rust's core innovations
+that have methods and contain state. One of Rust's core innovations
 is its ability to provide compile-time guarantees about working with such instances,
 including:
 
@@ -10,21 +10,33 @@ including:
   active at any point in the program.
 * Guarding against data races.
 
-Uniffi aims to maintain these guarantees even when the Rust code is being invoked
-from a foreign language, at the cost of turning them into run-time checks rather
-than compile-time guarantees.
+The very nature of the problems Uniffi tries to solve is that calls may come
+from foreign languages on any thread. Uniffi itself tries to take a hands-off
+approach as much as possible to allow the Rust compiler itself to ensure these
+guarantees can be met - which in practice means all instances exposed by uniffi
+must be, in Rust terminology, `Send+Sync`, and `&mut self` type params
+typically can't be supported.
 
-## Handle Maps
+Typically this will mean your implementation uses some data structures
+explicitly designed for this purpose, such as a `Mutex` or `RwLock` - but this
+detail is completely up to you - as much as possible, uniffi tries to stay out
+of your way, so ultimately it is the Rust compiler itself which is the ultimate
+arbiter.
 
-We achieve this by indirecting all object access through a
-[handle map](https://docs.rs/ffi-support/0.4.0/ffi_support/handle_map/index.html),
-a mapping from opaque integer handles to object instances. This indirection
-imposes a small runtime cost but helps us guard against errors or oversights
-in the generated bindings.
+## Arcs
 
-For each interface declared in the UDL, the uniffi-generated Rust scaffolding
-will create a global handlemap that is responsible for owning all instances
-of that interface, and handing out references to them when methods are called.
+In order to allow for instances to be used as flexibly as possible, uniffi
+works with `Arc`s holding a pointer to your instances and leverages their
+reference-count based lifetimes, allowing uniffi to largely stay out
+of handling lifetimes entirely for these objects.
+
+However, this does come at a cost - when you want to return instances from
+your dictionaries or methods, you must return an `Arc<>` directly. When
+accepting instances as arguments, you can choose to accept it as an `Arc<>` or
+as the underlying struct - there are different use-cases for each scenario.
+
+The exception to the above is constructors - these are expected to just provide
+the instance and uniffi will wrap it in the `Arc<>`.
 
 For example, given a interface definition like this:
 
@@ -36,70 +48,91 @@ interface TodoList {
 };
 ```
 
-The Rust scaffolding would define a lazyily-initialized global static like:
-
-```rust
-lazy_static! {
-    static ref UNIFFI_HANDLE_MAP_TODOLIST: ConcurrentHandleMap<TodoList> = ConcurrentHandleMap::new();
-}
-```
-
 On the Rust side of the generated bindings, the instance constructor will create an instance of the
-corresponding `TodoList` Rust struct, insert it into the handlemap, and return the resulting integer
-handle to the foreign language code:
+corresponding `TodoList` Rust struct, wrap it in an `Arc<>` and return a raw
+pointer to the foreign language code:
 
 ```rust
-pub extern "C" fn todolist_TodoList_new(err: &mut ExternError) -> u64 {
-    // Give ownership of the new instance to the handlemap.
-    // We will only ever operate on borrowed references to it.
-    UNIFFI_HANDLE_MAP_TODOLIST.insert_with_output(err, || TodoList::new())
-}
-```
-
-When invoking a method on the instance, the foreign-language code passes the integer handle back
-to the Rust code, which borrows a mutable reference to the instance from the handlemap for the duration
-of the method call:
-
-```rust
-pub extern "C" fn todolist_TodoList_add_item(handle: u64, todo: RustBuffer, err: &mut ExternError) -> () {
-    let todo = <String as uniffi::ViaFfi>::try_lift(todo).unwrap()
-    // Borrow a reference to the instance so that we can call a method on it.
-    UNIFFI_HANDLE_MAP_TODOLIST.call_with_result_mut(err, handle, |obj| -> Result<(), TodoError> {
-        TodoList::add_item(obj, todo)
+pub extern "C" fn todolist_12ba_TodoList_new(
+    err: &mut uniffi::deps::ffi_support::ExternError,
+) -> *const std::os::raw::c_void /* *const TodoList */ {
+    uniffi::deps::ffi_support::call_with_output(err, || {
+        let _new = TodoList::new();
+        let _arc = std::sync::Arc::new(_new);
+        uniffi::UniffiVoidPtr(<std::sync::Arc<TodoList> as uniffi::ViaFfi>::lower(_arc))
     })
 }
 ```
 
-Finally, when the foreign-language code frees the instance, it passes the integer handle to
-a special destructor function so that the Rust code can delete it from the handlemap:
+and the uniffi runtime defines:
 
 ```rust
-pub extern "C" fn ffi_todolist_TodoList_object_free(handle: u64) {
-    UNIFFI_HANDLE_MAP_TODOLIST.delete_u64(handle);
+unsafe impl<T: Sync + Send> ViaFfi for std::sync::Arc<T> {
+    type FfiType = *const std::os::raw::c_void;
+    fn lower(self) -> Self::FfiType {
+        std::sync::Arc::into_raw(self) as Self::FfiType
+    }
 }
 ```
 
-This indirection gives us some important safety properties:
+which does the "arc to pointer" dance for us. Note that this has "leaked" the
+`Arc<>` reference - if we never see that pointer again, our instance will leak.
 
-* If the generated bindings incorrectly pass an invalid handle, or a handle for a different type of object,
-  then the handlemap will throw an error with high probability, providing some amount of run-time typechecking
-  for correctness of the generated bindings.
-* The handlemap can ensure we uphold Rust's requirements around unique mutable references and threadsafey,
-  using a combination of compile-time checks and runtime locking depending on the details of the underlying
-  Rust struct that implements the interface.
+When invoking a method on the instance, the foreign-language code passes the
+raw pointer back to the Rust code, which turns it back into a cloned `Arc<>` which
+lives for the duration of the method call:
+
+```rust
+pub extern "C" fn todolist_12ba_TodoList_add_item(
+    ptr: *const std::os::raw::c_void,
+    todo: uniffi::RustBuffer,
+    err: &mut uniffi::deps::ffi_support::ExternError,
+) -> () {
+    uniffi::deps::ffi_support::call_with_result(err, || -> Result<_, TodoError> {
+        let _obj = <std::sync::Arc<TodoList> as uniffi::ViaFfi>::try_lift(ptr).unwrap();
+        let _retval =
+            TodoList::add_item(&_obj, <String as uniffi::ViaFfi>::try_lift(todo).unwrap())?;
+        Ok(_retval)
+    })
+}
+```
+
+where the uniffi runtime defines:
+
+```rust
+unsafe impl<T: Sync + Send> ViaFfi for std::sync::Arc<T> {
+    type FfiType = *const std::os::raw::c_void;
+    fn try_lift(v: Self::FfiType) -> Result<Self> {
+        let v = v as *const T;
+        // We musn't drop the `Arc<T>` that is owned by the foreign-language code.
+        let foreign_arc = std::mem::ManuallyDrop::new(unsafe { Self::from_raw(v) });
+        // Take a clone for our own use.
+        Ok(std::sync::Arc::clone(&*foreign_arc))
+    }
+```
+
+Notice that we take care to ensure the reference added by the constructor
+remains alive. Finally, when the foreign-language code frees the instance, it
+passes the raw pointer a special destructor function so that the Rust code can
+drop that initial final reference (and if that happens to be the final reference,
+the rust object will be dropped.)
+
+```rust
+pub extern "C" fn ffi_todolist_12ba_TodoList_object_free(ptr: *const std::os::raw::c_void) {
+    if let Err(e) = std::panic::catch_unwind(|| {
+        assert!(!ptr.is_null());
+        unsafe { std::sync::Arc::from_raw(ptr as *const TodoList) };
+    }) {
+        uniffi::deps::log::error!("ffi_todolist_12ba_TodoList_object_free panicked: {:?}", e);
+    }
+}
+```
 
 ## Managing Concurrency
 
-By default, uniffi uses the [ffi_support::ConcurrentHandleMap](https://docs.rs/ffi-support/0.4.0/ffi_support/handle_map/struct.ConcurrentHandleMap.html) struct as the handlemap for each declared instance. This class
-wraps each instance with a `Mutex`, which serializes access to the instance and upholds Rust's guarantees
-against shared mutable access.  This approach is simple and safe, but it means that all method calls
-on an instance are run in a strictly sequential fashion, limiting concurrency.
-
-For instances that are explicited tagged with the `[Threadsafe]` attribute, uniffi instead uses
-a custom `ArcHandleMap` struct. This replaces the run-time `Mutex` with compile-time assertions
-about the safety of the underlying Rust struct. Specifically:
-
-* The `ArcHandleMap` will never give out a mutable reference to an instance, forcing the
-  underlying struct to use interior mutability and manage its own locking.
-* The `ArcHandleMap` can only contain structs that are `Sync` and `Send`, ensuring that
-  shared references can safely be accessed from multiple threads.
+You might be noticing a distinct lack of concurrency management, and this is
+by design - it means that concurrency management is the responsibility of the
+Rust implementations. The `T` in an `Arc<T>` is supplied by the Rust code
+being wrapped and the Rust compiler will complain if that isn't `Send+Sync`.
+This means that uniffi can take a hands-off approach, letting the Rust compiler
+guide the component author.

--- a/examples/todolist/Cargo.toml
+++ b/examples/todolist/Cargo.toml
@@ -14,6 +14,7 @@ name = "uniffi_todolist"
 uniffi_macros = {path = "../../uniffi_macros"}
 uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
 thiserror = "1.0"
+lazy_static = "1.4"
 
 [build-dependencies]
 uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/examples/todolist/src/todolist.udl
+++ b/examples/todolist/src/todolist.udl
@@ -1,4 +1,7 @@
 namespace todolist {
+    TodoList? get_default_list();
+    undefined set_default_list(TodoList list);
+
     [Throws=TodoError]
     TodoEntry create_entry_with(string todo);
 };
@@ -31,4 +34,6 @@ interface TodoList {
     string get_first();
     [Throws=TodoError]
     void clear_item(string todo);
+    [ByArc]
+    undefined make_default();
 };

--- a/examples/todolist/tests/bindings/test_todolist.py
+++ b/examples/todolist/tests/bindings/test_todolist.py
@@ -23,3 +23,24 @@ assert(todo.get_last() == "Test Ünicode hàndling without an entry can't believ
 entry2 = TodoEntry("Test Ünicode hàndling in an entry can't believe I didn't test this at first 🤣")
 todo.add_entry(entry2)
 assert(todo.get_last_entry().text == "Test Ünicode hàndling in an entry can't believe I didn't test this at first 🤣")
+
+todo2 = TodoList()
+assert(todo != todo2)
+assert(todo is not todo2)
+
+assert(get_default_list() is None)
+
+set_default_list(todo)
+assert(get_default_list() is todo)
+assert(get_default_list() is not todo2)
+
+todo2.make_default()
+assert(get_default_list() is not todo)
+assert(get_default_list() is todo2)
+
+todo.add_item("Test liveness after being demoted from default")
+assert(todo.get_last() == "Test liveness after being demoted from default")
+
+todo2.add_item("Test shared state through local vs default reference")
+assert(get_default_list().get_last() == "Test shared state through local vs default reference")
+

--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -22,6 +22,7 @@ dictionary SimpleDict {
     float? maybe_float32;
     double float64;
     double? maybe_float64;
+    Coveralls? coveralls;
 };
 
 [Error]
@@ -48,15 +49,14 @@ interface Coveralls {
 
     void panic(string message);
 
-    /// *** Test functions which take `self` as an `Arc<Self>` ***
+    /// *** Test functions which take either `self` or other params as `Arc<Self>` ***
     ///
-    /// Takes an `Arc<Self>` and stores it in `self` - thus making a circular
-    /// ref.
-    [ByArc]
-    void take_other();
+    /// Takes an `Arc<Self>` and stores it in `self`, dropping the existing
+    /// reference. Note you can create circular references by passing `self`.
+    void take_other(Coveralls? other);
 
-    /// Drops any references made by `take_other()`
-    void drop_other();
+    /// Returns what was previously set via `take_other()`, or null.
+    Coveralls? get_other();
 
     /// Calls `Arc::strong_count()`
     [ByArc]
@@ -70,4 +70,17 @@ interface Coveralls {
     /// panics with that message..
     [ByArc]
     void take_other_panic(string message);
+
+    // can't name it `clone` as it conflicts with the Clone trait and ours has a different signature
+    Coveralls clone_me();
+};
+
+// All coveralls end up with a patch.
+enum Color {"Red", "Blue", "Green"};
+
+[Threadsafe]
+interface Patch {
+    constructor(Color color);
+
+    Color get_color();
 };

--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -47,4 +47,27 @@ interface Coveralls {
     boolean maybe_throw(boolean should_throw);
 
     void panic(string message);
+
+    /// *** Test functions which take `self` as an `Arc<Self>` ***
+    ///
+    /// Takes an `Arc<Self>` and stores it in `self` - thus making a circular
+    /// ref.
+    [ByArc]
+    void take_other();
+
+    /// Drops any references made by `take_other()`
+    void drop_other();
+
+    /// Calls `Arc::strong_count()`
+    [ByArc]
+    u64 strong_count();
+
+    /// Same signature as `take_other` but always fails.
+    [ByArc, Throws=CoverallError]
+    void take_other_fallible();
+
+    /// Same signature as `take_other` but with an extra string arg - always
+    /// panics with that message..
+    [ByArc]
+    void take_other_panic(string message);
 };

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::sync::RwLock;
+use std::sync::{Arc, Mutex, RwLock};
 
 lazy_static::lazy_static! {
     static ref NUM_ALIVE: RwLock<u64> = {
@@ -87,12 +87,18 @@ type Result<T, E = CoverallError> = std::result::Result<T, E>;
 #[derive(Debug)]
 pub struct Coveralls {
     name: String,
+    // A reference to another Coveralls. Currently will be only a reference
+    // to `self`, so will create a circular reference.
+    other: Mutex<Option<Arc<Self>>>,
 }
 
 impl Coveralls {
     fn new(name: String) -> Self {
         *NUM_ALIVE.write().unwrap() += 1;
-        Self { name }
+        Self {
+            name,
+            other: Mutex::new(None),
+        }
     }
 
     fn fallible_new(name: String, should_fail: bool) -> Result<Self> {
@@ -120,6 +126,26 @@ impl Coveralls {
     }
 
     fn panic(&self, message: String) {
+        panic!("{}", message);
+    }
+
+    fn take_other(self: Arc<Self>) {
+        *self.other.lock().unwrap() = Some(Arc::clone(&self));
+    }
+
+    fn drop_other(&self) {
+        *self.other.lock().unwrap() = None;
+    }
+
+    fn strong_count(self: Arc<Self>) -> u64 {
+        Arc::strong_count(&self) as u64
+    }
+
+    fn take_other_fallible(self: Arc<Self>) -> Result<()> {
+        Err(CoverallError::TooManyHoles)
+    }
+
+    fn take_other_panic(self: Arc<Self>, message: String) -> () {
         panic!("{}", message);
     }
 }

--- a/fixtures/coverall/tests/bindings/test_coverall.py
+++ b/fixtures/coverall/tests/bindings/test_coverall.py
@@ -103,6 +103,8 @@ class TestCoverall(unittest.TestCase):
         self.assertEqual(get_num_alive(), 1)
         # and check it's the correct object.
         self.assertEqual(coveralls.get_other().get_name(), "test_arcs")
+        # even better - it should be the same Python object
+        self.assertTrue(coveralls.get_other() is coveralls)
 
         with self.assertRaises(CoverallError.TooManyHoles):
             coveralls.take_other_fallible()
@@ -129,6 +131,9 @@ class TestCoverall(unittest.TestCase):
         self.assertEqual(get_num_alive(), 2)
         self.assertEqual(coveralls.strong_count(), 2)
         self.assertEqual(c2.strong_count(), 3)
+
+        # and get_other() should return the exact same instance.
+        self.assertTrue(coveralls.get_other() is c2)
 
         # We can drop Python's reference to `c2`, but the rust struct will not
         # be dropped as coveralls hold an `Arc<>` to it.

--- a/fixtures/coverall/tests/bindings/test_coverall.py
+++ b/fixtures/coverall/tests/bindings/test_coverall.py
@@ -25,6 +25,7 @@ class TestCoverall(unittest.TestCase):
         self.assertEqual(d.maybe_signed8, 0)
         self.assertEqual(d.signed64, 9223372036854775807)
         self.assertEqual(d.maybe_signed64, 0)
+        self.assertEqual(d.coveralls.get_name(), "some_dict")
 
         # floats should be "close enough" - although it's mildly surprising that
         # we need to specify `places=6` whereas the default is 7.
@@ -52,6 +53,7 @@ class TestCoverall(unittest.TestCase):
         self.assertIsNone(d.maybe_float32)
         self.assertAlmostEqual(d.float64, 0.0)
         self.assertIsNone(d.maybe_float64)
+        self.assertIsNone(d.coveralls)
 
     def test_constructors(self):
         self.assertEqual(get_num_alive(), 0)
@@ -72,7 +74,7 @@ class TestCoverall(unittest.TestCase):
         with self.assertRaisesRegex(InternalError, "expected panic: woe is me"):
             Coveralls.panicing_new("expected panic: woe is me")
 
-        # in the absence of cycles Python is deterministic killing refs
+        # in the absence of cycles Python is deterministic in killing refs
         coveralls2 = None
         self.assertEqual(get_num_alive(), 1)
         coveralls = None
@@ -93,11 +95,14 @@ class TestCoverall(unittest.TestCase):
         coveralls = Coveralls("test_arcs")
         self.assertEqual(get_num_alive(), 1)
         self.assertEqual(coveralls.strong_count(), 2)
-        coveralls.take_other()
+        self.assertIsNone(coveralls.get_other())
+        coveralls.take_other(coveralls)
         # should now be a new strong ref.
         self.assertEqual(coveralls.strong_count(), 3)
         # but the same number of instances.
         self.assertEqual(get_num_alive(), 1)
+        # and check it's the correct object.
+        self.assertEqual(coveralls.get_other().get_name(), "test_arcs")
 
         with self.assertRaises(CoverallError.TooManyHoles):
             coveralls.take_other_fallible()
@@ -105,10 +110,41 @@ class TestCoverall(unittest.TestCase):
         with self.assertRaisesRegex(InternalError, "expected panic: with an arc!"):
             coveralls.take_other_panic("expected panic: with an arc!")
 
-        coveralls.drop_other()
+        coveralls.take_other(None)
         self.assertEqual(coveralls.strong_count(), 2)
         coveralls = None
         self.assertEqual(get_num_alive(), 0)
+
+    def test_return_objects(self):
+        coveralls = Coveralls("test_return_objects")
+        self.assertEqual(get_num_alive(), 1)
+        self.assertEqual(coveralls.strong_count(), 2)
+        c2 = coveralls.clone_me()
+        self.assertEqual(c2.get_name(), coveralls.get_name())
+        self.assertEqual(get_num_alive(), 2)
+        self.assertEqual(c2.strong_count(), 2)
+
+        coveralls.take_other(c2)
+        # same number alive but `c2` has an additional ref count.
+        self.assertEqual(get_num_alive(), 2)
+        self.assertEqual(coveralls.strong_count(), 2)
+        self.assertEqual(c2.strong_count(), 3)
+
+        # We can drop Python's reference to `c2`, but the rust struct will not
+        # be dropped as coveralls hold an `Arc<>` to it.
+        c2 = None
+        self.assertEqual(get_num_alive(), 2)
+
+        # Dropping `coveralls` will kill both.
+        coveralls = None
+        self.assertEqual(get_num_alive(), 0)
+
+    def test_bad_objects(self):
+        coveralls = Coveralls("test_return_objects")
+        patch = Patch(Color.RED)
+        # `coveralls.take_other` wants `Coveralls` not `Patch`
+        with self.assertRaisesRegex(TypeError, "Coveralls.*Patch"):
+            coveralls.take_other(patch)
 
 if __name__=='__main__':
     unittest.main()

--- a/uniffi_bindgen/src/bindings/gecko_js/gen_gecko_js.rs
+++ b/uniffi_bindgen/src/bindings/gecko_js/gen_gecko_js.rs
@@ -332,6 +332,7 @@ mod filters {
             FFIType::Float32 => "float".into(),
             FFIType::Float64 => "double".into(),
             FFIType::RustCString => "const char*".into(),
+            FFIType::RustArcPtr => unimplemented!("object pointers are not implemented"),
             FFIType::RustBuffer => context.ffi_rustbuffer_type(),
             FFIType::RustError => context.ffi_rusterror_type(),
             FFIType::ForeignBytes => context.ffi_foreignbytes_type(),

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin.rs
@@ -112,6 +112,8 @@ mod filters {
             FFIType::Float32 => "Float".to_string(),
             FFIType::Float64 => "Double".to_string(),
             FFIType::RustCString => "Pointer".to_string(),
+            // XXX - make this `Pointer` (but things like Helpers.kt need upgrading in non-obvious ways. )
+            FFIType::RustArcPtr => "Long".to_string(),
             FFIType::RustBuffer => "RustBuffer.ByValue".to_string(),
             FFIType::RustError => "RustError".to_string(),
             FFIType::ForeignBytes => "ForeignBytes.ByValue".to_string(),

--- a/uniffi_bindgen/src/bindings/python/gen_python.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python.rs
@@ -199,7 +199,7 @@ mod filters {
             Type::Float32 | Type::Float64 => format!("float({})", nm),
             Type::Boolean => format!("(True if {} else False)", nm),
             Type::String => format!("{}.consumeIntoString()", nm),
-            Type::Object(classname) => format!("{}._make_instance_({})", classname, nm),
+            Type::Object(classname) => format!("{}._get_or_make_instance_({})", classname, nm),
             Type::CallbackInterface(_) => panic!("No support for lifting callback interfaces, yet"),
             Type::Error(_) => panic!("No support for lowering errors, yet"),
             Type::Enum(_)

--- a/uniffi_bindgen/src/bindings/python/gen_python.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python.rs
@@ -73,6 +73,7 @@ mod filters {
             FFIType::Float32 => "ctypes.c_float".to_string(),
             FFIType::Float64 => "ctypes.c_double".to_string(),
             FFIType::RustCString => "ctypes.c_voidp".to_string(),
+            FFIType::RustArcPtr => "ctypes.c_voidp".to_string(),
             FFIType::RustBuffer => "RustBuffer".to_string(),
             FFIType::RustError => "ctypes.POINTER(RustError)".to_string(),
             FFIType::ForeignBytes => "ForeignBytes".to_string(),

--- a/uniffi_bindgen/src/bindings/python/gen_python.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python.rs
@@ -199,7 +199,7 @@ mod filters {
             Type::Float32 | Type::Float64 => format!("float({})", nm),
             Type::Boolean => format!("(True if {} else False)", nm),
             Type::String => format!("{}.consumeIntoString()", nm),
-            Type::Object(_) => panic!("No support for lifting objects, yet"),
+            Type::Object(classname) => format!("{}._make_instance_({})", classname, nm),
             Type::CallbackInterface(_) => panic!("No support for lifting callback interfaces, yet"),
             Type::Error(_) => panic!("No support for lowering errors, yet"),
             Type::Enum(_)

--- a/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
@@ -1,9 +1,15 @@
 class {{ obj.name()|class_name_py }}(object):
+    _instances = WeakValueDictionary()
     {%- match obj.primary_constructor() %}
     {%- when Some with (cons) %}
     def __init__(self, {% call py::arg_list_decl(cons) -%}):
         {%- call py::coerce_args_extra_indent(cons) %}
-        self._handle = {% call py::to_ffi_call(cons) %}\
+        self._handle = {% call py::to_ffi_call(cons) %}
+        {# A constructor, by definition, returns a new object. If we really
+           wanted to be thorough, we could consider asserting the handle isn't
+           already in the map, but that doesn't seem to offer much value.
+        #}
+        self.__class__._instances[self._handle] = self
     {%- when None %}
     {%- endmatch %}
 
@@ -15,12 +21,27 @@ class {{ obj.name()|class_name_py }}(object):
         )
 
     # Used by alternative constructors or any methods which return this type.
+    # May return an existing instance, or create a new one if we can't find one.
     @classmethod
-    def _make_instance_(cls, handle):
+    def _get_or_make_instance_(cls, handle):
+        {# Look in our weak map for an instance already associated with this
+           pointer. If it exists we can return it, but the pointer we have
+           is a clone of an `Arc<>` so has a reference we need to destroy.
+        #}
+        existing = cls._instances.get(handle)
+        if existing is not None:
+            rust_call_with_error(
+                InternalError,
+                _UniFFILib.{{ obj.ffi_object_free().name() }},
+                handle
+            )
+            return existing
+
         # Lightly yucky way to bypass the usual __init__ logic
         # and just create a new instance with the required handle.
         inst = cls.__new__(cls)
         inst._handle = handle
+        cls._instances[handle] = inst
         return inst
 
     {% for cons in obj.alternate_constructors() -%}
@@ -29,7 +50,7 @@ class {{ obj.name()|class_name_py }}(object):
         {%- call py::coerce_args_extra_indent(cons) %}
         # Call the (fallible) function before creating any half-baked object instances.
         handle = {% call py::to_ffi_call(cons) %}
-        return cls._make_instance_(handle)
+        return cls._get_or_make_instance_(handle)
     {% endfor %}
 
     {% for meth in obj.methods() -%}

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
@@ -108,10 +108,12 @@ class RustBufferBuilder(object):
 
     {% when Type::Object with (object_name) -%}
     # The Object type {{ object_name }}.
-    # Objects cannot currently be serialized, but we can produce a helpful error.
+    # We write the pointer value directly - what could possibly go wrong?
 
-    def write{{ canonical_type_name }}(self):
-        raise InternalError("RustBufferStream.write() not implemented yet for {{ canonical_type_name }}")
+    def write{{ canonical_type_name }}(self, v):
+        if not isinstance(v, {{ object_name|class_name_py }}):
+            raise TypeError("Expected {{ object_name|class_name_py }} instance, {} found".format(v.__class__.__name__))
+        self.writeU64(v._handle) # really should stop uncondionally using u64!
 
     {% when Type::CallbackInterface with (object_name) -%}
     # The Callback Interface type {{ object_name }}.

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
@@ -105,10 +105,10 @@ class RustBufferStream(object):
 
     {% when Type::Object with (object_name) -%}
     # The Object type {{ object_name }}.
-    # Objects cannot currently be serialized, but we can produce a helpful error.
 
     def read{{ canonical_type_name }}(self):
-        raise InternalError("RustBufferStream.read not implemented yet for {{ canonical_type_name }}")
+        handle = self.readU64();
+        return {{ object_name|class_name_py }}._make_instance_(handle)
 
     {% when Type::CallbackInterface with (object_name) -%}
     # The Callback Interface type {{ object_name }}.

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
@@ -108,7 +108,7 @@ class RustBufferStream(object):
 
     def read{{ canonical_type_name }}(self):
         handle = self.readU64();
-        return {{ object_name|class_name_py }}._make_instance_(handle)
+        return {{ object_name|class_name_py }}._get_or_make_instance_(handle)
 
     {% when Type::CallbackInterface with (object_name) -%}
     # The Callback Interface type {{ object_name }}.

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
@@ -107,7 +107,7 @@ class RustBufferStream(object):
     # The Object type {{ object_name }}.
 
     def read{{ canonical_type_name }}(self):
-        handle = self.readU64();
+        handle = self._unpack_from(8, ">Q")
         return {{ object_name|class_name_py }}._get_or_make_instance_(handle)
 
     {% when Type::CallbackInterface with (object_name) -%}

--- a/uniffi_bindgen/src/bindings/python/templates/wrapper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/wrapper.py
@@ -19,6 +19,7 @@ import ctypes
 import enum
 import struct
 import contextlib
+from weakref import WeakValueDictionary
 
 {% include "RustBufferTemplate.py" %}
 {% include "RustBufferStream.py" %}

--- a/uniffi_bindgen/src/bindings/swift/gen_swift.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift.rs
@@ -164,6 +164,7 @@ mod filters {
             FFIType::Float32 => "float".into(),
             FFIType::Float64 => "double".into(),
             FFIType::RustCString => "const char*_Nonnull".into(),
+            FFIType::RustArcPtr => "UnsafeRawPointer".into(), // ??
             FFIType::RustBuffer => "RustBuffer".into(),
             FFIType::RustError => "NativeRustError".into(),
             FFIType::ForeignBytes => "ForeignBytes".into(),

--- a/uniffi_bindgen/src/interface/ffi.rs
+++ b/uniffi_bindgen/src/interface/ffi.rs
@@ -35,6 +35,10 @@ pub enum FFIType {
     /// If you've got one of these, you must call the appropriate rust function to free it.
     /// This is currently only used for error messages, and may go away in future.
     RustCString,
+    /// A `*const c_void` pointer to a rust-owned `Arc<T>`.
+    /// If you've got one of these, you must call the appropriate rust function to free it.
+    /// The templates will generate a unique `free` function for each T.
+    RustArcPtr,
     /// A byte buffer allocated by rust, and owned by whoever currently holds it.
     /// If you've got one of these, you must either call the appropriate rust function to free it
     /// or pass it to someone that will.

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -136,6 +136,7 @@ pub struct Argument {
     pub(super) name: String,
     pub(super) type_: Type,
     pub(super) by_ref: bool,
+    pub(super) by_arc: bool,
     pub(super) optional: bool,
     pub(super) default: Option<Literal>,
 }
@@ -149,6 +150,9 @@ impl Argument {
     }
     pub fn by_ref(&self) -> bool {
         self.by_ref
+    }
+    pub fn by_arc(&self) -> bool {
+        self.by_arc
     }
     pub fn default_value(&self) -> Option<Literal> {
         self.default.clone()
@@ -184,10 +188,12 @@ impl APIConverter<Argument> for weedle::argument::SingleArgument<'_> {
             Some(v) => Some(convert_default_value(&v.value, &type_)?),
         };
         let by_ref = ArgumentAttributes::try_from(self.attributes.as_ref())?.by_ref();
+        let by_arc = ArgumentAttributes::try_from(self.attributes.as_ref())?.by_arc();
         Ok(Argument {
             name: self.identifier.0.to_string(),
             type_,
             by_ref,
+            by_arc,
             optional: self.optional.is_some(),
             default,
         })

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -112,9 +112,6 @@ impl APIConverter<Function> for weedle::namespace::NamespaceMember<'_> {
 impl APIConverter<Function> for weedle::namespace::OperationNamespaceMember<'_> {
     fn convert(&self, ci: &mut ComponentInterface) -> Result<Function> {
         let return_type = ci.resolve_return_type_expression(&self.return_type)?;
-        if let Some(Type::Object(_)) = return_type {
-            bail!("Objects cannot currently be returned from functions");
-        }
         Ok(Function {
             name: match self.identifier {
                 None => bail!("anonymous functions are not supported {:?}", self),
@@ -180,9 +177,6 @@ impl APIConverter<Argument> for weedle::argument::Argument<'_> {
 impl APIConverter<Argument> for weedle::argument::SingleArgument<'_> {
     fn convert(&self, ci: &mut ComponentInterface) -> Result<Argument> {
         let type_ = ci.resolve_type_expression(&self.type_)?;
-        if let Type::Object(_) = type_ {
-            bail!("Objects cannot currently be passed as arguments");
-        }
         let default = match self.default {
             None => None,
             Some(v) => Some(convert_default_value(&v.value, &type_)?),

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -322,6 +322,7 @@ impl Method {
             // is contained in the proper `TypeUniverse`, but this works for now.
             type_: Type::Object(self.object_name.clone()),
             by_ref: false,
+            by_arc: false,
             optional: false,
             default: None,
         }
@@ -329,6 +330,10 @@ impl Method {
 
     pub fn throws(&self) -> Option<&str> {
         self.attributes.get_throws_err()
+    }
+
+    pub fn self_by_arc(&self) -> bool {
+        self.attributes.get_by_arc()
     }
 
     pub fn derive_ffi_func(&mut self, ci_prefix: &str, obj_prefix: &str) -> Result<()> {

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -377,9 +377,6 @@ impl APIConverter<Method> for weedle::interface::OperationInterfaceMember<'_> {
             bail!("method modifiers are not supported")
         }
         let return_type = ci.resolve_return_type_expression(&self.return_type)?;
-        if let Some(Type::Object(_)) = return_type {
-            bail!("Objects cannot currently be returned from functions");
-        }
         Ok(Method {
             name: match self.identifier {
                 None => bail!("anonymous methods are not supported {:?}", self),

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -129,8 +129,8 @@ impl Into<FFIType> for &Type {
             // Strings are always owned rust values.
             // We might add a separate type for borrowed strings in future.
             Type::String => FFIType::RustBuffer,
-            // Objects are passed as opaque integer handles.
-            Type::Object(_) => FFIType::UInt64,
+            // Objects are pointers to an Arc<>
+            Type::Object(_) => FFIType::RustArcPtr,
             // Callback interfaces are passed as opaque integer handles.
             Type::CallbackInterface(_) => FFIType::UInt64,
             // Errors have their own special type.

--- a/uniffi_bindgen/src/templates/macros.rs
+++ b/uniffi_bindgen/src/templates/macros.rs
@@ -9,8 +9,8 @@
 {%- macro to_rs_call_with_argname(arg_name, func, obj) -%}
     {{ func.name() }}(
     {%- if obj.threadsafe() %}
-        {# threadsafe objects assume `&self` #}
-        &{{- arg_name -}}
+        {# threadsafe objects either `&self` or `self` depending on receiver. #}
+        {% if !func.self_by_arc() %}&{% endif %}{{- arg_name -}}
     {%- else -%}
         {# non-threadsafe objects must acquire the mutex we wrapped them in, allowing a `&mut self` #}
         &mut *{{- arg_name }}.lock().unwrap()


### PR DESCRIPTION
The context for this is Ryan's [proposal for passing around object instances]( https://github.com/mozilla/uniffi-rs/issues/419) - which has steps 1 and 2 in a rough way - replacing Handlemaps with `Arc<>` (or to-be-deprecated `Arc<Mutex<>>`) and allowing them to be args and results.

This is turning out better than I hoped - for example, [see this new test](https://github.com/mhammond/uniffi-rs/blob/419-step1/fixtures/coverall/src/lib.rs#L135-L151) which exercises most of what this does.

I think the Kotlin generation works, but the Swift generation most certainly does not. @jhugman now you are back from PTO I'd love your feedback and to gauge your interest in collaborating on this? Note that my intent is to iterate slowly, just in time for Ryan to get back and review.