### PR TITLE
Define our rust version policy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
   Check Rust formatting:
     docker:
       # Our policy for updating this rust version is at https://github.com/mozilla/uniffi-rs/tree/main/docs/policies/rust-versions.md
+      # See also rust-toolchain.toml in the root of this repo, which is used to ensure the local version of rust matches.
       - image: circleci/rust:1.47.0
     resource_class: small
     steps:
@@ -29,6 +30,7 @@ jobs:
   Lint Rust with clippy:
     docker:
       # Our policy for updating this rust version is at https://github.com/mozilla/uniffi-rs/tree/main/docs/policies/rust-versions.md
+      # See also rust-toolchain.toml in the root of this repo, which is used to ensure the local version of rust matches.
       - image: circleci/rust:1.47.0
     resource_class: small
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,7 @@ jobs:
       - checkout
       - run: rustup component add clippy
       - run: cargo clippy --version
-      # todo: add ` -- -D warnings` below (which implies fixing the fallout)
-      - run: cargo clippy --all --all-targets
+      - run: cargo clippy --all --all-targets -- -D warnings
   Rust and Foreign Language tests:
     docker:
       - image: rfkelly/uniffi-ci:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,8 @@ orbs:
 jobs:
   Check Rust formatting:
     docker:
-      - image: circleci/rust:latest
+      # Our policy for updating this rust version is at https://github.com/mozilla/uniffi-rs/tree/main/docs/policies/rust-versions.md
+      - image: circleci/rust:1.47.0
     resource_class: small
     steps:
       - checkout
@@ -27,12 +28,14 @@ jobs:
       - run: cargo fmt -- --check
   Lint Rust with clippy:
     docker:
-      - image: circleci/rust:latest
+      # Our policy for updating this rust version is at https://github.com/mozilla/uniffi-rs/tree/main/docs/policies/rust-versions.md
+      - image: circleci/rust:1.47.0
     resource_class: small
     steps:
       - checkout
       - run: rustup component add clippy
       - run: cargo clippy --version
+      # todo: add ` -- -D warnings` below (which implies fixing the fallout)
       - run: cargo clippy --all --all-targets
   Rust and Foreign Language tests:
     docker:

--- a/docs/policies/README.md
+++ b/docs/policies/README.md
@@ -1,0 +1,9 @@
+# Policies
+
+This directory contains the current policies for the `uniffi` project. Unlike
+our [Architectural Decision Records](../adr), the documents here should be
+considered living documents - they will be updated as the policies change.
+
+The policies might include things like what version of Rust we track, how
+often we make releases, what requirements exists for PRs from contributors,
+etc.

--- a/docs/policies/rust-versions.md
+++ b/docs/policies/rust-versions.md
@@ -1,0 +1,56 @@
+# Rust Versions
+
+Like almost all Rust projects, the entire point of the uniffi project is that
+it be used by external projects. If uniffi always uses Rust features available
+in only the very latest Rust version, this will cause problems for projects
+which aren't always able to be on that latest version.
+
+This is particularly important while uniffi is new and young - it's not always
+possible for our policy to be something like "defer updating uniffi until your
+project is on the same version of rust", because there's a good chance these
+projects *need* the latest version of uniffi for it to be a useful solution.
+
+Given uniffi is currently developed and maintained by Mozilla staff, it should
+be no surprise that the elephant in the room is mozilla-central (aka, the
+main Firefox repository). While at time of writing uniffi is not used by
+mozilla-central, this policy is unashamedly focused on ensuring it will be
+able to in the short term.
+
+## Mozilla-central rust policies.
+
+It should also come as no surprise that the Rust policy for mozilla-central
+is somewhat flexible. There is an official [Rust Update Policy Document
+](https://wiki.mozilla.org/Rust_Update_Policy_for_Firefox]) but at time of writing
+is nearly 12 months out of date. There is a [meta bug to track rust version updates
+](https://bugzilla.mozilla.org/show_bug.cgi?id=1504858) but that doesn't define a
+policy, just tracks things as they happen.
+
+Ultimately though, mozilla-central defines a [minimum rust version
+](https://searchfox.org/mozilla-central/search?q=MINIMUM_RUST_VERSION) from which
+we assume Firefox can be built.
+
+# Uniffi rust version policy
+
+Our official rust version policy is:
+
+**uniffi should have all tests passing, and have clippy emit no warnings, with
+the current minimum Rust version supported by mozilla-central.**
+
+## Implications of this
+
+All CI for this project will try and pin itself to this same version. At
+time of writing, this means that [our circle CI integration
+](https://github.com/mozilla/uniffi-rs/blob/main/.circleci/config.yml) will pin
+itself to this same version.
+
+As the minimum version changes, we will bump this version. While newer versions
+of Rust can be expected to work correctly with our existing code, it's likely
+that clippy will complain in various ways with the new version. Thus, a PR
+to bump the minimum version is likely to also require a PR to make changes
+which keep clippy happy.
+
+In the interests of avoiding redundant information which will inevitably
+become stale, [our circle CI integration
+](https://github.com/mozilla/uniffi-rs/blob/main/.circleci/config.yml) configuration
+should be considered the canonical source of truth for the currently supported
+official rust version.

--- a/examples/callbacks/src/lib.rs
+++ b/examples/callbacks/src/lib.rs
@@ -57,6 +57,12 @@ impl RustGetters {
     }
 }
 
+impl Default for RustGetters {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // Use Send if we want to store the callback in an exposed object.
 trait StoredForeignStringifier: Send + std::fmt::Debug {
     fn from_simple_type(&self, value: i32) -> String;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,13 @@
+# See https://rust-lang.github.io/rustup/overrides.html for details on how this file works
+# and how you can override the choices made herein.
+[toolchain]
+channel = "1.47.0"
+targets = [
+    "aarch64-linux-android",
+    "armv7-linux-androideabi",
+    "i686-linux-android",
+    "x86_64-linux-android",
+    "aarch64-apple-ios",
+    "x86_64-apple-ios"
+]
+components = ["clippy", "rustfmt"]

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -61,6 +61,7 @@ static_assertions::const_assert!(PACKAGE_VERSION.as_bytes().len() < 10);
 /// The result of this check may be used to ensure that generated Rust scaffolding is
 /// using a compatible version of the uniffi runtime crate. It's a `const fn` so that it
 /// can be used to perform such a check at compile time.
+#[allow(clippy::len_zero)]
 pub const fn check_compatible_version(bindgen_version: &'static str) -> bool {
     // While UniFFI is still under heavy development, we require that
     // the runtime support crate be precisely the same version as the

--- a/uniffi_bindgen/src/bindings/gecko_js/webidl.rs
+++ b/uniffi_bindgen/src/bindings/gecko_js/webidl.rs
@@ -385,7 +385,7 @@ impl FieldExt for Field {
             // in WebIDL.
             return Some(Literal::EmptyMap);
         }
-        return None;
+        None
     }
 }
 

--- a/uniffi_bindgen/src/bindings/gecko_js/webidl.rs
+++ b/uniffi_bindgen/src/bindings/gecko_js/webidl.rs
@@ -80,10 +80,9 @@ impl WebIDLType {
 
     pub fn is_optional_record(&self) -> bool {
         match self {
-            WebIDLType::OptionalWithDefaultValue(inner) => match inner.as_ref() {
-                WebIDLType::Flat(Type::Record(_)) => true,
-                _ => false,
-            },
+            WebIDLType::OptionalWithDefaultValue(inner) => {
+                matches!(inner.as_ref(), WebIDLType::Flat(Type::Record(_)))
+            }
             _ => false,
         }
     }
@@ -373,10 +372,7 @@ impl FieldExt for Field {
     }
 
     fn required(&self) -> bool {
-        match self.type_() {
-            Type::Optional(_) => false,
-            _ => true,
-        }
+        !matches!(self.type_(), Type::Optional(_))
     }
 
     fn webidl_default_value(&self) -> Option<Literal> {

--- a/uniffi_bindgen/src/bindings/kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/mod.rs
@@ -46,7 +46,7 @@ pub fn write_bindings(
 }
 
 fn full_bindings_path(config: &Config, out_dir: &Path) -> Result<PathBuf> {
-    let package_path: PathBuf = config.package_name().split(".").collect();
+    let package_path: PathBuf = config.package_name().split('.').collect();
     Ok(PathBuf::from(out_dir).join(package_path))
 }
 

--- a/uniffi_bindgen/src/interface/attributes.rs
+++ b/uniffi_bindgen/src/interface/attributes.rs
@@ -387,7 +387,7 @@ mod test {
     }
 
     #[test]
-    fn test_unsupported() -> Result<()> {
+    fn test_unsupported() {
         let (_, node) =
             weedle::attribute::ExtendedAttribute::parse("UnsupportedAttribute").unwrap();
         let err = Attribute::try_from(&node).unwrap_err();
@@ -403,20 +403,17 @@ mod test {
             err.to_string(),
             "Attribute identity Identifier not supported: \"Unsupported\""
         );
-
-        Ok(())
     }
 
     #[test]
-    fn test_other_attributes_not_supported_for_enums() -> Result<()> {
+    fn test_other_attributes_not_supported_for_enums() {
         let (_, node) = weedle::attribute::ExtendedAttributeList::parse("[Error, ByRef]").unwrap();
         let err = EnumAttributes::try_from(&node).unwrap_err();
         assert_eq!(err.to_string(), "ByRef not supported for enums");
-        Ok(())
     }
 
     #[test]
-    fn test_throws_attribute() -> Result<()> {
+    fn test_throws_attribute() {
         let (_, node) = weedle::attribute::ExtendedAttributeList::parse("[Throws=Error]").unwrap();
         let attrs = FunctionAttributes::try_from(&node).unwrap();
         assert!(matches!(attrs.get_throws_err(), Some("Error")));
@@ -424,12 +421,10 @@ mod test {
         let (_, node) = weedle::attribute::ExtendedAttributeList::parse("[]").unwrap();
         let attrs = FunctionAttributes::try_from(&node).unwrap();
         assert!(matches!(attrs.get_throws_err(), None));
-
-        Ok(())
     }
 
     #[test]
-    fn test_other_attributes_not_supported_for_functions() -> Result<()> {
+    fn test_other_attributes_not_supported_for_functions() {
         let (_, node) =
             weedle::attribute::ExtendedAttributeList::parse("[Throws=Error, ByRef]").unwrap();
         let err = FunctionAttributes::try_from(&node).unwrap_err();
@@ -437,11 +432,10 @@ mod test {
             err.to_string(),
             "ByRef not supported for functions or methods"
         );
-        Ok(())
     }
 
     #[test]
-    fn test_constructor_attributes() -> Result<()> {
+    fn test_constructor_attributes() {
         let (_, node) = weedle::attribute::ExtendedAttributeList::parse("[Throws=Error]").unwrap();
         let attrs = ConstructorAttributes::try_from(&node).unwrap();
         assert!(matches!(attrs.get_throws_err(), Some("Error")));
@@ -459,21 +453,18 @@ mod test {
         let attrs = ConstructorAttributes::try_from(&node).unwrap();
         assert!(matches!(attrs.get_throws_err(), Some("Error")));
         assert!(matches!(attrs.get_name(), Some("MyFactory")));
-
-        Ok(())
     }
 
     #[test]
-    fn test_other_attributes_not_supported_for_constructors() -> Result<()> {
+    fn test_other_attributes_not_supported_for_constructors() {
         let (_, node) =
             weedle::attribute::ExtendedAttributeList::parse("[Throws=Error, ByRef]").unwrap();
         let err = ConstructorAttributes::try_from(&node).unwrap_err();
         assert_eq!(err.to_string(), "ByRef not supported for constructors");
-        Ok(())
     }
 
     #[test]
-    fn test_byref_attribute() -> Result<()> {
+    fn test_byref_attribute() {
         let (_, node) = weedle::attribute::ExtendedAttributeList::parse("[ByRef]").unwrap();
         let attrs = ArgumentAttributes::try_from(&node).unwrap();
         assert!(matches!(attrs.by_ref(), true));
@@ -481,12 +472,10 @@ mod test {
         let (_, node) = weedle::attribute::ExtendedAttributeList::parse("[]").unwrap();
         let attrs = ArgumentAttributes::try_from(&node).unwrap();
         assert!(matches!(attrs.by_ref(), false));
-
-        Ok(())
     }
 
     #[test]
-    fn test_other_attributes_not_supported_for_arguments() -> Result<()> {
+    fn test_other_attributes_not_supported_for_arguments() {
         let (_, node) =
             weedle::attribute::ExtendedAttributeList::parse("[Throws=Error, ByRef]").unwrap();
         let err = ArgumentAttributes::try_from(&node).unwrap_err();
@@ -494,11 +483,10 @@ mod test {
             err.to_string(),
             "Throws(\"Error\") not supported for arguments"
         );
-        Ok(())
     }
 
     #[test]
-    fn test_threadsafe_attribute() -> Result<()> {
+    fn test_threadsafe_attribute() {
         let (_, node) = weedle::attribute::ExtendedAttributeList::parse("[Threadsafe]").unwrap();
         let attrs = InterfaceAttributes::try_from(&node).unwrap();
         assert!(matches!(attrs.threadsafe(), true));
@@ -506,12 +494,10 @@ mod test {
         let (_, node) = weedle::attribute::ExtendedAttributeList::parse("[]").unwrap();
         let attrs = InterfaceAttributes::try_from(&node).unwrap();
         assert!(matches!(attrs.threadsafe(), false));
-
-        Ok(())
     }
 
     #[test]
-    fn test_enum_attribute() -> Result<()> {
+    fn test_enum_attribute() {
         let (_, node) = weedle::attribute::ExtendedAttributeList::parse("[Enum]").unwrap();
         let attrs = InterfaceAttributes::try_from(&node).unwrap();
         assert!(matches!(attrs.contains_enum_attr(), true));
@@ -531,12 +517,10 @@ mod test {
             err.to_string(),
             "conflicting attributes on interface definition"
         );
-
-        Ok(())
     }
 
     #[test]
-    fn test_other_attributes_not_supported_for_interfaces() -> Result<()> {
+    fn test_other_attributes_not_supported_for_interfaces() {
         let (_, node) =
             weedle::attribute::ExtendedAttributeList::parse("[Threadsafe, Error]").unwrap();
         let err = InterfaceAttributes::try_from(&node).unwrap_err();
@@ -544,6 +528,5 @@ mod test {
             err.to_string(),
             "Error not supported for interface definition"
         );
-        Ok(())
     }
 }

--- a/uniffi_bindgen/src/interface/callbacks.rs
+++ b/uniffi_bindgen/src/interface/callbacks.rs
@@ -74,14 +74,13 @@ impl CallbackInterface {
         &self.ffi_init_callback
     }
 
-    pub(super) fn derive_ffi_funcs(&mut self, ci_prefix: &str) -> Result<()> {
+    pub(super) fn derive_ffi_funcs(&mut self, ci_prefix: &str) {
         self.ffi_init_callback.name = format!("ffi_{}_{}_init_callback", ci_prefix, self.name);
         self.ffi_init_callback.arguments = vec![FFIArgument {
             name: "callback_stub".to_string(),
             type_: FFIType::ForeignCallback,
         }];
         self.ffi_init_callback.return_type = None;
-        Ok(())
     }
 }
 
@@ -129,7 +128,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_empty_interface() -> Result<()> {
+    fn test_empty_interface() {
         const UDL: &str = r#"
             namespace test{};
             // Weird, but allowed.
@@ -144,11 +143,10 @@ mod test {
                 .len(),
             0
         );
-        Ok(())
     }
 
     #[test]
-    fn test_multiple_interfaces() -> Result<()> {
+    fn test_multiple_interfaces() {
         const UDL: &str = r#"
             namespace test{};
             callback interface One {
@@ -170,6 +168,5 @@ mod test {
         assert_eq!(callbacks_two.methods().len(), 2);
         assert_eq!(callbacks_two.methods()[0].name(), "two");
         assert_eq!(callbacks_two.methods()[1].name(), "too");
-        Ok(())
     }
 }

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -176,7 +176,7 @@ impl Variant {
     }
 
     pub fn has_fields(&self) -> bool {
-        self.fields.len() > 0
+        !self.fields.is_empty()
     }
 }
 
@@ -255,7 +255,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_duplicate_variants() -> Result<()> {
+    fn test_duplicate_variants() {
         const UDL: &str = r#"
             namespace test{};
             // Weird, but currently allowed!
@@ -268,11 +268,10 @@ mod test {
             ci.get_enum_definition("Testing").unwrap().variants().len(),
             3
         );
-        Ok(())
     }
 
     #[test]
-    fn test_associated_data() -> Result<()> {
+    fn test_associated_data() {
         const UDL: &str = r##"
             namespace test {
                 void takes_an_enum(TestEnum e);
@@ -394,7 +393,5 @@ mod test {
             fret.ffi_func().return_type(),
             Some(FFIType::RustBuffer)
         ));
-
-        Ok(())
     }
 }

--- a/uniffi_bindgen/src/interface/error.rs
+++ b/uniffi_bindgen/src/interface/error.rs
@@ -83,7 +83,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_duplicate_variants() -> Result<()> {
+    fn test_duplicate_variants() {
         const UDL: &str = r#"
             namespace test{};
             // Weird, but currently allowed!
@@ -97,6 +97,5 @@ mod test {
             ci.get_error_definition("Testing").unwrap().values().len(),
             3
         );
-        Ok(())
     }
 }

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -77,7 +77,7 @@ impl Function {
 
     pub fn derive_ffi_func(&mut self, ci_prefix: &str) -> Result<()> {
         self.ffi_func.name.push_str(ci_prefix);
-        self.ffi_func.name.push_str("_");
+        self.ffi_func.name.push('_');
         self.ffi_func.name.push_str(&self.name);
         self.ffi_func.arguments = self.arguments.iter().map(|arg| arg.into()).collect();
         self.ffi_func.return_type = self.return_type.as_ref().map(|rt| rt.into());

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -156,7 +156,7 @@ impl Argument {
 }
 
 impl Into<FFIArgument> for &Argument {
-    fn into(self: Self) -> FFIArgument {
+    fn into(self) -> FFIArgument {
         FFIArgument {
             name: self.name.clone(),
             type_: (&self.type_).into(),

--- a/uniffi_bindgen/src/interface/literal.rs
+++ b/uniffi_bindgen/src/interface/literal.rs
@@ -171,7 +171,7 @@ mod test {
         Ok(())
     }
     #[test]
-    fn test_error_on_type_mismatch() -> Result<()> {
+    fn test_error_on_type_mismatch() {
         assert_eq!(
             parse_and_convert("0", Type::Boolean)
                 .unwrap_err()
@@ -182,6 +182,5 @@ mod test {
             .unwrap_err()
             .to_string()
             .starts_with("No support for"));
-        Ok(())
     }
 }

--- a/uniffi_bindgen/src/interface/namespace.rs
+++ b/uniffi_bindgen/src/interface/namespace.rs
@@ -93,17 +93,16 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_empty_namespace() -> Result<()> {
+    fn test_empty_namespace() {
         const UDL: &str = r#"
             namespace foobar{};
         "#;
         let ci = ComponentInterface::from_webidl(UDL).unwrap();
         assert_eq!(ci.namespace(), "foobar");
-        Ok(())
     }
 
     #[test]
-    fn test_namespace_with_functions() -> Result<()> {
+    fn test_namespace_with_functions() {
         const UDL: &str = r#"
             namespace foobar{
                 boolean hello();
@@ -116,11 +115,10 @@ mod test {
         assert!(ci.get_function_definition("hello").is_some());
         assert!(ci.get_function_definition("world").is_some());
         assert!(ci.get_function_definition("potato").is_none());
-        Ok(())
     }
 
     #[test]
-    fn test_rejects_duplicate_namespaces() -> Result<()> {
+    fn test_rejects_duplicate_namespaces() {
         const UDL: &str = r#"
             namespace foobar{
                 boolean hello();
@@ -130,6 +128,5 @@ mod test {
         "#;
         let err = ComponentInterface::from_webidl(UDL).unwrap_err();
         assert_eq!(err.to_string(), "duplicate namespace definition");
-        Ok(())
     }
 }

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -132,7 +132,7 @@ impl Object {
         }];
         self.ffi_func_free.return_type = None;
         for cons in self.constructors.iter_mut() {
-            cons.derive_ffi_func(ci_prefix, &self.name)?
+            cons.derive_ffi_func(ci_prefix, &self.name)
         }
         for meth in self.methods.iter_mut() {
             meth.derive_ffi_func(ci_prefix, &self.name)?
@@ -225,15 +225,14 @@ impl Constructor {
         self.attributes.get_throws_err()
     }
 
-    fn derive_ffi_func(&mut self, ci_prefix: &str, obj_prefix: &str) -> Result<()> {
+    fn derive_ffi_func(&mut self, ci_prefix: &str, obj_prefix: &str) {
         self.ffi_func.name.push_str(ci_prefix);
-        self.ffi_func.name.push_str("_");
+        self.ffi_func.name.push('_');
         self.ffi_func.name.push_str(obj_prefix);
-        self.ffi_func.name.push_str("_");
+        self.ffi_func.name.push('_');
         self.ffi_func.name.push_str(&self.name);
         self.ffi_func.arguments = self.arguments.iter().map(Into::into).collect();
         self.ffi_func.return_type = Some(FFIType::UInt64);
-        Ok(())
     }
 
     fn is_primary_constructor(&self) -> bool {
@@ -330,9 +329,9 @@ impl Method {
 
     pub fn derive_ffi_func(&mut self, ci_prefix: &str, obj_prefix: &str) -> Result<()> {
         self.ffi_func.name.push_str(ci_prefix);
-        self.ffi_func.name.push_str("_");
+        self.ffi_func.name.push('_');
         self.ffi_func.name.push_str(obj_prefix);
-        self.ffi_func.name.push_str("_");
+        self.ffi_func.name.push('_');
         self.ffi_func.name.push_str(&self.name);
         self.ffi_func.arguments = vec![self.first_argument()]
             .iter()
@@ -398,7 +397,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_that_all_argument_and_return_types_become_known() -> Result<()> {
+    fn test_that_all_argument_and_return_types_become_known() {
         const UDL: &str = r#"
             namespace test{};
             interface Testing {
@@ -411,42 +410,28 @@ mod test {
         ci.get_object_definition("Testing").unwrap();
 
         assert_eq!(ci.iter_types().len(), 6);
+        assert!(ci.iter_types().iter().any(|t| t.canonical_name() == "u16"));
+        assert!(ci.iter_types().iter().any(|t| t.canonical_name() == "u32"));
         assert!(ci
             .iter_types()
             .iter()
-            .find(|t| t.canonical_name() == "u16")
-            .is_some());
+            .any(|t| t.canonical_name() == "Sequenceu32"));
         assert!(ci
             .iter_types()
             .iter()
-            .find(|t| t.canonical_name() == "u32")
-            .is_some());
+            .any(|t| t.canonical_name() == "string"));
         assert!(ci
             .iter_types()
             .iter()
-            .find(|t| t.canonical_name() == "Sequenceu32")
-            .is_some());
+            .any(|t| t.canonical_name() == "Optionalstring"));
         assert!(ci
             .iter_types()
             .iter()
-            .find(|t| t.canonical_name() == "string")
-            .is_some());
-        assert!(ci
-            .iter_types()
-            .iter()
-            .find(|t| t.canonical_name() == "Optionalstring")
-            .is_some());
-        assert!(ci
-            .iter_types()
-            .iter()
-            .find(|t| t.canonical_name() == "ObjectTesting")
-            .is_some());
-
-        Ok(())
+            .any(|t| t.canonical_name() == "ObjectTesting"));
     }
 
     #[test]
-    fn test_alternate_constructors() -> Result<()> {
+    fn test_alternate_constructors() {
         const UDL: &str = r#"
             namespace test{};
             interface Testing {
@@ -472,12 +457,10 @@ mod test {
         assert_eq!(cons.name(), "new_with_u32");
         assert_eq!(cons.arguments.len(), 1);
         assert_eq!(cons.ffi_func.arguments.len(), 1);
-
-        Ok(())
     }
 
     #[test]
-    fn test_the_name_new_identifies_the_primary_constructor() -> Result<()> {
+    fn test_the_name_new_identifies_the_primary_constructor() {
         const UDL: &str = r#"
             namespace test{};
             interface Testing {
@@ -503,8 +486,6 @@ mod test {
         assert_eq!(cons.name(), "newish");
         assert_eq!(cons.arguments.len(), 0);
         assert_eq!(cons.ffi_func.arguments.len(), 0);
-
-        Ok(())
     }
 
     #[test]

--- a/uniffi_bindgen/src/interface/record.rs
+++ b/uniffi_bindgen/src/interface/record.rs
@@ -134,7 +134,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_multiple_record_types() -> Result<()> {
+    fn test_multiple_record_types() {
         const UDL: &str = r#"
             namespace test{};
             dictionary Empty {};
@@ -183,12 +183,10 @@ mod test {
         assert_eq!(record.fields()[2].type_().canonical_name(), "bool");
         assert_eq!(record.fields()[2].required, true);
         assert!(record.fields()[2].default_value().is_none());
-
-        Ok(())
     }
 
     #[test]
-    fn test_that_all_field_types_become_known() -> Result<()> {
+    fn test_that_all_field_types_become_known() {
         const UDL: &str = r#"
             namespace test{};
             dictionary Testing {
@@ -204,27 +202,18 @@ mod test {
         assert_eq!(record.fields()[1].name(), "value");
 
         assert_eq!(ci.iter_types().len(), 4);
+        assert!(ci.iter_types().iter().any(|t| t.canonical_name() == "u32"));
         assert!(ci
             .iter_types()
             .iter()
-            .find(|t| t.canonical_name() == "u32")
-            .is_some());
+            .any(|t| t.canonical_name() == "string"));
         assert!(ci
             .iter_types()
             .iter()
-            .find(|t| t.canonical_name() == "string")
-            .is_some());
+            .any(|t| t.canonical_name() == "Optionalstring"));
         assert!(ci
             .iter_types()
             .iter()
-            .find(|t| t.canonical_name() == "Optionalstring")
-            .is_some());
-        assert!(ci
-            .iter_types()
-            .iter()
-            .find(|t| t.canonical_name() == "RecordTesting")
-            .is_some());
-
-        Ok(())
+            .any(|t| t.canonical_name() == "RecordTesting"));
     }
 }

--- a/uniffi_bindgen/src/interface/types/finder.rs
+++ b/uniffi_bindgen/src/interface/types/finder.rs
@@ -161,7 +161,7 @@ mod test {
     }
 
     #[test]
-    fn test_error_on_unresolved_typedef() -> Result<()> {
+    fn test_error_on_unresolved_typedef() {
         const UDL: &str = r#"
             // Sorry, no forward declarations yet...
             typedef TestRecord Alias;
@@ -174,6 +174,5 @@ mod test {
         let mut types = TypeUniverse::default();
         let err = types.add_type_definitions_from(idl.as_ref()).unwrap_err();
         assert_eq!(err.to_string(), "unknown type reference: TestRecord");
-        Ok(())
     }
 }

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -111,7 +111,7 @@ impl Type {
 /// Note that the conversion is one-way - given an FFIType, it is not in general possible to
 /// tell what the corresponding Type is that it's being used to represent.
 impl Into<FFIType> for &Type {
-    fn into(self: Self) -> FFIType {
+    fn into(self) -> FFIType {
         match self {
             // Types that are the same map to themselves, naturally.
             Type::UInt8 => FFIType::UInt8,

--- a/uniffi_bindgen/src/interface/types/resolver.rs
+++ b/uniffi_bindgen/src/interface/types/resolver.rs
@@ -212,7 +212,7 @@ mod test {
     }
 
     #[test]
-    fn test_resolving_optional_type_adds_inner_type() -> Result<()> {
+    fn test_resolving_optional_type_adds_inner_type() {
         let mut types = TypeUniverse::default();
         assert_eq!(types.iter_known_types().count(), 0);
         let (_, expr) = weedle::types::Type::parse("u32?").unwrap();
@@ -221,17 +221,14 @@ mod test {
         assert_eq!(types.iter_known_types().count(), 2);
         assert!(types
             .iter_known_types()
-            .find(|t| t.canonical_name() == "u32")
-            .is_some());
+            .any(|t| t.canonical_name() == "u32"));
         assert!(types
             .iter_known_types()
-            .find(|t| t.canonical_name() == "Optionalu32")
-            .is_some());
-        Ok(())
+            .any(|t| t.canonical_name() == "Optionalu32"));
     }
 
     #[test]
-    fn test_resolving_sequence_type_adds_inner_type() -> Result<()> {
+    fn test_resolving_sequence_type_adds_inner_type() {
         let mut types = TypeUniverse::default();
         assert_eq!(types.iter_known_types().count(), 0);
         let (_, expr) = weedle::types::Type::parse("sequence<string>").unwrap();
@@ -240,17 +237,14 @@ mod test {
         assert_eq!(types.iter_known_types().count(), 2);
         assert!(types
             .iter_known_types()
-            .find(|t| t.canonical_name() == "Sequencestring")
-            .is_some());
+            .any(|t| t.canonical_name() == "Sequencestring"));
         assert!(types
             .iter_known_types()
-            .find(|t| t.canonical_name() == "string")
-            .is_some());
-        Ok(())
+            .any(|t| t.canonical_name() == "string"));
     }
 
     #[test]
-    fn test_resolving_map_type_adds_string_and_inner_type() -> Result<()> {
+    fn test_resolving_map_type_adds_string_and_inner_type() {
         let mut types = TypeUniverse::default();
         assert_eq!(types.iter_known_types().count(), 0);
         let (_, expr) = weedle::types::Type::parse("record<DOMString, float>").unwrap();
@@ -259,17 +253,13 @@ mod test {
         assert_eq!(types.iter_known_types().count(), 3);
         assert!(types
             .iter_known_types()
-            .find(|t| t.canonical_name() == "Mapf32")
-            .is_some());
+            .any(|t| t.canonical_name() == "Mapf32"));
         assert!(types
             .iter_known_types()
-            .find(|t| t.canonical_name() == "string")
-            .is_some());
+            .any(|t| t.canonical_name() == "string"));
         assert!(types
             .iter_known_types()
-            .find(|t| t.canonical_name() == "f32")
-            .is_some());
-        Ok(())
+            .any(|t| t.canonical_name() == "f32"));
     }
 
     #[test]


### PR DESCRIPTION
Clippy is getting upset because it's running 1.5x, but we have an [informal policy](https://github.com/mozilla/uniffi-rs/blob/a7ddeed2ab555f684d521dded9d049145901dcee/uniffi_bindgen/src/interface/literal.rs#L67-L68) of tracking mozilla-central's version - let's formalize that.