### PR TITLE
Document optional fields & arguments

### DIFF
--- a/docs/manual/src/udl/functions.md
+++ b/docs/manual/src/udl/functions.md
@@ -16,3 +16,34 @@ namespace Example {
     string hello_world();
 }
 ```
+
+## Optional arguments & default values
+
+Function arguments can be marked `optional` with a default value specified.
+
+In the UDL file:
+
+```idl
+namespace Example {
+    string hello_name(optional string name = "world");
+}
+```
+
+The Rust code will take a required argument:
+
+```rust
+fn hello_name(name: String) -> String {
+    format!("Hello {}", name)
+}
+```
+
+The generated foreign-language bindings will use function parameters with default values.
+This works for the Kotlin, Swift and Python targets.
+
+For example the generated Kotlin code will be equivalent to:
+
+```kotlin
+fun helloName(name: String = "world" ): String {
+    // ...
+}
+```

--- a/docs/manual/src/udl/structs.md
+++ b/docs/manual/src/udl/structs.md
@@ -63,3 +63,72 @@ destroyed to avoid leaking the underlying memory, and this also applies to Objec
 in record fields.
 
 You can read more about managing object references in the section on [interfaces](./interfaces.md).
+
+## Default values for fields
+
+Fields can be specified with a default value:
+
+```idl
+dictionary TodoEntry {
+    boolean done = false;
+    string text;
+};
+```
+
+The corresponding generated Kotlin code would be equivalent to:
+
+```kotlin
+data class TodoEntry (
+    var done: Boolean = false,
+    var text: String
+)  {
+    // ...
+}
+```
+
+This works for Swift and Python targets too.
+If not set otherwise the default value for a field is passed to the Rust constructor.
+
+## Optional fields and default values
+
+Fields can be made optional using a `T?` type.
+
+```idl
+dictionary TodoEntry {
+    boolean done;
+    string? text;
+};
+```
+
+The corresponding generated Kotlin code would be equivalent to:
+
+```kotlin
+data class TodoEntry (
+    var done: Boolean,
+    var text: String?
+)  {
+    // ...
+}
+```
+
+Optional fields can also be set to a default `null` value:
+
+```idl
+dictionary TodoEntry {
+    boolean done;
+    string? text = null;
+};
+```
+
+The corresponding generated Kotlin code would be equivalent to:
+
+```kotlin
+data class TodoEntry (
+    var done: Boolean,
+    var text: String? = null
+)  {
+    // ...
+}
+```
+
+This works for Swift and Python targets too.

--- a/docs/manual/src/udl/structs.md
+++ b/docs/manual/src/udl/structs.md
@@ -57,7 +57,7 @@ struct TodoEntry {
 }
 ```
 
-Depending on the languge, the foreign-language bindings may also need to be aware of
+Depending on the language, the foreign-language bindings may also need to be aware of
 these embedded references. For example in Kotlin, each Object instance must be explicitly
 destroyed to avoid leaking the underlying memory, and this also applies to Objects stored
 in record fields.

--- a/docs/manual/src/udl/structs.md
+++ b/docs/manual/src/udl/structs.md
@@ -6,7 +6,7 @@ Think of them like a Rust struct without any methods.
 
 A Rust struct like this:
 
-```rust
+```rust,no_run
 struct TodoEntry {
     done: bool,
     due_date: u64,
@@ -50,7 +50,7 @@ dictionary TodoEntry {
 
 Then the corresponding Rust code would need to look like this:
 
-```rust
+```rust,no_run
 struct TodoEntry {
     owner: std::sync::Arc<User>,
     text: String,
@@ -87,7 +87,7 @@ data class TodoEntry (
 ```
 
 This works for Swift and Python targets too.
-If not set otherwise the default value for a field is passed to the Rust constructor.
+If not set otherwise the default value for a field is used when constructing the Rust struct.
 
 ## Optional fields and default values
 
@@ -98,6 +98,15 @@ dictionary TodoEntry {
     boolean done;
     string? text;
 };
+```
+
+The corresponding Rust struct would need to look like this:
+
+```rust,no_run
+struct TodoEntry {
+    done: bool,
+    text: Option<String>,
+}
 ```
 
 The corresponding generated Kotlin code would be equivalent to:


### PR DESCRIPTION
While playing around with UniFFI, in order to figure out how we can use it in Glean, I came across these essential things for us: default values.

While implemented it lacks documentation, so I went ahead and added that.