### PR TITLE
Adds ktlint to kotlin requirements in contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -47,7 +47,8 @@ recommend installing the language dependencies on your local machine. In order t
 test suite you will need:
 
 * Kotlin:
-  * `kotlinc`, the [Kotlin command-line compiler](https://kotlinlang.org/docs/command-line.html)
+  * `kotlinc`, the [Kotlin command-line compiler](https://kotlinlang.org/docs/command-line.html).
+  * `ktlint`, the [Kotlin linter used to format the generated bindings](https://ktlint.github.io/).
   * The [Java Native Access](https://github.com/java-native-access/jna#download) JAR downloaded and its path
     added to your `$CLASSPATH` environment variable.
 * Swift:


### PR DESCRIPTION
~~I remember having to install ktlint to have the kotlin tests pass on my local environment~~ Looks like it just emits a message saying that that the files couldn't be formated, nevertheless, we should probably add it to our docs so adding that to the `contributing.md`


(as a side point, when picking who to review this, should I be picking `uniffi-devs` or `uniffi-review`? I notice `uniffi-devs` is the more complete list?)