### PR TITLE
Guard against race between Kotlin method calls and object destruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@
   will be removed in a future release. More details on the motivation for this change can be found
   in [ADR-0004](https://github.com/mozilla/uniffi-rs/blob/main/docs/adr/0004-only-threadsafe-interfaces.md).
 
+
+### What's Changed
+
+- Kotlin objects can now safely have their `destroy()` method or `.use` block execute concurrently
+  with other method calls. It's recommended that you *not* do this, but if you accidentally do so,
+  it will now work correctly rather than triggering a panic in the underlying Rust code.
+
 ## v0.10.0 (_2021-05-26_)
 
 [All changes in v0.10.0](https://github.com/mozilla/uniffi-rs/compare/v0.9.0...v0.10.0).

--- a/fixtures/coverall/tests/bindings/test_handlerace.kts
+++ b/fixtures/coverall/tests/bindings/test_handlerace.kts
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import java.util.concurrent.*
+import uniffi.coverall.*
+
+// This tests the thread-safety of operations on object handles.
+// The idea is to have a method call running on one thread while
+// we try to destroy the object on another thread. This should
+// be handled correctly at the Kotlin level, rather than triggering
+// any fail-safe checks (or worse, memory unsafety!) in the underlying
+// Rust code.
+//
+// This test was able to reproduce the concurrency issue in
+// https://github.com/mozilla/uniffi-rs/issues/457, and is kept
+// to prevent regressions.
+
+// Give ourselves enough opportunity to trigger concurrency issues.
+for (i in 1..1000) {
+    // So we can operate concurrently.
+    val executor = Executors.newFixedThreadPool(2)
+    try {
+        // On the main thread here, we're going to create and then destroy a `Coveralls` instance.
+        val concurrentMethodCall: Future<String> = Coveralls("test_handlerace").use { coveralls ->
+            // Make a method call on a separate thread thread.
+            val concurrentMethodCall = executor.submit(Callable {
+                coveralls.getName()
+            })
+            // Sleep a little, to give the background thread a chance to start operating.
+            Thread.sleep(1)
+            concurrentMethodCall
+        }
+        // At this point the object has been destroyed.
+        // The concurrent method call should either have failed to run at all (if the object was destroyed
+        // before it started) or should have completely succeeded (if it started before the object was
+        // destroyed). It should not fail in the Rust code (which currently fails cleanly on handlemap
+        // safety checks, but in future might be a use-after-free).
+        try {
+            concurrentMethodCall.get()
+        } catch (e: ExecutionException) {
+            if (e.cause is IllegalStateException && e.message!!.endsWith("has already been destroyed")) {
+                // This is fine, we rejected the call after the object had been destroyed.
+            } else {
+                // Any other behaiour signals a possible problem.
+                throw e
+            }
+        }
+    } finally {
+        executor.shutdown()
+    }
+}

--- a/fixtures/coverall/tests/test_generated_bindings.rs
+++ b/fixtures/coverall/tests/test_generated_bindings.rs
@@ -3,6 +3,7 @@ uniffi_macros::build_foreign_language_testcases!(
     [
         "tests/bindings/test_coverall.py",
         "tests/bindings/test_coverall.kts",
-        "tests/bindings/test_coverall.rb"
+        "tests/bindings/test_coverall.rb",
+        "tests/bindings/test_handlerace.kts",
     ]
 );

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
@@ -2,21 +2,131 @@
 // This would be a good candidate for isolating in its own ffi-support lib.
 
 {% if ci.iter_object_definitions().len() > 0 %}
+// The base class for all UniFFI Object types.
+//
+// This class provides core operations for working with the integer handle that
+// maps to the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// the Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each `FFIObject` instance has an opaque integer "handle" that is a reference
+//     to the underlying Rust struct. Method calls need to read this handle from the
+//     object's state and pass it in to the Rust FFI.
+//
+//   * When an `FFIObject` is no longer needed, its handle should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an `FFIObject` instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so will
+//     leak the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+// If we try to implement this with mutual exclusion on access to the handle, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the handle, but is interrupted
+//      before it can pass the handle over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read handle value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each `FFIObject` an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// In the future we may be able to replace some of this with automatic finalization logic, such as using
+// the new "Cleaner" functionaility in Java 9. The above scheme has been designed to work even if `destroy` is
+// invoked by garbage-collection machinery rather than by calling code (which by the way, it's apparently also
+// possible for the JVM to finalize an object while there is an in-flight call to one of its methods [1],
+// so there would still be some complexity here).
+//
+// Sigh...all of this for want of a robust finalization mechanism.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
 abstract class FFIObject(
-    private val handle: AtomicLong
+    protected val handle: Long
 ) {
-    open fun destroy() {
-        this.handle.set(0L)
+
+    val wasDestroyed = AtomicBoolean(false)
+    val callCounter = AtomicLong(1)
+
+    open protected fun freeHandle() {
+        // To be overridden in subclasses.
     }
 
-    internal inline fun <R> callWithHandle(block: (handle: Long) -> R) =
-        this.handle.get().let { handle -> 
-            if (handle != 0L) {
-                block(handle)
-            } else {
-                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+    open fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                this.freeHandle()
             }
         }
+    }
+
+    internal inline fun <R> callWithHandle(block: (handle: Long) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (! this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the handle being freed concurrently.
+        try {
+            return block(handle)
+        } finally {
+            // This decrement aways matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                this.freeHandle()
+            }
+        }
+    }
 }
 
 inline fun <T : FFIObject, R> T.use(block: (T) -> R) =

--- a/uniffi_bindgen/src/bindings/kotlin/templates/wrapper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/wrapper.kt
@@ -24,6 +24,7 @@ import com.sun.jna.Structure
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock


### PR DESCRIPTION
Currently just a test case that reproduces the issue on my machine, but I'm thinking about a fix.

(Depends on the Kotlin codegen fix from https://github.com/mozilla/uniffi-rs/pull/451)