### PR TITLE
Remove lots of boilerplate from bindings by using askama's 'else'

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
@@ -494,8 +494,8 @@ internal fun write{{ canonical_type_name }}(v: Map<String, {{ inner_type_name }}
 {% when Type::CallbackInterface with (interface_name) -%}
 {# Helpers for Callback Interface types are defined inline with the CallbackInterface class #}
 
-{% when Type::Error with (error_name) -%}
-{# Error types cannot be lifted, lowered or serialized (yet) #}
+{% else %}
+{# This type cannot be lifted, lowered or serialized (yet) #}
 
 {% endmatch %}
 {% endfor %}

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
@@ -131,27 +131,6 @@ class RustBufferBuilder(object):
         self._pack_into(8, ">Q", seconds)
         self._pack_into(4, ">I", nanoseconds)
 
-    {% when Type::Object with (object_name) -%}
-    # The Object type {{ object_name }}.
-    # Objects cannot currently be serialized, but we can produce a helpful error.
-
-    def write{{ canonical_type_name }}(self):
-        raise InternalError("RustBufferStream.write() not implemented yet for {{ canonical_type_name }}")
-
-    {% when Type::CallbackInterface with (object_name) -%}
-    # The Callback Interface type {{ object_name }}.
-    # Objects cannot currently be serialized, but we can produce a helpful error.
-
-    def write{{ canonical_type_name }}(self):
-        raise InternalError("RustBufferStream.write() not implemented yet for {{ canonical_type_name }}")
-
-    {% when Type::Error with (error_name) -%}
-    # The Error type {{ error_name }}.
-    # Errors cannot currently be serialized, but we can produce a helpful error.
-
-    def write{{ canonical_type_name }}(self):
-        raise InternalError("RustBufferStream.write() not implemented yet for {{ canonical_type_name }}")
-
     {% when Type::Enum with (enum_name) -%}
     {%- let e = ci.get_enum_definition(enum_name).unwrap() -%}
     # The Enum type {{ enum_name }}.
@@ -204,6 +183,12 @@ class RustBufferBuilder(object):
         for (k, v) in items.items():
             self.writeString(k)
             self.write{{ inner_type.canonical_name()|class_name_py }}(v)
+
+    {%- else -%}
+    # This type cannot currently be serialized, but we can produce a helpful error.
+
+    def write{{ canonical_type_name }}(self):
+        raise InternalError("RustBufferStream.write() not implemented yet for {{ canonical_type_name }}")
 
     {%- endmatch -%}
     {%- endfor %}

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
@@ -187,7 +187,7 @@ class RustBufferBuilder(object):
     {%- else -%}
     # This type cannot currently be serialized, but we can produce a helpful error.
 
-    def write{{ canonical_type_name }}(self):
+    def write{{ canonical_type_name }}(self, value):
         raise InternalError("RustBufferStream.write() not implemented yet for {{ canonical_type_name }}")
 
     {%- endmatch -%}

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
@@ -127,27 +127,6 @@ class RustBufferStream(object):
     def read{{ canonical_type_name }}(self):
         return datetime.timedelta(seconds=self._unpack_from(8, ">Q"), microseconds=(self._unpack_from(4, ">I") / 1.0e3))
 
-    {% when Type::Object with (object_name) -%}
-    # The Object type {{ object_name }}.
-    # Objects cannot currently be serialized, but we can produce a helpful error.
-
-    def read{{ canonical_type_name }}(self):
-        raise InternalError("RustBufferStream.read not implemented yet for {{ canonical_type_name }}")
-
-    {% when Type::CallbackInterface with (object_name) -%}
-    # The Callback Interface type {{ object_name }}.
-    # Objects cannot currently be serialized, but we can produce a helpful error.
-
-    def read{{ canonical_type_name }}(self):
-        raise InternalError("RustBufferStream.read not implemented yet for {{ canonical_type_name }}")
-
-    {% when Type::Error with (error_name) -%}
-    # The Error type {{ error_name }}.
-    # Errors cannot currently be serialized, but we can produce a helpful error.
-
-    def read{{ canonical_type_name }}(self):
-        raise InternalError("RustBufferStream.read not implemented yet for {{ canonical_type_name }}")
-
     {% when Type::Enum with (enum_name) -%}
     {%- let e = ci.get_enum_definition(enum_name).unwrap() -%}
     # The Enum type {{ enum_name }}.
@@ -221,6 +200,11 @@ class RustBufferStream(object):
             items[key] = self.read{{ inner_type.canonical_name()|class_name_py }}()
             count -= 1
         return items
+
+    {%- else -%}
+    # This type cannot currently be serialized, but we can produce a helpful error.
+    def read{{ canonical_type_name }}(self):
+        raise InternalError("RustBufferStream.read not implemented yet for {{ canonical_type_name }}")
 
     {%- endmatch -%}
     {%- endfor %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -105,46 +105,6 @@ class RustBufferBuilder
     write v
   end
 
-  {% when Type::Timestamp -%}
-  # The Timestamp type.
-  # These are not yet supported in the Ruby backend.
-
-  def write_{{ canonical_type_name }}
-    raise InternalError('RustBufferStream.write() not implemented yet for {{ canonical_type_name }}')
-  end
-
-  {% when Type::Duration -%}
-  # The Timestamp type.
-  # These are not yet supported in the Ruby backend.
-
-  def write_{{ canonical_type_name }}
-    raise InternalError('RustBufferStream.write() not implemented yet for {{ canonical_type_name }}')
-  end
-
-  {% when Type::Object with (object_name) -%}
-  # The Object type {{ object_name }}.
-  # Objects cannot currently be serialized, but we can produce a helpful error.
-
-  def write_{{ canonical_type_name }}
-    raise InternalError('RustBufferStream.write() not implemented yet for {{ canonical_type_name }}')
-  end
-
-  {% when Type::CallbackInterface with (object_name) -%}
-  # The Callback Interface type {{ object_name }}.
-  # Objects cannot currently be serialized, but we can produce a helpful error.
-
-  def write_{{ canonical_type_name }}
-    raise InternalError('RustBufferStream.write() not implemented yet for {{ canonical_type_name }}')
-  end
-
-  {% when Type::Error with (error_name) -%}
-  # The Error type {{ error_name }}.
-  # Errors cannot currently be serialized, but we can produce a helpful error.
-
-  def write_{{ canonical_type_name }}
-    raise InternalError('RustBufferStream.write() not implemented yet for {{ canonical_type_name }}')
-  end
-
   {% when Type::Enum with (enum_name) -%}
   {%- let e = ci.get_enum_definition(enum_name).unwrap() -%}
   # The Enum type {{ enum_name }}.
@@ -207,6 +167,12 @@ class RustBufferBuilder
       write_String(k)
       self.write_{{ inner_type.canonical_name()|class_name_rb }}(v)
     end
+  end
+
+  {%- else -%}
+  # This type is not yet supported in the Ruby backend.
+  def write_{{ canonical_type_name }}
+    raise InternalError('RustBufferStream.write() not implemented yet for {{ canonical_type_name }}')
   end
 
   {%- endmatch -%}

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -171,7 +171,7 @@ class RustBufferBuilder
 
   {%- else -%}
   # This type is not yet supported in the Ruby backend.
-  def write_{{ canonical_type_name }}
+  def write_{{ canonical_type_name }}(v)
     raise InternalError('RustBufferStream.write() not implemented yet for {{ canonical_type_name }}')
   end
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
@@ -106,46 +106,6 @@ class RustBufferStream
     read(size).force_encoding(Encoding::UTF_8)
   end
 
-  {% when Type::Timestamp -%}
-  # The Timestamp type.
-  # These are not yet supported in the Ruby backend.
-
-  def read{{ canonical_type_name }}
-    raise InternalError, 'RustBufferStream.read not implemented yet for {{ canonical_type_name }}'
-  end
-
-  {% when Type::Duration -%}
-  # The Duration type.
-  # These are not yet supported in the Ruby backend.
-
-  def read{{ canonical_type_name }}
-    raise InternalError, 'RustBufferStream.read not implemented yet for {{ canonical_type_name }}'
-  end
-
-  {% when Type::Object with (object_name) -%}
-  # The Object type {{ object_name }}.
-  # Objects cannot currently be serialized, but we can produce a helpful error.
-
-  def read{{ canonical_type_name }}
-    raise InternalError, 'RustBufferStream.read not implemented yet for {{ canonical_type_name }}'
-  end
-
-  {% when Type::CallbackInterface with (object_name) -%}
-  # The Callback Interface type {{ object_name }}.
-  # Callback Interfaces cannot currently be serialized, but we can produce a helpful error.
-
-  def read{{ canonical_type_name }}
-    raise InternalError, 'RustBufferStream.read not implemented yet for {{ canonical_type_name }}'
-  end
-
-  {% when Type::Error with (error_name) -%}
-  # The Error type {{ error_name }}.
-  # Errors cannot currently be serialized, but we can produce a helpful error.
-
-  def read{{ canonical_type_name }}
-    raise InternalError, 'RustBufferStream.read not implemented yet for {{ canonical_type_name }}'
-  end
-
   {% when Type::Enum with (enum_name) -%}
   {%- let e = ci.get_enum_definition(enum_name).unwrap() -%}
   # The Enum type {{ enum_name }}.
@@ -237,6 +197,12 @@ class RustBufferStream
 
     items
   end
+  {%- else -%}
+  # This type is not yet supported in the Ruby backend.
+  def read{{ canonical_type_name }}
+    raise InternalError, 'RustBufferStream.read not implemented yet for {{ canonical_type_name }}'
+  end
+
   {%- endmatch -%}
   {%- endfor %}
 


### PR DESCRIPTION
There's a fair bit of copy/pasted "this type not supported" boilerplate in the bindings that would be simplified using `{% else %}` - when I found myself adding copy/pasting the same boilerplate in these locations I figured I'd see if it could be avoided.