### PR TITLE
Publish auto-generated Rust API docs as part of the UniFFI manual.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,13 @@ commands:
     steps:
       - run: rustup override set 1.47.0
       - run: rustup update
+  build-api-docs:
+    steps:
+      - run:
+          name: Build API Docs
+          command: cargo doc --no-deps --document-private-items -p uniffi_bindgen -p uniffi -p uniffi_build -p uniffi_macros
+          environment:
+            RUSTDOCFLAGS: -Dwarnings -Arustdoc::private-intra-doc-links
 
 orbs:
   gh-pages: sugarshin/gh-pages@0.0.6
@@ -50,6 +57,14 @@ jobs:
       - run: rustup component add clippy
       - run: cargo clippy --version
       - run: cargo clippy --all --all-targets -- -D warnings
+  Lint Rust Docs:
+    docker:
+      - image: rfkelly/uniffi-ci:latest
+    resource_class: small
+    steps:
+      - checkout
+      - prepare-rust-target-version
+      - build-api-docs
   Rust and Foreign Language tests:
     docker:
       - image: rfkelly/uniffi-ci:latest
@@ -87,6 +102,8 @@ jobs:
     steps:
       - install-mdbook
       - checkout
+      - build-api-docs
+      - run: cp -r ./target/doc ./docs/manual/src/internals/api
       - run: mdbook build docs/manual
       - gh-pages/deploy:
           build-dir: docs/manual/book
@@ -100,6 +117,9 @@ workflows:
   clippy:
     jobs:
       - Lint Rust with clippy
+  docs:
+    jobs:
+      - Lint Rust Docs
   run-tests:
     jobs:
       - Rust and Foreign Language tests

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 *.jar
 .vscode
 xcuserdata
+docs/manual/src/internals/api

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -71,7 +71,7 @@ Other directories of interest include:
 - **[`./uniffi_bindgen`](../uniffi_bindgen):** This is the source for the `uniffi-bindgen` executable and is where
   most of the logic for the UniFFI tool lives. Its contents include:
     - **[`./uniffi_bindgen/src/interface/`](../uniffi_bindgen/src/interface):** The logic for parsing `.udl` files
-      into an in-memory representation called `ComponentInterface`, from which we ca generate code for different languages.
+      into an in-memory representation called `ComponentInterface`, from which we can generate code for different languages.
     - **[`./uniffi_bindgen/src/scaffolding`](../uniffi_bindgen/src/scaffolding):** This module turns a `ComponentInterface`
       into *Rust scaffolding*, the code that wraps the user-provided Rust code and exposes it via a C-compatible FFI layer.
     - **[`./uniffi_bindgen/src/bindings/`](../uniffi_bindgen/src/bindings):** This module turns a `ComponentInterface` into

--- a/docs/manual/src/SUMMARY.md
+++ b/docs/manual/src/SUMMARY.md
@@ -26,6 +26,6 @@
 - [Integrating with XCode](./swift/xcode.md)
 
 # Internals
-
+- [Navigating the code](./internals/crates.md)
 - [Lifting, Lowering, and Serialization](./internals/lifting_and_lowering.md)
 - [Managing object references](./internals/object_references.md)

--- a/docs/manual/src/internals/crates.md
+++ b/docs/manual/src/internals/crates.md
@@ -1,0 +1,23 @@
+# Navigating the code
+
+The code for UniFFI is organized into the following crates:
+
+- **[`./uniffi_bindgen`](./api/uniffi_bindgen/index.html):** This is the source for the `uniffi-bindgen` executable and is where
+  most of the logic for the UniFFI tool lives. Its contents include:
+    - **[`./uniffi_bindgen/src/interface/`](./api/uniffi_bindgen/interface/index.html):** The logic for parsing `.udl` files
+      into an in-memory representation called [`ComponentInterface`](./api/uniffi_bindgen/interface/struct.ComponentInterface.html),
+      from which we can generate code for different languages.
+    - **[`./uniffi_bindgen/src/scaffolding`](./api/uniffi_bindgen/scaffolding/index.html):** This module turns a
+      [`ComponentInterface`](./api/uniffi_bindgen/interface/struct.ComponentInterface.html) into *Rust scaffolding*, the code that
+      wraps the user-provided Rust code and exposes it via a C-compatible FFI layer.
+    - **[`./uniffi_bindgen/src/bindings/`](./api/uniffi_bindgen/bindings/index.html):** This module turns a
+      [`ComponentInterface`](./api/uniffi_bindgen/interface/struct.ComponentInterface.html) into *foreign-language bindings*,
+      the code that can load the FFI layer exposed by the scaffolding and expose it as a
+      higher-level API in a target language. There is a sub-module for each supported language.
+- **[`./uniffi`](./api/uniffi/index.html):** This is a run-time support crate that is used by the generated Rust scaffolding. It
+  controls how values of various types are passed back-and-forth over the FFI layer, by means of the
+  [`ViaFfi`](./api/uniffi/trait.ViaFfi.html) trait.
+- **[`./uniffi_build`](./api/uniffi_build/index.html):** This is a small hook to run `uniffi-bindgen` from the `build.rs` script
+  of a UniFFI component, in order to automatically generate the Rust scaffolding as part of its build process.
+- **[`./uniffi_macros`](./api/uniffi_macros/index.html):** This contains some helper macros that UniFFI components can use to
+  simplify loading the generated scaffolding, and executing foreign-language tests.

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -11,14 +11,14 @@
 //! The key concept here is the [`ViaFfi`] trait, which must be implemented for any type that can
 //! be passed across the FFI, and which determines:
 //!
-//!  * How to [represent](ViaFfi::Value) values of that type in the low-level C-style type
+//!  * How to [represent](ViaFfi::FfiType) values of that type in the low-level C-style type
 //!    system of the FFI layer.
 //!  * How to ["lower"](ViaFfi::lower) rust values of that type into an appropriate low-level
 //!    FFI value.
-//!  * How to ["lift"](ViaFfi::lift) low-level FFI values back into rust values of that type.
+//!  * How to ["lift"](ViaFfi::try_lift) low-level FFI values back into rust values of that type.
 //!  * How to [write](ViaFfi::write) rust values of that type into a buffer, for cases
 //!    where they are part of a compound data structure that is serialized for transfer.
-//!  * How to [read](ViaFfi::read) rust values of that type from buffer, for cases
+//!  * How to [read](ViaFfi::try_read) rust values of that type from buffer, for cases
 //!    where they are received as part of a compound data structure that was serialized for transfer.
 //!
 //! This logic encapsulates the rust-side handling of data transfer. Each foreign-language binding

--- a/uniffi_bindgen/src/interface/attributes.rs
+++ b/uniffi_bindgen/src/interface/attributes.rs
@@ -18,7 +18,7 @@ use std::convert::{TryFrom, TryInto};
 
 use anyhow::{bail, Result};
 
-/// Represents an attribute parsed from UDL, like [ByRef] or [Throws].
+/// Represents an attribute parsed from UDL, like `[ByRef]` or `[Throws]`.
 ///
 /// This is a convenience enum for parsing UDL attributes and erroring out if we encounter
 /// any unsupported ones. These don't convert directly into parts of a `ComponentInterface`, but

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -19,7 +19,7 @@
 //!
 //! As a developer working on UniFFI itself, you're likely to spend a fair bit of time thinking
 //! about how these API-level types map into the lower-level types of the FFI layer as represented
-//! by the [`ffi::FFIType`] enum, but that's a detail that is invisible to end users.
+//! by the [`ffi::FFIType`](super::ffi::FFIType) enum, but that's a detail that is invisible to end users.
 
 use std::{collections::hash_map::Entry, collections::BTreeSet, collections::HashMap};
 

--- a/uniffi_bindgen/src/interface/types/resolver.rs
+++ b/uniffi_bindgen/src/interface/types/resolver.rs
@@ -7,7 +7,7 @@
 //! This module provides the [`TypeResolver`] trait, an abstraction for walking
 //! the parse tree of a weedle type expression and using a [`TypeUniverse`] to
 //! convert it into a concrete type definition (so it assumes that you're already
-//! used a [`TypeFinder`] to populate the universe).
+//! used a [`TypeFinder`](super::TypeFinder) to populate the universe).
 //!
 //! Perhaps most importantly, it knows how to error out if the UDL tries to reference
 //! an undefined or invalid type.

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -60,7 +60,7 @@
 //!
 //! First you will need to install `uniffi-bindgen` on your system using `cargo install uniffi_bindgen`.
 //! Then add to your crate `uniffi_build` under `[build-dependencies]`.
-//! Finally, add a `build.rs` script to your crate and have it call [uniffi_build::generate_scaffolding](uniffi_build::generate_scaffolding)
+//! Finally, add a `build.rs` script to your crate and have it call `uniffi_build::generate_scaffolding`
 //! to process your `.udl` file. This will generate some Rust code to be included in the top-level source
 //! code of your crate. If your UDL file is named `example.udl`, then your build script would call:
 //!


### PR DESCRIPTION
Rust has great tooling for API docs, and I think we should try to
get into the habit of using it. This commit generates API docs for
our main crates and includes them in the published UniFFI manual,
which will hopefully help folks onboarding into the codebase.