### PR TITLE
Experiment with what "external types" might look like.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "examples/sprites",
   "examples/todolist",
   "fixtures/coverall",
+  "fixtures/external-types",
   "fixtures/regressions/enum-without-i32-helpers",
   "fixtures/regressions/cdylib-crate-type-dependency/ffi-crate",
   "fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency",

--- a/fixtures/external-types/Cargo.toml
+++ b/fixtures/external-types/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "external-types"
+edition = "2018"
+version = "0.11.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["staticlib", "cdylib", "lib"]
+name = "uniffi_external_types"
+
+[dependencies]
+anyhow = "1"
+bytes = "1.0"
+serde_json = "1"
+uniffi_macros = {path = "../../uniffi_macros"}
+uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
+
+[build-dependencies]
+uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/external-types/build.rs
+++ b/fixtures/external-types/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/external-types.udl").unwrap();
+}

--- a/fixtures/external-types/src/external-types.udl
+++ b/fixtures/external-types/src/external-types.udl
@@ -1,0 +1,23 @@
+
+[External]
+typedef string Guid;
+
+[External]
+typedef string JSONObject;
+
+dictionary ExtTypes {
+    Guid guid;
+    sequence<Guid> guids;
+    JSONObject json;
+    sequence<JSONObject> jsons;
+    // should get all other recursive types.
+};
+
+namespace external_types {
+    string get_string(optional string? val);
+    Guid get_guid(optional Guid? val);
+
+    JSONObject? get_json_object(optional JSONObject? val);
+
+    ExtTypes get_ext_types(optional ExtTypes? vals);
+};

--- a/fixtures/external-types/src/lib.rs
+++ b/fixtures/external-types/src/lib.rs
@@ -1,0 +1,99 @@
+// A trivial Guid implementation.
+struct Guid(String);
+
+// A simple `type JSONObject = serde_json::Value;` would work, except that
+// we can't impl ViaFfi `impl doesn't use only types from inside the current crate`
+struct JSONObject(serde_json::Value);
+
+fn get_guid(guid: Option<Guid>) -> Guid {
+    match guid {
+        Some(guid) => guid,
+        None => Guid("NewGuid".to_string()),
+    }
+}
+
+fn get_string(s: Option<String>) -> String {
+    match s {
+        Some(s) => s,
+        None => "NewString".to_string(),
+    }
+}
+
+fn get_json_object(v: Option<JSONObject>) -> Option<JSONObject> {
+    match v {
+        Some(v) => Some(v),
+        None => Some(JSONObject(serde_json::json!({"foo": "bar"}))),
+    }
+}
+
+struct ExtTypes {
+    guid: Guid,
+    guids: Vec<Guid>,
+    json: JSONObject,
+    jsons: Vec<JSONObject>,
+}
+
+fn get_ext_types(vals: Option<ExtTypes>) -> ExtTypes {
+    match vals {
+        None => ExtTypes {
+            guid: Guid("first-guid".to_string()),
+            guids: vec![
+                Guid("second-guid".to_string()),
+                Guid("third-guid".to_string()),
+            ],
+            json: JSONObject(serde_json::json!({"foo": "bar"})),
+            jsons: vec![
+                JSONObject(serde_json::json!(["an", "array"])),
+                JSONObject(serde_json::json!(3)),
+            ],
+        },
+        Some(vals) => vals,
+    }
+}
+
+// And we need a ViaFfi for them. Both of these boil down to "to and from a
+// string" - this is the best markh could come up with, Maybe it should be
+// a proc macro? Whatever, this serves the purpose for now.
+use anyhow::Result;
+use bytes::buf::{Buf, BufMut};
+use std::convert::TryFrom;
+use uniffi::{check_remaining, RustBuffer, ViaFfi};
+
+#[macro_export]
+macro_rules! viaffi_simple_string {
+    ( $t:ident, $sel:ident, $to_string:expr, $from_string:expr ) => {
+        unsafe impl ViaFfi for $t {
+            type FfiType = RustBuffer;
+            fn lower($sel) -> <$t as ViaFfi>::FfiType {
+                RustBuffer::from_vec($to_string.into_bytes())
+            }
+            fn try_lift(v: Self::FfiType) -> Result<Self> {
+                let v = v.destroy_into_vec();
+                let s = unsafe { String::from_utf8_unchecked(v) };
+                Ok($from_string(s)) // XXX - wire up errors
+            }
+            fn write<B: BufMut>(&$sel, buf: &mut B) {
+                let s = &$to_string;
+                let len = i32::try_from(s.len()).unwrap();
+                buf.put_i32(len); // We limit strings to u32::MAX bytes
+                buf.put(s.as_bytes());
+            }
+            fn try_read<B: Buf>(buf: &mut B) -> Result<Self> {
+                check_remaining(buf, 4)?;
+                let len = usize::try_from(buf.get_i32())?;
+                check_remaining(buf, len)?;
+                let bytes = &buf.chunk()[..len];
+                let s = String::from_utf8(bytes.to_vec())?;
+                buf.advance(len);
+                Ok($from_string(s)) // XXX - wire up errors
+            }
+        }
+    }
+}
+
+viaffi_simple_string!(JSONObject, self, self.0.to_string(), |s: String| Self(
+    serde_json::from_str(&s).unwrap()
+));
+viaffi_simple_string!(Guid, self, self.0, |s| Self(s));
+
+include!(concat!(env!("OUT_DIR"), "/external-types.uniffi.rs"));

--- a/fixtures/external-types/tests/bindings/test_external_types.py
+++ b/fixtures/external-types/tests/bindings/test_external_types.py
@@ -1,0 +1,39 @@
+from external_types import *
+import unittest
+
+class TestExternalTypes(unittest.TestCase):
+    def test_guid(self):
+        guid = get_guid(None)
+        self.assertEqual(type(guid), str)
+
+        guid2 = get_guid(guid)
+        self.assertEqual(guid, guid2)
+
+    def test_json_object(self):
+        j = get_json_object(None)
+        self.assertEqual(type(j), dict)
+
+        j2 = get_json_object(j)
+        self.assertEqual(type(j2), dict)
+        self.assertEqual(j, j2)
+
+    def test_ext_types(self):
+        vals = get_ext_types(None)
+
+        self.assertEqual(type(vals.guid), str)
+        self.assertEqual(vals.guid, "first-guid")
+        self.assertEqual(type(vals.guids), list)
+        self.assertEqual(vals.guids, ["second-guid", "third-guid"])
+
+        self.assertEqual(type(vals.json), dict)
+        self.assertEqual(type(vals.jsons), list)
+        # first elt is a json array
+        self.assertEqual(vals.jsons[0], ["an", "array"])
+        # second a plain int.
+        self.assertEqual(vals.jsons[1], 3)
+
+        vals2 = get_ext_types(vals)
+        self.assertEqual(vals, vals2)
+
+if __name__=='__main__':
+    unittest.main()

--- a/fixtures/external-types/tests/test_generated_bindings.rs
+++ b/fixtures/external-types/tests/test_generated_bindings.rs
@@ -1,0 +1,4 @@
+uniffi_macros::build_foreign_language_testcases!(
+    "src/external-types.udl",
+    ["tests/bindings/test_external_types.py",]
+);

--- a/fixtures/external-types/uniffi.toml
+++ b/fixtures/external-types/uniffi.toml
@@ -1,0 +1,7 @@
+[bindings.python]
+
+[bindings.python.external_types]
+[bindings.python.external_types.JSONObject]
+setup = "import json"
+lift_from_primitive = "json.loads"
+lower_to_primitive = "json.dumps"

--- a/uniffi_bindgen/src/bindings/gecko_js/webidl.rs
+++ b/uniffi_bindgen/src/bindings/gecko_js/webidl.rs
@@ -105,6 +105,7 @@ impl From<Type> for WebIDLType {
             | inner @ Type::String
             | inner @ Type::Enum(_)
             | inner @ Type::Object(_)
+            | inner @ Type::ExternalType(..)
             | inner @ Type::Record(_) => WebIDLType::Flat(inner),
             Type::Error(_) => {
                 // TODO: We don't currently throw typed errors; see

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin.rs
@@ -95,6 +95,7 @@ mod filters {
             | Type::Object(name)
             | Type::Error(name)
             | Type::CallbackInterface(name) => class_name_kt(name)?,
+            Type::ExternalType(..) => unreachable!("future me hates me"),
             Type::Optional(t) => format!("{}?", type_kt(t)?),
             Type::Sequence(t) => format!("List<{}>", type_kt(t)?),
             Type::Map(t) => format!("Map<String, {}>", type_kt(t)?),

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
@@ -491,6 +491,9 @@ internal fun write{{ canonical_type_name }}(v: Map<String, {{ inner_type_name }}
 {% when Type::Object with (object_name) -%}
 {# Object types cannot be lifted, lowered or serialized (yet) #}
 
+{% when Type::ExternalType with (object_name, primitive_type) -%}
+{# ExternalType types cannot be lifted, lowered or serialized (yet) #}
+
 {% when Type::CallbackInterface with (interface_name) -%}
 {# Helpers for Callback Interface types are defined inline with the CallbackInterface class #}
 

--- a/uniffi_bindgen/src/bindings/python/gen_python.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python.rs
@@ -10,12 +10,23 @@ use serde::{Deserialize, Serialize};
 use crate::interface::*;
 use crate::MergeWith;
 
-// Some config options for it the caller wants to customize the generated python.
+// Support for custom helpers for external types.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ExternalTypeConfig {
+    // Something we'll execute before attempting to use the helpers
+    pub setup: String,
+    // The names of Python functions that lift/lower to/from the already lifted/lower primitive.
+    pub lift_from_primitive: String,
+    pub lower_to_primitive: String,
+}
+
+// Some config options for if the caller wants to customize the generated python.
 // Note that this can only be used to control details of the python *that do not affect the underlying component*,
-// sine the details of the underlying component are entirely determined by the `ComponentInterface`.
+// since the details of the underlying component are entirely determined by the `ComponentInterface`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Config {
     cdylib_name: Option<String>,
+    external_types: std::collections::HashMap<String, ExternalTypeConfig>,
 }
 
 impl Config {
@@ -26,20 +37,27 @@ impl Config {
             "uniffi".into()
         }
     }
+    pub fn find_external_type(&self, name: &str) -> Option<ExternalTypeConfig> {
+        self.external_types.get(name).map(|c| c.clone())
+    }
 }
 
 impl From<&ComponentInterface> for Config {
     fn from(ci: &ComponentInterface) -> Self {
         Config {
             cdylib_name: Some(format!("uniffi_{}", ci.namespace())),
+            ..Default::default()
         }
     }
 }
 
 impl MergeWith for Config {
     fn merge_with(&self, other: &Self) -> Self {
+        // merging doesn't make sense for external_types?
+        assert!(other.external_types.is_empty());
         Config {
             cdylib_name: self.cdylib_name.merge_with(&other.cdylib_name),
+            external_types: self.external_types.clone(),
         }
     }
 }
@@ -144,6 +162,7 @@ mod filters {
             Type::Boolean => format!("bool({})", nm),
             Type::String
             | Type::Object(_)
+            | Type::ExternalType(..)
             | Type::Enum(_)
             | Type::Error(_)
             | Type::Record(_)
@@ -176,6 +195,7 @@ mod filters {
             Type::Boolean => format!("(1 if {} else 0)", nm),
             Type::String => format!("RustBuffer.allocFromString({})", nm),
             Type::Object(_) => format!("({}._pointer)", nm),
+            Type::ExternalType(_, primitive) => return lower_py(nm, &primitive),
             Type::CallbackInterface(_) => panic!("No support for lowering callback interfaces yet"),
             Type::Error(_) => panic!("No support for lowering errors, yet"),
             Type::Enum(_)
@@ -192,7 +212,11 @@ mod filters {
         })
     }
 
-    pub fn lift_py(nm: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
+    pub fn lift_py(
+        nm: &dyn fmt::Display,
+        type_: &Type,
+        config: &Config,
+    ) -> Result<String, askama::Error> {
         Ok(match type_ {
             Type::Int8
             | Type::UInt8
@@ -206,6 +230,21 @@ mod filters {
             Type::Boolean => format!("(True if {} else False)", nm),
             Type::String => format!("{}.consumeIntoString()", nm),
             Type::Object(name) => format!("{}._make_instance_({})", class_name_py(name)?, nm),
+            Type::ExternalType(ext_name, primitive) => {
+                let prim_lift = format!(
+                    "{}.consumeInto{}()",
+                    nm,
+                    class_name_py(&primitive.canonical_name())?
+                );
+                match config.find_external_type(ext_name) {
+                    // A custom type - we lift via the primitive.
+                    Some(ext_config) => {
+                        format!("{}({})", ext_config.lift_from_primitive, prim_lift)
+                    }
+                    // We are using the primitive type directly
+                    None => prim_lift,
+                }
+            }
             Type::CallbackInterface(_) => panic!("No support for lifting callback interfaces, yet"),
             Type::Error(_) => panic!("No support for lowering errors, yet"),
             Type::Enum(_)

--- a/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
@@ -42,7 +42,7 @@ class {{ obj.name()|class_name_py }}(object):
     def {{ meth.name()|fn_name_py }}(self, {% call py::arg_list_decl(meth) %}):
         {%- call py::coerce_args_extra_indent(meth) %}
         _retval = {% call py::to_ffi_call_with_prefix("self._pointer", meth) %}
-        return {{ "_retval"|lift_py(return_type) }}
+        return {{ "_retval"|lift_py(return_type, config) }}
 
     {%- when None -%}
     def {{ meth.name()|fn_name_py }}(self, {% call py::arg_list_decl(meth) %}):

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
@@ -195,6 +195,20 @@ class RustBufferBuilder(object):
             self.writeString(k)
             self.write{{ inner_type.canonical_name()|class_name_py }}(v)
 
+    {% when Type::ExternalType with (name, primitive_type) -%}
+
+    # The external type {{ name }} is implemented as a {{ primitive_type.canonical_name() }}
+    {% match config.find_external_type(name) -%}
+    {%- when Some with (ext) -%}
+    # An external type: {{ name }}.
+    def write{{ canonical_type_name }}(self, value):
+        self.write{{ primitive_type.canonical_name()|class_name_py }}({{ ext.lower_to_primitive }}(value))
+
+    {%- when None -%}
+    def write{{ canonical_type_name }}(self, value):
+        self.write{{ primitive_type.canonical_name()|class_name_py }}(value)
+    {%- endmatch -%}
+
     {%- else -%}
     # This type cannot currently be serialized, but we can produce a helpful error.
 

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
@@ -210,6 +210,18 @@ class RustBufferStream(object):
             count -= 1
         return items
 
+    {% when Type::ExternalType with (name, primitive_type) %}
+    # The External type {{ name }} is implemented via {{ primitive_type.canonical_name() }}
+    {% match config.find_external_type(name) -%}
+    {%- when Some with (ext) -%}
+    # An external type: {{ name }}.
+    def read{{ canonical_type_name }}(self):
+        return {{ ext.lift_from_primitive }}(self.read{{ primitive_type.canonical_name()|class_name_py }}())
+    {%- when None -%}
+    def read{{ canonical_type_name }}(self):
+        return self.read{{ primitive_type.canonical_name()|class_name_py }}()
+    {%- endmatch -%}
+
     {%- else -%}
     # This type cannot currently be serialized, but we can produce a helpful error.
     def read{{ canonical_type_name }}(self):

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
@@ -62,7 +62,7 @@ class RustBuffer(ctypes.Structure):
     # of python's free-for-all type system.
 
     {%- for typ in ci.iter_types() -%}
-    {%- let canonical_type_name = typ.canonical_name() -%}
+    {%- let canonical_type_name = typ.canonical_name()|class_name_py -%}
     {%- match typ -%}
 
     {% when Type::String -%}

--- a/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
@@ -4,7 +4,7 @@
 def {{ func.name()|fn_name_py }}({%- call py::arg_list_decl(func) -%}):
     {%- call py::coerce_args(func) %}
     _retval = {% call py::to_ffi_call(func) %}
-    return {{ "_retval"|lift_py(return_type) }}
+    return {{ "_retval"|lift_py(return_type, config) }}
 
 {% when None -%}
 

--- a/uniffi_bindgen/src/bindings/python/templates/wrapper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/wrapper.py
@@ -21,6 +21,19 @@ import struct
 import contextlib
 import datetime
 
+{# Setup our external types #}
+{%- for typ in ci.iter_types() -%}
+{%- match typ -%}
+{%- when Type::ExternalType with (name, primitive_type) -%}
+{%- match config.find_external_type(name) -%}
+{%- when Some with (ext) %}
+{{ ext.setup }} # for {{ name }}
+{%- when None -%}
+{%- endmatch -%}
+{%- else -%}
+{%- endmatch -%}
+{%- endfor %}
+
 {% include "RustBufferTemplate.py" %}
 {% include "RustBufferStream.py" %}
 {% include "RustBufferBuilder.py" %}

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby.rs
@@ -166,6 +166,7 @@ mod filters {
             Type::Float32 | Type::Float64 => format!("{}.to_f", nm),
             Type::Boolean => format!("{} ? true : false", nm),
             Type::Object(_) | Type::Enum(_) | Type::Error(_) | Type::Record(_) => nm.to_string(),
+            Type::ExternalType(_, primitive) => return coerce_rb(nm, &primitive),
             Type::String => format!("{}.to_s", nm),
             Type::Timestamp => panic!("No support for timestamps in Ruby, yet"),
             Type::Duration => panic!("No support for durations in Ruby, yet"),
@@ -212,6 +213,7 @@ mod filters {
             Type::Timestamp => panic!("No support for timestamps in Ruby, yet"),
             Type::Duration => panic!("No support for durations in Ruby, yet"),
             Type::Object(name) => format!("({}._uniffi_lower {})", class_name_rb(name)?, nm),
+            Type::ExternalType(_, primitive) => return lower_rb(nm, &primitive),
             Type::CallbackInterface(_) => panic!("No support for lowering callback interfaces yet"),
             Type::Error(_) => panic!("No support for lowering errors, yet"),
             Type::Enum(_)
@@ -242,6 +244,7 @@ mod filters {
             Type::Timestamp => panic!("No support for timestamps in Ruby, yet"),
             Type::Duration => panic!("No support for durations in Ruby, yet"),
             Type::Object(name) => format!("{}._uniffi_allocate({})", class_name_rb(name)?, nm),
+            Type::ExternalType(..) => panic!("No support for lifting, yet"),
             Type::CallbackInterface(_) => panic!("No support for lifting callback interfaces, yet"),
             Type::Error(_) => panic!("No support for lowering errors, yet"),
             Type::Enum(_)

--- a/uniffi_bindgen/src/bindings/swift/gen_swift.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift.rs
@@ -148,6 +148,7 @@ mod filters {
             Type::Optional(type_) => format!("{}?", type_swift(type_)?),
             Type::Sequence(type_) => format!("[{}]", type_swift(type_)?),
             Type::Map(type_) => format!("[String:{}]", type_swift(type_)?),
+            Type::ExternalType(_name, type_) => return type_swift(type_),
         })
     }
 

--- a/uniffi_bindgen/src/interface/attributes.rs
+++ b/uniffi_bindgen/src/interface/attributes.rs
@@ -32,6 +32,7 @@ pub(super) enum Attribute {
     SelfType(SelfType),
     Threadsafe, // N.B. the `[Threadsafe]` attribute is deprecated and will be removed
     Throws(String),
+    External,
 }
 
 impl Attribute {
@@ -57,6 +58,7 @@ impl TryFrom<&weedle::attribute::ExtendedAttribute<'_>> for Attribute {
                 "Enum" => Ok(Attribute::Enum),
                 "Error" => Ok(Attribute::Error),
                 "Threadsafe" => Ok(Attribute::Threadsafe),
+                "External" => Ok(Attribute::External),
                 _ => anyhow::bail!("ExtendedAttributeNoArgs not supported: {:?}", (attr.0).0),
             },
             // Matches assignment-style attributes like ["Throws=Error"]
@@ -383,6 +385,46 @@ impl TryFrom<&weedle::attribute::IdentifierOrString<'_>> for SelfType {
                 bail!("Unsupported Self Type: {:?}", nm)
             }
         })
+    }
+}
+
+/// Represents UDL attributes that might appear on a typedef
+///
+/// This supports the `[External]` attribute for types which are implemented
+/// externally.
+#[derive(Debug, Clone, Hash, Default)]
+pub(super) struct TypedefAttributes(Vec<Attribute>);
+
+impl TypedefAttributes {
+    pub fn is_external(&self) -> bool {
+        self.0
+            .iter()
+            .any(|attr| matches!(attr, Attribute::External))
+    }
+}
+
+impl TryFrom<&weedle::attribute::ExtendedAttributeList<'_>> for TypedefAttributes {
+    type Error = anyhow::Error;
+    fn try_from(
+        weedle_attributes: &weedle::attribute::ExtendedAttributeList<'_>,
+    ) -> Result<Self, Self::Error> {
+        let attrs = parse_attributes(weedle_attributes, |attr| match attr {
+            Attribute::External => Ok(()),
+            _ => bail!(format!("{:?} not supported for typedefs", attr)),
+        })?;
+        Ok(Self(attrs))
+    }
+}
+
+impl<T: TryInto<TypedefAttributes, Error = anyhow::Error>> TryFrom<Option<T>>
+    for TypedefAttributes
+{
+    type Error = anyhow::Error;
+    fn try_from(value: Option<T>) -> Result<Self, Self::Error> {
+        match value {
+            None => Ok(Default::default()),
+            Some(v) => v.try_into(),
+        }
     }
 }
 

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -616,6 +616,8 @@ impl APIBuilder for weedle::Definition<'_> {
                 let obj = d.convert(ci)?;
                 ci.add_callback_interface_definition(obj);
             }
+            // everything needed for typedefs is done in finder.rs.
+            weedle::Definition::Typedef(_) => {}
             _ => bail!("don't know how to deal with {:?}", self),
         }
         Ok(())

--- a/uniffi_bindgen/src/interface/types/finder.rs
+++ b/uniffi_bindgen/src/interface/types/finder.rs
@@ -21,7 +21,7 @@ use std::convert::TryFrom;
 
 use anyhow::{bail, Result};
 
-use super::super::attributes::{EnumAttributes, InterfaceAttributes};
+use super::super::attributes::{EnumAttributes, InterfaceAttributes, TypedefAttributes};
 use super::{Type, TypeUniverse};
 
 /// Trait to help with an early "type discovery" phase when processing the UDL.
@@ -88,14 +88,30 @@ impl TypeFinder for weedle::EnumDefinition<'_> {
 
 impl TypeFinder for weedle::TypedefDefinition<'_> {
     fn add_type_definitions_to(&self, types: &mut TypeUniverse) -> Result<()> {
-        if self.attributes.is_some() {
-            bail!("no typedef attributes are currently supported");
+        let name = self.identifier.0;
+        let attrs = TypedefAttributes::try_from(self.attributes.as_ref())?;
+        // It is simple to support aliases, but it's not clear they really
+        // add value here and having such different semantics from `[External]`
+        // ones might just add confusion.
+        // If we *did*, it would be as easy as:
+        // > let t = types.resolve_type_expression(&self.type_)?;
+        // > types.add_type_definition(name, t)
+        // (which is very similar to what we do - although we are adding different type)
+        if !attrs.is_external() {
+            bail!("only `[External]` typedefs are supported");
         }
         // For now, we assume that the typedef must refer to an already-defined type, which means
         // we can look it up in the TypeUniverse. This should suffice for our needs for
         // a good long while before we consider implementing a more complex delayed resolution strategy.
         let t = types.resolve_type_expression(&self.type_)?;
-        types.add_type_definition(self.identifier.0, t)
+        match t {
+            // slight tension with `Type` being the "primitive" - `FfiType` is
+            // closer, but awkward in other ways. Let's insist on strings for now.
+            Type::String => {
+                types.add_type_definition(name, Type::ExternalType(name.to_string(), Box::new(t)))
+            }
+            _ => bail!("only external aliases to strings are supported"),
+        }
     }
 }
 
@@ -133,12 +149,13 @@ mod test {
                 constructor();
             };
 
-            typedef TestObject Alias;
+            [External]
+            typedef string Custom;
         "#;
         let idl = weedle::parse(UDL).unwrap();
         let mut types = TypeUniverse::default();
         types.add_type_definitions_from(idl.as_ref())?;
-        assert_eq!(types.iter_known_types().count(), 5);
+        assert_eq!(types.iter_known_types().count(), 7);
         assert!(
             matches!(types.get_type_definition("TestCallbacks").unwrap(), Type::CallbackInterface(nm) if nm == "TestCallbacks")
         );
@@ -155,24 +172,35 @@ mod test {
             matches!(types.get_type_definition("TestObject").unwrap(), Type::Object(nm) if nm == "TestObject")
         );
         assert!(
-            matches!(types.get_type_definition("Alias").unwrap(), Type::Object(nm) if nm == "TestObject")
+            matches!(types.get_type_definition("Custom").unwrap(), Type::ExternalType(nm, prim) if nm == "Custom" && prim == Box::new(Type::String))
         );
         Ok(())
     }
 
-    #[test]
-    fn test_error_on_unresolved_typedef() {
-        const UDL: &str = r#"
-            // Sorry, no forward declarations yet...
-            typedef TestRecord Alias;
-
-            dictionary TestRecord {
-                u32 field;
-            };
-        "#;
-        let idl = weedle::parse(UDL).unwrap();
+    fn get_err(udl: &str) -> String {
+        let parsed = weedle::parse(udl).unwrap();
         let mut types = TypeUniverse::default();
-        let err = types.add_type_definitions_from(idl.as_ref()).unwrap_err();
-        assert_eq!(err.to_string(), "unknown type reference: TestRecord");
+        let err = types
+            .add_type_definitions_from(parsed.as_ref())
+            .unwrap_err();
+        err.to_string()
+    }
+
+    #[test]
+    fn test_typedef_error_on_not_external() {
+        // Sorry, still working out what we want for non-external typedefs..
+        assert_eq!(
+            get_err("typedef string Custom;"),
+            "only `[External]` typedefs are supported"
+        );
+    }
+
+    #[test]
+    fn test_typedef_error_on_invalid_type() {
+        // Sorry, still working out what we want for non-strings
+        assert_eq!(
+            get_err("[External]typedef u32 Custom;"),
+            "only external aliases to strings are supported"
+        );
     }
 }

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -62,6 +62,9 @@ pub enum Type {
     Optional(Box<Type>),
     Sequence(Box<Type>),
     Map(/* String, */ Box<Type>),
+    // Types external to uniffi and converted via traits, setup via typedefs.
+    // Tuple of name and the type it is serialized as.
+    ExternalType(String, Box<Type>),
 }
 
 impl Type {
@@ -105,6 +108,8 @@ impl Type {
             Type::Optional(t) => format!("Optional{}", t.canonical_name()),
             Type::Sequence(t) => format!("Sequence{}", t.canonical_name()),
             Type::Map(t) => format!("Map{}", t.canonical_name()),
+            // A type that exists externally.
+            Type::ExternalType(nm, _) => format!("ExternalType{}", nm),
         }
     }
 }
@@ -147,6 +152,8 @@ impl From<&Type> for FFIType {
             | Type::Map(_)
             | Type::Timestamp
             | Type::Duration => FFIType::RustBuffer,
+            // The external type carries the primitive type that's used over the ffi.
+            Type::ExternalType(_, primitive) => FFIType::from(&**primitive),
         }
     }
 }

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -42,7 +42,7 @@ mod filters {
             Type::String => "String".into(),
             Type::Timestamp => "std::time::SystemTime".into(),
             Type::Duration => "std::time::Duration".into(),
-            Type::Enum(name) | Type::Record(name) | Type::Error(name) => name.clone(),
+            Type::Enum(name) | Type::Record(name) | Type::Error(name) | Type::ExternalType(name, _) => name.clone(),
             Type::Object(name) => format!("std::sync::Arc<{}>", name),
             Type::CallbackInterface(name) => format!("Box<dyn {}>", name),
             Type::Optional(t) => format!("Option<{}>", type_rs(t)?),


### PR DESCRIPTION
An experiment for what I described in #475.

The most interesting part is [a new fixture](https://github.com/mhammond/uniffi-rs/tree/typedefs/fixtures/external-types). It implements 2 types - a `Guid` and a `JSONObject`, with the idea that all languages except rust could use Guid as a String, but `JSONObject` would have all languages have a custom type. This support for foreign types is defined in [uniffi.toml](https://github.com/mhammond/uniffi-rs/blob/typedefs/fixtures/external-types/uniffi.toml) and only exists for Python, but I think should work fine in the others.

The JSONObject is a bit clunky - it would be perfect if rust could use serde::Value directly, but the "no traits on external types" means we need to wrap it. If we could use serde directly, the ergonomics for both sides of the FFI here seem almost identical to what we'd end up with otherwise.

Error handling will need some thought - if we are wrapping a function that doesn't Err<>, then do we allow use of custom types which might fail, or do we just unwrap for them? Everything currently unwraps, which is bad.

Quite a few other details you'll find too :)