### PR TITLE
Re-enable publishing in cargo-release configuration.

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -7,7 +7,6 @@ consolidate-commits = true
 # So we have to tag manually for now.
 disable-tag = true
 disable-push = true
-disable-publish = true
 
 # This is how we'd *like* to manage the sections in CHANGELOG.md, but it doesn't
 # currently work that way when doing a consolidated commit in a workspace.


### PR DESCRIPTION
This was accidentally left in as a result of my testing
from https://github.com/mozilla/uniffi-rs/pull/459