### PR TITLE
Add a test fixture for Kotlin "experimental unsigned types" warnings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "examples/threadsafe",
   "fixtures/coverall",
   "fixtures/regressions/enum-without-i32-helpers",
+  "fixtures/regressions/kotlin-experimental-unsigned-types",
   "fixtures/regressions/cdylib-crate-type-dependency/ffi-crate",
   "fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency",
 ]

--- a/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
+++ b/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "kotlin-experimental-unsigned-types"
+edition = "2018"
+version = "0.8.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+name = "uniffi_regression_test_kt_unsigned_types"
+
+[dependencies]
+uniffi_macros = {path = "../../../uniffi_macros"}
+uniffi = {path = "../../../uniffi", features=["builtin-bindgen"]}
+
+[build-dependencies]
+uniffi_build = {path = "../../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/regressions/kotlin-experimental-unsigned-types/README.md
+++ b/fixtures/regressions/kotlin-experimental-unsigned-types/README.md
@@ -1,0 +1,12 @@
+# Regression test for propagating annotations on Kotlin unsigned types.
+
+Kotlin's support for unsigned integers is currently experimental,
+and requires explicitly opt-in from the consuming application.
+Since we can generate Kotlin code that uses unsigned types, we
+need to ensure that such code is annotated with
+[`@ExperimentalUnsignedTypes`][https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-experimental-unsigned-types/]
+in order to avoid compilation warnings.
+
+This crate exposes an API that uses unsigned types in a variety of
+ways, and tests that the resulting Kotlin bindings can be compiled
+without warnings.

--- a/fixtures/regressions/kotlin-experimental-unsigned-types/build.rs
+++ b/fixtures/regressions/kotlin-experimental-unsigned-types/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/test.udl").unwrap();
+}

--- a/fixtures/regressions/kotlin-experimental-unsigned-types/src/lib.rs
+++ b/fixtures/regressions/kotlin-experimental-unsigned-types/src/lib.rs
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pub fn returns_u16() -> u16 {
+    16
+}
+
+pub fn accepts_and_returns_unsigned(a: u8, b: u16, c: u32, d: u64) -> u64 {
+    (a as u64) + (b as u64) + (c as u64) + d
+}
+
+pub struct DirectlyUsesU8 {
+    member: u8,
+    other: String,
+}
+
+pub struct RecursivelyUsesU8 {
+    member: DirectlyUsesU8,
+}
+
+include!(concat!(env!("OUT_DIR"), "/test.uniffi.rs"));

--- a/fixtures/regressions/kotlin-experimental-unsigned-types/src/test.udl
+++ b/fixtures/regressions/kotlin-experimental-unsigned-types/src/test.udl
@@ -1,0 +1,18 @@
+// This API doesn't really *do* anything, it's just designed
+// to include various unsigned types in various interesting
+// positions. The test passes if we can compile the resulting
+// Kotlin bindings without any warnings.
+
+namespace regression_test_kt_unsigned_types {
+  u16 returns_u16();
+  u64 accepts_and_returns_unsigned(u8 a, u16 b, u32 c, u64 d);
+};
+
+dictionary DirectlyUsesU8 {
+  u8 member;
+  string other;
+};
+
+dictionary RecursivelyUsesU8 {
+  DirectlyUsesU8 member;
+};

--- a/fixtures/regressions/kotlin-experimental-unsigned-types/tests/bindings/test.kts
+++ b/fixtures/regressions/kotlin-experimental-unsigned-types/tests/bindings/test.kts
@@ -1,0 +1,8 @@
+// This is just a basic "it compiled and ran" test.
+// What we're really guarding against is failure to
+// compile the bindings as a result of warnings about
+// experimental features.
+
+import uniffi.regression_test_kt_unsigned_types.*;
+
+assert(returnsU16().toInt() == 16)

--- a/fixtures/regressions/kotlin-experimental-unsigned-types/tests/test_generated_bindings.rs
+++ b/fixtures/regressions/kotlin-experimental-unsigned-types/tests/test_generated_bindings.rs
@@ -1,0 +1,1 @@
+uniffi_macros::build_foreign_language_testcases!("src/test.udl", ["tests/bindings/test.kts",]);


### PR DESCRIPTION
Previously, our test running infrastructure would specify the Kotlin option
 "-Xopt-in=kotlin.ExperimentalUnsignedTypes" when compiling the uniffi bindings,
in order to silence warnings about using the experimental unsigned types.

This is *not* how we intend to compile the generated bindings in practice.
Rather, we want to only opt in to experimental types at the level of the final
consumer, with all intermediate layers propagating the experimental types
annotation to the layer above them.

This commit removes the unsigned types opt-in when compiling bindings for
tests, and replaces it with `-Werror` so that any warnings when compiling
the bindings will fail the corresponding test.  (It keeps the opt-in when
running the actual test script, since that is the uppermost layer and is
where we intend real consumers to specify the opt-in behaviour).

It also adds a new test fixture that deliberately uses a bunch of unsigned
types, and tests that the Kotlin bindings compile and run successfully.

This test currently fails, because we're not propagating the annotations
correctly. Making the test pass is issue #444.