### PR TITLE
Implement try_read/write for concrete types, not Buf/BufMut generics.

### DIFF
--- a/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
@@ -99,7 +99,8 @@ unsafe impl uniffi::ViaFfi for {{ trait_impl }} {
         self.handle
     }
 
-    fn write<B: uniffi::deps::bytes::BufMut>(&self, buf: &mut B) {
+    fn write(&self, buf: &mut Vec<u8>) {
+        use uniffi::deps::bytes::BufMut;
         buf.put_u64(self.handle);
     }
 
@@ -107,7 +108,8 @@ unsafe impl uniffi::ViaFfi for {{ trait_impl }} {
         Ok(Self { handle: v })
     }
 
-    fn try_read<B: uniffi::deps::bytes::Buf>(buf: &mut B) -> uniffi::deps::anyhow::Result<Self> {
+    fn try_read(buf: &mut &[u8]) -> uniffi::deps::anyhow::Result<Self> {
+        use uniffi::deps::bytes::Buf;
         uniffi::check_remaining(buf, 8)?;
         <Self as uniffi::ViaFfi>::try_lift(buf.get_u64())
     }

--- a/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
@@ -15,7 +15,8 @@ unsafe impl uniffi::ViaFfi for {{ e.name() }} {
         uniffi::try_lift_from_buffer(v)
     }
 
-    fn write<B: uniffi::deps::bytes::BufMut>(&self, buf: &mut B) {
+    fn write(&self, buf: &mut Vec<u8>) {
+        use uniffi::deps::bytes::BufMut;
         match self {
             {%- for variant in e.variants() %}
             {{ e.name() }}::{{ variant.name() }} { {% for field in variant.fields() %}{{ field.name() }}, {%- endfor %} } => {
@@ -28,7 +29,8 @@ unsafe impl uniffi::ViaFfi for {{ e.name() }} {
         };
     }
 
-    fn try_read<B: uniffi::deps::bytes::Buf>(buf: &mut B) -> uniffi::deps::anyhow::Result<Self> {
+    fn try_read(buf: &mut &[u8]) -> uniffi::deps::anyhow::Result<Self> {
+        use uniffi::deps::bytes::Buf;
         uniffi::check_remaining(buf, 4)?;
         Ok(match buf.get_i32() {
             {%- for variant in e.variants() %}

--- a/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
@@ -16,7 +16,7 @@ unsafe impl uniffi::ViaFfi for {{ rec.name() }} {
         uniffi::try_lift_from_buffer(v)
     }
 
-    fn write<B: uniffi::deps::bytes::BufMut>(&self, buf: &mut B) {
+    fn write(&self, buf: &mut Vec<u8>) {
         // If the provided struct doesn't match the fields declared in the UDL, then
         // the generated code here will fail to compile with somewhat helpful error.
         {%- for field in rec.fields() %}
@@ -24,11 +24,11 @@ unsafe impl uniffi::ViaFfi for {{ rec.name() }} {
         {%- endfor %}
     }
 
-    fn try_read<B: uniffi::deps::bytes::Buf>(buf: &mut B) -> uniffi::deps::anyhow::Result<Self> {
-      Ok(Self {
-        {%- for field in rec.fields() %}
-            {{ field.name() }}: <{{ field.type_()|type_rs }} as uniffi::ViaFfi>::try_read(buf)?,
-        {%- endfor %}
-      })
+    fn try_read(buf: &mut &[u8]) -> uniffi::deps::anyhow::Result<Self> {
+        Ok(Self {
+            {%- for field in rec.fields() %}
+                {{ field.name() }}: <{{ field.type_()|type_rs }} as uniffi::ViaFfi>::try_read(buf)?,
+            {%- endfor %}
+        })
     }
 }


### PR DESCRIPTION
This is a followup to the upgrade of our `bytes` dependency from #454.

Our use of the `bytes::Buf` trait assumes that `Buf::chunks` will return
all the remaining data. This is not guaranteed by the trait, but it is
guaranteed in practice by its implementation on the concrete types that
we use.

Since we don't really work with any generic `Buf` impl anyway, this commit
removes the generics from `ViaFfi::try_read` and `ViaFii:write`, replacing
them with the single concrete type that we actually ues in practice. This
should reduce potential for future confusion, and also make compilation
slightly easier on the Rust compiler.