### PR TITLE
Fix Kotlin codegen for writing optional integers.

### DIFF
--- a/fixtures/coverall/tests/bindings/test_coverall.kts
+++ b/fixtures/coverall/tests/bindings/test_coverall.kts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import uniffi.coverall.*
+
+// Test some_dict().
+// TODO: use an actual test runner.
+
+val d = createSomeDict();
+assert(d.text == "text");
+assert(d.maybeText == "maybe_text");
+assert(d.aBool);
+assert(d.maybeABool == false);
+assert(d.unsigned8 == 1.toUByte())
+assert(d.maybeUnsigned8 == 2.toUByte())
+assert(d.unsigned64 == 18446744073709551615UL)
+assert(d.maybeUnsigned64 == 0UL)
+assert(d.signed8 == 8.toByte())
+assert(d.maybeSigned8 == 0.toByte())
+assert(d.signed64 == 9223372036854775807L)
+assert(d.maybeSigned64 == 0L)
+
+// floats should be "close enough".
+fun Float.almostEquals(other: Float) = Math.abs(this - other) < 0.000001
+fun Double.almostEquals(other: Double) = Math.abs(this - other) < 0.000001
+
+assert(d.float32.almostEquals(1.2345F))
+assert(d.maybeFloat32!!.almostEquals(22.0F/7.0F))
+assert(d.float64.almostEquals(0.0))
+assert(d.maybeFloat64!!.almostEquals(1.0))

--- a/fixtures/coverall/tests/test_generated_bindings.rs
+++ b/fixtures/coverall/tests/test_generated_bindings.rs
@@ -1,4 +1,7 @@
 uniffi_macros::build_foreign_language_testcases!(
     "src/coverall.udl",
-    ["tests/bindings/test_coverall.py"]
+    [
+        "tests/bindings/test_coverall.py",
+        "tests/bindings/test_coverall.kts"
+    ]
 );

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
@@ -307,7 +307,7 @@ internal fun lower{{ canonical_type_name }}(v: {{ inner_type_name }}?): RustBuff
 }
 
 internal fun write{{ canonical_type_name }}(v: {{ inner_type_name }}?, buf: RustBufferBuilder) {
-    if (v === null) {
+    if (v == null) {
         buf.putByte(0)
     } else {
         buf.putByte(1)


### PR DESCRIPTION
Seems like you can't use `v=== null` on when `v` is an optional primitive type like `UByte?`. I noticed this while working on something else, but figured it would be simpler as a standalone PR. Also, a good excuse to get started on a Kotlin coveralls file.