### PR TITLE
Generates cargo clippy safe code

### DIFF
--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -40,7 +40,6 @@ pub extern "C" fn {{ ffi_free.name() }}(ptr: *const std::os::raw::c_void) {
 }
 
 {%- for cons in obj.constructors() %}
-    #[allow(clippy::all)]
     #[doc(hidden)]
     #[no_mangle]
     pub extern "C" fn {{ cons.ffi_func().name() }}(
@@ -57,12 +56,11 @@ pub extern "C" fn {{ ffi_free.name() }}(ptr: *const std::os::raw::c_void) {
 {%- endfor %}
 
 {%- for meth in obj.methods() %}
-    #[allow(clippy::all)]
     #[doc(hidden)]
     #[no_mangle]
     pub extern "C" fn {{ meth.ffi_func().name() }}(
         {%- call rs::arg_list_ffi_decl(meth.ffi_func()) %}
-    ) -> {% call rs::return_type_func(meth) %} {
+    ) {% call rs::return_signature(meth) %} {
         uniffi::deps::log::debug!("{{ meth.ffi_func().name() }}");
         // If the method does not have the same signature as declared in the UDL, then
         // this attempt to call it will fail with a (somewhat) helpful compiler error.

--- a/uniffi_bindgen/src/scaffolding/templates/TopLevelFunctionTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/TopLevelFunctionTemplate.rs
@@ -4,12 +4,11 @@
 // send data across the FFI, which will fail to compile if the provided function does not match what's
 // specified in the UDL.    
 #}
-#[allow(clippy::all)]
 #[doc(hidden)]
 #[no_mangle]
 pub extern "C" fn {{ func.ffi_func().name() }}(
     {% call rs::arg_list_ffi_decl(func.ffi_func()) %}
-) -> {% call rs::return_type_func(func) %} {
+) {% call rs::return_signature(func) %} {
     // If the provided function does not match the signature specified in the UDL
     // then this attempt to call it will not compile, and will give guidance as to why.
     uniffi::deps::log::debug!("{{ func.ffi_func().name() }}");


### PR DESCRIPTION
fixes #257 

We had two main issues with the generated code clippy-wise:
- We had a `-> ()` on ffi functions that don't have a return value, clippy prefers if you simply omit that. For example:
```rust
pub exter "C" fn func() -> () {  // clippy prefers if we remove the "-> ()"
.
.
}
```
- We had a `let` binding to functions that don't return `Result`, clippy wanted us to simply return the called library function. For example:
```rust
uniffi::deps::ffi_support::call_with_output(err, || {
let _retval = rust_library_func();
_retval // clippy prefers if instead of those two lines, we just did "rust_library_func()" and returned that
}
```

Before merging, I'll try this out on `fxa_client` and make sure that it indeed generates clippy safe code. I manually installed `uniffi-bindgen` from local source code and ran `cargo clippy` in Application Services and it seems fine, but for some reason I can't locate the generated bindings and I wanna double check that