### PR TITLE
Issue deprecation warning for non-Threadsafe interfaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,10 @@ jobs:
       - checkout
       - run: rustup component add clippy
       - run: cargo clippy --version
-      - run: cargo clippy --all --all-targets -- -D warnings
+        # allow deprecated because we intentionally emit deprecation warnings
+        # for our non-threadsafe examples. Finer grained control would be
+        # ideal.
+      - run: cargo clippy --all --all-targets -- -D warnings -A deprecated
   Rust and Foreign Language tests:
     docker:
       - image: rfkelly/uniffi-ci:latest
@@ -49,7 +52,10 @@ jobs:
           command: rustc --version
       - run:
           name: "Set RUSTFLAGS to fail the build if there are warnings"
-          command: echo 'export RUSTFLAGS="-D warnings"' >> $BASH_ENV
+          # allow deprecated because we intentionally emit deprecation warnings
+          # for our non-threadsafe examples. Finer grained control would be
+          # ideal.
+          command: echo 'export RUSTFLAGS="-D warnings -A deprecated"' >> $BASH_ENV
       - checkout
       - run: cargo test
   Deploy website:


### PR DESCRIPTION
Now that [adr-0004](https://github.com/mozilla/uniffi-rs/blob/main/docs/adr/0004-only-threadsafe-interfaces.md)
has been approved, we should deprecate non-threadsafe interfaces ASAP,
to ensure that consumers have as much time as possible to migrate
before we drop support for non-threadsafe interfaces entirely.