### PR TITLE
Add ruby dependencies into CI docker image

### DIFF
--- a/docker/Dockerfile-build
+++ b/docker/Dockerfile-build
@@ -22,6 +22,8 @@ RUN sudo apt-get update -qq \
         libcurl4 \
         openjdk-11-jdk-headless \
         python3 \
+        ruby \
+        ruby-dev \
         git \
         curl \
         unzip \
@@ -70,3 +72,5 @@ RUN mkdir -p /tmp/setup-jna \
     && echo "export CLASSPATH=\"\$CLASSPATH:/opt/jna.jar\"" >> /home/circleci/.profile \
     && cd ../ \
     && rm -rf ./setup-jna
+
+RUN sudo gem install ffi --no-ri


### PR DESCRIPTION
This PR adds ruby and `ffi` package into CI docker image as discussed [here](https://github.com/mozilla/uniffi-rs/pull/436#discussion_r638428599) (PR: https://github.com/mozilla/uniffi-rs/pull/436)

JFYI: I've verified both current `main` and `rb` branch from https://github.com/mozilla/uniffi-rs/pull/436 to have all tests passing with the new version of this docker image.