### PR TITLE
Make all examples, other than Threadsafe, Threadsafe.

### DIFF
--- a/examples/callbacks/src/callbacks.udl
+++ b/examples/callbacks/src/callbacks.udl
@@ -1,5 +1,6 @@
 namespace callbacks {};
 
+[Threadsafe]
 interface Telephone {
   void call(boolean domestic, OnCallAnswered call_responder);
 };
@@ -21,6 +22,7 @@ callback interface ForeignGetters {
 
 /// These objects are implemented in Rust, and call out to `ForeignGetters`
 /// to get the value.
+[Threadsafe]
 interface RustGetters {
   boolean get_bool(ForeignGetters callback, boolean v, boolean arg2);
   string get_string(ForeignGetters callback, string v, boolean arg2);
@@ -42,6 +44,7 @@ callback interface StoredForeignStringifier {
 
 /// Rust object that uses the StoredForeignStringifier to produce string representations
 /// of passed arguments.
+[Threadsafe]
 interface RustStringifier {
   constructor(StoredForeignStringifier callback);
   string from_simple_type(i32 value);

--- a/examples/callbacks/src/lib.rs
+++ b/examples/callbacks/src/lib.rs
@@ -63,8 +63,9 @@ impl Default for RustGetters {
     }
 }
 
-// Use Send if we want to store the callback in an exposed object.
-trait StoredForeignStringifier: Send + std::fmt::Debug {
+// Use `Send+Send` because we want to store the callback in an exposed
+// `Send+Sync` object.
+trait StoredForeignStringifier: Send + Sync + std::fmt::Debug {
     fn from_simple_type(&self, value: i32) -> String;
     fn from_complex_type(&self, values: Option<Vec<Option<f64>>>) -> String;
 }

--- a/examples/rondpoint/src/rondpoint.udl
+++ b/examples/rondpoint/src/rondpoint.udl
@@ -48,6 +48,7 @@ dictionary DictionnaireNombresSignes {
     i64 gros_nombre;
 };
 
+[Threadsafe]
 interface Retourneur {
   i8 identique_i8(i8 value);
   u8 identique_u8(u8 value);
@@ -67,6 +68,7 @@ interface Retourneur {
   OptionneurDictionnaire    identique_optionneur_dictionnaire(OptionneurDictionnaire value);
 };
 
+[Threadsafe]
 interface Stringifier {
   string well_known_string(string value);
 
@@ -83,6 +85,7 @@ interface Stringifier {
   string to_string_boolean(boolean value);
 };
 
+[Threadsafe]
 interface Optionneur {
   boolean sinon_boolean(optional boolean value = false);
   string sinon_string(optional string value = "default");

--- a/examples/sprites/src/sprites.udl
+++ b/examples/sprites/src/sprites.udl
@@ -13,6 +13,7 @@ dictionary Vector {
   double dy;
 };
 
+[Threadsafe]
 interface Sprite {
   constructor(Point? initial_position);
   [Name=new_relative_to] constructor(Point reference, Vector direction);


### PR DESCRIPTION
We are leaving the Threadsafe example as the only one
which supports a non-threadsafe interface until we actually
remove support for non-theadsafe interfaces.

I guess this is the next logical step after #429? Note I can't yet remove the `-A deprecated` because one non-threadsafe interface remains.