### PR TITLE
Fixed timestamp conversion during DST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### What's Changed
 
 - Both python and ruby backends now handle U16 correctly.
+- Python timestamps will now be in UTC and timezone-aware rather than naive.
 
 ## v0.12.0 (2021-06-14)
 

--- a/fixtures/uniffi-fixture-time/tests/bindings/test_chronological.py
+++ b/fixtures/uniffi-fixture-time/tests/bindings/test_chronological.py
@@ -3,39 +3,40 @@ from datetime import datetime, timedelta, timezone, MAXYEAR
 import sys
 
 # Test passing timestamp and duration while returning timestamp
-assert add(datetime.fromtimestamp(100.000001), timedelta(seconds=1, microseconds=1)).timestamp() == 101.000002
+assert add(datetime.fromtimestamp(100.000001, timezone.utc), timedelta(seconds=1, microseconds=1)).timestamp() == 101.000002
 
 # Test passing timestamp while returning duration
-assert diff(datetime.fromtimestamp(101.000002), datetime.fromtimestamp(100.000001)) == timedelta(seconds=1, microseconds=1)
+assert diff(datetime.fromtimestamp(101.000002, timezone.utc), datetime.fromtimestamp(100.000001, timezone.utc)) == timedelta(seconds=1, microseconds=1)
 
 # Test pre-epoch timestamps
-assert add(datetime.fromisoformat('1955-11-05T00:06:00.283001'), timedelta(seconds=1, microseconds=1)) == datetime.fromisoformat('1955-11-05T00:06:01.283002')
+assert add(datetime.fromisoformat('1955-11-05T00:06:00.283001+00:00'), timedelta(seconds=1, microseconds=1)) == datetime.fromisoformat('1955-11-05T00:06:01.283002+00:00')
 
 # Test exceptions are propagated
 try:
-    diff(datetime.fromtimestamp(100), datetime.fromtimestamp(101))
+    diff(datetime.fromtimestamp(100, timezone.utc), datetime.fromtimestamp(101, timezone.utc))
     assert(not("Should have thrown a TimeDiffError exception!"))
 except ChronologicalError.TimeDiffError:
     # It's okay!
     pass
 
 # Test near max timestamp bound, no microseconds due to python floating point precision issues
-assert add(datetime(MAXYEAR, 12, 31, 23, 59, 59, 0), timedelta(seconds=0)) == datetime(MAXYEAR, 12, 31, 23, 59, 59, 0)
+assert add(datetime(MAXYEAR, 12, 31, 23, 59, 59, 0, tzinfo=timezone.utc), timedelta(seconds=0)) == datetime(MAXYEAR, 12, 31, 23, 59, 59, 0, tzinfo=timezone.utc)
 
 # Test overflow at max timestamp bound
 try:
-    add(datetime(MAXYEAR, 12, 31, 23, 59, 59, 0), timedelta(seconds=1))
+    add(datetime(MAXYEAR, 12, 31, 23, 59, 59, 0, tzinfo=timezone.utc), timedelta(seconds=1))
     assert(not("Should have thrown a ValueError exception!"))
 except OverflowError:
     # It's okay!
     pass
 
 # Test that rust timestamps behave like kotlin timestamps
-pythonBefore = datetime.now()
+pythonBefore = datetime.now(timezone.utc)
 rustNow = now()
-pythonAfter = datetime.now()
+pythonAfter = datetime.now(timezone.utc)
 
 assert pythonBefore <= rustNow <= pythonAfter
 
-# Test that uniffi returns naive datetime
-assert now().tzinfo is None
+# Test that uniffi returns UTC times
+assert now().tzinfo is timezone.utc
+assert abs(datetime.now(timezone.utc) - now()) <= timedelta(seconds=1)

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
@@ -109,12 +109,12 @@ class RustBufferBuilder(object):
     {% when Type::Timestamp -%}
 
     def write{{ canonical_type_name }}(self, v):
-        if v >= datetime.datetime.fromtimestamp(0):
+        if v >= datetime.datetime.fromtimestamp(0, datetime.timezone.utc):
             sign = 1
-            delta = v - datetime.datetime.fromtimestamp(0)
+            delta = v - datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
         else:
             sign = -1
-            delta = datetime.datetime.fromtimestamp(0) - v
+            delta = datetime.datetime.fromtimestamp(0, datetime.timezone.utc) - v
 
         seconds = delta.seconds + delta.days * 24 * 3600
         nanoseconds = delta.microseconds * 1000

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
@@ -113,10 +113,13 @@ class RustBufferStream(object):
     def read{{ canonical_type_name }}(self):
         seconds = self._unpack_from(8, ">q")
         microseconds = self._unpack_from(4, ">I") / 1000
+        # Use fromtimestamp(0) then add the seconds using a timedelta.  This
+        # ensures that we get OverflowError rather than ValueError when
+        # seconds is too large.
         if seconds >= 0:
-            return datetime.datetime.fromtimestamp(0, tz=None) + datetime.timedelta(seconds=seconds, microseconds=microseconds)
+            return datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc) + datetime.timedelta(seconds=seconds, microseconds=microseconds)
         else:
-            return datetime.datetime.fromtimestamp(0, tz=None) - datetime.timedelta(seconds=-seconds, microseconds=microseconds)
+            return datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc) - datetime.timedelta(seconds=-seconds, microseconds=microseconds)
 
     {% when Type::Duration -%}
     # The Duration type.


### PR DESCRIPTION
I'm not totally sure about this one, but I believe it's an improvement.  Here's snippet showing how the two pieces of code are different (NOTE, the same snippet may give you a different result if you're not in the Eastern timezone):

```
>>> print(datetime.datetime.fromtimestamp(1623965559))
2021-06-17 17:32:39
>>> print(datetime.datetime.fromtimestamp(0) + datetime.timedelta(seconds=1623965559))
2021-06-17 16:32:39
```
 
OTOH, I don't like the way we have to catch all ValueErrors and convert them to OverflowErrors.  [The python docs say that this was changed in version 3.3](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromtimestamp).  They also say that there's some errors that get classified as OSErrors.  With this code, they will get misclassified as OverflowErrors.  But it seems to me the DST issue is more likely to cause problems than failures in `localtime()`

BTW, what version of python are we targetting with uniffi?