### PR TITLE
Compatibility updates for latest askama

### DIFF
--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -18,7 +18,8 @@ path = "src/main.rs"
 cargo_metadata = "0.13"
 weedle = "0.12"
 anyhow = "1"
-askama = { version = "0.10", default-features = false, features = ["config"] }
+askama = { git = "https://github.com/djc/askama", branch = "main", features = ["config"] }
+#askama = { version = "0.10", default-features = false, features = ["config"] }
 heck = "0.3"
 clap = { version = "2", default-features = false }
 serde = "1"

--- a/uniffi_bindgen/src/bindings/gecko_js/gen_gecko_js.rs
+++ b/uniffi_bindgen/src/bindings/gecko_js/gen_gecko_js.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::borrow::Borrow;
 use std::borrow::Cow;
 
 use anyhow::Result;
@@ -262,7 +263,7 @@ mod filters {
     ///   In WebIDL, arguments with default values must have the `optional`
     ///   keyword.
     pub fn type_webidl(
-        type_: &WebIDLType,
+        type_: &WebIDLType<'_>,
         context: &Context<'_, '_>,
     ) -> Result<String, askama::Error> {
         Ok(match type_ {
@@ -342,7 +343,7 @@ mod filters {
 
     /// Declares a C++ type.
     pub fn type_cpp(
-        type_: &WebIDLType,
+        type_: &WebIDLType<'_>,
         context: &Context<'_, '_>,
     ) -> Result<String, askama::Error> {
         Ok(match type_ {
@@ -384,7 +385,7 @@ mod filters {
     }
 
     fn in_arg_type_cpp(
-        type_: &WebIDLType,
+        type_: &WebIDLType<'_>,
         context: &Context<'_, '_>,
     ) -> Result<String, askama::Error> {
         Ok(match type_ {
@@ -418,7 +419,7 @@ mod filters {
                 match arg.webidl_type() {
                     WebIDLType::Flat(Type::String) => "const nsAString&".into(),
                     WebIDLType::Flat(Type::Object(name)) => {
-                        format!("{}&", class_name_cpp(&name, context)?)
+                        format!("{}&", class_name_cpp(name, context)?)
                     }
                     WebIDLType::Nullable(inner) => match inner.as_ref() {
                         WebIDLType::Flat(Type::String) => "const nsAString&".into(),
@@ -454,7 +455,7 @@ mod filters {
 
     /// Declares a C++ return type.
     pub fn ret_type_cpp(
-        type_: &WebIDLType,
+        type_: &WebIDLType<'_>,
         context: &Context<'_, '_>,
     ) -> Result<String, askama::Error> {
         Ok(match type_ {
@@ -475,7 +476,7 @@ mod filters {
     /// declares a return type must return some value of that type, even if it
     /// throws a DOM exception via the `ErrorResult`.
     pub fn dummy_ret_value_cpp(
-        return_type: &WebIDLType,
+        return_type: &WebIDLType<'_>,
         context: &Context<'_, '_>,
     ) -> Result<String, askama::Error> {
         Ok(match return_type {
@@ -510,7 +511,7 @@ mod filters {
     /// Generates an expression for lowering a C++ type into a C type when
     /// calling an FFI function.
     pub fn lower_cpp(
-        type_: &WebIDLType,
+        type_: &WebIDLType<'_>,
         from: &str,
         context: &Context<'_, '_>,
     ) -> Result<String, askama::Error> {
@@ -538,7 +539,7 @@ mod filters {
     /// Generates an expression for lifting a C return type from the FFI into a
     /// C++ out parameter.
     pub fn lift_cpp(
-        type_: &WebIDLType,
+        type_: &WebIDLType<'_>,
         from: &str,
         into: &str,
         context: &Context<'_, '_>,

--- a/uniffi_bindgen/src/bindings/gecko_js/gen_gecko_js.rs
+++ b/uniffi_bindgen/src/bindings/gecko_js/gen_gecko_js.rs
@@ -395,7 +395,7 @@ mod filters {
                 _ => format!("Nullable<{}>", in_arg_type_cpp(inner, context)?),
             },
             WebIDLType::Sequence(inner) => {
-                format!("Sequence<{}>", in_arg_type_cpp(&inner, context)?)
+                format!("Sequence<{}>", in_arg_type_cpp(inner, context)?)
             }
             _ => type_cpp(type_, context)?,
         })
@@ -423,7 +423,7 @@ mod filters {
                     WebIDLType::Nullable(inner) => match inner.as_ref() {
                         WebIDLType::Flat(Type::String) => "const nsAString&".into(),
                         WebIDLType::Flat(Type::Object(name)) => {
-                            format!("{}*", class_name_cpp(&name, context)?)
+                            format!("{}*", class_name_cpp(name, context)?)
                         }
                         _ => format!("const {}&", in_arg_type_cpp(&arg.webidl_type(), context)?),
                     },

--- a/uniffi_bindgen/src/bindings/gecko_js/templates/SharedHeaderTemplate.h
+++ b/uniffi_bindgen/src/bindings/gecko_js/templates/SharedHeaderTemplate.h
@@ -68,7 +68,7 @@ template <>
 struct Serializable<{{ rec.name()|class_name_cpp(context) }}> {
   [[nodiscard]] static bool ReadFrom(Reader& aReader, {{ rec.name()|class_name_cpp(context) }}& aValue) {
     {%- for field in rec.fields() %}
-    if (!Serializable<{{ field.webidl_type()|type_cpp(context) }}>::ReadFrom(aReader, aValue.{{ field.name()|field_name_cpp }})) {
+    if (!Serializable<{{ field.webidl_type().borrow()|type_cpp(context) }}>::ReadFrom(aReader, aValue.{{ field.name()|field_name_cpp }})) {
       return false;
     }
     {%- endfor %}
@@ -77,7 +77,7 @@ struct Serializable<{{ rec.name()|class_name_cpp(context) }}> {
 
   static void WriteInto(Writer& aWriter, const {{ rec.name()|class_name_cpp(context) }}& aValue) {
     {%- for field in rec.fields() %}
-    Serializable<{{ field.webidl_type()|type_cpp(context) }}>::WriteInto(aWriter, aValue.{{ field.name()|field_name_cpp }});
+    Serializable<{{ field.webidl_type().borrow()|type_cpp(context) }}>::WriteInto(aWriter, aValue.{{ field.name()|field_name_cpp }});
     {%- endfor %}
   }
 };

--- a/uniffi_bindgen/src/bindings/gecko_js/templates/WebIDLTemplate.webidl
+++ b/uniffi_bindgen/src/bindings/gecko_js/templates/WebIDLTemplate.webidl
@@ -4,7 +4,7 @@
 {%- for rec in ci.iter_record_definitions() %}
 dictionary {{ rec.name()|class_name_webidl(context)  }} {
   {%- for field in rec.fields() %}
-  {% if field.required() -%}required{%- else -%}{%- endif %} {{ field.webidl_type()|type_webidl(context) }} {{ field.name()|var_name_webidl }}
+  {% if field.required() -%}required{%- else -%}{%- endif %} {{ field.webidl_type().borrow()|type_webidl(context) }} {{ field.name()|var_name_webidl }}
   {%- match field.webidl_default_value() %}
   {%- when Some with (literal) %} = {{ literal|literal_webidl }}
   {%- else %}
@@ -35,7 +35,7 @@ namespace {{ context.namespace()|class_name_webidl(context) }} {
   {% endif %}
   {%- match func.webidl_return_type() -%}{%- when Some with (type_) %}{{ type_|type_webidl(context) }}{% when None %}void{% endmatch %} {{ func.name()|fn_name_webidl }}(
     {%- for arg in func.arguments() %}
-    {% if arg.optional() -%}optional{%- else -%}{%- endif %} {{ arg.webidl_type()|type_webidl(context) }} {{ arg.name() }}
+    {% if arg.optional() -%}optional{%- else -%}{%- endif %} {{ arg.webidl_type().borrow()|type_webidl(context) }} {{ arg.name() }}
     {%- match arg.webidl_default_value() %}
     {%- when Some with (literal) %} = {{ literal|literal_webidl }}
     {%- else %}
@@ -58,7 +58,7 @@ interface {{ obj.name()|class_name_webidl(context)  }} {
   {% endif %}
   constructor(
       {%- for arg in cons.arguments() %}
-      {% if arg.optional() -%}optional{%- else -%}{%- endif %} {{ arg.webidl_type()|type_webidl(context) }} {{ arg.name() }}
+      {% if arg.optional() -%}optional{%- else -%}{%- endif %} {{ arg.webidl_type().borrow()|type_webidl(context) }} {{ arg.name() }}
       {%- match arg.webidl_default_value() %}
       {%- when Some with (literal) %} = {{ literal|literal_webidl }}
       {%- else %}
@@ -75,7 +75,7 @@ interface {{ obj.name()|class_name_webidl(context)  }} {
   {% endif %}
   {{ obj.name()|class_name_webidl(context)  }} {{ cons.name()|fn_name_webidl }}(
       {%- for arg in cons.arguments() %}
-      {% if arg.optional() -%}optional{%- else -%}{%- endif %} {{ arg.webidl_type()|type_webidl(context) }} {{ arg.name() }}
+      {% if arg.optional() -%}optional{%- else -%}{%- endif %} {{ arg.webidl_type().borrow()|type_webidl(context) }} {{ arg.name() }}
       {%- match arg.webidl_default_value() %}
       {%- when Some with (literal) %} = {{ literal|literal_webidl }}
       {%- else %}
@@ -91,7 +91,7 @@ interface {{ obj.name()|class_name_webidl(context)  }} {
   {% endif %}
   {%- match meth.webidl_return_type() -%}{%- when Some with (type_) %}{{ type_|type_webidl(context) }}{% when None %}void{% endmatch %} {{ meth.name()|fn_name_webidl }}(
       {%- for arg in meth.arguments() %}
-      {% if arg.optional() -%}optional{%- else -%}{%- endif %} {{ arg.webidl_type()|type_webidl(context) }} {{ arg.name() }}
+      {% if arg.optional() -%}optional{%- else -%}{%- endif %} {{ arg.webidl_type().borrow()|type_webidl(context) }} {{ arg.name() }}
       {%- match arg.webidl_default_value() %}
       {%- when Some with (literal) %} = {{ literal|literal_webidl }}
       {%- else %}

--- a/uniffi_bindgen/src/bindings/gecko_js/templates/macros.cpp
+++ b/uniffi_bindgen/src/bindings/gecko_js/templates/macros.cpp
@@ -11,8 +11,8 @@
     {{ prefix }}
     {%- let args = func.arguments() -%}
     {%- if !args.is_empty() %},{% endif -%}
-    {%- for arg in args %}
-    {{ arg.webidl_type()|lower_cpp(arg.name(), context) }}{%- if !loop.last %},{% endif -%}
+    {%- for arg in args.iter() %}
+    {{ arg.webidl_type().borrow()|lower_cpp(arg.name(), context) }}{%- if !loop.last %},{% endif -%}
     {%- endfor %}
     , &err
   );
@@ -26,8 +26,8 @@
   {{ context.ffi_rusterror_type() }} {{ error }} = {0, nullptr};
   {% match func.ffi_func().return_type() %}{% when Some with (type_) %}const {{ type_|type_ffi(context) }} {{ result }} ={% else %}{% endmatch %}{{ func.ffi_func().name() }}(
     {%- let args = func.arguments() -%}
-    {%- for arg in args %}
-    {{ arg.webidl_type()|lower_cpp(arg.name(), context) }}{%- if !loop.last %},{% endif -%}
+    {%- for arg in args.iter() %}
+    {{ arg.webidl_type().borrow()|lower_cpp(arg.name(), context) }}{%- if !loop.last %},{% endif -%}
     {%- endfor %}
     {% if !args.is_empty() %}, {% endif %}&{{ error }}
   );

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin.rs
@@ -69,7 +69,6 @@ impl<'a> KotlinWrapper<'a> {
 
 mod filters {
     use super::*;
-    use std::fmt;
 
     /// Get the Kotlin syntax for representing a given api-level `Type`.
     pub fn type_kt(type_: &Type) -> Result<String, askama::Error> {
@@ -166,22 +165,24 @@ mod filters {
     }
 
     /// Get the idiomatic Kotlin rendering of a class name (for enums, records, errors, etc).
-    pub fn class_name_kt(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
-        Ok(nm.to_string().to_camel_case())
+    pub fn class_name_kt<T: AsRef<str>>(nm: T) -> Result<String, askama::Error> {
+        // Using `T: Into<String>` would be neater here, but Askama likes to add
+        // several layers of references, and they make the `Into` mapping not work.
+        Ok(nm.as_ref().to_string().to_camel_case())
     }
 
     /// Get the idiomatic Kotlin rendering of a function name.
-    pub fn fn_name_kt(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+    pub fn fn_name_kt(nm: &str) -> Result<String, askama::Error> {
         Ok(nm.to_string().to_mixed_case())
     }
 
     /// Get the idiomatic Kotlin rendering of a variable name.
-    pub fn var_name_kt(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+    pub fn var_name_kt(nm: &str) -> Result<String, askama::Error> {
         Ok(nm.to_string().to_mixed_case())
     }
 
     /// Get the idiomatic Kotlin rendering of an individual enum variant.
-    pub fn enum_variant_kt(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+    pub fn enum_variant_kt(nm: &str) -> Result<String, askama::Error> {
         Ok(nm.to_string().to_shouty_snake_case())
     }
 
@@ -189,7 +190,7 @@ mod filters {
     ///
     /// Where possible, this delegates to a `lower()` method on the type itself, but special
     /// handling is required for some compound data types.
-    pub fn lower_kt(nm: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
+    pub fn lower_kt(nm: &str, type_: &Type) -> Result<String, askama::Error> {
         let nm = var_name_kt(nm)?;
         Ok(match type_ {
             Type::CallbackInterface(_) => format!(
@@ -212,11 +213,7 @@ mod filters {
     ///
     /// Where possible, this delegates to a `write()` method on the type itself, but special
     /// handling is required for some compound data types.
-    pub fn write_kt(
-        nm: &dyn fmt::Display,
-        target: &dyn fmt::Display,
-        type_: &Type,
-    ) -> Result<String, askama::Error> {
+    pub fn write_kt(nm: &str, target: &str, type_: &Type) -> Result<String, askama::Error> {
         let nm = var_name_kt(nm)?;
         Ok(match type_ {
             Type::CallbackInterface(_) => format!(
@@ -243,7 +240,7 @@ mod filters {
     ///
     /// Where possible, this delegates to a `lift()` method on the type itself, but special
     /// handling is required for some compound data types.
-    pub fn lift_kt(nm: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
+    pub fn lift_kt(nm: &str, type_: &Type) -> Result<String, askama::Error> {
         let nm = nm.to_string();
         Ok(match type_ {
             Type::CallbackInterface(_) => format!(
@@ -264,7 +261,7 @@ mod filters {
     ///
     /// Where possible, this delegates to a `read()` method on the type itself, but special
     /// handling is required for some compound data types.
-    pub fn read_kt(nm: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
+    pub fn read_kt(nm: &str, type_: &Type) -> Result<String, askama::Error> {
         let nm = nm.to_string();
         Ok(match type_ {
             Type::CallbackInterface(_) => format!(

--- a/uniffi_bindgen/src/bindings/kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/mod.rs
@@ -24,11 +24,11 @@ pub fn write_bindings(
     try_format_code: bool,
     _is_testing: bool,
 ) -> Result<()> {
-    let mut kt_file = full_bindings_path(&config, out_dir)?;
+    let mut kt_file = full_bindings_path(config, out_dir)?;
     std::fs::create_dir_all(&kt_file)?;
     kt_file.push(format!("{}.kt", ci.namespace()));
     let mut f = File::create(&kt_file).context("Failed to create .kt file for bindings")?;
-    write!(f, "{}", generate_bindings(config, &ci)?)?;
+    write!(f, "{}", generate_bindings(config, ci)?)?;
     if try_format_code {
         if let Err(e) = Command::new("ktlint")
             .arg("-F")
@@ -53,7 +53,7 @@ fn full_bindings_path(config: &Config, out_dir: &Path) -> Result<PathBuf> {
 // Generate kotlin bindings for the given ComponentInterface, as a string.
 pub fn generate_bindings(config: &Config, ci: &ComponentInterface) -> Result<String> {
     use askama::Template;
-    KotlinWrapper::new(config.clone(), &ci)
+    KotlinWrapper::new(config.clone(), ci)
         .render()
         .map_err(|_| anyhow::anyhow!("failed to render kotlin bindings"))
 }

--- a/uniffi_bindgen/src/bindings/mod.rs
+++ b/uniffi_bindgen/src/bindings/mod.rs
@@ -120,19 +120,19 @@ where
     let out_dir = out_dir.as_ref();
     match language {
         TargetLanguage::Kotlin => {
-            kotlin::write_bindings(&config.kotlin, &ci, out_dir, try_format_code, is_testing)?
+            kotlin::write_bindings(&config.kotlin, ci, out_dir, try_format_code, is_testing)?
         }
         TargetLanguage::Swift => {
-            swift::write_bindings(&config.swift, &ci, out_dir, try_format_code, is_testing)?
+            swift::write_bindings(&config.swift, ci, out_dir, try_format_code, is_testing)?
         }
         TargetLanguage::Python => {
-            python::write_bindings(&config.python, &ci, out_dir, try_format_code, is_testing)?
+            python::write_bindings(&config.python, ci, out_dir, try_format_code, is_testing)?
         }
         TargetLanguage::Ruby => {
-            ruby::write_bindings(&config.ruby, &ci, out_dir, try_format_code, is_testing)?
+            ruby::write_bindings(&config.ruby, ci, out_dir, try_format_code, is_testing)?
         }
         TargetLanguage::GeckoJs => {
-            gecko_js::write_bindings(&config.gecko_js, &ci, out_dir, try_format_code, is_testing)?
+            gecko_js::write_bindings(&config.gecko_js, ci, out_dir, try_format_code, is_testing)?
         }
     }
     Ok(())
@@ -150,8 +150,8 @@ where
 {
     let out_dir = out_dir.as_ref();
     match language {
-        TargetLanguage::Kotlin => kotlin::compile_bindings(&config.kotlin, &ci, out_dir)?,
-        TargetLanguage::Swift => swift::compile_bindings(&config.swift, &ci, out_dir)?,
+        TargetLanguage::Kotlin => kotlin::compile_bindings(&config.kotlin, ci, out_dir)?,
+        TargetLanguage::Swift => swift::compile_bindings(&config.swift, ci, out_dir)?,
         TargetLanguage::Python => (),
         TargetLanguage::Ruby => (),
         TargetLanguage::GeckoJs => (),

--- a/uniffi_bindgen/src/bindings/python/gen_python.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python.rs
@@ -58,7 +58,6 @@ impl<'a> PythonWrapper<'a> {
 
 mod filters {
     use super::*;
-    use std::fmt;
 
     pub fn type_ffi(type_: &FFIType) -> Result<String, askama::Error> {
         Ok(match type_ {
@@ -114,23 +113,25 @@ mod filters {
         })
     }
 
-    pub fn class_name_py(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
-        Ok(nm.to_string().to_camel_case())
+    pub fn class_name_py<T: AsRef<str>>(nm: T) -> Result<String, askama::Error> {
+        // Using `T: Into<String>` would be neater here, but Askama likes to add
+        // several layers of references, and they make the `Into` mapping not work.
+        Ok(nm.as_ref().to_string().to_camel_case())
     }
 
-    pub fn fn_name_py(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+    pub fn fn_name_py(nm: &str) -> Result<String, askama::Error> {
         Ok(nm.to_string().to_snake_case())
     }
 
-    pub fn var_name_py(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+    pub fn var_name_py(nm: &str) -> Result<String, askama::Error> {
         Ok(nm.to_string().to_snake_case())
     }
 
-    pub fn enum_name_py(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+    pub fn enum_name_py(nm: &str) -> Result<String, askama::Error> {
         Ok(nm.to_string().to_shouty_snake_case())
     }
 
-    pub fn coerce_py(nm: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
+    pub fn coerce_py(nm: &str, type_: &Type) -> Result<String, askama::Error> {
         Ok(match type_ {
             Type::Int8
             | Type::UInt8
@@ -151,17 +152,17 @@ mod filters {
             | Type::Duration => nm.to_string(),
             Type::CallbackInterface(_) => panic!("No support for coercing callback interfaces yet"),
             Type::Optional(t) => format!("(None if {} is None else {})", nm, coerce_py(nm, t)?),
-            Type::Sequence(t) => format!("list({} for x in {})", coerce_py(&"x", t)?, nm),
+            Type::Sequence(t) => format!("list({} for x in {})", coerce_py("x", t)?, nm),
             Type::Map(t) => format!(
                 "dict(({},{}) for (k, v) in {}.items())",
-                coerce_py(&"k", &Type::String)?,
-                coerce_py(&"v", t)?,
+                coerce_py("k", &Type::String)?,
+                coerce_py("v", t)?,
                 nm
             ),
         })
     }
 
-    pub fn lower_py(nm: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
+    pub fn lower_py(nm: &str, type_: &Type) -> Result<String, askama::Error> {
         Ok(match type_ {
             Type::Int8
             | Type::UInt8
@@ -192,7 +193,7 @@ mod filters {
         })
     }
 
-    pub fn lift_py(nm: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
+    pub fn lift_py(nm: &str, type_: &Type) -> Result<String, askama::Error> {
         Ok(match type_ {
             Type::Int8
             | Type::UInt8

--- a/uniffi_bindgen/src/bindings/python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/mod.rs
@@ -30,7 +30,7 @@ pub fn write_bindings(
     let mut py_file = PathBuf::from(out_dir);
     py_file.push(format!("{}.py", ci.namespace()));
     let mut f = File::create(&py_file).context("Failed to create .py file for bindings")?;
-    write!(f, "{}", generate_python_bindings(config, &ci)?)?;
+    write!(f, "{}", generate_python_bindings(config, ci)?)?;
 
     if try_format_code {
         if let Err(e) = Command::new("yapf").arg(py_file.to_str().unwrap()).output() {
@@ -49,7 +49,7 @@ pub fn write_bindings(
 
 pub fn generate_python_bindings(config: &Config, ci: &ComponentInterface) -> Result<String> {
     use askama::Template;
-    PythonWrapper::new(config.clone(), &ci)
+    PythonWrapper::new(config.clone(), ci)
         .render()
         .map_err(|_| anyhow::anyhow!("failed to render python bindings"))
 }

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
@@ -40,7 +40,7 @@ class RustBufferBuilder(object):
     # these implementation details from consumers, in the face of python's free-for-all
     # type system.
 
-    {%- for typ in ci.iter_types() -%}
+    {% for typ in ci.iter_types() -%}
     {%- let canonical_type_name = typ.canonical_name()|class_name_py -%}
     {%- match typ -%}
 

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
@@ -29,7 +29,7 @@ class RustBufferStream(object):
     # implementation details from consumers, in the face of python's free-for-all type
     # system.
 
-    {%- for typ in ci.iter_types() -%}
+    {% for typ in ci.iter_types() -%}
     {%- let canonical_type_name = typ.canonical_name()|class_name_py -%}
     {%- match typ -%}
 

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/tests.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/tests.rs
@@ -35,7 +35,7 @@ fn cdylib_path() {
     };
 
     assert_eq!("", config.cdylib_path());
-    assert_eq!(false, config.custom_cdylib_path());
+    assert!(!config.custom_cdylib_path());
 
     let config = Config {
         cdylib_name: None,
@@ -43,5 +43,5 @@ fn cdylib_path() {
     };
 
     assert_eq!("/foo/bar", config.cdylib_path());
-    assert_eq!(true, config.custom_cdylib_path());
+    assert!(config.custom_cdylib_path());
 }

--- a/uniffi_bindgen/src/bindings/ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/mod.rs
@@ -30,7 +30,7 @@ pub fn write_bindings(
     let mut rb_file = PathBuf::from(out_dir);
     rb_file.push(format!("{}.rb", ci.namespace()));
     let mut f = File::create(&rb_file).context("Failed to create .rb file for bindings")?;
-    write!(f, "{}", generate_ruby_bindings(config, &ci)?)?;
+    write!(f, "{}", generate_ruby_bindings(config, ci)?)?;
 
     if try_format_code {
         if let Err(e) = Command::new("rubocop")
@@ -53,7 +53,7 @@ pub fn write_bindings(
 
 pub fn generate_ruby_bindings(config: &Config, ci: &ComponentInterface) -> Result<String> {
     use askama::Template;
-    RubyWrapper::new(config.clone(), &ci)
+    RubyWrapper::new(config.clone(), ci)
         .render()
         .map_err(|_| anyhow::anyhow!("failed to render ruby bindings"))
 }

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -27,7 +27,7 @@ class RustBufferBuilder
     end
   end
 
-  {%- for typ in ci.iter_types() -%}
+  {% for typ in ci.iter_types() -%}
   {%- let canonical_type_name = typ.canonical_name()|class_name_rb -%}
   {%- match typ -%}
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
@@ -21,7 +21,7 @@ class RustBufferStream
     data
   end
 
-  {%- for typ in ci.iter_types() -%}
+  {% for typ in ci.iter_types() -%}
   {%- let canonical_type_name = typ.canonical_name()|class_name_rb -%}
   {%- match typ -%}
 

--- a/uniffi_bindgen/src/bindings/swift/gen_swift.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift.rs
@@ -121,7 +121,6 @@ impl<'config, 'ci> SwiftWrapper<'config, 'ci> {
 /// header) and Swift (for the actual library) declarations.
 mod filters {
     use super::*;
-    use std::fmt;
 
     /// Declares a Swift type in the public interface for the library.
     pub fn type_swift(type_: &Type) -> Result<String, askama::Error> {
@@ -223,7 +222,7 @@ mod filters {
     /// Lower a Swift type into an FFI type.
     ///
     /// This is used to pass arguments over the FFI, from Swift to Rust.
-    pub fn lower_swift(name: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
+    pub fn lower_swift(name: &str, type_: &Type) -> Result<String, askama::Error> {
         match type_ {
             Type::Duration => Ok(format!(
                 "{}.lower{}()",
@@ -237,7 +236,7 @@ mod filters {
     /// Lift a Swift type from an FFI type.
     ///
     /// This is used to receive values over the FFI, from Rust to Swift.
-    pub fn lift_swift(name: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
+    pub fn lift_swift(name: &str, type_: &Type) -> Result<String, askama::Error> {
         match type_ {
             Type::Duration => Ok(format!(
                 "{}.lift{}({})",
@@ -253,7 +252,7 @@ mod filters {
     ///
     /// This is used to receive values over the FFI, when they're part of a complex type
     /// that is passed by serializing into bytes.
-    pub fn read_swift(name: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
+    pub fn read_swift(name: &str, type_: &Type) -> Result<String, askama::Error> {
         match type_ {
             Type::Duration => Ok(format!(
                 "{}.read{}(from: {})",
@@ -265,19 +264,19 @@ mod filters {
         }
     }
 
-    pub fn enum_variant_swift(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+    pub fn enum_variant_swift(nm: &str) -> Result<String, askama::Error> {
         Ok(nm.to_string().to_mixed_case())
     }
 
-    pub fn class_name_swift(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+    pub fn class_name_swift(nm: &str) -> Result<String, askama::Error> {
         Ok(nm.to_string().to_camel_case())
     }
 
-    pub fn fn_name_swift(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+    pub fn fn_name_swift(nm: &str) -> Result<String, askama::Error> {
         Ok(nm.to_string().to_mixed_case())
     }
 
-    pub fn var_name_swift(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+    pub fn var_name_swift(nm: &str) -> Result<String, askama::Error> {
         Ok(nm.to_string().to_mixed_case())
     }
 

--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -38,7 +38,7 @@ pub fn write_bindings(
     let mut source_file = out_path.clone();
     source_file.push(format!("{}.swift", ci.namespace()));
 
-    let Bindings { header, library } = generate_bindings(config, &ci, is_testing)?;
+    let Bindings { header, library } = generate_bindings(config, ci, is_testing)?;
 
     let header_filename = config.header_filename();
     let mut header_file = out_path.clone();
@@ -59,7 +59,7 @@ pub fn write_bindings(
         write!(
             m,
             "{}",
-            generate_module_map(config, &ci, &Path::new(&header_filename))?
+            generate_module_map(config, ci, Path::new(&header_filename))?
         )?;
     }
 
@@ -86,10 +86,10 @@ pub fn generate_bindings(
     is_testing: bool,
 ) -> Result<Bindings> {
     use askama::Template;
-    let header = BridgingHeader::new(config, &ci)
+    let header = BridgingHeader::new(config, ci)
         .render()
         .map_err(|_| anyhow!("failed to render Swift bridging header"))?;
-    let library = SwiftWrapper::new(&config, &ci, is_testing)
+    let library = SwiftWrapper::new(config, ci, is_testing)
         .render()
         .map_err(|_| anyhow!("failed to render Swift library"))?;
     Ok(Bindings { header, library })
@@ -101,7 +101,7 @@ fn generate_module_map(
     header_path: &Path,
 ) -> Result<String> {
     use askama::Template;
-    let module_map = ModuleMap::new(&config, &ci, header_path)
+    let module_map = ModuleMap::new(config, ci, header_path)
         .render()
         .map_err(|_| anyhow!("failed to render Swift module map"))?;
     Ok(module_map)

--- a/uniffi_bindgen/src/bindings/swift/templates/wrapper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/wrapper.swift
@@ -10,7 +10,6 @@ import {{ config.module_name() }}
 {% include "RustBufferHelper.swift" %}
 
 // Public interface members begin here.
-
 {% for e in ci.iter_enum_definitions() %}
 {% include "EnumTemplate.swift" %}
 {%- endfor -%}

--- a/uniffi_bindgen/src/interface/attributes.rs
+++ b/uniffi_bindgen/src/interface/attributes.rs
@@ -107,7 +107,7 @@ where
         .collect::<Result<Vec<_>, _>>()?;
 
     for attr in attrs.iter() {
-        validator(&attr)?;
+        validator(attr)?;
     }
 
     Ok(attrs)

--- a/uniffi_bindgen/src/interface/callbacks.rs
+++ b/uniffi_bindgen/src/interface/callbacks.rs
@@ -45,6 +45,7 @@ use super::{APIConverter, ComponentInterface};
 #[derive(Debug, Clone)]
 pub struct CallbackInterface {
     pub(super) name: String,
+    pub(super) type_: Type,
     pub(super) methods: Vec<Method>,
     pub(super) ffi_init_callback: FFIFunction,
 }
@@ -52,7 +53,8 @@ pub struct CallbackInterface {
 impl CallbackInterface {
     fn new(name: String) -> CallbackInterface {
         CallbackInterface {
-            name,
+            name: name.clone(),
+            type_: Type::CallbackInterface(name),
             methods: Default::default(),
             ffi_init_callback: Default::default(),
         }
@@ -62,8 +64,8 @@ impl CallbackInterface {
         &self.name
     }
 
-    pub fn type_(&self) -> Type {
-        Type::CallbackInterface(self.name.clone())
+    pub fn type_(&self) -> &Type {
+        &self.type_
     }
 
     pub fn methods(&self) -> Vec<&Method> {

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -340,7 +340,7 @@ mod test {
                 .iter()
                 .map(|f| f.type_())
                 .collect::<Vec<_>>(),
-            vec![Type::UInt32]
+            vec![&Type::UInt32]
         );
         assert_eq!(
             ed.variants()[2]
@@ -356,7 +356,7 @@ mod test {
                 .iter()
                 .map(|f| f.type_())
                 .collect::<Vec<_>>(),
-            vec![Type::UInt32, Type::String]
+            vec![&Type::UInt32, &Type::String]
         );
 
         // The enum declared via interface, but with no associated data.
@@ -374,8 +374,8 @@ mod test {
         // (It might be nice to optimize these to pass as plain integers, but that's
         // difficult atop the current factoring of `ComponentInterface` and friends).
         let farg = ci.get_function_definition("takes_an_enum").unwrap();
-        assert_eq!(farg.arguments()[0].type_(), Type::Enum("TestEnum".into()));
-        assert_eq!(farg.ffi_func().arguments()[0].type_(), FFIType::RustBuffer);
+        assert_eq!(farg.arguments()[0].type_(), &Type::Enum("TestEnum".into()));
+        assert_eq!(farg.ffi_func().arguments()[0].type_(), &FFIType::RustBuffer);
         let fret = ci.get_function_definition("returns_an_enum").unwrap();
         assert!(matches!(fret.return_type(), Some(Type::Enum(nm)) if nm == "TestEnum"));
         assert!(matches!(
@@ -389,9 +389,9 @@ mod test {
             .unwrap();
         assert_eq!(
             farg.arguments()[0].type_(),
-            Type::Enum("TestEnumWithData".into())
+            &Type::Enum("TestEnumWithData".into())
         );
-        assert_eq!(farg.ffi_func().arguments()[0].type_(), FFIType::RustBuffer);
+        assert_eq!(farg.ffi_func().arguments()[0].type_(), &FFIType::RustBuffer);
         let fret = ci
             .get_function_definition("returns_an_enum_with_data")
             .unwrap();

--- a/uniffi_bindgen/src/interface/ffi.rs
+++ b/uniffi_bindgen/src/interface/ffi.rs
@@ -95,8 +95,8 @@ impl FFIArgument {
     pub fn name(&self) -> &str {
         &self.name
     }
-    pub fn type_(&self) -> FFIType {
-        self.type_.clone()
+    pub fn type_(&self) -> &FFIType {
+        &self.type_
     }
 }
 

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -148,8 +148,8 @@ impl Argument {
     pub fn name(&self) -> &str {
         &self.name
     }
-    pub fn type_(&self) -> Type {
-        self.type_.clone()
+    pub fn type_(&self) -> &Type {
+        &self.type_
     }
     pub fn by_ref(&self) -> bool {
         self.by_ref

--- a/uniffi_bindgen/src/interface/literal.rs
+++ b/uniffi_bindgen/src/interface/literal.rs
@@ -116,11 +116,11 @@ pub(super) fn convert_default_value(
             Literal::Enum(s.0.to_string(), type_.clone())
         }
         (weedle::literal::DefaultValue::Null(_), Type::Optional(_)) => Literal::Null,
-        (_, Type::Optional(inner_type)) => convert_default_value(default_value, &inner_type)?,
+        (_, Type::Optional(inner_type)) => convert_default_value(default_value, inner_type)?,
 
         // We'll ensure the type safety in the convert_* number methods.
-        (weedle::literal::DefaultValue::Integer(i), _) => convert_integer(&i, type_)?,
-        (weedle::literal::DefaultValue::Float(i), _) => convert_float(&i, type_)?,
+        (weedle::literal::DefaultValue::Integer(i), _) => convert_integer(i, type_)?,
+        (weedle::literal::DefaultValue::Float(i), _) => convert_float(i, type_)?,
 
         _ => bail!("No support for {:?} literal yet", default_value),
     })

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -100,7 +100,7 @@ pub struct ComponentInterface {
     errors: Vec<Error>,
 }
 
-impl<'ci> ComponentInterface {
+impl ComponentInterface {
     /// Parse a `ComponentInterface` from a string containing a WebIDL definition.
     pub fn from_webidl(idl: &str) -> Result<Self> {
         let mut ci = Self {

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -74,6 +74,7 @@ use super::{APIConverter, ComponentInterface};
 #[derive(Debug, Clone)]
 pub struct Object {
     pub(super) name: String,
+    pub(super) type_: Type,
     pub(super) constructors: Vec<Constructor>,
     pub(super) methods: Vec<Method>,
     pub(super) ffi_func_free: FFIFunction,
@@ -83,7 +84,8 @@ pub struct Object {
 impl Object {
     fn new(name: String) -> Object {
         Object {
-            name,
+            name: name.clone(),
+            type_: Type::Object(name),
             constructors: Default::default(),
             methods: Default::default(),
             ffi_func_free: Default::default(),
@@ -95,8 +97,8 @@ impl Object {
         &self.name
     }
 
-    pub fn type_(&self) -> Type {
-        Type::Object(self.name.clone())
+    pub fn type_(&self) -> &Type {
+        &self.type_
     }
 
     pub fn constructors(&self) -> Vec<&Constructor> {

--- a/uniffi_bindgen/src/interface/record.rs
+++ b/uniffi_bindgen/src/interface/record.rs
@@ -166,7 +166,7 @@ mod test {
         assert_eq!(record.fields().len(), 1);
         assert_eq!(record.fields()[0].name(), "field");
         assert_eq!(record.fields()[0].type_().canonical_name(), "u32");
-        assert_eq!(record.fields()[0].required, false);
+        assert!(!record.fields()[0].required);
         assert!(record.fields()[0].default_value().is_none());
 
         let record = ci.get_record_definition("Complex").unwrap();
@@ -177,18 +177,18 @@ mod test {
             record.fields()[0].type_().canonical_name(),
             "Optionalstring"
         );
-        assert_eq!(record.fields()[0].required, false);
+        assert!(!record.fields()[0].required);
         assert!(record.fields()[0].default_value().is_none());
         assert_eq!(record.fields()[1].name(), "value");
         assert_eq!(record.fields()[1].type_().canonical_name(), "u32");
-        assert_eq!(record.fields()[1].required, false);
+        assert!(!record.fields()[1].required);
         assert!(matches!(
             record.fields()[1].default_value(),
             Some(Literal::UInt(0, Radix::Decimal, Type::UInt32))
         ));
         assert_eq!(record.fields()[2].name(), "spin");
         assert_eq!(record.fields()[2].type_().canonical_name(), "bool");
-        assert_eq!(record.fields()[2].required, true);
+        assert!(record.fields()[2].required);
         assert!(record.fields()[2].default_value().is_none());
     }
 

--- a/uniffi_bindgen/src/interface/record.rs
+++ b/uniffi_bindgen/src/interface/record.rs
@@ -105,8 +105,8 @@ impl Field {
     pub fn name(&self) -> &str {
         &self.name
     }
-    pub fn type_(&self) -> Type {
-        self.type_.clone()
+    pub fn type_(&self) -> &Type {
+        &self.type_
     }
     pub fn default_value(&self) -> Option<Literal> {
         self.default.clone()

--- a/uniffi_bindgen/src/interface/types/finder.rs
+++ b/uniffi_bindgen/src/interface/types/finder.rs
@@ -36,7 +36,7 @@ pub(in super::super) trait TypeFinder {
 impl<T: TypeFinder> TypeFinder for &[T] {
     fn add_type_definitions_to(&self, types: &mut TypeUniverse) -> Result<()> {
         for item in self.iter() {
-            (&item).add_type_definitions_to(types)?;
+            item.add_type_definitions_to(types)?;
         }
         Ok(())
     }

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -125,14 +125,14 @@ pub fn generate_component_scaffolding<P: AsRef<Path>>(
     let config_file_override = config_file_override.as_ref().map(|p| p.as_ref());
     let out_dir_override = out_dir_override.as_ref().map(|p| p.as_ref());
     let udl_file = udl_file.as_ref();
-    let component = parse_udl(&udl_file)?;
+    let component = parse_udl(udl_file)?;
     let _config = get_config(&component, udl_file, config_file_override);
     let mut filename = Path::new(&udl_file)
         .file_stem()
         .ok_or_else(|| anyhow!("not a file"))?
         .to_os_string();
     filename.push(".uniffi.rs");
-    let mut out_dir = get_out_dir(&udl_file, out_dir_override)?;
+    let mut out_dir = get_out_dir(udl_file, out_dir_override)?;
     out_dir.push(filename);
     let mut f =
         File::create(&out_dir).map_err(|e| anyhow!("Failed to create output file: {:?}", e))?;
@@ -157,9 +157,9 @@ pub fn generate_bindings<P: AsRef<Path>>(
     let config_file_override = config_file_override.as_ref().map(|p| p.as_ref());
     let udl_file = udl_file.as_ref();
 
-    let component = parse_udl(&udl_file)?;
+    let component = parse_udl(udl_file)?;
     let config = get_config(&component, udl_file, config_file_override)?;
-    let out_dir = get_out_dir(&udl_file, out_dir_override)?;
+    let out_dir = get_out_dir(udl_file, out_dir_override)?;
     for language in target_languages {
         bindings::write_bindings(
             &config.bindings,
@@ -185,7 +185,7 @@ pub fn run_tests<P: AsRef<Path>>(
     let udl_file = udl_file.as_ref();
     let config_file_override = config_file_override.as_ref().map(|p| p.as_ref());
 
-    let component = parse_udl(&udl_file)?;
+    let component = parse_udl(udl_file)?;
     let config = get_config(&component, udl_file, config_file_override)?;
 
     // Group the test scripts by language first.
@@ -339,7 +339,7 @@ pub fn run_main() -> Result<()> {
                         .short("-l")
                         .multiple(true)
                         .number_of_values(1)
-                        .possible_values(&POSSIBLE_LANGUAGES)
+                        .possible_values(POSSIBLE_LANGUAGES)
                         .help("Foreign language(s) for which to build bindings"),
                 )
                 .arg(

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -24,7 +24,6 @@ impl<'a> RustScaffolding<'a> {
 
 mod filters {
     use super::*;
-    use std::fmt;
 
     pub fn type_rs(type_: &Type) -> Result<String, askama::Error> {
         Ok(match type_ {
@@ -72,7 +71,7 @@ mod filters {
         })
     }
 
-    pub fn lower_rs(nm: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
+    pub fn lower_rs(nm: &str, type_: &Type) -> Result<String, askama::Error> {
         // By explicitly naming the type here, we help the rust compiler to type-check the user-provided
         // implementations of the functions that we're wrapping (and also to type-check our generated code).
         Ok(match type_ {
@@ -84,7 +83,7 @@ mod filters {
         })
     }
 
-    pub fn lift_rs(nm: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
+    pub fn lift_rs(nm: &str, type_: &Type) -> Result<String, askama::Error> {
         // By explicitly naming the type here, we help the rust compiler to type-check the user-provided
         // implementations of the functions that we're wrapping (and also to type-check our generated code).
         // This will panic if the bindings provide an invalid value over the FFI.
@@ -102,11 +101,7 @@ mod filters {
     }
 
     /// Get a Rust expression for writing a value into a byte buffer.
-    pub fn write_rs(
-        nm: &dyn fmt::Display,
-        target: &dyn fmt::Display,
-        type_: &Type,
-    ) -> Result<String, askama::Error> {
+    pub fn write_rs(nm: &str, target: &str, type_: &Type) -> Result<String, askama::Error> {
         Ok(match type_ {
             Type::CallbackInterface(type_name) => unimplemented!(
                 "uniffi::ViaFfi::write is not supported for callback interfaces ({})",
@@ -122,7 +117,7 @@ mod filters {
     }
 
     /// Get a Rust expression for writing a value into a byte buffer.
-    pub fn read_rs(target: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
+    pub fn read_rs(target: &str, type_: &Type) -> Result<String, askama::Error> {
         Ok(match type_ {
             Type::CallbackInterface(type_name) => unimplemented!(
                 "uniffi::ViaFfi::try_read is not supported for callback interfaces ({})",

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -37,7 +37,7 @@ pub fn build_foreign_language_testcases(paths: proc_macro::TokenStream) -> proc_
     let test_functions = paths.test_scripts
         .iter()
         .map(|file_path| {
-            let test_file_pathbuf: PathBuf = [&pkg_dir, &file_path].iter().collect();
+            let test_file_pathbuf: PathBuf = [&pkg_dir, file_path].iter().collect();
             let test_file_path = test_file_pathbuf.to_string_lossy();
             let test_file_name = test_file_pathbuf
                 .file_name()


### PR DESCRIPTION
There's a new Askama release coming out soon, and it'll change some of the details of how the generated code does borrows, passes arguments etc. I think it'll be a win for us overall, as it seems to resolve some issues we had in the past with using `impl Iterator` in `{% for %}` loops. But it also means a fair bit of churn in our templates.

This draft is me hacking through the compiler errors and resolving them, mostly by adding explicit borrows in places where Askama was previously borrowing inside its generated code. I'm planning to use this as an opportunity to think through the owned-vs-borrowed semantics of `ComponentInterface` more holistically, which is something I've been planning to do for a while for my own education anyway.