### PR TITLE
Adjust expected `trybuild` error output for new rust version.

### DIFF
--- a/uniffi/tests/ui/version_mismatch.stderr
+++ b/uniffi/tests/ui/version_mismatch.stderr
@@ -2,6 +2,6 @@ error[E0080]: evaluation of constant value failed
  --> $DIR/version_mismatch.rs:2:1
   |
 2 | uniffi::assert_compatible_version!("0.0.1"); // An error message would go here.
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize` which would overflow
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
I recently updated the docker image that we use to run CI, which
seems to have perturbed the version of Rust being used, which has
subtly changed the expected error output from `trybuild`. This
should get CI passing again.