### PR TITLE
Store the universe of known types in an ordered BTreeSet (#374)

### DIFF
--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -21,7 +21,7 @@
 //! about how these API-level types map into the lower-level types of the FFI layer as represented
 //! by the [`ffi::FFIType`] enum, but that's a detail that is invisible to end users.
 
-use std::{collections::hash_map::Entry, collections::HashMap, collections::HashSet};
+use std::{collections::hash_map::Entry, collections::BTreeSet, collections::HashMap};
 
 use anyhow::{bail, Result};
 
@@ -35,7 +35,7 @@ pub(super) use resolver::{resolve_builtin_type, TypeResolver};
 /// Represents all the different high-level types that can be used in a component interface.
 /// At this level we identify user-defined types by name, without knowing any details
 /// of their internal structure apart from what type of thing they are (record, enum, etc).
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum Type {
     // Primitive types.
     UInt8,
@@ -159,8 +159,8 @@ impl Into<FFIType> for &Type {
 pub(crate) struct TypeUniverse {
     // Named type definitions (including aliases).
     type_definitions: HashMap<String, Type>,
-    // All the types in the universe, by canonical type name.
-    all_known_types: HashSet<Type>,
+    // All the types in the universe, by canonical type name, in a well-defined order.
+    all_known_types: BTreeSet<Type>,
 }
 
 impl TypeUniverse {

--- a/uniffi_bindgen/src/interface/types/resolver.rs
+++ b/uniffi_bindgen/src/interface/types/resolver.rs
@@ -292,4 +292,32 @@ mod test {
         assert_eq!(err.to_string(), "no support for union types yet");
         Ok(())
     }
+
+    #[test]
+    fn test_type_set_is_well_ordered() -> Result<()> {
+        // The set (universe) of types should have a well-defined order. When
+        // the data structure does not guarantee the order of its elements, such as
+        // HashSet, then the resulting generated source code is likely not
+        // deterministic, and the compiled binary file may not be reproducible. We
+        // avoid this issue by using an implementation that defines the order of its
+        // elements. This test verifies that the elements are sorted as expected.
+        let mut types = TypeUniverse::default();
+        types.add_type_definition("TestRecord", Type::Record("TestRecord".into()))?;
+        assert_eq!(types.iter_known_types().count(), 1);
+        types.add_type_definition("TestRecord2", Type::Record("TestRecord2".into()))?;
+        assert_eq!(types.iter_known_types().count(), 2);
+        types.add_type_definition("TestInt64", Type::Int64)?;
+        types.add_type_definition("TestInt8", Type::Int8)?;
+        types.add_type_definition("TestUInt8", Type::UInt8)?;
+        types.add_type_definition("TestBoolean", Type::Boolean)?;
+        assert_eq!(types.iter_known_types().count(), 6);
+        let mut iter = types.iter_known_types();
+        assert_eq!(Some(Type::UInt8), iter.next());
+        assert_eq!(Some(Type::Int8), iter.next());
+        assert_eq!(Some(Type::Int64), iter.next());
+        assert_eq!(Some(Type::Boolean), iter.next());
+        assert_eq!(Some(Type::Record("TestRecord".into())), iter.next());
+        assert_eq!(Some(Type::Record("TestRecord2".into())), iter.next());
+        Ok(())
+    }
 }


### PR DESCRIPTION
The set of types is used in multiple places during FFI creation. When
the data structure does not guarantee the order of elements, such as
HashSet, the resulting generated source code is not deterministic. Using
a BTreeSet resolves this issue by providing a well-defined element order
over which the the set may be iterated.