### PR TITLE
Fix swiftformat issues with Swift extension template

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -27,7 +27,7 @@ public struct {{ rec.name()|class_name_swift }}: Equatable, Hashable {
     }
 }
 
-fileprivate extension {{ rec.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi {
+fileprivate extension {{ rec.name()|class_name_swift }} {
     static func read(from buf: Reader) throws -> {{ rec.name()|class_name_swift }} {
         return try {{ rec.name()|class_name_swift }}(
             {%- for field in rec.fields() %}
@@ -42,3 +42,5 @@ fileprivate extension {{ rec.name()|class_name_swift }}: ViaFfiUsingByteBuffer, 
         {%- endfor %}
     }
 }
+
+extension {{ rec.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi {}

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -27,8 +27,8 @@ public struct {{ rec.name()|class_name_swift }}: Equatable, Hashable {
     }
 }
 
-extension {{ rec.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi {
-    fileprivate static func read(from buf: Reader) throws -> {{ rec.name()|class_name_swift }} {
+fileprivate extension {{ rec.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi {
+    static func read(from buf: Reader) throws -> {{ rec.name()|class_name_swift }} {
         return try {{ rec.name()|class_name_swift }}(
             {%- for field in rec.fields() %}
             {{ field.name()|var_name_swift }}: {{ "buf"|read_swift(field.type_()) }}{% if loop.last %}{% else %},{% endif %}
@@ -36,7 +36,7 @@ extension {{ rec.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi {
         )
     }
 
-    fileprivate func write(into buf: Writer) {
+    func write(into buf: Writer) {
         {%- for field in rec.fields() %}
         {{ field.name()|var_name_swift }}.write(into: buf)
         {%- endfor %}


### PR DESCRIPTION
This reduces swiftformat noise in generated files by moving the extension access modifier to the extension declaration and removing it from the function declarations. The functions should inherit the fileprivate access from the extension declaration.