### PR TITLE
re-enable python tests for the todolist example.

### DIFF
--- a/examples/todolist/tests/test_generated_bindings.rs
+++ b/examples/todolist/tests/test_generated_bindings.rs
@@ -3,6 +3,6 @@ uniffi_macros::build_foreign_language_testcases!(
     [
         "tests/bindings/test_todolist.kts",
         "tests/bindings/test_todolist.swift",
-        // "tests/bindings/test_todolist.py"
+        "tests/bindings/test_todolist.py"
     ]
 );


### PR DESCRIPTION
Not clear why is was disabled, but it passes locally and python tests remain enabled for all other ones. Let's see what CI says.