### PR TITLE
Adds support for JSON Objects

### DIFF
--- a/docker/Dockerfile-build
+++ b/docker/Dockerfile-build
@@ -61,12 +61,13 @@ RUN mkdir -p /tmp/setup-kotlin \
     && cd ../ \
     && rm -rf ./setup-kotlin
 
-RUN mkdir -p /tmp/setup-jna \
-    && cd /tmp/setup-jna \
+RUN mkdir -p /tmp/setup-kotlin-env \
+    && cd /tmp/setup-kotlin-env \
     && curl -o jna.jar https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.6.0/jna-5.6.0.jar \
+    && curl -o json.jar https://repo1.maven.org/maven2/org/json/json/20190722/json-20190722.jar \
     # XXX TODO: should check a sha256sum or something here...
-    && sudo mv jna.jar /opt \
-    && echo "export CLASSPATH=\"\$CLASSPATH:/opt/jna.jar\"" >> /home/circleci/.bashrc \
-    && echo "export CLASSPATH=\"\$CLASSPATH:/opt/jna.jar\"" >> /home/circleci/.profile \
+    && sudo mv *.jar /opt \
+    && echo "export CLASSPATH=\"\$CLASSPATH:/opt/jna.jar:/opt/json.jar\"" >> /home/circleci/.bashrc \
+    && echo "export CLASSPATH=\"\$CLASSPATH:/opt/jna.jar:/opt/json.jar\"" >> /home/circleci/.profile \
     && cd ../ \
-    && rm -rf ./setup-jna
+    && rm -rf ./setup-kotlin-env

--- a/docs/manual/src/udl/builtin_types.md
+++ b/docs/manual/src/udl/builtin_types.md
@@ -13,7 +13,7 @@ The following built-in types can be passed as arguments/returned by Rust methods
 | `Option<T>`          | `T?`                   |                                   |
 | `Vec<T>`             | `sequence<T>`          |                                   |
 | `HashMap<String, T>` | `record<DOMString, T>` | Only string keys are supported    |
-| `serde_json::Value`  | `JSONValue`            | Top level object is a JSON Object |
+| `serde_json::Value`  | `JSONObject`           | Top level object is a JSON Object |
 | `()`                 | `void`                 | Empty return                      |
 | `Result<T, E>`       | N/A                    | See [Errors](./errors.md) section |
 

--- a/docs/manual/src/udl/builtin_types.md
+++ b/docs/manual/src/udl/builtin_types.md
@@ -13,6 +13,7 @@ The following built-in types can be passed as arguments/returned by Rust methods
 | `Option<T>`          | `T?`                   |                                   |
 | `Vec<T>`             | `sequence<T>`          |                                   |
 | `HashMap<String, T>` | `record<DOMString, T>` | Only string keys are supported    |
+| `serde_json::Value`  | `JSONValue`            | Top level object is a JSON Object |
 | `()`                 | `void`                 | Empty return                      |
 | `Result<T, E>`       | N/A                    | See [Errors](./errors.md) section |
 

--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "uniffi-example-arithmetic"
 edition = "2018"
-version = "0.7.2"
+version = "0.7.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 
 [lib]
 crate-type = ["staticlib", "cdylib", "lib"]
-name = "arithmetical"
+name = "arithmetical"   
 
 [dependencies]
 uniffi_macros = {path = "../../uniffi_macros"}

--- a/examples/rondpoint/Cargo.toml
+++ b/examples/rondpoint/Cargo.toml
@@ -13,6 +13,7 @@ name = "uniffi_rondpoint"
 [dependencies]
 uniffi_macros = {path = "../../uniffi_macros"}
 uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
+serde_json = "1.0.64"
 
 [build-dependencies]
 uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/examples/rondpoint/src/lib.rs
+++ b/examples/rondpoint/src/lib.rs
@@ -121,6 +121,9 @@ impl Retourneur {
     fn identique_string(&self, value: String) -> String {
         value
     }
+    fn identique_json_value(&self, value: Value) -> Value {
+        value
+    }
     fn identique_nombres_signes(
         &self,
         value: DictionnaireNombresSignes,
@@ -179,7 +182,7 @@ impl Stringifier {
     fn to_string_boolean(&self, value: bool) -> String {
         value.to_string()
     }
-    fn to_string_json_value(&self, value: serde_json::Value) -> String {
+    fn to_string_json_value(&self, value: Value) -> String {
         value.to_string()
     }
     fn well_known_string(&self, value: String) -> String {

--- a/examples/rondpoint/src/lib.rs
+++ b/examples/rondpoint/src/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use serde_json::Value;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
@@ -176,6 +177,9 @@ impl Stringifier {
         value.to_string()
     }
     fn to_string_boolean(&self, value: bool) -> String {
+        value.to_string()
+    }
+    fn to_string_json_value(&self, value: serde_json::Value) -> String {
         value.to_string()
     }
     fn well_known_string(&self, value: String) -> String {

--- a/examples/rondpoint/src/lib.rs
+++ b/examples/rondpoint/src/lib.rs
@@ -121,7 +121,7 @@ impl Retourneur {
     fn identique_string(&self, value: String) -> String {
         value
     }
-    fn identique_json_value(&self, value: Value) -> Value {
+    fn identique_json_object(&self, value: Value) -> Value {
         value
     }
     fn identique_nombres_signes(
@@ -182,7 +182,7 @@ impl Stringifier {
     fn to_string_boolean(&self, value: bool) -> String {
         value.to_string()
     }
-    fn to_string_json_value(&self, value: Value) -> String {
+    fn to_string_json_object(&self, value: Value) -> String {
         value.to_string()
     }
     fn well_known_string(&self, value: String) -> String {

--- a/examples/rondpoint/src/lib.rs
+++ b/examples/rondpoint/src/lib.rs
@@ -76,6 +76,10 @@ fn switcheroo(b: bool) -> bool {
     !b
 }
 
+struct DictionnaireAvecJSON {
+    value: Value,
+}
+
 // Test that values can traverse both ways across the FFI.
 // Even if roundtripping works, it's possible we have
 // symmetrical errors that cancel each other out.
@@ -122,6 +126,12 @@ impl Retourneur {
         value
     }
     fn identique_json_object(&self, value: Value) -> Value {
+        value
+    }
+    fn identique_dictionnaire_avec_json(
+        &self,
+        value: DictionnaireAvecJSON,
+    ) -> DictionnaireAvecJSON {
         value
     }
     fn identique_nombres_signes(

--- a/examples/rondpoint/src/rondpoint.udl
+++ b/examples/rondpoint/src/rondpoint.udl
@@ -61,7 +61,7 @@ interface Retourneur {
   double identique_double(double value);
   boolean identique_boolean(boolean value);
   string identique_string(string value);
-  JSONValue identique_json_value(JSONValue value);
+  JSONObject identique_json_object(JSONObject value);
 
   DictionnaireNombresSignes identique_nombres_signes(DictionnaireNombresSignes value);
   DictionnaireNombres       identique_nombres(DictionnaireNombres value);
@@ -82,7 +82,7 @@ interface Stringifier {
   string to_string_float(float value);
   string to_string_double(double value);
   string to_string_boolean(boolean value);
-  string to_string_json_value(JSONValue value);
+  string to_string_json_object(JSONObject value);
 };
 
 interface Optionneur {

--- a/examples/rondpoint/src/rondpoint.udl
+++ b/examples/rondpoint/src/rondpoint.udl
@@ -61,6 +61,7 @@ interface Retourneur {
   double identique_double(double value);
   boolean identique_boolean(boolean value);
   string identique_string(string value);
+  JSONValue identique_json_value(JSONValue value);
 
   DictionnaireNombresSignes identique_nombres_signes(DictionnaireNombresSignes value);
   DictionnaireNombres       identique_nombres(DictionnaireNombres value);

--- a/examples/rondpoint/src/rondpoint.udl
+++ b/examples/rondpoint/src/rondpoint.udl
@@ -81,6 +81,7 @@ interface Stringifier {
   string to_string_float(float value);
   string to_string_double(double value);
   string to_string_boolean(boolean value);
+  string to_string_json_value(JSONValue value);
 };
 
 interface Optionneur {

--- a/examples/rondpoint/src/rondpoint.udl
+++ b/examples/rondpoint/src/rondpoint.udl
@@ -48,6 +48,10 @@ dictionary DictionnaireNombresSignes {
     i64 gros_nombre;
 };
 
+dictionary DictionnaireAvecJSON {
+  JSONObject value;
+};
+
 interface Retourneur {
   i8 identique_i8(i8 value);
   u8 identique_u8(u8 value);
@@ -62,6 +66,7 @@ interface Retourneur {
   boolean identique_boolean(boolean value);
   string identique_string(string value);
   JSONObject identique_json_object(JSONObject value);
+  DictionnaireAvecJSON identique_dictionnaire_avec_json(DictionnaireAvecJSON value);
 
   DictionnaireNombresSignes identique_nombres_signes(DictionnaireNombresSignes value);
   DictionnaireNombres       identique_nombres(DictionnaireNombres value);

--- a/examples/rondpoint/tests/bindings/test_rondpoint.kts
+++ b/examples/rondpoint/tests/bindings/test_rondpoint.kts
@@ -78,7 +78,7 @@ listOf(0, 1).map { DictionnaireNombres(it.toUByte(), it.toUShort(), it.toUInt(),
 
 // Must be a JSON object, not an array or bare type.
 listOf("{}", "{\"a\":true}", "{\"a\":[1,2,3]}").map { JSONObject(it) }
-    .affirmAllerRetour(rt::identiqueJsonValue) { a, b -> a.toString() == b.toString() }
+    .affirmAllerRetour(rt::identiqueJsonObject) { a, b -> a.toString() == b.toString() }
 
 rt.destroy()
 
@@ -140,7 +140,7 @@ listOf(0.0F, 1.0F, -1.0F, Float.MIN_VALUE, Float.MAX_VALUE).affirmEnchaine(st::t
 // MIN_VALUE is 4.9E-324. Accuracy and formatting get weird at small sizes.
 listOf(0.0, 1.0, -1.0, Double.MIN_VALUE, Double.MAX_VALUE).affirmEnchaine(st::toStringDouble)  { s, n -> s.toDouble() == n }
 
-listOf("{\"a\": true}", "{\"a\": [1, 2, 3]}").map { JSONObject(it) }.affirmEnchaine(st::toStringJsonValue)
+listOf("{\"a\": true}", "{\"a\": [1, 2, 3]}").map { JSONObject(it) }.affirmEnchaine(st::toStringJsonObject)
 
 st.destroy()
 

--- a/examples/rondpoint/tests/bindings/test_rondpoint.kts
+++ b/examples/rondpoint/tests/bindings/test_rondpoint.kts
@@ -80,6 +80,8 @@ listOf(0, 1).map { DictionnaireNombres(it.toUByte(), it.toUShort(), it.toUInt(),
 listOf("{}", "{\"a\":true}", "{\"a\":[1,2,3]}").map { JSONObject(it) }
     .affirmAllerRetour(rt::identiqueJsonObject) { a, b -> a.toString() == b.toString() }
 
+listOf("{}", "{\"a\":true}", "{\"a\":[1,2,3]}").map { DictionnaireAvecJson(JSONObject(it)) }
+    .affirmAllerRetour(rt::identiqueDictionnaireAvecJson) { a, b -> a.value.toString() == b.value.toString() }
 rt.destroy()
 
 // Test one way across the FFI.

--- a/examples/rondpoint/tests/bindings/test_rondpoint.py
+++ b/examples/rondpoint/tests/bindings/test_rondpoint.py
@@ -85,7 +85,7 @@ affirmAllerRetour(
 # JSON
 affirmAllerRetour(
   [{}, {'a': [1, 2, 3]}, {'a': None, 'b': True}],
-  rt.identique_json_value,
+  rt.identique_json_object,
 )
 
 # Test one way across the FFI.
@@ -159,6 +159,6 @@ def rustyJsonToStr(v):
 
 affirmEnchaine(
   [{}, {'a': [1, 2, 3]}, {'a': None, 'b': True}],
-  st.to_string_json_value,
+  st.to_string_json_object,
   rustyJsonToStr,
 )

--- a/examples/rondpoint/tests/bindings/test_rondpoint.py
+++ b/examples/rondpoint/tests/bindings/test_rondpoint.py
@@ -88,6 +88,11 @@ affirmAllerRetour(
   rt.identique_json_object,
 )
 
+affirmAllerRetour(
+  map(lambda d: DictionnaireAvecJson(d), [{}, {'a': [1, 2, 3]}, {'a': None, 'b': True}]),
+  rt.identique_dictionnaire_avec_json,
+)
+
 # Test one way across the FFI.
 #
 # We send one representation of a value to lib.rs, and it transforms it into another, a string.

--- a/examples/rondpoint/tests/bindings/test_rondpoint.py
+++ b/examples/rondpoint/tests/bindings/test_rondpoint.py
@@ -82,6 +82,12 @@ affirmAllerRetour(
   rt.identique_string
 )
 
+# JSON
+affirmAllerRetour(
+  [{}, {'a': [1, 2, 3]}, {'a': None, 'b': True}],
+  rt.identique_json_value,
+)
+
 # Test one way across the FFI.
 #
 # We send one representation of a value to lib.rs, and it transforms it into another, a string.
@@ -99,8 +105,9 @@ st = Stringifier()
 
 def affirmEnchaine(vals, toString, rustyStringify=lambda v: str(v).lower()):
     for v in vals:
-        str_v = toString(v)
-        assert rustyStringify(v) == str_v, f"String compare error {v} => {str_v}"
+        obs = toString(v)
+        exp = rustyStringify(v)
+        assert obs == exp, f"String compare error {exp} => {obs}"
 
 # Test the efficacy of the string transport from rust. If this fails, but everything else
 # works, then things are very weird.
@@ -143,4 +150,15 @@ affirmEnchaine(
   [0.0, 0.5, 0.25, 1.0, 1.0 / 3],
   st.to_string_double,
   rustyFloatToStr,
+)
+
+import json
+def rustyJsonToStr(v):
+    """Stringify an dictionary in the same way rust has"""
+    return json.dumps(v, separators=(',', ':'))
+
+affirmEnchaine(
+  [{}, {'a': [1, 2, 3]}, {'a': None, 'b': True}],
+  st.to_string_json_value,
+  rustyJsonToStr,
 )

--- a/examples/rondpoint/tests/bindings/test_rondpoint.swift
+++ b/examples/rondpoint/tests/bindings/test_rondpoint.swift
@@ -60,7 +60,7 @@ let rt = Retourneur()
     .affirmAllerRetour(rt.identiqueString)
 
 [["a": [1,2,3]], ["a": true]]
-    .affirmAllerRetour(rt.identiqueJsonValue) { a, b in toString(a) == toString(b) }
+    .affirmAllerRetour(rt.identiqueJsonObject) { a, b in toString(a) == toString(b) }
 
 func toString(_ jsonObject: [String: Any]) -> String {
     if let data = try? JSONSerialization.data(withJSONObject: jsonObject, options: []),
@@ -115,7 +115,7 @@ assert("uniffi 💚 swift!" == wellKnown, "wellKnownString 'uniffi 💚 swift!' 
 // Doubles
 [.zero, 1, -1, .leastNonzeroMagnitude, .greatestFiniteMagnitude].affirmEnchaine(st.toStringDouble) { Double.init($0) == $1 }
 
-[["a": [1,2,3]], ["a": true]].affirmEnchaine(st.toStringJsonValue) { $0 == toString($1) }
+[["a": [1,2,3]], ["a": true]].affirmEnchaine(st.toStringJsonObject) { $0 == toString($1) }
 
 // Some extension functions for testing the results of roundtripping and stringifying
 extension Array where Element: Equatable {

--- a/examples/rondpoint/tests/bindings/test_rondpoint.swift
+++ b/examples/rondpoint/tests/bindings/test_rondpoint.swift
@@ -62,6 +62,9 @@ let rt = Retourneur()
 [["a": [1,2,3]], ["a": true]]
     .affirmAllerRetour(rt.identiqueJsonObject) { a, b in toString(a) == toString(b) }
 
+[["a": [1,2,3]], ["a": true]].map { json in DictionnaireAvecJson(value: json) }
+    .affirmAllerRetour(rt.identiqueDictionnaireAvecJson) { a, b in toString(a.value) == toString(b.value) }
+
 func toString(_ jsonObject: [String: Any]) -> String {
     if let data = try? JSONSerialization.data(withJSONObject: jsonObject, options: []),
         let string = String(data: data, encoding: .utf8) {

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -22,6 +22,7 @@ cargo_metadata = "0.11"
 paste = "1.0"
 uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "= 0.7.2"}
 static_assertions = "1.1.0"
+serde_json = "1.0.64"
 
 [features]
 default = []

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -285,6 +285,36 @@ unsafe impl ViaFfi for String {
     }
 }
 
+unsafe impl ViaFfi for serde_json::Value {
+    type FfiType = RustBuffer;
+
+    fn lower(self) -> Self::FfiType {
+        match serde_json::to_string(&self) {
+            Ok(string) => string.lower(),
+            _ => panic!("JSON can't be serialized"),
+        }
+    }
+
+    // The argument here *must* be a uniquely-owned `RustBuffer` previously obtained
+    // from `lower` above, and hence must be the bytes of a valid rust string.
+    fn try_lift(v: Self::FfiType) -> Result<Self> {
+        let json_string = String::try_lift(v)?;
+        Ok(serde_json::from_str(&json_string)?)
+    }
+
+    fn write<B: BufMut>(&self, buf: &mut B) {
+        match serde_json::to_string(&self) {
+            Ok(json_string) => json_string.write(buf),
+            _ => panic!("Unable to serialize JSON"),
+        };
+    }
+
+    fn try_read<B: Buf>(buf: &mut B) -> Result<Self> {
+        let json_string = String::try_read(buf)?;
+        Ok(serde_json::from_str(&json_string)?)
+    }
+}
+
 /// Support for passing optional values via the FFI.
 ///
 /// Optional values are currently always passed by serializing to a buffer.

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -285,36 +285,6 @@ unsafe impl ViaFfi for String {
     }
 }
 
-unsafe impl ViaFfi for serde_json::Value {
-    type FfiType = RustBuffer;
-
-    fn lower(self) -> Self::FfiType {
-        match serde_json::to_string(&self) {
-            Ok(string) => string.lower(),
-            _ => panic!("JSON can't be serialized"),
-        }
-    }
-
-    // The argument here *must* be a uniquely-owned `RustBuffer` previously obtained
-    // from `lower` above, and hence must be the bytes of a valid rust string.
-    fn try_lift(v: Self::FfiType) -> Result<Self> {
-        let json_string = String::try_lift(v)?;
-        Ok(serde_json::from_str(&json_string)?)
-    }
-
-    fn write<B: BufMut>(&self, buf: &mut B) {
-        match serde_json::to_string(&self) {
-            Ok(json_string) => json_string.write(buf),
-            _ => panic!("Unable to serialize JSON"),
-        };
-    }
-
-    fn try_read<B: Buf>(buf: &mut B) -> Result<Self> {
-        let json_string = String::try_read(buf)?;
-        Ok(serde_json::from_str(&json_string)?)
-    }
-}
-
 /// Support for passing optional values via the FFI.
 ///
 /// Optional values are currently always passed by serializing to a buffer.
@@ -434,5 +404,62 @@ unsafe impl<V: ViaFfi> ViaFfi for HashMap<String, V> {
             map.insert(key, value);
         }
         Ok(map)
+    }
+}
+
+use serde_json::Value;
+
+/// Support for passing JSON objects.
+///
+/// For correctness and speed of implementation, objects are serialized into a String.
+/// This can definitely be improved in efficiency, however high-quality JSON parsers and
+/// stringifiers are available on both sides of the FFI.
+///
+/// Only top-level objects are supported: i.e. the value must be a `Value::Object`.
+/// If the Rust side tries to pass back a `JSONArray` or a scalar, and the foreign language side
+/// is expecting a dictionary shaped value, it would be a failure.
+///
+/// In this implementation, the value is wrapped in an object with the error message as the key.
+unsafe impl ViaFfi for Value {
+    type FfiType = RustBuffer;
+
+    fn lower(self) -> Self::FfiType {
+        match to_supported_string(&self) {
+            Ok(string) => string.lower(),
+            Err(_) => panic!("Unserializable JSON"),
+        }
+    }
+
+    // The argument here *must* be a uniquely-owned `RustBuffer` previously obtained
+    // from `lower` above, and hence must be the bytes of a valid rust string.
+    fn try_lift(v: Self::FfiType) -> Result<Self> {
+        let json_string = String::try_lift(v)?;
+        Ok(serde_json::from_str(&json_string)?)
+    }
+
+    fn write<B: BufMut>(&self, buf: &mut B) {
+        match to_supported_string(&self) {
+            Ok(json_string) => json_string.write(buf),
+            Err(_) => panic!("Unserializable JSON"),
+        };
+    }
+
+    fn try_read<B: Buf>(buf: &mut B) -> Result<Self> {
+        let json_string = String::try_read(buf)?;
+        Ok(serde_json::from_str(&json_string)?)
+    }
+}
+
+fn to_supported_string(value: &Value) -> Result<String> {
+    match value {
+        Value::Object(_) => Ok(serde_json::to_string(value)?),
+        _ => {
+            // We can either cause a panic! when unsupported/unsanitized JSON is
+            // accidently given to us, or we can wrap it up as an object with an error message
+            // as a key. Neither is ideal, but this should cause failure down stream quick enough
+            // for the developer to catch it.
+            let scalar = serde_json::to_string(value)?;
+            Ok(format!("{{\"Only top level objects supported by Uniffi\":{}}}", scalar))
+        }
     }
 }

--- a/uniffi_bindgen/src/bindings/gecko_js/webidl.rs
+++ b/uniffi_bindgen/src/bindings/gecko_js/webidl.rs
@@ -113,6 +113,7 @@ impl From<Type> for WebIDLType {
                 panic!("[TODO: From<Type>({:?})]", type_)
             }
             Type::CallbackInterface(_) => panic!("Callback interfaces unimplemented"),
+            Type::JSONValue => panic!("Untyped JSON values unimplemented"),
             Type::Optional(inner) => match *inner {
                 Type::Record(name) => {
                     WebIDLType::OptionalWithDefaultValue(Box::new(Type::Record(name).into()))

--- a/uniffi_bindgen/src/bindings/gecko_js/webidl.rs
+++ b/uniffi_bindgen/src/bindings/gecko_js/webidl.rs
@@ -113,7 +113,7 @@ impl From<Type> for WebIDLType {
                 panic!("[TODO: From<Type>({:?})]", type_)
             }
             Type::CallbackInterface(_) => panic!("Callback interfaces unimplemented"),
-            Type::JSONValue => panic!("Untyped JSON values unimplemented"),
+            Type::JSONObject => panic!("Untyped JSON values unimplemented"),
             Type::Optional(inner) => match *inner {
                 Type::Record(name) => {
                     WebIDLType::OptionalWithDefaultValue(Box::new(Type::Record(name).into()))

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin.rs
@@ -88,6 +88,7 @@ mod filters {
             // These types need conversion, and special handling for lifting/lowering.
             Type::Boolean => "Boolean".to_string(),
             Type::String => "String".to_string(),
+            Type::JSONValue => "JSONObject".to_string(),
             Type::Enum(name)
             | Type::Record(name)
             | Type::Object(name)
@@ -194,7 +195,7 @@ mod filters {
                 class_name_kt(&type_.canonical_name())?,
                 nm,
             ),
-            Type::Optional(_) | Type::Sequence(_) | Type::Map(_) => {
+            Type::Optional(_) | Type::Sequence(_) | Type::Map(_) | Type::JSONValue => {
                 format!("lower{}({})", class_name_kt(&type_.canonical_name())?, nm,)
             }
             _ => format!("{}.lower()", nm),
@@ -218,7 +219,7 @@ mod filters {
                 nm,
                 target,
             ),
-            Type::Optional(_) | Type::Sequence(_) | Type::Map(_) => format!(
+            Type::Optional(_) | Type::Sequence(_) | Type::Map(_) | Type::JSONValue => format!(
                 "write{}({}, {})",
                 class_name_kt(&type_.canonical_name())?,
                 nm,
@@ -240,7 +241,7 @@ mod filters {
                 class_name_kt(&type_.canonical_name())?,
                 nm,
             ),
-            Type::Optional(_) | Type::Sequence(_) | Type::Map(_) => {
+            Type::Optional(_) | Type::Sequence(_) | Type::Map(_) | Type::JSONValue => {
                 format!("lift{}({})", class_name_kt(&type_.canonical_name())?, nm,)
             }
             _ => format!("{}.lift({})", type_kt(type_)?, nm),
@@ -259,7 +260,7 @@ mod filters {
                 class_name_kt(&type_.canonical_name())?,
                 nm,
             ),
-            Type::Optional(_) | Type::Sequence(_) | Type::Map(_) => {
+            Type::Optional(_) | Type::Sequence(_) | Type::Map(_) | Type::JSONValue => {
                 format!("read{}({})", class_name_kt(&type_.canonical_name())?, nm,)
             }
             _ => format!("{}.read({})", type_kt(type_)?, nm),

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin.rs
@@ -88,7 +88,7 @@ mod filters {
             // These types need conversion, and special handling for lifting/lowering.
             Type::Boolean => "Boolean".to_string(),
             Type::String => "String".to_string(),
-            Type::JSONValue => "JSONObject".to_string(),
+            Type::JSONObject => "JSONObject".to_string(),
             Type::Enum(name)
             | Type::Record(name)
             | Type::Object(name)
@@ -195,7 +195,7 @@ mod filters {
                 class_name_kt(&type_.canonical_name())?,
                 nm,
             ),
-            Type::Optional(_) | Type::Sequence(_) | Type::Map(_) | Type::JSONValue => {
+            Type::Optional(_) | Type::Sequence(_) | Type::Map(_) | Type::JSONObject => {
                 format!("lower{}({})", class_name_kt(&type_.canonical_name())?, nm,)
             }
             _ => format!("{}.lower()", nm),
@@ -219,7 +219,7 @@ mod filters {
                 nm,
                 target,
             ),
-            Type::Optional(_) | Type::Sequence(_) | Type::Map(_) | Type::JSONValue => format!(
+            Type::Optional(_) | Type::Sequence(_) | Type::Map(_) | Type::JSONObject => format!(
                 "write{}({}, {})",
                 class_name_kt(&type_.canonical_name())?,
                 nm,
@@ -241,7 +241,7 @@ mod filters {
                 class_name_kt(&type_.canonical_name())?,
                 nm,
             ),
-            Type::Optional(_) | Type::Sequence(_) | Type::Map(_) | Type::JSONValue => {
+            Type::Optional(_) | Type::Sequence(_) | Type::Map(_) | Type::JSONObject => {
                 format!("lift{}({})", class_name_kt(&type_.canonical_name())?, nm,)
             }
             _ => format!("{}.lift({})", type_kt(type_)?, nm),
@@ -260,7 +260,7 @@ mod filters {
                 class_name_kt(&type_.canonical_name())?,
                 nm,
             ),
-            Type::Optional(_) | Type::Sequence(_) | Type::Map(_) | Type::JSONValue => {
+            Type::Optional(_) | Type::Sequence(_) | Type::Map(_) | Type::JSONObject => {
                 format!("read{}({})", class_name_kt(&type_.canonical_name())?, nm,)
             }
             _ => format!("{}.read({})", type_kt(type_)?, nm),

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
@@ -282,7 +282,7 @@ internal fun String.write(buf: RustBufferBuilder) {
     buf.put(byteArr)
 }
 
-{% when Type::JSONValue -%}
+{% when Type::JSONObject -%}
 {% let inner_type_name = "JSONObject" %}
 
 internal fun lift{{ canonical_type_name }}(rbuf: RustBuffer.ByValue): {{ inner_type_name }} {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
@@ -282,6 +282,29 @@ internal fun String.write(buf: RustBufferBuilder) {
     buf.put(byteArr)
 }
 
+{% when Type::JSONValue -%}
+{% let inner_type_name = "JSONObject" %}
+
+internal fun lift{{ canonical_type_name }}(rbuf: RustBuffer.ByValue): {{ inner_type_name }}? {
+    val string = String.lift(rbuf)
+    return JSONObject(string)
+}
+
+internal fun read{{ canonical_type_name }}(buf: ByteBuffer): {{ inner_type_name }} {
+    val string = String.read(buf)
+    return JSONObject(string)
+}
+
+internal fun lower{{ canonical_type_name }}(v: {{ inner_type_name }}?): RustBuffer.ByValue {
+    val string = v.toString()
+    return string.lower()
+}
+
+internal fun write{{ canonical_type_name }}(v: {{ inner_type_name }}?, buf: RustBufferBuilder) {
+    val string = v.toString()
+    return string.write(buf)
+}
+
 {% when Type::Optional with (inner_type) -%}
 {% let inner_type_name = inner_type|type_kt %}
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
@@ -285,7 +285,7 @@ internal fun String.write(buf: RustBufferBuilder) {
 {% when Type::JSONValue -%}
 {% let inner_type_name = "JSONObject" %}
 
-internal fun lift{{ canonical_type_name }}(rbuf: RustBuffer.ByValue): {{ inner_type_name }}? {
+internal fun lift{{ canonical_type_name }}(rbuf: RustBuffer.ByValue): {{ inner_type_name }} {
     val string = String.lift(rbuf)
     return JSONObject(string)
 }
@@ -295,12 +295,12 @@ internal fun read{{ canonical_type_name }}(buf: ByteBuffer): {{ inner_type_name 
     return JSONObject(string)
 }
 
-internal fun lower{{ canonical_type_name }}(v: {{ inner_type_name }}?): RustBuffer.ByValue {
+internal fun lower{{ canonical_type_name }}(v: {{ inner_type_name }}): RustBuffer.ByValue {
     val string = v.toString()
     return string.lower()
 }
 
-internal fun write{{ canonical_type_name }}(v: {{ inner_type_name }}?, buf: RustBufferBuilder) {
+internal fun write{{ canonical_type_name }}(v: {{ inner_type_name }}, buf: RustBufferBuilder) {
     val string = v.toString()
     return string.write(buf)
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/wrapper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/wrapper.kt
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
-{%- if ci.uses_type(Type::JSONValue) %}
+{%- if ci.uses_type(Type::JSONObject) %}
 import org.json.JSONObject
 {%- endif %}
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/wrapper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/wrapper.kt
@@ -27,6 +27,9 @@ import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
+{%- if ci.uses_type(Type::JSONValue) %}
+import org.json.JSONObject
+{%- endif %}
 
 {% include "RustBufferTemplate.kt" %}
 

--- a/uniffi_bindgen/src/bindings/python/gen_python.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python.rs
@@ -141,7 +141,7 @@ mod filters {
             | Type::UInt64 => format!("int({})", nm), // TODO: check max/min value
             Type::Float32 | Type::Float64 => format!("float({})", nm),
             Type::Boolean => format!("bool({})", nm),
-            Type::String | Type::Object(_) | Type::Enum(_) | Type::Error(_) | Type::Record(_) => {
+            Type::String | Type::Object(_) | Type::Enum(_) | Type::Error(_) | Type::Record(_) | Type::JSONValue => {
                 nm.to_string()
             }
             Type::CallbackInterface(_) => panic!("No support for coercing callback interfaces yet"),
@@ -177,7 +177,8 @@ mod filters {
             | Type::Record(_)
             | Type::Optional(_)
             | Type::Sequence(_)
-            | Type::Map(_) => format!(
+            | Type::Map(_) 
+            | Type::JSONValue => format!(
                 "RustBuffer.allocFrom{}({})",
                 class_name_py(&type_.canonical_name())?,
                 nm
@@ -200,12 +201,13 @@ mod filters {
             Type::String => format!("{}.consumeIntoString()", nm),
             Type::Object(_) => panic!("No support for lifting objects, yet"),
             Type::CallbackInterface(_) => panic!("No support for lifting callback interfaces, yet"),
-            Type::Error(_) => panic!("No support for lowering errors, yet"),
+            Type::Error(_) => panic!("No support for lifting errors, yet"),
             Type::Enum(_)
             | Type::Record(_)
             | Type::Optional(_)
             | Type::Sequence(_)
-            | Type::Map(_) => format!(
+            | Type::Map(_) 
+            | Type::JSONValue => format!(
                 "{}.consumeInto{}()",
                 nm,
                 class_name_py(&type_.canonical_name())?

--- a/uniffi_bindgen/src/bindings/python/gen_python.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python.rs
@@ -141,7 +141,7 @@ mod filters {
             | Type::UInt64 => format!("int({})", nm), // TODO: check max/min value
             Type::Float32 | Type::Float64 => format!("float({})", nm),
             Type::Boolean => format!("bool({})", nm),
-            Type::String | Type::Object(_) | Type::Enum(_) | Type::Error(_) | Type::Record(_) | Type::JSONValue => {
+            Type::String | Type::Object(_) | Type::Enum(_) | Type::Error(_) | Type::Record(_) | Type::JSONObject => {
                 nm.to_string()
             }
             Type::CallbackInterface(_) => panic!("No support for coercing callback interfaces yet"),
@@ -178,7 +178,7 @@ mod filters {
             | Type::Optional(_)
             | Type::Sequence(_)
             | Type::Map(_) 
-            | Type::JSONValue => format!(
+            | Type::JSONObject => format!(
                 "RustBuffer.allocFrom{}({})",
                 class_name_py(&type_.canonical_name())?,
                 nm
@@ -207,7 +207,7 @@ mod filters {
             | Type::Optional(_)
             | Type::Sequence(_)
             | Type::Map(_) 
-            | Type::JSONValue => format!(
+            | Type::JSONObject => format!(
                 "{}.consumeInto{}()",
                 nm,
                 class_name_py(&type_.canonical_name())?

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
@@ -106,6 +106,13 @@ class RustBufferBuilder(object):
         self._pack_into(4, ">i", len(utf8Bytes))
         self.write(utf8Bytes)
 
+    {% when Type::JSONValue -%}
+
+    def writeJsonValue(self, v):
+        import json
+        json_string = json.dumps(v)
+        self.writeString(json_string)
+
     {% when Type::Object with (object_name) -%}
     # The Object type {{ object_name }}.
     # Objects cannot currently be serialized, but we can produce a helpful error.

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
@@ -106,9 +106,9 @@ class RustBufferBuilder(object):
         self._pack_into(4, ">i", len(utf8Bytes))
         self.write(utf8Bytes)
 
-    {% when Type::JSONValue -%}
+    {% when Type::JSONObject -%}
 
-    def writeJsonValue(self, v):
+    def writeJsonObject(self, v):
         import json
         json_string = json.dumps(v, separators=(',', ':'))
         self.writeString(json_string)

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
@@ -110,7 +110,7 @@ class RustBufferBuilder(object):
 
     def writeJsonValue(self, v):
         import json
-        json_string = json.dumps(v)
+        json_string = json.dumps(v, separators=(',', ':'))
         self.writeString(json_string)
 
     {% when Type::Object with (object_name) -%}

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
@@ -103,9 +103,9 @@ class RustBufferStream(object):
         utf8Bytes = self.read(size)
         return utf8Bytes.decode("utf-8")
 
-    {% when Type::JSONValue -%}
+    {% when Type::JSONObject -%}
 
-    def readJsonValue(self):
+    def readJsonObject(self):
         import json
         json_string = self.readString()
         return json.loads(json_string)

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
@@ -103,6 +103,13 @@ class RustBufferStream(object):
         utf8Bytes = self.read(size)
         return utf8Bytes.decode("utf-8")
 
+    {% when Type::JSONValue -%}
+
+    def readJsonValue(self):
+        import json
+        json_string = self.readString()
+        return json.loads(json_string)
+
     {% when Type::Object with (object_name) -%}
     # The Object type {{ object_name }}.
     # Objects cannot currently be serialized, but we can produce a helpful error.

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
@@ -83,8 +83,8 @@ class RustBuffer(ctypes.Structure):
     @staticmethod
     def allocFromJsonValue(value):
         import json
-        json_string = json.dumps(value)
-        return allocFromString(json_string)
+        json_string = json.dumps(value, separators=(',', ':'))
+        return RustBuffer.allocFromString(json_string)
 
     def consumeIntoJsonValue(self):
         import json

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
@@ -78,6 +78,19 @@ class RustBuffer(ctypes.Structure):
         with self.consumeWithStream() as stream:
             return stream.read(stream.remaining()).decode("utf-8")
 
+    {% when Type::JSONValue -%}
+    # The JSONValue type.
+    @staticmethod
+    def allocFromJsonValue(value):
+        import json
+        json_string = json.dumps(value)
+        return allocFromString(json_string)
+
+    def consumeIntoJsonValue(self):
+        import json
+        json_string = self.consumeIntoString()
+        return json.loads(json_string)
+
     {% when Type::Record with (record_name) -%}
     {%- let rec = ci.get_record_definition(record_name).unwrap() -%}
     # The Record type {{ record_name }}.

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
@@ -78,15 +78,15 @@ class RustBuffer(ctypes.Structure):
         with self.consumeWithStream() as stream:
             return stream.read(stream.remaining()).decode("utf-8")
 
-    {% when Type::JSONValue -%}
-    # The JSONValue type.
+    {% when Type::JSONObject -%}
+    # The JSONObject type.
     @staticmethod
-    def allocFromJsonValue(value):
+    def allocFromJsonObject(value):
         import json
         json_string = json.dumps(value, separators=(',', ':'))
         return RustBuffer.allocFromString(json_string)
 
-    def consumeIntoJsonValue(self):
+    def consumeIntoJsonObject(self):
         import json
         json_string = self.consumeIntoString()
         return json.loads(json_string)

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
@@ -62,7 +62,7 @@ class RustBuffer(ctypes.Structure):
     # of python's free-for-all type system.
 
     {%- for typ in ci.iter_types() -%}
-    {%- let canonical_type_name = typ.canonical_name() -%}
+    {%- let canonical_type_name = typ.canonical_name()|class_name_py -%}
     {%- match typ -%}
 
     {% when Type::String -%}
@@ -80,6 +80,7 @@ class RustBuffer(ctypes.Structure):
 
     {% when Type::JSONObject -%}
     # The JSONObject type.
+
     @staticmethod
     def allocFromJsonObject(value):
         import json

--- a/uniffi_bindgen/src/bindings/swift/gen_swift.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift.rs
@@ -236,7 +236,7 @@ mod filters {
     pub fn lift_swift(name: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
         Ok(
             match type_ {
-                Type::JSONValue => format!("JSONValue.lift({})", var_name_swift(name)?),
+                Type::JSONValue => format!("JSONValue.lift({})", name),
                 _ => format!("{}.lift({})", type_swift(type_)?, name),
             }
         )

--- a/uniffi_bindgen/src/bindings/swift/gen_swift.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift.rs
@@ -138,7 +138,7 @@ mod filters {
             Type::Float64 => "Double".into(),
             Type::Boolean => "Bool".into(),
             Type::String => "String".into(),
-            Type::JSONValue => "Dictionary<String, Any>".into(),
+            Type::JSONObject => "Dictionary<String, Any>".into(),
             Type::Enum(name)
             | Type::Record(name)
             | Type::Object(name)
@@ -224,7 +224,7 @@ mod filters {
     pub fn lower_swift(name: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
         Ok(
             match type_ {
-                Type::JSONValue => format!("JSONValue.lower({})", var_name_swift(name)?),
+                Type::JSONObject => format!("JSONObject.lower({})", var_name_swift(name)?),
                 _ => format!("{}.lower()", var_name_swift(name)?),
             }
         )
@@ -236,7 +236,7 @@ mod filters {
     pub fn lift_swift(name: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
         Ok(
             match type_ {
-                Type::JSONValue => format!("JSONValue.lift({})", name),
+                Type::JSONObject => format!("JSONObject.lift({})", name),
                 _ => format!("{}.lift({})", type_swift(type_)?, name),
             }
         )
@@ -249,7 +249,7 @@ mod filters {
     pub fn read_swift(name: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
         Ok(
             match type_ {
-                Type::JSONValue => format!("JSONValue.read(from: {})", var_name_swift(name)?),
+                Type::JSONObject => format!("JSONObject.read(from: {})", var_name_swift(name)?),
                 _ => format!("{}.read(from: {})", type_swift(type_)?, name),
             }
         )

--- a/uniffi_bindgen/src/bindings/swift/gen_swift.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift.rs
@@ -138,6 +138,7 @@ mod filters {
             Type::Float64 => "Double".into(),
             Type::Boolean => "Bool".into(),
             Type::String => "String".into(),
+            Type::JSONValue => "Dictionary<String, Any>".into(),
             Type::Enum(name)
             | Type::Record(name)
             | Type::Object(name)
@@ -220,15 +221,25 @@ mod filters {
     /// Lower a Swift type into an FFI type.
     ///
     /// This is used to pass arguments over the FFI, from Swift to Rust.
-    pub fn lower_swift(name: &dyn fmt::Display, _type_: &Type) -> Result<String, askama::Error> {
-        Ok(format!("{}.lower()", var_name_swift(name)?))
+    pub fn lower_swift(name: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
+        Ok(
+            match type_ {
+                Type::JSONValue => format!("JSONValue.lower({})", var_name_swift(name)?),
+                _ => format!("{}.lower()", var_name_swift(name)?),
+            }
+        )
     }
 
     /// Lift a Swift type from an FFI type.
     ///
     /// This is used to receive values over the FFI, from Rust to Swift.
     pub fn lift_swift(name: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
-        Ok(format!("{}.lift({})", type_swift(type_)?, name))
+        Ok(
+            match type_ {
+                Type::JSONValue => format!("JSONValue.lift({})", var_name_swift(name)?),
+                _ => format!("{}.lift({})", type_swift(type_)?, name),
+            }
+        )
     }
 
     /// Read a Swift type from a byte buffer.
@@ -236,7 +247,12 @@ mod filters {
     /// This is used to receive values over the FFI, when they're part of a complex type
     /// that is passed by serializing into bytes.
     pub fn read_swift(name: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
-        Ok(format!("{}.read(from: {})", type_swift(type_)?, name))
+        Ok(
+            match type_ {
+                Type::JSONValue => format!("JSONValue.read(from: {})", var_name_swift(name)?),
+                _ => format!("{}.read(from: {})", type_swift(type_)?, name),
+            }
+        )
     }
 
     pub fn enum_variant_swift(nm: &dyn fmt::Display) -> Result<String, askama::Error> {

--- a/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
@@ -17,6 +17,7 @@ fileprivate enum UniffiInternalError: RustError {
     case unexpectedOptionalTag
     case unexpectedEnumCase
     case emptyResult
+    case corruptData
     case unknown(_ message: String)
 
     public var errorDescription: String? {
@@ -26,6 +27,7 @@ fileprivate enum UniffiInternalError: RustError {
         case .unexpectedOptionalTag: return "Unexpected optional tag; should be 0 or 1"
         case .unexpectedEnumCase: return "Raw enum value doesn't match any cases"
         case .emptyResult: return "Unexpected nil returned from FFI function"
+        case .corruptData: return "The low level data format was corrupted"
         case let .unknown(message): return "FFI function returned unknown error: \(message)"
         }
     }

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -13,16 +13,20 @@ public struct {{ rec.name()|class_name_swift }}: Equatable, Hashable {
 
     public static func ==(lhs: {{ rec.name()|class_name_swift }}, rhs: {{ rec.name()|class_name_swift }}) -> Bool {
         {%- for field in rec.fields() %}
+        {%- if field.type_() != Type::JSONObject %}
         if lhs.{{ field.name()|var_name_swift }} != rhs.{{ field.name()|var_name_swift }} {
             return false
         }
+        {% endif %}
         {%- endfor %}
         return true
     }
 
     public func hash(into hasher: inout Hasher) {
         {%- for field in rec.fields() %}
+        {%- if field.type_() != Type::JSONObject %}
         hasher.combine({{ field.name()|var_name_swift }})
+        {% endif -%}
         {%- endfor %}
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/RustBufferHelper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RustBufferHelper.swift
@@ -204,6 +204,46 @@ extension String: ViaFfi {
     }
 }
 
+fileprivate enum JSONValue {
+    fileprivate typealias JSONObject = Dictionary<String, Any>
+    fileprivate typealias FfiType = RustBuffer
+    
+    fileprivate static func lift(_ v: FfiType) throws -> JSONObject {
+        let jsonString = try String.lift(v)
+        return try JSONValue.from(string: jsonString)
+    }
+
+    fileprivate static func read(from buf: Reader) throws -> JSONObject {
+        let jsonString = try String.read(from: buf)
+        return try JSONValue.from(string: jsonString)
+    }
+
+    fileprivate static func from(string: String) throws -> JSONObject {
+        if let data = string.data(using: .utf8),
+            let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
+                return json
+            }
+        throw UniffiInternalError.corruptData
+    }
+
+    fileprivate static func lower(_ jsonObject: JSONObject) -> FfiType {
+        let jsonString = JSONValue.intoString(jsonObject)
+        return jsonString.lower()
+    }
+
+    fileprivate static func write(_ jsonObject: JSONObject, into buf: Writer) {
+        let jsonString = JSONValue.intoString(jsonObject)
+        return jsonString.write(into: buf)
+    }
+
+    fileprivate static func intoString(_ jsonObject: JSONObject) -> String {
+        if let data = try? JSONSerialization.data(withJSONObject: self, options: []),
+            let string = String(data: data, encoding: .utf8) {
+            return string
+        }
+        return "{}"
+    }
+}
 
 extension Bool: ViaFfi {
     fileprivate typealias FfiType = Int8

--- a/uniffi_bindgen/src/bindings/swift/templates/RustBufferHelper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RustBufferHelper.swift
@@ -204,21 +204,21 @@ extension String: ViaFfi {
     }
 }
 
-fileprivate enum JSONValue {
-    fileprivate typealias JSONObject = [String: Any]
+fileprivate enum JSONObject {
+    fileprivate typealias SwiftType = [String: Any]
     fileprivate typealias FfiType = RustBuffer
     
-    fileprivate static func lift(_ v: FfiType) throws -> JSONObject {
+    fileprivate static func lift(_ v: FfiType) throws -> SwiftType {
         let jsonString = try String.lift(v)
-        return try JSONValue.from(string: jsonString)
+        return try JSONObject.from(string: jsonString)
     }
 
-    fileprivate static func read(from buf: Reader) throws -> JSONObject {
+    fileprivate static func read(from buf: Reader) throws -> SwiftType {
         let jsonString = try String.read(from: buf)
-        return try JSONValue.from(string: jsonString)
+        return try JSONObject.from(string: jsonString)
     }
 
-    fileprivate static func from(string: String) throws -> JSONObject {
+    fileprivate static func from(string: String) throws -> SwiftType {
         if let data = string.data(using: .utf8),
             let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
                 return json
@@ -226,17 +226,17 @@ fileprivate enum JSONValue {
         throw UniffiInternalError.corruptData
     }
 
-    fileprivate static func lower(_ jsonObject: JSONObject) -> FfiType {
-        let jsonString = JSONValue.stringify(jsonObject)
+    fileprivate static func lower(_ jsonObject: SwiftType) -> FfiType {
+        let jsonString = JSONObject.stringify(jsonObject)
         return jsonString.lower()
     }
 
-    fileprivate static func write(_ jsonObject: JSONObject, into buf: Writer) {
-        let jsonString = JSONValue.stringify(jsonObject)
+    fileprivate static func write(_ jsonObject: SwiftType, into buf: Writer) {
+        let jsonString = JSONObject.stringify(jsonObject)
         return jsonString.write(into: buf)
     }
 
-    fileprivate static func stringify(_ jsonObject: JSONObject) -> String {
+    fileprivate static func stringify(_ jsonObject: SwiftType) -> String {
         if let data = try? JSONSerialization.data(withJSONObject: jsonObject, options: []),
             let string = String(data: data, encoding: .utf8) {
             return string

--- a/uniffi_bindgen/src/bindings/swift/templates/RustBufferHelper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RustBufferHelper.swift
@@ -205,7 +205,7 @@ extension String: ViaFfi {
 }
 
 fileprivate enum JSONValue {
-    fileprivate typealias JSONObject = Dictionary<String, Any>
+    fileprivate typealias JSONObject = [String: Any]
     fileprivate typealias FfiType = RustBuffer
     
     fileprivate static func lift(_ v: FfiType) throws -> JSONObject {
@@ -227,17 +227,17 @@ fileprivate enum JSONValue {
     }
 
     fileprivate static func lower(_ jsonObject: JSONObject) -> FfiType {
-        let jsonString = JSONValue.intoString(jsonObject)
+        let jsonString = JSONValue.stringify(jsonObject)
         return jsonString.lower()
     }
 
     fileprivate static func write(_ jsonObject: JSONObject, into buf: Writer) {
-        let jsonString = JSONValue.intoString(jsonObject)
+        let jsonString = JSONValue.stringify(jsonObject)
         return jsonString.write(into: buf)
     }
 
-    fileprivate static func intoString(_ jsonObject: JSONObject) -> String {
-        if let data = try? JSONSerialization.data(withJSONObject: self, options: []),
+    fileprivate static func stringify(_ jsonObject: JSONObject) -> String {
+        if let data = try? JSONSerialization.data(withJSONObject: jsonObject, options: []),
             let string = String(data: data, encoding: .utf8) {
             return string
         }

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -197,6 +197,13 @@ impl<'ci> ComponentInterface {
         self.types.iter_known_types().collect()
     }
 
+    pub fn uses_type(&self, type_: &Type) -> bool {
+        match self.types.iter_known_types().find(|t| t == type_) {
+            Some(_) => true,
+            None => false,
+        }
+    }
+
     /// Calculate a numeric checksum for this ComponentInterface.
     ///
     /// The checksum can be used to guard against accidentally using foreign-language bindings

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -50,6 +50,7 @@ pub enum Type {
     Float64,
     Boolean,
     String,
+    JSONValue,
     // Types defined in the component API, each of which has a string name.
     Object(String),
     Record(String),
@@ -84,6 +85,7 @@ impl Type {
             Type::Float64 => "f64".into(),
             Type::String => "string".into(),
             Type::Boolean => "bool".into(),
+            Type::JSONValue => "JSONValue".into(),
             // API defined types.
             // Note that these all get unique names, and the parser ensures that the names do not
             // conflict with a builtin type. We add a prefix to the name to guard against pathological
@@ -129,6 +131,8 @@ impl Into<FFIType> for &Type {
             // Strings are always owned rust values.
             // We might add a separate type for borrowed strings in future.
             Type::String => FFIType::RustBuffer,
+            // We'll serialize JSON via a RustBuffer.
+            Type::JSONValue => FFIType::RustBuffer,
             // Objects are passed as opaque integer handles.
             Type::Object(_) => FFIType::UInt64,
             // Callback interfaces are passed as opaque integer handles.

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -50,7 +50,7 @@ pub enum Type {
     Float64,
     Boolean,
     String,
-    JSONValue,
+    JSONObject,
     // Types defined in the component API, each of which has a string name.
     Object(String),
     Record(String),
@@ -85,7 +85,7 @@ impl Type {
             Type::Float64 => "f64".into(),
             Type::String => "string".into(),
             Type::Boolean => "bool".into(),
-            Type::JSONValue => "JSONValue".into(),
+            Type::JSONObject => "JSONObject".into(),
             // API defined types.
             // Note that these all get unique names, and the parser ensures that the names do not
             // conflict with a builtin type. We add a prefix to the name to guard against pathological
@@ -132,7 +132,7 @@ impl Into<FFIType> for &Type {
             // We might add a separate type for borrowed strings in future.
             Type::String => FFIType::RustBuffer,
             // We'll serialize JSON via a RustBuffer.
-            Type::JSONValue => FFIType::RustBuffer,
+            Type::JSONObject => FFIType::RustBuffer,
             // Objects are passed as opaque integer handles.
             Type::Object(_) => FFIType::UInt64,
             // Callback interfaces are passed as opaque integer handles.

--- a/uniffi_bindgen/src/interface/types/resolver.rs
+++ b/uniffi_bindgen/src/interface/types/resolver.rs
@@ -181,7 +181,7 @@ pub(in super::super) fn resolve_builtin_type(name: &str) -> Option<Type> {
         "i64" => Some(Type::Int64),
         "f32" => Some(Type::Float32),
         "f64" => Some(Type::Float64),
-        "JSONValue" => Some(Type::JSONValue),
+        "JSONObject" => Some(Type::JSONObject),
         _ => None,
     }
 }

--- a/uniffi_bindgen/src/interface/types/resolver.rs
+++ b/uniffi_bindgen/src/interface/types/resolver.rs
@@ -181,6 +181,7 @@ pub(in super::super) fn resolve_builtin_type(name: &str) -> Option<Type> {
         "i64" => Some(Type::Int64),
         "f32" => Some(Type::Float32),
         "f64" => Some(Type::Float64),
+        "JSONValue" => Some(Type::JSONValue),
         _ => None,
     }
 }

--- a/uniffi_bindgen/src/scaffolding.rs
+++ b/uniffi_bindgen/src/scaffolding.rs
@@ -48,6 +48,7 @@ mod filters {
             Type::Float64 => "f64".into(),
             Type::Boolean => "bool".into(),
             Type::String => "String".into(),
+            Type::JSONValue => "serde_json::Value".into(),
             Type::Enum(name) | Type::Record(name) | Type::Object(name) | Type::Error(name) => {
                 name.clone()
             }

--- a/uniffi_bindgen/src/scaffolding.rs
+++ b/uniffi_bindgen/src/scaffolding.rs
@@ -48,7 +48,7 @@ mod filters {
             Type::Float64 => "f64".into(),
             Type::Boolean => "bool".into(),
             Type::String => "String".into(),
-            Type::JSONValue => "serde_json::Value".into(),
+            Type::JSONObject => "serde_json::Value".into(),
             Type::Enum(name) | Type::Record(name) | Type::Object(name) | Type::Error(name) => {
                 name.clone()
             }


### PR DESCRIPTION
This PR introduces support for passing JSON objects back and forth across the FFI.

It fixes [SDK-267][1].

This maps `serde_json::Value::Object` from Rust to an untyped dictionary on the foreign language side.

This corresponds to `org.json.JSONObject` in Kotlin, `[String: Any]` (via `JSONSerialization`) in swift and `dict`s with `String` keys in Python.

Serialization and de-serialization is necessarily dumb: uniffi serializes into Strings and then passes it across the FFI. On the other side, 
the object is deserialized from the passed String. This is inefficient, but correct. Clients requiring efficient transport across the FFI would be encouraged to use the existing types `record<string, T>` if they can. 

[1]: https://jira.mozilla.com/browse/SDK-276