### PR TITLE
Make `ViaFfi.write()` input an owned value instead of a reference

### DIFF
--- a/uniffi/src/ffi/rustcalls.rs
+++ b/uniffi/src/ffi/rustcalls.rs
@@ -210,7 +210,7 @@ mod test {
 
     // Use RustBufferViaFfi to simplify lifting TestError out of RustBuffer to check it
     impl RustBufferViaFfi for TestError {
-        fn write(&self, buf: &mut Vec<u8>) {
+        fn write(self, buf: &mut Vec<u8>) {
             self.0.write(buf);
         }
 

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -111,7 +111,7 @@ mod filters {
                 type_name
             ),
             _ => format!(
-                "<{} as uniffi::ViaFfi>::write(&{}, {})",
+                "<{} as uniffi::ViaFfi>::write({}, {})",
                 type_rs(type_)?,
                 nm,
                 target

--- a/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
@@ -99,7 +99,7 @@ unsafe impl uniffi::ViaFfi for {{ trait_impl }} {
         self.handle
     }
 
-    fn write(&self, buf: &mut Vec<u8>) {
+    fn write(self, buf: &mut Vec<u8>) {
         use uniffi::deps::bytes::BufMut;
         buf.put_u64(self.handle);
     }

--- a/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
@@ -5,7 +5,7 @@
 #}
 #[doc(hidden)]
 impl uniffi::RustBufferViaFfi for {{ e.name() }} {
-    fn write(&self, buf: &mut Vec<u8>) {
+    fn write(self, buf: &mut Vec<u8>) {
         use uniffi::deps::bytes::BufMut;
         match self {
             {%- for variant in e.variants() %}

--- a/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
@@ -5,7 +5,7 @@
 #}
 #[doc(hidden)]
 impl uniffi::RustBufferViaFfi for {{ e.name() }} {
-    fn write(&self, buf: &mut Vec<u8>) {
+    fn write(self, buf: &mut Vec<u8>) {
         use uniffi::deps::bytes::BufMut;
         match self {
             {%- for variant in e.variants() %}

--- a/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
@@ -6,11 +6,11 @@
 #}
 #[doc(hidden)]
 impl uniffi::RustBufferViaFfi for {{ rec.name() }} {
-    fn write(&self, buf: &mut Vec<u8>) {
+    fn write(self, buf: &mut Vec<u8>) {
         // If the provided struct doesn't match the fields declared in the UDL, then
         // the generated code here will fail to compile with somewhat helpful error.
         {%- for field in rec.fields() %}
-        uniffi::ViaFfi::write(&self.{{ field.name() }}, buf);
+        uniffi::ViaFfi::write(self.{{ field.name() }}, buf);
         {%- endfor %}
     }
 


### PR DESCRIPTION
This makes sense since the idea is that code in FFI-land is taking
ownership of the value.  I think that some of my next work is going to
be easier if write() and lower() both have the same self type.