### PR TITLE
New 'coverall' fixture to test coverage and edge-cases.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "examples/sprites",
   "examples/todolist",
   "examples/threadsafe",
+  "fixtures/coverall",
   "fixtures/regressions/enum-without-i32-helpers",
   "fixtures/regressions/cdylib-crate-type-dependency/ffi-crate",
   "fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency",

--- a/fixtures/coverall/Cargo.toml
+++ b/fixtures/coverall/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "coverall"
+version = "0.8.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+edition = "2018"
+publish = false
+
+[lib]
+crate-type = ["staticlib", "cdylib"]
+name = "uniffi_coverall"
+
+[dependencies]
+uniffi_macros = {path = "../../uniffi_macros"}
+uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
+thiserror = "1.0"
+lazy_static = "1.4"
+
+[build-dependencies]
+uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/coverall/README.md
+++ b/fixtures/coverall/README.md
@@ -1,0 +1,9 @@
+# A "Coverall" test for uniffi components
+
+This is similar to our examples, but it's intended to be contrived and to
+ensure we get good test coverage of all possible options.
+
+It's here so it doesn't even need to make a cursory effort to be a "good"
+example; it intentionally panics, asserts params are certain values, has
+no-op methods etc. If you're trying to get your head around uniffi then the
+"examples" directory will be a much better bet.

--- a/fixtures/coverall/build.rs
+++ b/fixtures/coverall/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/coverall.udl").unwrap();
+}

--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -1,0 +1,50 @@
+namespace coverall {
+    SimpleDict create_some_dict();
+    SimpleDict create_none_dict();
+
+    u64 get_num_alive();
+};
+
+dictionary SimpleDict {
+    string text;
+    string? maybe_text;
+    boolean	a_bool;
+    boolean? maybe_a_bool;
+    u8 unsigned8;
+    u8? maybe_unsigned8;
+    u64 unsigned64;
+    u64? maybe_unsigned64;
+    i8 signed8;
+    i8? maybe_signed8;
+    i64 signed64;
+    i64? maybe_signed64;
+    float float32;
+    float? maybe_float32;
+    double float64;
+    double? maybe_float64;
+};
+
+[Error]
+enum CoverallError {
+    "TooManyHoles"
+};
+
+[Threadsafe]
+interface Coveralls {
+    constructor(string name);
+
+    // Either constructs a new object or throws an error.
+    [Throws=CoverallError, Name="fallible_new"]
+    constructor(string name, boolean should_fail);
+
+    // Always panics, just to test panics in ctors are handled.
+    [Name="panicing_new"]
+    constructor(string message);
+
+    string get_name();
+
+    [Throws=CoverallError]
+    boolean maybe_throw(boolean should_throw);
+
+    void panic(string message);
+};

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -1,0 +1,132 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::sync::RwLock;
+
+lazy_static::lazy_static! {
+    static ref NUM_ALIVE: RwLock<u64> = {
+        RwLock::new(0)
+    };
+}
+
+#[derive(Debug, thiserror::Error)]
+enum CoverallError {
+    #[error("The coverall has too many holes")]
+    TooManyHoles,
+}
+
+#[derive(Debug, Clone)]
+pub struct SimpleDict {
+    text: String,
+    maybe_text: Option<String>,
+    a_bool: bool,
+    maybe_a_bool: Option<bool>,
+    unsigned8: u8,
+    maybe_unsigned8: Option<u8>,
+    unsigned64: u64,
+    maybe_unsigned64: Option<u64>,
+    signed8: i8,
+    maybe_signed8: Option<i8>,
+    signed64: i64,
+    maybe_signed64: Option<i64>,
+    float32: f32,
+    maybe_float32: Option<f32>,
+    float64: f64,
+    maybe_float64: Option<f64>,
+}
+
+fn create_some_dict() -> SimpleDict {
+    SimpleDict {
+        text: "text".to_string(),
+        maybe_text: Some("maybe_text".to_string()),
+        a_bool: true,
+        maybe_a_bool: Some(false),
+        unsigned8: 1,
+        maybe_unsigned8: Some(2),
+        unsigned64: u64::MAX,
+        maybe_unsigned64: Some(u64::MIN),
+        signed8: 8,
+        maybe_signed8: Some(0),
+        signed64: i64::MAX,
+        maybe_signed64: Some(0),
+        float32: 1.2345,
+        maybe_float32: Some(22.0 / 7.0),
+        float64: 0.0,
+        maybe_float64: Some(1.0),
+    }
+}
+
+fn create_none_dict() -> SimpleDict {
+    SimpleDict {
+        text: "text".to_string(),
+        maybe_text: None,
+        a_bool: true,
+        maybe_a_bool: None,
+        unsigned8: 1,
+        maybe_unsigned8: None,
+        unsigned64: u64::MAX,
+        maybe_unsigned64: None,
+        signed8: 8,
+        maybe_signed8: None,
+        signed64: i64::MAX,
+        maybe_signed64: None,
+        float32: 1.2345,
+        maybe_float32: None,
+        float64: 0.0,
+        maybe_float64: None,
+    }
+}
+
+fn get_num_alive() -> u64 {
+    *NUM_ALIVE.read().unwrap()
+}
+
+type Result<T, E = CoverallError> = std::result::Result<T, E>;
+
+#[derive(Debug)]
+pub struct Coveralls {
+    name: String,
+}
+
+impl Coveralls {
+    fn new(name: String) -> Self {
+        *NUM_ALIVE.write().unwrap() += 1;
+        Self { name }
+    }
+
+    fn fallible_new(name: String, should_fail: bool) -> Result<Self> {
+        if should_fail {
+            Err(CoverallError::TooManyHoles)
+        } else {
+            Ok(Self::new(name))
+        }
+    }
+
+    fn get_name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn panicing_new(message: String) -> Self {
+        panic!("{}", message);
+    }
+
+    fn maybe_throw(&self, should_throw: bool) -> Result<bool> {
+        if should_throw {
+            Err(CoverallError::TooManyHoles)
+        } else {
+            Ok(true)
+        }
+    }
+
+    fn panic(&self, message: String) {
+        panic!("{}", message);
+    }
+}
+
+impl Drop for Coveralls {
+    fn drop(&mut self) {
+        *NUM_ALIVE.write().unwrap() -= 1;
+    }
+}
+include!(concat!(env!("OUT_DIR"), "/coverall.uniffi.rs"));

--- a/fixtures/coverall/tests/bindings/test_coverall.py
+++ b/fixtures/coverall/tests/bindings/test_coverall.py
@@ -1,0 +1,88 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import unittest
+from coverall import *
+
+class TestCoverall(unittest.TestCase):
+    def test_some_dict(self):
+        d = create_some_dict()
+        self.assertEqual(d.text, "text")
+        self.assertEqual(d.maybe_text, "maybe_text")
+        self.assertTrue(d.a_bool)
+        self.assertFalse(d.maybe_a_bool)
+        self.assertEqual(d.unsigned8, 1)
+        self.assertEqual(d.maybe_unsigned8, 2)
+        self.assertEqual(d.unsigned64, 18446744073709551615)
+        self.assertEqual(d.maybe_unsigned64, 0)
+        self.assertEqual(d.signed8, 8)
+        self.assertEqual(d.maybe_signed8, 0)
+        self.assertEqual(d.signed64, 9223372036854775807)
+        self.assertEqual(d.maybe_signed64, 0)
+
+        # floats should be "close enough" - although it's mildly surprising that
+        # we need to specify `places=6` whereas the default is 7.
+        self.assertAlmostEqual(d.float32, 1.2345, places=6)
+        self.assertAlmostEqual(d.maybe_float32, 22.0/7.0, places=6)
+        self.assertAlmostEqual(d.float64, 0.0)
+        self.assertAlmostEqual(d.maybe_float64, 1.0)
+
+    def test_none_dict(self):
+        d = create_none_dict()
+        self.assertEqual(d.text, "text")
+        self.assertIsNone(d.maybe_text)
+        self.assertTrue(d.a_bool)
+        self.assertIsNone(d.maybe_a_bool)
+        self.assertEqual(d.unsigned8, 1)
+        self.assertIsNone(d.maybe_unsigned8)
+        self.assertEqual(d.unsigned64, 18446744073709551615)
+        self.assertIsNone(d.maybe_unsigned64)
+        self.assertEqual(d.signed8, 8)
+        self.assertIsNone(d.maybe_signed8)
+        self.assertEqual(d.signed64, 9223372036854775807)
+        self.assertIsNone(d.maybe_signed64)
+
+        self.assertAlmostEqual(d.float32, 1.2345, places=6)
+        self.assertIsNone(d.maybe_float32)
+        self.assertAlmostEqual(d.float64, 0.0)
+        self.assertIsNone(d.maybe_float64)
+
+    def test_constructors(self):
+        self.assertEqual(get_num_alive(), 0)
+        # must work.
+        coveralls = Coveralls("c1")
+        self.assertEqual(get_num_alive(), 1)
+        # make sure it really is our Coveralls object.
+        self.assertEqual(coveralls.get_name(), "c1")
+        # must also work.
+        coveralls2 = Coveralls.fallible_new("c2", False)
+        self.assertEqual(get_num_alive(), 2)
+        # make sure it really is our Coveralls object.
+        self.assertEqual(coveralls2.get_name(), "c2")
+
+        with self.assertRaises(CoverallError.TooManyHoles):
+            Coveralls.fallible_new("", True)
+
+        with self.assertRaisesRegex(InternalError, "expected panic: woe is me"):
+            Coveralls.panicing_new("expected panic: woe is me")
+
+        # in the absence of cycles Python is deterministic killing refs
+        coveralls2 = None
+        self.assertEqual(get_num_alive(), 1)
+        coveralls = None
+        self.assertEqual(get_num_alive(), 0)
+
+
+    def test_errors(self):
+        coveralls = Coveralls("test_errors")
+        self.assertEqual(coveralls.get_name(), "test_errors")
+
+        with self.assertRaises(CoverallError.TooManyHoles):
+            coveralls.maybe_throw(True)
+
+        with self.assertRaisesRegex(InternalError, "expected panic: oh no"):
+            coveralls.panic("expected panic: oh no")
+
+if __name__=='__main__':
+    unittest.main()

--- a/fixtures/coverall/tests/test_generated_bindings.rs
+++ b/fixtures/coverall/tests/test_generated_bindings.rs
@@ -1,0 +1,4 @@
+uniffi_macros::build_foreign_language_testcases!(
+    "src/coverall.udl",
+    ["tests/bindings/test_coverall.py"]
+);


### PR DESCRIPTION
This is similar to our examples, but it's intended to be contrived and to
ensure we get good test coverage of all possible options - particularly for
future changes.

It's in the "fixtures" directory so it doesn't even need to make a cursory
effort to be a "good example"; it intentionally panics, asserts params are
certain values, has no-op methods etc. If you're trying to get your head
around uniffi then the "examples" directory will be a much better bet.