### PR TITLE
WIP give `ComponentInterface` members a pointer to their parent.

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
@@ -36,7 +36,7 @@ enum class {{ e.name()|class_name_kt }} {
 {% else %}
 
 {% call kt::unsigned_types_annotation(e) %}
-sealed class {{ e.name()|class_name_kt }}{% if e.contains_object_references(ci) %}: Disposable {% endif %} {
+sealed class {{ e.name()|class_name_kt }}{% if e.contains_object_references() %}: Disposable {% endif %} {
     {% for variant in e.variants() -%}
     {% if !variant.has_fields() -%}
     object {{ variant.name()|class_name_kt }} : {{ e.name()|class_name_kt }}()
@@ -85,14 +85,14 @@ sealed class {{ e.name()|class_name_kt }}{% if e.contains_object_references(ci) 
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
 
-    {% if e.contains_object_references(ci) %}
+    {% if e.contains_object_references() %}
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
     override fun destroy() {
         when(this) {
             {%- for variant in e.variants() %}
             is {{ e.name()|class_name_kt }}.{{ variant.name()|class_name_kt }} -> {
                 {% for field in variant.fields() -%}
-                    {%- if ci.type_contains_object_references(field.type_()) -%}
+                    {%- if field.contains_object_references() -%}
                     this.{{ field.name() }}?.destroy()
                     {% endif -%}
                 {%- endfor %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
@@ -27,7 +27,7 @@ interface CallStatusErrorHandler<E> {
 
 // Error {{ e.name() }}
 {%- let toplevel_name=e.name()|exception_name_kt %}
-sealed class {{ toplevel_name }}: Exception(){% if e.contains_object_references(ci) %}, Disposable {% endif %} {
+sealed class {{ toplevel_name }}: Exception(){% if e.contains_object_references() %}, Disposable {% endif %} {
     // Each variant is a nested class
     {% for variant in e.variants() -%}
     {% if !variant.has_fields() -%}
@@ -60,14 +60,14 @@ sealed class {{ toplevel_name }}: Exception(){% if e.contains_object_references(
         }
     }
 
-    {% if e.contains_object_references(ci) %}
+    {% if e.contains_object_references() %}
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
     override fun destroy() {
         when(this) {
             {%- for variant in e.variants() %}
             is {{ e.name()|class_name_kt }}.{{ variant.name()|class_name_kt }} -> {
                 {% for field in variant.fields() -%}
-                    {%- if ci.type_contains_object_references(field.type_()) -%}
+                    {%- if field.contains_object_references() -%}
                     this.{{ field.name() }}?.destroy()
                     {% endif -%}
                 {%- endfor %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
@@ -8,7 +8,7 @@ data class {{ rec.name()|class_name_kt }} (
     {%- endmatch -%}
     {% if !loop.last %}, {% endif %}
     {%- endfor %}
-) {% if rec.contains_object_references(ci) %}: Disposable {% endif %}{
+) {% if rec.contains_object_references() %}: Disposable {% endif %}{
     companion object {
         internal fun lift(rbuf: RustBuffer.ByValue): {{ rec.name()|class_name_kt }} {
             return liftFromRustBuffer(rbuf) { buf -> {{ rec.name()|class_name_kt }}.read(buf) }
@@ -33,11 +33,11 @@ data class {{ rec.name()|class_name_kt }} (
         {% endfor %}
     }
 
-    {% if rec.contains_object_references(ci) %}
+    {% if rec.contains_object_references() %}
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
     override fun destroy() {
         {% for field in rec.fields() %}
-            {%- if ci.type_contains_object_references(field.type_()) -%}
+            {%- if field.contains_object_references() -%}
             this.{{ field.name() }}?.destroy()
             {% endif -%}
         {%- endfor %}

--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -40,6 +40,6 @@ extension {{ e.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi {
     }
 }
 
-{% if ! e.contains_object_references(ci) %}
+{% if ! e.contains_object_references() %}
 extension {{ e.name()|class_name_swift }}: Equatable, Hashable {}
 {% endif %}

--- a/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
@@ -82,7 +82,7 @@ extension {{ e.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi {
     }
 }
 
-{% if !e.contains_object_references(ci) %}
+{% if !e.contains_object_references() %}
 extension {{ e.name()|class_name_swift }}: Equatable, Hashable {}
 {% endif %}
 extension {{ e.name()|class_name_swift }}: Error { }

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -12,7 +12,7 @@ public struct {{ rec.name()|class_name_swift }} {
     }
 }
 
-{% if ! rec.contains_object_references(ci) %}
+{% if ! rec.contains_object_references() %}
 extension {{ rec.name()|class_name_swift }}: Equatable, Hashable {
     public static func ==(lhs: {{ rec.name()|class_name_swift }}, rhs: {{ rec.name()|class_name_swift }}) -> Bool {
         {%- for field in rec.fields() %}


### PR DESCRIPTION
Here's something I wanted to toy with given recent work on refactoring our code-generation templates, and the desire for each interface member to be able to render itself. The issue is that sometimes we need to know information about the surrounding interface or its types in order to do the code generation, which shows up in awkward calls like:

```
{% if e.contains_object_references(ci) %}
```

What would it take to make this be just a plain method call without extra global context? Like so:

```
{% if e.contains_object_references() %}
```

In a garbage-collected language, we might conveniently give the `Record`, `Enum` etc objects a reference to their containing `ComponentInterface` and be done with it. That's hard to do in the obvious way in Rust, and the usual workarounds like handing out an `Arc<RefCell<ComponentInterface>>` seem extremely verbose/complex for our needs.

Here's a sketch of something that might work, although I'm not convinced of the value/complexity tradeoff.

Taking the `Enum` struct as an example, I've split it up into two parts:

* `EnumDescr` is the data that describes an enum. Instances of this are owned by a `ComponentInterface` in a normal tree structure without backwards references.
* `Enum` is a kind of aggregate transient pointer, combining a reference to an `EnumDescr` with a reference to its containing `ComponentInterface`. Instances of this are synthesized on demand when inspecting a `ComponentInterface`.

From the consumer's perspective, it calls `ci.get_enum_definition("MyEnum")` and receives an `Enum` struct, and it can call methods on the `Enum` struct to inspect its definition. But these methods all delegate to the underlying `EnumDescr` for the actual data.

It gets a little complicated in the details of nested strcuts like `Variant` and `Field`, and I'll leave some musings inline.

Thoughts?