### PR TITLE
Fixes mismatch in kotlin panic exceptions

### DIFF
--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -56,6 +56,9 @@ interface Coveralls {
 
     void panic(string message);
 
+    [Throws=CoverallError]
+    void fallible_panic(string message);
+
     // *** Test functions which take either `self` or other params as `Arc<Self>` ***
 
     /// Calls `Arc::strong_count()` on the `Arc` containing `self`.

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -125,6 +125,10 @@ impl Coveralls {
         }
     }
 
+    fn fallible_panic(&self, message: String) -> Result<()> {
+        panic!("{}", message);
+    }
+
     fn get_name(&self) -> String {
         self.name.clone()
     }

--- a/fixtures/coverall/tests/bindings/test_coverall.kts
+++ b/fixtures/coverall/tests/bindings/test_coverall.kts
@@ -68,6 +68,13 @@ Coveralls("test_arcs").use { coveralls ->
     } catch (e: InternalException) {
         // No problemo!
     }
+
+    try {
+        coveralls.falliblePanic("Expected panic in a fallible function!")
+        throw RuntimeException("Should have thrown an InternalException")
+    } catch (e: InternalException) {
+        // No problemo!
+    }
     coveralls.takeOther(null);
     assert(coveralls.strongCount() == 2UL);
 }

--- a/fixtures/coverall/tests/bindings/test_coverall.swift
+++ b/fixtures/coverall/tests/bindings/test_coverall.swift
@@ -66,6 +66,11 @@ do {
     }
     // TODO: kinda hard to test this, as it triggers a fatal error.
     // coveralls!.takeOtherPanic(message: "expected panic: with an arc!")
+    // do {
+    //     try coveralls.falliblePanic(message: "Expected Panic!!")
+    // } catch CoverallError.TooManyHoles {
+    //     fatalError("Should have paniced!")
+    // }
     coveralls.takeOther(other: nil);
     assert(coveralls.strongCount() == 2);
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
@@ -113,7 +113,8 @@ internal open class {{e.name()}} : RustError() {
             {% for value in e.values() -%}
             {{loop.index}} -> return {{e.name()}}Exception.{{value}}(message) as E
             {% endfor -%}
-            else -> return InternalException(message) as E
+            -1 -> return InternalException(message) as E
+            else -> throw RuntimeException("invalid error code passed across the FFI")
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
@@ -113,7 +113,7 @@ internal open class {{e.name()}} : RustError() {
             {% for value in e.values() -%}
             {{loop.index}} -> return {{e.name()}}Exception.{{value}}(message) as E
             {% endfor -%}
-            else -> throw RuntimeException("Invalid error received: $code, $message")
+            else -> return InternalException(message) as E
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
@@ -83,12 +83,16 @@ public enum {{e.name()}}: RustError {
         switch rustError.code {
             case 0:
                 return nil
+            case -1:
+            // TODO: Return a Uniffi defined error here
+            // to indicate a panic
+                fatalError("Panic detected!")
             {% for value in e.values() %}
             case {{loop.index}}:
                 return .{{value}}(message: String(cString: message!))
             {% endfor %}
             default:
-                return nil
+                fatalError("Invalid error")
         }
     }
 }


### PR DESCRIPTION
fixes #485 

As a follow-up I'll take a look at the other bindings and make sure this behaviour is consistent. I'll file an issue to add a coverall.falliblePanic test for the other bindings (which will include figuring out if this behaviour is also wrong there), ref for follow up: #487 