### PR TITLE
Try to consistently capitalize "UniFFI" in consumer docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# uniffi - a multi-language bindings generator for rust
+# UniFFI - a multi-language bindings generator for rust
 
 - [User manual](https://mozilla.github.io/uniffi-rs/)
 
@@ -44,7 +44,7 @@ That kind of tooling is not available to shipping applications today, but that d
 mean we can't take a small step in that general direction while the Rust and Wasm ecosystem
 continues to evolve.
 
-Using `uniffi`, you can:
+Using UniFFI, you can:
 
 * Implement your software component as a `cdylib` crate in Rust; let's say the code is in `./src/lib.rs`.
 * Specify the desired component API using an *Interface Definition Language* (specifically, a variant of WebIDL) in a separate file like `./src/lib.udl`.
@@ -100,7 +100,7 @@ an abstract description of your component's API using a variant of [WebIDL](http
 This turns out to be a bit of an awkward fit, but good enough for a first version.
 In the future we may be able to generate the Interface Definition from annotations on the Rust code
 (in the style of `wasm_bindgen` or perhaps the [`cxx` crate](https://github.com/dtolnay/cxx))
-rather than from a separate UDL (Uniffi Definition Language) file.
+rather than from a separate UDL (UniFFI Definition Language) file.
 
 The code for defining a component interface lives in [./uniffi_bindgen/src/interface/mod.rs](./uniffi_bindgen/src/interface/mod.rs)
 and is currently the best source of truth for syntax and semantics of the UDL.

--- a/docs/manual/book.toml
+++ b/docs/manual/book.toml
@@ -1,6 +1,6 @@
 [book]
-authors = ["Edouard Oger"]
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 language = "en"
 multilingual = false
 src = "src"
-title = "The uniffi user guide"
+title = "The UniFFI user guide"

--- a/docs/manual/src/Getting_started.md
+++ b/docs/manual/src/Getting_started.md
@@ -9,4 +9,4 @@ fn add(a: u32, b: u32) -> u32 {
 ```
 
 And top brass would like you to expose this *business-critical* operation to Kotlin and Swift.  
-**Don't panic!** We will show you how do that using uniffi.
+**Don't panic!** We will show you how do that using UniFFI.

--- a/docs/manual/src/Overview.md
+++ b/docs/manual/src/Overview.md
@@ -1,13 +1,13 @@
-# uniffi
+# UniFFI
 
-Uniffi is a tool that automatically generates foreign-language bindings targeting Rust libraries.  
+UniFFI is a tool that automatically generates foreign-language bindings targeting Rust libraries.  
 It fits in the practice of consolidating business logic in a single Rust library while targeting multiple platforms, making it simpler to develop and maintain a cross-platform codebase.  
 Note that this tool will not help you ship a Rust library to these platforms, but simply not have to write bindings code by hand [[0]](https://i.kym-cdn.com/photos/images/newsfeed/000/572/078/d6d.jpg).
 
 ## Design
 
-uniffi requires to write an Interface Definition Language (based on [WebIDL](https://heycam.github.io/webidl/)) file describing the methods and data structures available to the targeted languages.  
-This .udl (Uniffi Definition Language) file, whose definitions must match with the exposed Rust code, is then used to generate Rust *scaffolding* code and foreign-languages *bindings*. This process can take place either during the build process or be manually initiated by the developer.
+UniFFI requires to write an Interface Definition Language (based on [WebIDL](https://heycam.github.io/webidl/)) file describing the methods and data structures available to the targeted languages.  
+This .udl (UniFFI Definition Language) file, whose definitions must match with the exposed Rust code, is then used to generate Rust *scaffolding* code and foreign-languages *bindings*. This process can take place either during the build process or be manually initiated by the developer.
 
 ![uniffi diagram](./uniffi_diagram.png)
 
@@ -16,4 +16,4 @@ This .udl (Uniffi Definition Language) file, whose definitions must match with t
 - Kotlin
 - Swift
 - Python
-- [Gecko](https://en.wikipedia.org/wiki/Gecko_(software)) C++
+- [Gecko](https://en.wikipedia.org/wiki/Gecko_(software)) C++ (Work in Progress)

--- a/docs/manual/src/SUMMARY.md
+++ b/docs/manual/src/SUMMARY.md
@@ -1,7 +1,5 @@
 # Summary
 
-Hello everyone
-
 [Overview](./Overview.md)
 - [Tutorial](./Getting_started.md)
   - [Prerequisites](./tutorial/Prerequisites.md)

--- a/docs/manual/src/internals/lifting_and_lowering.md
+++ b/docs/manual/src/internals/lifting_and_lowering.md
@@ -1,10 +1,10 @@
 # Lifting, Lowering and Serialization
 
-Uniffi is able to transfer rich data types back-and-forth between the Rust
+UniFFI is able to transfer rich data types back-and-forth between the Rust
 code and the foreign-language code via a process we refer to as "lowering"
 and "lifting".
 
-Recall that uniffi interoperates between different languages by defining
+Recall that UniFFI interoperates between different languages by defining
 a C-style FFI layer which operates in terms of primitive data types and
 plain functions. To transfer data from one side of this layer to the other,
 the sending side "***lowers***" the data from a language-specific data type
@@ -30,13 +30,13 @@ namespace example {
 Calling this function from foreign language code involves the following steps:
 
 1. The user-provided calling code invokes the `add_to_list` function that is exposed by the
-   uniffi-generated foreign language bindings, passing `item` as an appropriate language-native
+   UniFFI-generated foreign language bindings, passing `item` as an appropriate language-native
    integer.
 2. The foreign language bindings ***lower*** each argument to a function call into
    something that can be passed over the C-style FFI. Since the `item` argument is a plain integer,
    it is lowered by casting to an `int32_t`.
 3. The foreign language bindings pass the lowered arguments to a C FFI function named
-   like `example_XYZ_add_to_list` that is exposed by the uniffi-generated Rust scaffolding.
+   like `example_XYZ_add_to_list` that is exposed by the UniFFI-generated Rust scaffolding.
 4. The Rust scaffolding ***lifts*** each argument received over the FFI into a native
    Rust type. Since `item` is a plain integer it is lifted by casting to a Rust `i32`.
 5. The Rust scaffolding passes the lifted arguments to the user-provided Rust code for
@@ -69,9 +69,9 @@ Calling this function from foreign language code involves the following steps:
 
 ## Serialization Format
 
-When serializing complex data types into a byte buffer, uniffi uses an
+When serializing complex data types into a byte buffer, UniFFI uses an
 ad-hoc fixed-width format which is designed mainly for simplicity.
-The details of this format are internal only and may change between versions of uniffi.
+The details of this format are internal only and may change between versions of UniFFI.
 
 | UDL Type | Representation in serialized bytes |
 |----------|-----------------------------|

--- a/docs/manual/src/internals/object_references.md
+++ b/docs/manual/src/internals/object_references.md
@@ -1,6 +1,6 @@
 # Managing Object References
 
-Uniffi [interfaces](../udl/interfaces.md) represent instances of objects
+UniFFI [interfaces](../udl/interfaces.md) represent instances of objects
 that have methods and contain shared mutable state. One of Rust's core innovations
 is its ability to provide compile-time guarantees about working with such instances,
 including:
@@ -10,7 +10,7 @@ including:
   active at any point in the program.
 * Guarding against data races.
 
-Uniffi aims to maintain these guarantees even when the Rust code is being invoked
+UniFFI aims to maintain these guarantees even when the Rust code is being invoked
 from a foreign language, at the cost of turning them into run-time checks rather
 than compile-time guarantees.
 
@@ -22,7 +22,7 @@ a mapping from opaque integer handles to object instances. This indirection
 imposes a small runtime cost but helps us guard against errors or oversights
 in the generated bindings.
 
-For each interface declared in the UDL, the uniffi-generated Rust scaffolding
+For each interface declared in the UDL, the UniFFI-generated Rust scaffolding
 will create a global handlemap that is responsible for owning all instances
 of that interface, and handing out references to them when methods are called.
 
@@ -90,12 +90,12 @@ This indirection gives us some important safety properties:
 
 ## Managing Concurrency
 
-By default, uniffi uses the [ffi_support::ConcurrentHandleMap](https://docs.rs/ffi-support/0.4.0/ffi_support/handle_map/struct.ConcurrentHandleMap.html) struct as the handlemap for each declared instance. This class
+By default, UniFFI uses the [ffi_support::ConcurrentHandleMap](https://docs.rs/ffi-support/0.4.0/ffi_support/handle_map/struct.ConcurrentHandleMap.html) struct as the handlemap for each declared instance. This class
 wraps each instance with a `Mutex`, which serializes access to the instance and upholds Rust's guarantees
 against shared mutable access.  This approach is simple and safe, but it means that all method calls
 on an instance are run in a strictly sequential fashion, limiting concurrency.
 
-For instances that are explicited tagged with the `[Threadsafe]` attribute, uniffi instead uses
+For instances that are explicited tagged with the `[Threadsafe]` attribute, UniFFI instead uses
 a custom `ArcHandleMap` struct. This replaces the run-time `Mutex` with compile-time assertions
 about the safety of the underlying Rust struct. Specifically:
 

--- a/docs/manual/src/kotlin/gradle.md
+++ b/docs/manual/src/kotlin/gradle.md
@@ -4,7 +4,7 @@ It is possible to generate Kotlin bindings at compile time for Kotlin Android pr
 
 ```groovy
 android.libraryVariants.all { variant ->
-    def t = tasks.register("generate${variant.name.capitalize()}UniffiBindings", Exec) {
+    def t = tasks.register("generate${variant.name.capitalize()}UniFFIBindings", Exec) {
         workingDir "${project.projectDir}"
         // Runs the bindings generation, note that you must have uniffi-bindgen installed and in your PATH environment variable
         commandLine 'uniffi-bindgen', 'generate', '<PATH TO .udl FILE>', '--language', 'kotlin', '--out-dir', "${buildDir}/generated/source/uniffi/${variant.name}/java"

--- a/docs/manual/src/tutorial/Rust_scaffolding.md
+++ b/docs/manual/src/tutorial/Rust_scaffolding.md
@@ -4,7 +4,7 @@
 
 Now we generate some Rust helper code to make the `add` method available to foreign-language bindings.  
 
-First, add `uniffi` to your crate dependencies: it is the runtime support code that powers uniffi's serialization of data types across languages:
+First, add `uniffi` to your crate dependencies; this is the runtime support code that powers UniFFI's serialization of data types across languages:
 
 ```toml
 [dependencies]
@@ -37,7 +37,7 @@ settings then this can be done using a handy macro:
 uniffi_macros::include_scaffolding!("math");
 ```
 
-If you have generated the scaffolding in a custom location, use the standard `!include` macro
+If you have generated the scaffolding in a custom location, use the standard `include!` macro
 to include the generated file by name, like this:
 
 

--- a/docs/manual/src/tutorial/foreign_language_bindings.md
+++ b/docs/manual/src/tutorial/foreign_language_bindings.md
@@ -20,4 +20,4 @@ then check out `src/math.swift`
 
 Note that these commands could be integrated as part of your gradle/XCode build process.
 
-This is it, you have an MVP integration of uniffi in your project.
+This is it, you have an MVP integration of UniFFI in your project.

--- a/docs/manual/src/udl/errors.md
+++ b/docs/manual/src/udl/errors.md
@@ -1,7 +1,7 @@
 # Throwing errors
 
 It is often the case that a function does not return `T` in Rust but `Result<T, E>` to reflect that it is fallible.  
-For uniffi to expose this error, your error type (`E`) must be an `enum` and implement `std::error::Error` ([thiserror](https://crates.io/crates/thiserror) works!).
+For UniFFI to expose this error, your error type (`E`) must be an `enum` and implement `std::error::Error` ([thiserror](https://crates.io/crates/thiserror) works!).
 
 Here's how you would write a Rust failible function and how you'd expose it in UDL:
 

--- a/docs/manual/src/udl/interfaces.md
+++ b/docs/manual/src/udl/interfaces.md
@@ -2,7 +2,7 @@
 
 Interfaces are represented in the Rust world as a struct with an `impl` block containing methods. In the Kotlin or Swift world, it's a class.
 
-Because Objects are passed by reference and Dictionaries by value, in the uniffi world it is impossible to be both an Object and a [Dictionary](./structs.md).
+Because Objects are passed by reference and Dictionaries by value, in the UniFFI world it is impossible to be both an Object and a [Dictionary](./structs.md).
 
 The following Rust code:
 
@@ -42,7 +42,7 @@ By convention, the `constructor()` calls the Rust's `new()` method.
 
 Conceptually, these `interface` objects are live Rust objects that have a proxy on the foreign language side; calling any methods on them, including a constructor or destructor results in the corresponding methods being call in Rust.
 
-`uniffi` will generate these proxies of live objects with an interface or protocol.
+UniFFI will generate these proxies of live objects with an interface or protocol.
 
 e.g. in Kotlin.
 
@@ -97,14 +97,14 @@ Rust struct.
 
 ## Concurrent Access
 
-Since interfaces represent mutable data, uniffi has to take extra care
+Since interfaces represent mutable data, UniFFI has to take extra care
 to uphold Rust's safety guarantees around shared and mutable references.
 The foreign-language code may attempt to operate on an interface instance
 from multiple threads, and it's important that this not violate Rust's
 assumption that there is at most a single mutable reference to a struct
 at any point in time.
 
-By default, uniffi enforces this using runtime locking. Each interface instance
+By default, UniFFI enforces this using runtime locking. Each interface instance
 has an associated lock which is transparently acquired at the beginning of each
 call to a method of that instance, and released once the method returns. This
 approach is simple and safe, but it means that all method calls on an instance
@@ -121,11 +121,11 @@ interface Counter {
 };
 ```
 
-The uniffi-generated code will allow concurrent method calls on threadsafe interfaces
+The UniFFI-generated code will allow concurrent method calls on threadsafe interfaces
 without any locking.
 
 For this to be safe, the underlying Rust struct must adhere to certain restrictions, and
-uniffi's generated Rust scaffolding will emit compile-time errors if it does not.
+UniFFI's generated Rust scaffolding will emit compile-time errors if it does not.
 
 The Rust struct must not expose any methods that take `&mut self`. The following implementation
 of the `Counter` interface will fail to compile because it relies on mutable references:


### PR DESCRIPTION
We don't currently have much consistency around how we capitalize the name of this project. I'd like to propose "UniFFI" as the preferred rendering, as both a Proper Noun and containing a correctly capitalized embedded acronym "FFI". My preference for this particular rendering is weakly held, I just want to pick *something* that we can use consistently :-)