### PR TITLE
Implement `[Self=ByArc]` annotation for methods on threadsafe objects.

### DIFF
--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -47,4 +47,10 @@ interface Coveralls {
     boolean maybe_throw(boolean should_throw);
 
     void panic(string message);
+
+    // *** Test functions which take either `self` or other params as `Arc<Self>` ***
+
+    /// Calls `Arc::strong_count()` on the `Arc` containing `self`.
+    [Self=ByArc]
+    u64 strong_count();
 };

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 lazy_static::lazy_static! {
     static ref NUM_ALIVE: RwLock<u64> = {
@@ -121,6 +121,10 @@ impl Coveralls {
 
     fn panic(&self, message: String) {
         panic!("{}", message);
+    }
+
+    fn strong_count(self: Arc<Self>) -> u64 {
+        Arc::strong_count(&self) as u64
     }
 }
 

--- a/fixtures/coverall/tests/bindings/test_coverall.py
+++ b/fixtures/coverall/tests/bindings/test_coverall.py
@@ -84,5 +84,10 @@ class TestCoverall(unittest.TestCase):
         with self.assertRaisesRegex(InternalError, "expected panic: oh no"):
             coveralls.panic("expected panic: oh no")
 
+    def test_self_by_arc(self):
+        coveralls = Coveralls("test_self_by_arc")
+        # One reference is held by the handlemap, and one by the `Arc<Self>` method receiver.
+        self.assertEqual(coveralls.strong_count(), 2)
+
 if __name__=='__main__':
     unittest.main()

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -327,6 +327,10 @@ impl Method {
         self.attributes.get_throws_err()
     }
 
+    pub fn takes_self_by_arc(&self) -> bool {
+        self.attributes.get_by_arc()
+    }
+
     pub fn derive_ffi_func(&mut self, ci_prefix: &str, obj_prefix: &str) -> Result<()> {
         self.ffi_func.name.push_str(ci_prefix);
         self.ffi_func.name.push('_');

--- a/uniffi_bindgen/src/templates/macros.rs
+++ b/uniffi_bindgen/src/templates/macros.rs
@@ -65,12 +65,12 @@ use uniffi::UniffiMethodCall;
 {%- endif -%}
 {% match meth.throws() -%}
 {% when Some with (e) -%}
-{{ this_handle_map }}.method_call_with_result(err, {{ meth.first_argument().name() }}, |obj| -> Result<{% call return_type_func(meth) %}, {{e}}> {
+{{ this_handle_map }}.method_call_{% if meth.takes_self_by_arc() %}by_arc_{% endif %}with_result(err, {{ meth.first_argument().name() }}, |obj| -> Result<{% call return_type_func(meth) %}, {{e}}> {
     let _retval = {{ obj.name() }}::{%- call to_rs_call_with_prefix("obj", meth) -%}?;
     Ok({% call ret(meth) %})
 })
 {% else -%}
-{{ this_handle_map }}.method_call_with_output(err, {{ meth.first_argument().name() }}, |obj| {
+{{ this_handle_map }}.method_call_{% if meth.takes_self_by_arc() %}by_arc_{% endif %}with_output(err, {{ meth.first_argument().name() }}, |obj| {
     let _retval = {{ obj.name() }}::{%- call to_rs_call_with_prefix("obj", meth) -%};
     {% call ret(meth) %}
 })


### PR DESCRIPTION
As of ADR-0005, the use of `Arc<T>` for passing object instances will
be part of the official Rust-facing  API of UniFFI rather than being
a private implementation detail. A full implementation of that ADR is
still in progress, but in the meantime we can get a relatively easy
implementation of one small part of it: support for `Arc<Self>` as
method receiver.

This commit implements support for the `[ByArc]` annotation on method
definitions, indicating they the underlying Rust code will accept
`self: Arc<Self>` rather than `self: &Self` as method receiver. This
only works for `[Threadsafe]` interfaces since they are the only ones
that use `Arc<Self>` internally, but that's OK because we intend to
require that all interfaces are threadsafe in the near future.

The implementation is small, but not particularly pretty. I think
it's fine to push forward with given our broader plans to simplify
away a lot of the branching in this code.