### PR TITLE
Update our rust policy to match mozilla-central's 'uses' version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,10 +75,10 @@ jobs:
       - run:
           name: "Print the Rust version, to help with debugging"
           command: rustc --version
-      # some tests fail on MSR:
+      # some tests fail on earlier rust versions and we want to ignore them:
       # * trybuild_ui_tests - error message had a comma inserted! Can probably
       #   be re-enabled after the next rust version bump.
-      - run: cargo test --skip trybuild_ui_tests
+      - run: cargo test -- --skip trybuild_ui_tests
   Deploy website:
     docker:
       - image: circleci/node:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
           name: "Set RUSTFLAGS to fail the build if there are warnings"
           command: echo 'export RUSTFLAGS="-D warnings"' >> $BASH_ENV
       - run: cargo test
-  Rust and Foreign Language tests - MSR:
+  Rust and Foreign Language tests - min. supported rust:
     docker:
       - image: rfkelly/uniffi-ci:latest
     resource_class: large
@@ -75,7 +75,10 @@ jobs:
       - run:
           name: "Print the Rust version, to help with debugging"
           command: rustc --version
-      - run: cargo test
+      # some tests fail on MSR:
+      # * trybuild_ui_tests - error message had a comma inserted! Can probably
+      #   be re-enabled after the next rust version bump.
+      - run: cargo test --skip trybuild_ui_tests
   Deploy website:
     docker:
       - image: circleci/node:latest
@@ -99,7 +102,7 @@ workflows:
   run-tests:
     jobs:
       - Rust and Foreign Language tests
-      - Rust and Foreign Language tests - MSR
+      - Rust and Foreign Language tests - min. supported rust
   deploy-website:
     jobs:
       - Deploy website:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,15 @@ commands:
             curl -sfSL --retry 5 --retry-delay 10 https://github.com/rust-lang-nursery/mdBook/releases/download/v0.4.2/mdbook-v0.4.2-x86_64-unknown-linux-gnu.tar.gz | tar xz
             echo 'export PATH="$HOME/.bin:$PATH"' >> $BASH_ENV
             popd
+  # Our policy for updating these rust versions is at https://github.com/mozilla/uniffi-rs/tree/main/docs/policies/rust-versions.md
+  # See also rust-toolchain.toml in the root of this repo, which is used to ensure the local version of rust matches.
+  prepare-rust-target-version:
+    steps:
+      - run: rustup default 1.52.1
+  prepare-rust-min-version:
+    steps:
+      - run rustup default 1.47.0
+
 orbs:
   gh-pages: sugarshin/gh-pages@0.0.6
 jobs:
@@ -20,21 +29,21 @@ jobs:
     docker:
       # Our policy for updating this rust version is at https://github.com/mozilla/uniffi-rs/tree/main/docs/policies/rust-versions.md
       # See also rust-toolchain.toml in the root of this repo, which is used to ensure the local version of rust matches.
-      - image: circleci/rust:1.52.1
+      - image: rfkelly/uniffi-ci:latest
     resource_class: small
     steps:
       - checkout
+      - prepare-rust-target-version
       - run: rustup component add rustfmt
       - run: rustfmt --version
-      - run: cargo fmt -- --check
+      - run: cargo +$RUST_TARGET_VERSION fmt -- --check
   Lint Rust with clippy:
     docker:
-      # Our policy for updating this rust version is at https://github.com/mozilla/uniffi-rs/tree/main/docs/policies/rust-versions.md
-      # See also rust-toolchain.toml in the root of this repo, which is used to ensure the local version of rust matches.
-      - image: circleci/rust:1.52.1
+      - image: rfkelly/uniffi-ci:latest
     resource_class: small
     steps:
       - checkout
+      - prepare-rust-target-version
       - run: rustup component add clippy
       - run: cargo clippy --version
       - run: cargo clippy --all --all-targets -- -D warnings
@@ -44,12 +53,25 @@ jobs:
     resource_class: large
     steps:
       - run: cat ~/.profile >> $BASH_ENV
+      - prepare-rust-target-version
       - run:
           name: "Print the Rust version, to help with debugging"
           command: rustc --version
       - run:
           name: "Set RUSTFLAGS to fail the build if there are warnings"
           command: echo 'export RUSTFLAGS="-D warnings"' >> $BASH_ENV
+      - checkout
+      - run: cargo test
+  Rust and Foreign Language tests - MSR:
+    docker:
+      - image: rfkelly/uniffi-ci:latest
+    resource_class: large
+    steps:
+      - run: cat ~/.profile >> $BASH_ENV
+      - prepare-rust-min-version
+      - run:
+          name: "Print the Rust version, to help with debugging"
+          command: rustc --version
       - checkout
       - run: cargo test
   Deploy website:
@@ -75,6 +97,7 @@ workflows:
   run-tests:
     jobs:
       - Rust and Foreign Language tests
+      - Rust and Foreign Language tests - MSR
   deploy-website:
     jobs:
       - Deploy website:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
     docker:
       # Our policy for updating this rust version is at https://github.com/mozilla/uniffi-rs/tree/main/docs/policies/rust-versions.md
       # See also rust-toolchain.toml in the root of this repo, which is used to ensure the local version of rust matches.
-      - image: circleci/rust:1.47.0
+      - image: circleci/rust:1.52.1
     resource_class: small
     steps:
       - checkout
@@ -31,7 +31,7 @@ jobs:
     docker:
       # Our policy for updating this rust version is at https://github.com/mozilla/uniffi-rs/tree/main/docs/policies/rust-versions.md
       # See also rust-toolchain.toml in the root of this repo, which is used to ensure the local version of rust matches.
-      - image: circleci/rust:1.47.0
+      - image: circleci/rust:1.52.1
     resource_class: small
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
           name: "Set RUSTFLAGS to fail the build if there are warnings"
           command: echo 'export RUSTFLAGS="-D warnings"' >> $BASH_ENV
       - run: cargo test
-  Rust and Foreign Language tests - min. supported rust:
+  Rust and Foreign Language tests - min supported rust:
     docker:
       - image: rfkelly/uniffi-ci:latest
     resource_class: large
@@ -102,7 +102,7 @@ workflows:
   run-tests:
     jobs:
       - Rust and Foreign Language tests
-      - Rust and Foreign Language tests - min. supported rust
+      - Rust and Foreign Language tests - min supported rust
   deploy-website:
     jobs:
       - Deploy website:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,13 @@ commands:
             curl -sfSL --retry 5 --retry-delay 10 https://github.com/rust-lang-nursery/mdBook/releases/download/v0.4.2/mdbook-v0.4.2-x86_64-unknown-linux-gnu.tar.gz | tar xz
             echo 'export PATH="$HOME/.bin:$PATH"' >> $BASH_ENV
             popd
-  # Our policy for updating these rust versions is at https://github.com/mozilla/uniffi-rs/tree/main/docs/policies/rust-versions.md
-  # See also rust-toolchain.toml in the root of this repo, which is used to ensure the local version of rust matches.
+  # Our policy for updating rust versions is at https://github.com/mozilla/uniffi-rs/tree/main/docs/policies/rust-versions.md
+  # See also rust-toolchain.toml in the root of this repo, which is used to specify our official target version.
   prepare-rust-target-version:
     steps:
       # So long as this is executed after the checkout it will use the version specified in rust-toolchain.yaml
       - run: rustup update
+  # Our minimum supported rust version is specified here.
   prepare-rust-min-version:
     steps:
       - run: rustup override set 1.47.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,12 @@ commands:
   # See also rust-toolchain.toml in the root of this repo, which is used to ensure the local version of rust matches.
   prepare-rust-target-version:
     steps:
-      - run: rustup default 1.52.1
+      # So long as this is executed after the checkout it will use the version specified in rust-toolchain.yaml
+      - run: rustup update
   prepare-rust-min-version:
     steps:
-      - run: rustup default 1.47.0
+      - run: rustup override set 1.47.0
+      - run: rustup update
 
 orbs:
   gh-pages: sugarshin/gh-pages@0.0.6
@@ -53,6 +55,7 @@ jobs:
     resource_class: large
     steps:
       - run: cat ~/.profile >> $BASH_ENV
+      - checkout
       - prepare-rust-target-version
       - run:
           name: "Print the Rust version, to help with debugging"
@@ -60,7 +63,6 @@ jobs:
       - run:
           name: "Set RUSTFLAGS to fail the build if there are warnings"
           command: echo 'export RUSTFLAGS="-D warnings"' >> $BASH_ENV
-      - checkout
       - run: cargo test
   Rust and Foreign Language tests - MSR:
     docker:
@@ -68,11 +70,11 @@ jobs:
     resource_class: large
     steps:
       - run: cat ~/.profile >> $BASH_ENV
+      - checkout
       - prepare-rust-min-version
       - run:
           name: "Print the Rust version, to help with debugging"
           command: rustc --version
-      - checkout
       - run: cargo test
   Deploy website:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ commands:
       - run: rustup default 1.52.1
   prepare-rust-min-version:
     steps:
-      - run rustup default 1.47.0
+      - run: rustup default 1.47.0
 
 orbs:
   gh-pages: sugarshin/gh-pages@0.0.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - prepare-rust-target-version
       - run: rustup component add rustfmt
       - run: rustfmt --version
-      - run: cargo +$RUST_TARGET_VERSION fmt -- --check
+      - run: cargo fmt -- --check
   Lint Rust with clippy:
     docker:
       - image: rfkelly/uniffi-ci:latest

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Our docker build doesn't need anything but `rust-toolchain.toml`.
+# This excludes everything, then includes just that one file..
+*
+!rust-toolchain.toml

--- a/docker/Dockerfile-build
+++ b/docker/Dockerfile-build
@@ -36,10 +36,8 @@ RUN sudo apt-get update -qq \
         python3-pip \
     && sudo apt-get clean
 
-RUN rustup update \
-    # This specific version of Rust is required for compatibility with mozilla-central
-    && rustup install 1.47.0 \
-    && rustup default 1.47.0
+# This should automatically install the version specified in rust-toolchain.toml
+RUN rustup update
 
 RUN mkdir -p /tmp/setup-swift \
     && cd /tmp/setup-swift \

--- a/docker/Dockerfile-build
+++ b/docker/Dockerfile-build
@@ -37,7 +37,10 @@ RUN sudo apt-get update -qq \
     && sudo apt-get clean
 
 # This should automatically install the version specified in rust-toolchain.toml
+ADD rust-toolchain.toml rust-toolchain.toml
+RUN rustup self update
 RUN rustup update
+RUN rustup show
 
 RUN mkdir -p /tmp/setup-swift \
     && cd /tmp/setup-swift \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,9 +1,10 @@
 This directory contains a Dockerfile for building the
 `uniffi-ci` docker image that we use for running tests
-in CI. To build a new version of this docker image, use:
+in CI. To build a new version of this docker image, run
+the following from the root of the repository:
 
 ```
-docker build -t rfkelly/uniffi-ci -f Dockerfile-build .
+docker build -t rfkelly/uniffi-ci -f docker/Dockerfile-build .
 docker push rfkelly/uniffi-ci
 ```
 

--- a/docs/policies/rust-versions.md
+++ b/docs/policies/rust-versions.md
@@ -5,52 +5,53 @@ it be used by external projects. If uniffi always uses Rust features available
 in only the very latest Rust version, this will cause problems for projects
 which aren't always able to be on that latest version.
 
-This is particularly important while uniffi is new and young - it's not always
-possible for our policy to be something like "defer updating uniffi until your
-project is on the same version of rust", because there's a good chance these
-projects *need* the latest version of uniffi for it to be a useful solution.
-
 Given uniffi is currently developed and maintained by Mozilla staff, it should
-be no surprise that the elephant in the room is mozilla-central (aka, the
+be no surprise that an important consideration is mozilla-central (aka, the
 main Firefox repository). While at time of writing uniffi is not used by
 mozilla-central, this policy is unashamedly focused on ensuring it will be
-able to in the short term.
+able to.
 
 ## Mozilla-central rust policies.
 
 It should also come as no surprise that the Rust policy for mozilla-central
 is somewhat flexible. There is an official [Rust Update Policy Document
-](https://wiki.mozilla.org/Rust_Update_Policy_for_Firefox]) but at time of writing
-is nearly 12 months out of date. There is a [meta bug to track rust version updates
-](https://bugzilla.mozilla.org/show_bug.cgi?id=1504858) but that doesn't define a
-policy, just tracks things as they happen.
+](https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html])
+but everything in the future is documented as "estimated".
 
-Ultimately though, mozilla-central defines a [minimum rust version
-](https://searchfox.org/mozilla-central/search?q=MINIMUM_RUST_VERSION) from which
-we assume Firefox can be built.
+Ultimately though, that page defines 2 rust versions - "Uses" and "Requires",
+and our policy revolves around these.
 
 # Uniffi rust version policy
 
 Our official rust version policy is:
 
-**uniffi should have all tests passing, and have clippy emit no warnings, with
-the current minimum Rust version supported by mozilla-central.**
+* uniffi will ship using, have all tests passing, and have clippy emit no
+  warnings, with the same version mozilla-central currently "uses".
+
+* uniffi must be capable of building (although not necessarily with all tests
+  passing nor without clippy errors or other warnings) with the same version
+  mozilla-central currently "requires".
+
+* This policy only applies to the "major" and "minor" versions - a different
+  patch level is still considered compliant with this policy.
 
 ## Implications of this
 
 All CI for this project will try and pin itself to this same version. At
 time of writing, this means that [our circle CI integration
-](https://github.com/mozilla/uniffi-rs/blob/main/.circleci/config.yml) will pin
-itself to this same version.
+](https://github.com/mozilla/uniffi-rs/blob/main/.circleci/config.yml) and
+[rust-toolchain configuration](https://github.com/mozilla/uniffi-rs/blob/main/rust-toolchain.toml)
+will specify the version.
 
-As the minimum version changes, we will bump this version. While newer versions
-of Rust can be expected to work correctly with our existing code, it's likely
-that clippy will complain in various ways with the new version. Thus, a PR
-to bump the minimum version is likely to also require a PR to make changes
-which keep clippy happy.
+We should maintain CI to ensure we still build with the "Requires" version.
+
+As versions inside mozilla-central changes, we will bump our versions
+accordingly. While newer versions of Rust can be expected to work correctly
+with our existing code, it's likely that clippy will complain in various ways
+with the new version. Thus, a PR to bump the minimum version is likely to also
+require a PR to make changes which keep clippy happy.
 
 In the interests of avoiding redundant information which will inevitably
-become stale, [our circle CI integration
-](https://github.com/mozilla/uniffi-rs/blob/main/.circleci/config.yml) configuration
+become stale, the circleci and rust-toolchain configuration links above
 should be considered the canonical source of truth for the currently supported
 official rust version.

--- a/docs/policies/rust-versions.md
+++ b/docs/policies/rust-versions.md
@@ -1,34 +1,34 @@
 # Rust Versions
 
-Like almost all Rust projects, the entire point of the uniffi project is that
-it be used by external projects. If uniffi always uses Rust features available
+Like almost all Rust projects, the entire point of the UniFFI project is that
+it be used by external projects. If UniFFI always uses Rust features available
 in only the very latest Rust version, this will cause problems for projects
 which aren't always able to be on that latest version.
 
-Given uniffi is currently developed and maintained by Mozilla staff, it should
+Given UniFFI is currently developed and maintained by Mozilla staff, it should
 be no surprise that an important consideration is mozilla-central (aka, the
-main Firefox repository). While at time of writing uniffi is not used by
+main Firefox repository). While at time of writing UniFFI is not used by
 mozilla-central, this policy is unashamedly focused on ensuring it will be
 able to.
 
-## Mozilla-central rust policies.
+## Mozilla-central Rust policies.
 
 It should also come as no surprise that the Rust policy for mozilla-central
 is somewhat flexible. There is an official [Rust Update Policy Document
 ](https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html])
 but everything in the future is documented as "estimated".
 
-Ultimately though, that page defines 2 rust versions - "Uses" and "Requires",
+Ultimately though, that page defines 2 Rust versions - "Uses" and "Requires",
 and our policy revolves around these.
 
-# Uniffi rust version policy
+# UniFFI Rust version policy
 
-Our official rust version policy is:
+Our official Rust version policy is:
 
-* uniffi will ship using, have all tests passing, and have clippy emit no
+* UniFFI will ship using, have all tests passing, and have clippy emit no
   warnings, with the same version mozilla-central currently "uses".
 
-* uniffi must be capable of building (although not necessarily with all tests
+* UniFFI must be capable of building (although not necessarily with all tests
   passing nor without clippy errors or other warnings) with the same version
   mozilla-central currently "requires".
 
@@ -54,4 +54,4 @@ require a PR to make changes which keep clippy happy.
 In the interests of avoiding redundant information which will inevitably
 become stale, the circleci and rust-toolchain configuration links above
 should be considered the canonical source of truth for the currently supported
-official rust version.
+official Rust version.

--- a/docs/policies/rust-versions.md
+++ b/docs/policies/rust-versions.md
@@ -46,7 +46,7 @@ avoid duplicating the information in `rust-toolchain.toml`)
 
 We should maintain CI to ensure we still build with the "Requires" version.
 
-As versions inside mozilla-central changes, we will bump our versions
+As versions inside mozilla-central change, we will bump the UniFI versions
 accordingly. While newer versions of Rust can be expected to work correctly
 with our existing code, it's likely that clippy will complain in various ways
 with the new version. Thus, a PR to bump the minimum version is likely to also

--- a/docs/policies/rust-versions.md
+++ b/docs/policies/rust-versions.md
@@ -41,7 +41,8 @@ All CI for this project will try and pin itself to this same version. At
 time of writing, this means that [our circle CI integration
 ](https://github.com/mozilla/uniffi-rs/blob/main/.circleci/config.yml) and
 [rust-toolchain configuration](https://github.com/mozilla/uniffi-rs/blob/main/rust-toolchain.toml)
-will specify the version.
+will specify the version (and where possible, the CI configuration file will
+avoid duplicating the information in `rust-toolchain.toml`)
 
 We should maintain CI to ensure we still build with the "Requires" version.
 

--- a/examples/sprites/src/lib.rs
+++ b/examples/sprites/src/lib.rs
@@ -40,7 +40,7 @@ impl Sprite {
     fn new(initial_position: Option<Point>) -> Sprite {
         Sprite {
             current_position: RwLock::new(
-                initial_position.unwrap_or_else(|| Point { x: 0.0, y: 0.0 }),
+                initial_position.unwrap_or(Point { x: 0.0, y: 0.0 }),
             ),
         }
     }

--- a/examples/sprites/src/lib.rs
+++ b/examples/sprites/src/lib.rs
@@ -39,9 +39,7 @@ pub struct Sprite {
 impl Sprite {
     fn new(initial_position: Option<Point>) -> Sprite {
         Sprite {
-            current_position: RwLock::new(
-                initial_position.unwrap_or(Point { x: 0.0, y: 0.0 }),
-            ),
+            current_position: RwLock::new(initial_position.unwrap_or(Point { x: 0.0, y: 0.0 })),
         }
     }
 

--- a/examples/todolist/src/lib.rs
+++ b/examples/todolist/src/lib.rs
@@ -25,7 +25,7 @@ enum TodoError {
 
 fn create_entry_with<S: Into<String>>(item: S) -> Result<TodoEntry> {
     let text = item.into();
-    if text == "" {
+    if text.is_empty() {
         return Err(TodoError::EmptyString(
             "Cannot add empty string as entry".to_string(),
         ));
@@ -52,7 +52,7 @@ impl TodoList {
 
     fn add_item<S: Into<String>>(&self, item: S) -> Result<()> {
         let item = item.into();
-        if item == "" {
+        if item.is_empty() {
             return Err(TodoError::EmptyString(
                 "Cannot add empty string as item".to_string(),
             ));

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # See https://rust-lang.github.io/rustup/overrides.html for details on how this file works
 # and how you can override the choices made herein.
 [toolchain]
-channel = "1.47.0"
+channel = "1.52.1"
 targets = [
     "aarch64-linux-android",
     "armv7-linux-androideabi",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,9 @@
 # See https://rust-lang.github.io/rustup/overrides.html for details on how this file works
 # and how you can override the choices made herein.
+# See also:
+# * ./docs/policies/rust-versions.md for our policy on what version is specified here.
+# * ./.circleci/config.yml which also specifies the rust versions used in CI.
+
 [toolchain]
 channel = "1.52.1"
 targets = [
@@ -9,6 +13,8 @@ targets = [
     "x86_64-linux-android",
     "aarch64-apple-ios",
     "x86_64-apple-ios",
-    "x86_64-linux-gnu"
+    # If `rustup show` isn't showing the version specified above, it seems your
+    # target might be missing - which are those below.
+    "x86_64-linux-gnu", # needed for WSL.
 ]
 components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -12,9 +12,6 @@ targets = [
     "i686-linux-android",
     "x86_64-linux-android",
     "aarch64-apple-ios",
-    "x86_64-apple-ios",
-    # If `rustup show` isn't showing the version specified above, it seems your
-    # target might be missing - which are those below.
-    "x86_64-linux-gnu", # needed for WSL.
+    "x86_64-apple-ios"
 ]
 components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,6 +8,7 @@ targets = [
     "i686-linux-android",
     "x86_64-linux-android",
     "aarch64-apple-ios",
-    "x86_64-apple-ios"
+    "x86_64-apple-ios",
+    "x86_64-linux-gnu"
 ]
 components = ["clippy", "rustfmt"]

--- a/uniffi/tests/ui/version_mismatch.rs
+++ b/uniffi/tests/ui/version_mismatch.rs
@@ -1,4 +1,6 @@
 // This should fail with a version mismatch.
+// *sob* - someone fixed the grammar on this output!
+// normalize-stdout-test: ", which would overflow" -> "which would overflow"
 uniffi::assert_compatible_version!("0.0.1"); // An error message would go here.
 
 fn main() {}

--- a/uniffi/tests/ui/version_mismatch.rs
+++ b/uniffi/tests/ui/version_mismatch.rs
@@ -1,6 +1,4 @@
 // This should fail with a version mismatch.
-// *sob* - someone fixed the grammar on this output!
-// normalize-stderr-test: ", which would overflow" -> "which would overflow"
 uniffi::assert_compatible_version!("0.0.1"); // An error message would go here.
 
 fn main() {}

--- a/uniffi/tests/ui/version_mismatch.rs
+++ b/uniffi/tests/ui/version_mismatch.rs
@@ -1,6 +1,6 @@
 // This should fail with a version mismatch.
 // *sob* - someone fixed the grammar on this output!
-// normalize-stdout-test: ", which would overflow" -> "which would overflow"
+// normalize-stderr-test: ", which would overflow" -> "which would overflow"
 uniffi::assert_compatible_version!("0.0.1"); // An error message would go here.
 
 fn main() {}

--- a/uniffi/tests/ui/version_mismatch.stderr
+++ b/uniffi/tests/ui/version_mismatch.stderr
@@ -1,7 +1,7 @@
 error[E0080]: evaluation of constant value failed
- --> $DIR/version_mismatch.rs:4:1
+ --> $DIR/version_mismatch.rs:2:1
   |
-4 | uniffi::assert_compatible_version!("0.0.1"); // An error message would go here.
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize` which would overflow
+2 | uniffi::assert_compatible_version!("0.0.1"); // An error message would go here.
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/uniffi/tests/ui/version_mismatch.stderr
+++ b/uniffi/tests/ui/version_mismatch.stderr
@@ -1,7 +1,7 @@
 error[E0080]: evaluation of constant value failed
  --> $DIR/version_mismatch.rs:2:1
   |
-2 | uniffi::assert_compatible_version!("0.0.1"); // An error message would go here.
+4 | uniffi::assert_compatible_version!("0.0.1"); // An error message would go here.
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize` which would overflow
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/uniffi/tests/ui/version_mismatch.stderr
+++ b/uniffi/tests/ui/version_mismatch.stderr
@@ -2,6 +2,6 @@ error[E0080]: evaluation of constant value failed
  --> $DIR/version_mismatch.rs:2:1
   |
 2 | uniffi::assert_compatible_version!("0.0.1"); // An error message would go here.
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize` which would overflow
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/uniffi/tests/ui/version_mismatch.stderr
+++ b/uniffi/tests/ui/version_mismatch.stderr
@@ -2,6 +2,6 @@ error[E0080]: evaluation of constant value failed
  --> $DIR/version_mismatch.rs:2:1
   |
 2 | uniffi::assert_compatible_version!("0.0.1"); // An error message would go here.
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize` which would overflow
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/uniffi/tests/ui/version_mismatch.stderr
+++ b/uniffi/tests/ui/version_mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0080]: evaluation of constant value failed
- --> $DIR/version_mismatch.rs:2:1
+ --> $DIR/version_mismatch.rs:4:1
   |
 4 | uniffi::assert_compatible_version!("0.0.1"); // An error message would go here.
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize` which would overflow

--- a/uniffi_bindgen/src/interface/callbacks.rs
+++ b/uniffi_bindgen/src/interface/callbacks.rs
@@ -158,7 +158,7 @@ mod test {
             };
         "#;
         let ci = ComponentInterface::from_webidl(UDL).unwrap();
-        assert_eq!(ci.iter_callback_interface_definitions().iter().count(), 2);
+        assert_eq!(ci.iter_callback_interface_definitions().len(), 2);
 
         let callbacks_one = ci.get_callback_interface_definition("One").unwrap();
         assert_eq!(callbacks_one.methods().len(), 1);

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -155,11 +155,11 @@ impl Argument {
     }
 }
 
-impl Into<FFIArgument> for &Argument {
-    fn into(self) -> FFIArgument {
+impl From<&Argument> for FFIArgument {
+    fn from(a: &Argument) -> FFIArgument {
         FFIArgument {
-            name: self.name.clone(),
-            type_: (&self.type_).into(),
+            name: a.name.clone(),
+            type_: (&a.type_).into(),
         }
     }
 }

--- a/uniffi_bindgen/src/interface/literal.rs
+++ b/uniffi_bindgen/src/interface/literal.rs
@@ -64,10 +64,9 @@ pub(super) fn convert_default_value(
             radix
         };
 
-        // Using `strip_prefix` would be better here, but that's not available in the version
-        // of Rust that is currently used in mozilla-central. Using `trim_start_matches` will
-        // *repeatedly* strip the given prefix, but that's fine because legit literals can't
-        // contain multiple instances of it anyway.
+        // Clippy seems to think we should be using `strip_prefix` here, but
+        // it seems confused as to what this is actually doing.
+        #[allow(clippy::manual_strip)]
         let string = if string.starts_with('-') {
             ("-".to_string() + string[1..].trim_start_matches("0x")).to_lowercase()
         } else {

--- a/uniffi_bindgen/src/interface/namespace.rs
+++ b/uniffi_bindgen/src/interface/namespace.rs
@@ -111,7 +111,7 @@ mod test {
         "#;
         let ci = ComponentInterface::from_webidl(UDL).unwrap();
         assert_eq!(ci.namespace(), "foobar");
-        assert_eq!(ci.iter_function_definitions().iter().count(), 2);
+        assert_eq!(ci.iter_function_definitions().len(), 2);
         assert!(ci.get_function_definition("hello").is_some());
         assert!(ci.get_function_definition("world").is_some());
         assert!(ci.get_function_definition("potato").is_none());

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -114,9 +114,9 @@ impl Type {
 ///
 /// Note that the conversion is one-way - given an FFIType, it is not in general possible to
 /// tell what the corresponding Type is that it's being used to represent.
-impl Into<FFIType> for &Type {
-    fn into(self) -> FFIType {
-        match self {
+impl From<&Type> for FFIType {
+    fn from(t: &Type) -> FFIType {
+        match t {
             // Types that are the same map to themselves, naturally.
             Type::UInt8 => FFIType::UInt8,
             Type::Int8 => FFIType::Int8,


### PR DESCRIPTION
[Rendered version](https://github.com/mhammond/uniffi-rs/blob/update-rust-policy/docs/policies/rust-versions.md)

Ryan and I have come up with this policy for our rust components. We want uniffi and app-services to have the same policy, and because this repo already had a documented I figured I'd start here, then once approved, copy it into the app-services repo.

This updates #432 - @dmose reviewed/approved that, but he's out, so I'm going with just @rfk 