### PR TITLE
(cargo-release) version v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@
 
 ## [[UnreleasedVersion]] (_[[ReleaseDate]]_)
 
-[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.10.0...HEAD).
+[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.11.0...HEAD).
+
+## v0.11.0 2021-06-03
+
+[All changes in v0.11.0](https://github.com/mozilla/uniffi-rs/compare/v0.10.0...v0.11.0).
 
 ### What's Changed
  - Swift structs and Kotlin data classes generated from `dictionary` are now mutable by default:

--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-arithmetic"
 edition = "2018"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/callbacks/Cargo.toml
+++ b/examples/callbacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-callbacks"
 edition = "2018"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/geometry/Cargo.toml
+++ b/examples/geometry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-geometry"
 edition = "2018"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/rondpoint/Cargo.toml
+++ b/examples/rondpoint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-rondpoint"
 edition = "2018"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/sprites/Cargo.toml
+++ b/examples/sprites/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-sprites"
 edition = "2018"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/todolist/Cargo.toml
+++ b/examples/todolist/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-todolist"
 edition = "2018"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/coverall/Cargo.toml
+++ b/fixtures/coverall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coverall"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 publish = false

--- a/fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency/Cargo.toml
+++ b/fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cdylib-dependency"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["king6cong <king6cong@gmail.com>"]
 edition = "2018"
 publish = false

--- a/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
+++ b/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ffi-crate"
 edition = "2018"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
+++ b/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "i356-enum-without-int-helpers"
 edition = "2018"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/uniffi-fixture-time/Cargo.toml
+++ b/fixtures/uniffi-fixture-time/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-time"
 edition = "2018"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -4,7 +4,7 @@ description = "a multi-language bindings generator for rust (runtime support cod
 documentation = "https://mozilla.github.io/uniffi-rs"
 homepage = "https://mozilla.github.io/uniffi-rs"
 repository = "https://github.com/mozilla/uniffi-rs"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 edition = "2018"
@@ -20,7 +20,7 @@ log = "0.4"
 # Regular dependencies
 cargo_metadata = "0.13"
 paste = "1.0"
-uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "= 0.10.0"}
+uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "= 0.11.0"}
 static_assertions = "1.1.0"
 
 [features]

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_bindgen"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (codegen and cli tooling)"
 documentation = "https://mozilla.github.io/uniffi-rs"

--- a/uniffi_build/Cargo.toml
+++ b/uniffi_build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_build"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (build script helpers)"
 documentation = "https://mozilla.github.io/uniffi-rs"
@@ -12,7 +12,7 @@ keywords = ["ffi", "bindgen"]
 
 [dependencies]
 anyhow = "1"
-uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "= 0.10.0"}
+uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "= 0.11.0"}
 
 [features]
 default = []

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_macros"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (convenience macros)"
 documentation = "https://mozilla.github.io/uniffi-rs"


### PR DESCRIPTION
This is a semver breaking change due to interface implementations must now be `Sync + Send` and deprecating `[Threadsafe]`. Also kotlin and swift generation for dictionaries now make it mutable by default.