### PR TITLE
Replace lower_into_buffer and try_lift_from_buffer with a trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- The sections in this file are intended to be managed automatically by `cargo release` -->
+  <!-- The sections in this file are intended to be managed automatically by `cargo release` -->
 <!-- See https://github.com/sunng87/cargo-release/blob/master/docs/faq.md#maintaining-changelog for details -->
 <!-- Unfortunately that doesn't currently work in a workspace, so for now we update it by hand: -->
 <!--   * Replace `[[UnreleasedVersion]]` with `vX.Y.Z` -->
@@ -19,6 +19,10 @@
 
 - Both python and ruby backends now handle U16 correctly.
 - Python timestamps will now be in UTC and timezone-aware rather than naive.
+- Replaced `lower_into_buffer()` and `try_lift_from_buffer()` with the
+  `RustBufferViaFfi` trait.  If you use those functions in your custom ViaFfi
+  implementation then you'll need to update the code.  Check out the `Option<>`
+  implementation in uniffi/src/lib.rs for an example.
 
 ## v0.12.0 (2021-06-14)
 

--- a/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
@@ -4,17 +4,7 @@
 // compile if the provided struct has a different shape to the one declared in the UDL.
 #}
 #[doc(hidden)]
-unsafe impl uniffi::ViaFfi for {{ e.name() }} {
-    type FfiType = uniffi::RustBuffer;
-
-    fn lower(self) -> Self::FfiType {
-        uniffi::lower_into_buffer(self)
-    }
-
-    fn try_lift(v: Self::FfiType) -> uniffi::deps::anyhow::Result<Self> {
-        uniffi::try_lift_from_buffer(v)
-    }
-
+impl uniffi::RustBufferViaFfi for {{ e.name() }} {
     fn write(&self, buf: &mut Vec<u8>) {
         use uniffi::deps::bytes::BufMut;
         match self {

--- a/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
@@ -5,17 +5,7 @@
 // compiler will complain with a type error.
 #}
 #[doc(hidden)]
-unsafe impl uniffi::ViaFfi for {{ rec.name() }} {
-    type FfiType = uniffi::RustBuffer;
-
-    fn lower(self) -> Self::FfiType {
-        uniffi::lower_into_buffer(self)
-    }
-
-    fn try_lift(v: Self::FfiType) -> uniffi::deps::anyhow::Result<Self> {
-        uniffi::try_lift_from_buffer(v)
-    }
-
+impl uniffi::RustBufferViaFfi for {{ rec.name() }} {
     fn write(&self, buf: &mut Vec<u8>) {
         // If the provided struct doesn't match the fields declared in the UDL, then
         // the generated code here will fail to compile with somewhat helpful error.


### PR DESCRIPTION
I'm not totally sure about this one, but it seems like it could be an improvement.  What do you all think?

The main motivation is to eliminate the possibility of calling
`try_lift_from_buffer()` on a `RustBuffer` that wasn't created with
`lower_into_buffer()`.  For example, this code seems reasonable, but it
totally fails:

```
let buf: RustBuffer = ViaFfi::lower("Test".to_string());
assert_eq!(try_lift_from_buffer::<String>(buf).unwrap(), "Test")
```

This is because Strings have an asymmetry between `lower()` and
`write()`.  `write()` needs to write out the string length, but
`lower()` can optimize to avoid that and just use `RustBuffer.len`.

It also reduces some boilerplate code, which is nice too.