### PR TITLE
Make Swift enums Hashable

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -1,7 +1,7 @@
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
-public enum {{ e.name()|class_name_swift }}: Equatable {
+public enum {{ e.name()|class_name_swift }}: Equatable, Hashable {
     {% for variant in e.variants() %}
     case {{ variant.name()|enum_variant_swift }}{% if variant.fields().len() > 0 %}({% call swift::field_list_decl(variant) %}){% endif -%}
     {% endfor %}


### PR DESCRIPTION
Hey!

First, thanks for your work on this project. I've been having fun trying to integrate it into a personal app I've been working on.

Hopefully this is a minor thing. I'm trying to use a sequence of dictionaries that contain enums with associated values. Tests will fail for this case for Swift because those enums do not conform to `Hashable`. 

```
error: instance method 'combine' requires that 'Relationship' conform to 'Hashable'
        hasher.combine(relationship)
        ^
Swift.Hasher:3:37: note: where 'H' = 'Relationship'
    @inlinable public mutating func combine<H>(_ value: H) where H : Hashable
```

It looks like ![record types conform to `Hashable` by default](https://github.com/mozilla/uniffi-rs/blob/main/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift#L1) so perhaps the same could be done for enums.