### PR TITLE
Use rust version from rust-toolchain.toml file.

### DIFF
--- a/docker/Dockerfile-build
+++ b/docker/Dockerfile-build
@@ -38,8 +38,8 @@ RUN sudo apt-get update -qq \
 
 RUN rustup update \
     # This specific version of Rust is required for compatibility with mozilla-central
-    && rustup install 1.50.0 \
-    && rustup default 1.50.0
+    && rustup install 1.47.0 \
+    && rustup default 1.47.0
 
 RUN mkdir -p /tmp/setup-swift \
     && cd /tmp/setup-swift \


### PR DESCRIPTION
FYI: I'd prefer to be able to tell `rustup` to look at `rust-toolchain.toml` and install everything, but it looks like `rustup` is [not quite there yet](https://github.com/rust-lang/rustup/issues/2686).