### PR TITLE
Start keeping a changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+<!-- The sections in this file are intended to be managed automatically by `cargo release` -->
+<!-- See https://github.com/sunng87/cargo-release/blob/master/docs/faq.md#maintaining-changelog for details -->
+<!-- Unfortunately that doesn't currently work in a workspace, so for now we update it by hand: -->
+<!--   * Replace `[[UnreleasedVersion]]` with `vX.Y.Z` -->
+<!--   * Replace `[[ReleaseDate]]` with `YYYY-MM-DD` -->
+<!--   * Replace `...HEAD` with `...vX.Y.Z` -->
+<!--   * Insert a fresh copy of the templated bits under the `next-header` comment  -->
+
+<!-- next-header -->
+
+## [[UnreleasedVersion]] - (_[[ReleaseDate]]_)
+
+[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.9.0...HEAD).
+
+### What's New
+
+- Threadsafe Object methods can now use `self: Arc<Self>` as the method receiver in the underlying
+  Rust code, in addition to the default `self: &Self`. To do so, annotate the method with
+  `[Self=ByArc]` in the `.udl` file and update the corresponding Rust method signature to match.
+  This will not change the generated foreign-language bindings in any way but may be useful for
+  more explicit management of Object references in the Rust code.
+
+### What's Changed
+
+- **Kotlin:** Fixed buggy codegen for optional primitive types like `i32?`; on earlier versions
+  this would generate invalid Kotlin code which would fail to compile.
+
+## v0.9.0 (_2021-05-21_)
+
+[All changes in v0.9.0](https://github.com/mozilla/uniffi-rs/compare/v0.8.0...v0.9.0).
+
+### ⚠️ Breaking Changes ⚠️
+
+- Support for non-`[Threadsafe]` interfaces has been deprecated. A future release will require that
+  all interface implementations be `Sync + Send`, making the `[Threadsafe]` annotation redundant.
+
+### What's Changed
+
+- Errors when parsing a `.udl` file are now marginally more useful (they're still not great, but they're better).
+- Generated code should now be deterministic between runs with the same input file and version of UniFFI.
+  Previously, the generated code could depend on the iteration order of an internal hash table.
+- **Swift:** Generated Swift Enums now conform to `Hashable` by default.
+- **Swift:** There are now additional docs on how to consume the generated Swift bindings via XCode.
+
+## Previous releases.
+
+We did not maintain a changelog for previous releases.

--- a/README.md
+++ b/README.md
@@ -179,20 +179,27 @@ Please check the project's [code of conduct](./CODE_OF_CONDUCT.md).
 We use [cargo-release](https://crates.io/crates/cargo-release) to simplify the release process.
 It's not (yet) quite an ideal fit for our workflow, but it helps! Steps:
 
+1. Take a look over `CHANGELOG.md` and make sure it accurately reflects the contents of
+   the new release.
 1. Start a new branch for the release. We typically use a single branch for all point releases,
    so it should be named something like `release-v0.6.x`:
     * `git checkout -b release-v{MAJOR}.{MINOR}.x`
     * `git push -u origin release-v{MAJOR}.{MINOR}.x`
-2. Run `cargo release --dry-run -vv {MAJOR}.{MINOR}.{PATCH}` and check that the things
+1. Run `cargo release --dry-run -vv {MAJOR}.{MINOR}.{PATCH}` and check that the things
    it is proposing to do seem reasonable.
-3. Run `cargo release {MAJOR}.{MINOR}.{PATCH}` to bump version numbers and
+1. Run `cargo release {MAJOR}.{MINOR}.{PATCH}` to bump version numbers and
    publish the release to crates.io.
-4. Run `git commit --amend` to fix up the version number in the commit message.
+1. Manually update the section header in `CHANGELOG.md` following the instructions
+   at the top of the file.
+    * This is a limitation of using `cargo release` in a workspace, possibly related
+      to [sunng87/cargo-release#222](https://github.com/sunng87/cargo-release/issues/222)
+1. Run `git commit -a --amend` to include the changelog fixes and fix up the version number
+   in the commit message.
     * Manually replace `{{version}}` with `v{MAJOR}.{MINOR}.{PATCH}`.
     * This is a limitation of using `cargo release` in a workspace,
       ref [sunng87/cargo-release#222](https://github.com/sunng87/cargo-release/issues/222)
-5. Tag the release commit in github.
+1. Tag the release commit in github.
     * `git tag v{MAJOR}.{MINOR}.{PATCH}`
     * `git push origin v{MAJOR}.{MINOR}.{PATCH}`
-6. Push your branch, and make a PR to request it be merged to the main branch.
+1. Push your branch, and make a PR to request it be merged to the main branch.
     * `git push origin`

--- a/release.toml
+++ b/release.toml
@@ -7,3 +7,13 @@ consolidate-commits = true
 # So we have to tag manually for now.
 disable-tag = true
 disable-push = true
+disable-publish = true
+
+# This is how we'd *like* to manage the sections in CHANGELOG.md, but it doesn't
+# currently work that way when doing a consolidated commit in a workspace.
+#pre-release-replacements = [
+#  {file="CHANGELOG.md", search="\\[\\[UnreleasedVersion\\]\\]", replace="v{{version}}", exactly=2},
+#  {file="CHANGELOG.md", search="\\[\\[ReleaseDate\\]\\]", replace="{{date}}", exactly=1},
+#  {file="CHANGELOG.md", search="\\.\\.\\.HEAD)", replace="...{{tag_name}})", exactly=1},
+#  {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [[UnreleasedVersion]] - (_[[ReleaseDate]]_)\n\n[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.9.0...HEAD).", exactly=1},
+#]


### PR DESCRIPTION
If we're going to be issuing deprecation notices and such, we really ought to
be keeping a changelog. This commit adds one, with some retroactive notes from
the `v0.9.0` release.

I had hoped to be able to automatically manage updating the section headers
in the changelog using `cargo release`, but that doesn't seem to work as I
hoped when releasing multiple crates in a single workspace. Still, let's
organize it as though we'll be using `cargo release` for this one day.