### PR TITLE
Add a re-usable abstraction for iterating over contained types.

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
@@ -36,7 +36,7 @@ enum class {{ e.name()|class_name_kt }} {
 {% else %}
 
 {% call kt::unsigned_types_annotation(e) %}
-sealed class {{ e.name()|class_name_kt }}{% if e.contains_object_references(ci) %}: Disposable {% endif %} {
+sealed class {{ e.name()|class_name_kt }}{% if ci.item_contains_object_references(e) %}: Disposable {% endif %} {
     {% for variant in e.variants() -%}
     {% if !variant.has_fields() -%}
     object {{ variant.name()|class_name_kt }} : {{ e.name()|class_name_kt }}()
@@ -85,14 +85,14 @@ sealed class {{ e.name()|class_name_kt }}{% if e.contains_object_references(ci) 
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
 
-    {% if e.contains_object_references(ci) %}
+    {% if ci.item_contains_object_references(e) %}
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
     override fun destroy() {
         when(this) {
             {%- for variant in e.variants() %}
             is {{ e.name()|class_name_kt }}.{{ variant.name()|class_name_kt }} -> {
                 {% for field in variant.fields() -%}
-                    {%- if ci.type_contains_object_references(field.type_()) -%}
+                    {%- if ci.item_contains_object_references(field) -%}
                     this.{{ field.name() }}?.destroy()
                     {% endif -%}
                 {%- endfor %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
@@ -27,7 +27,7 @@ interface CallStatusErrorHandler<E> {
 
 // Error {{ e.name() }}
 {%- let toplevel_name=e.name()|exception_name_kt %}
-sealed class {{ toplevel_name }}: Exception(){% if e.contains_object_references(ci) %}, Disposable {% endif %} {
+sealed class {{ toplevel_name }}: Exception(){% if ci.item_contains_object_references(e) %}, Disposable {% endif %} {
     // Each variant is a nested class
     {% for variant in e.variants() -%}
     {% if !variant.has_fields() -%}
@@ -60,14 +60,14 @@ sealed class {{ toplevel_name }}: Exception(){% if e.contains_object_references(
         }
     }
 
-    {% if e.contains_object_references(ci) %}
+    {% if ci.item_contains_object_references(e) %}
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
     override fun destroy() {
         when(this) {
             {%- for variant in e.variants() %}
             is {{ e.name()|class_name_kt }}.{{ variant.name()|class_name_kt }} -> {
                 {% for field in variant.fields() -%}
-                    {%- if ci.type_contains_object_references(field.type_()) -%}
+                    {%- if ci.item_contains_object_references(field) -%}
                     this.{{ field.name() }}?.destroy()
                     {% endif -%}
                 {%- endfor %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
@@ -8,7 +8,7 @@ data class {{ rec.name()|class_name_kt }} (
     {%- endmatch -%}
     {% if !loop.last %}, {% endif %}
     {%- endfor %}
-) {% if rec.contains_object_references(ci) %}: Disposable {% endif %}{
+) {% if ci.item_contains_object_references(rec) %}: Disposable {% endif %}{
     companion object {
         internal fun lift(rbuf: RustBuffer.ByValue): {{ rec.name()|class_name_kt }} {
             return liftFromRustBuffer(rbuf) { buf -> {{ rec.name()|class_name_kt }}.read(buf) }
@@ -33,11 +33,11 @@ data class {{ rec.name()|class_name_kt }} (
         {% endfor %}
     }
 
-    {% if rec.contains_object_references(ci) %}
+    {% if ci.item_contains_object_references(rec) %}
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
     override fun destroy() {
         {% for field in rec.fields() %}
-            {%- if ci.type_contains_object_references(field.type_()) -%}
+            {%- if ci.item_contains_object_references(field) -%}
             this.{{ field.name() }}?.destroy()
             {% endif -%}
         {%- endfor %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferHelpers.kt
@@ -382,14 +382,14 @@ internal fun write{{ canonical_type_name }}(v: {{ type_name }}, buf: RustBufferB
 {% let inner_type_name = inner_type|type_kt %}
 
 // Helper functions for pasing values of type {{ typ|type_kt }}
-{% if ci.type_contains_unsigned_types(inner_type) %}@ExperimentalUnsignedTypes{% endif %}
+{% call kt::unsigned_types_annotation(inner_type) %}
 internal fun lift{{ canonical_type_name }}(rbuf: RustBuffer.ByValue): {{ inner_type_name }}? {
     return liftFromRustBuffer(rbuf) { buf ->
         read{{ canonical_type_name }}(buf)
     }
 }
 
-{% if ci.type_contains_unsigned_types(inner_type) %}@ExperimentalUnsignedTypes{% endif %}
+{% call kt::unsigned_types_annotation(inner_type) %}
 internal fun read{{ canonical_type_name }}(buf: ByteBuffer): {{ inner_type_name }}? {
     if (buf.get().toInt() == 0) {
         return null
@@ -397,14 +397,14 @@ internal fun read{{ canonical_type_name }}(buf: ByteBuffer): {{ inner_type_name 
     return {{ "buf"|read_kt(inner_type) }}
 }
 
-{% if ci.type_contains_unsigned_types(inner_type) %}@ExperimentalUnsignedTypes{% endif %}
+{% call kt::unsigned_types_annotation(inner_type) %}
 internal fun lower{{ canonical_type_name }}(v: {{ inner_type_name }}?): RustBuffer.ByValue {
     return lowerIntoRustBuffer(v) { v, buf ->
         write{{ canonical_type_name }}(v, buf)
     }
 }
 
-{% if ci.type_contains_unsigned_types(inner_type) %}@ExperimentalUnsignedTypes{% endif %}
+{% call kt::unsigned_types_annotation(inner_type) %}
 internal fun write{{ canonical_type_name }}(v: {{ inner_type_name }}?, buf: RustBufferBuilder) {
     if (v == null) {
         buf.putByte(0)
@@ -419,14 +419,14 @@ internal fun write{{ canonical_type_name }}(v: {{ inner_type_name }}?, buf: Rust
 
 // Helper functions for pasing values of type {{ typ|type_kt }}
 
-{% if ci.type_contains_unsigned_types(inner_type) %}@ExperimentalUnsignedTypes{% endif %}
+{% call kt::unsigned_types_annotation(inner_type) %}
 internal fun lift{{ canonical_type_name }}(rbuf: RustBuffer.ByValue): List<{{ inner_type_name }}> {
     return liftFromRustBuffer(rbuf) { buf ->
         read{{ canonical_type_name }}(buf)
     }
 }
 
-{% if ci.type_contains_unsigned_types(inner_type) %}@ExperimentalUnsignedTypes{% endif %}
+{% call kt::unsigned_types_annotation(inner_type) %}
 internal fun read{{ canonical_type_name }}(buf: ByteBuffer): List<{{ inner_type_name }}> {
     val len = buf.getInt()
     return List<{{ inner_type|type_kt }}>(len) {
@@ -434,14 +434,14 @@ internal fun read{{ canonical_type_name }}(buf: ByteBuffer): List<{{ inner_type_
     }
 }
 
-{% if ci.type_contains_unsigned_types(inner_type) %}@ExperimentalUnsignedTypes{% endif %}
+{% call kt::unsigned_types_annotation(inner_type) %}
 internal fun lower{{ canonical_type_name }}(v: List<{{ inner_type_name }}>): RustBuffer.ByValue {
     return lowerIntoRustBuffer(v) { v, buf ->
         write{{ canonical_type_name }}(v, buf)
     }
 }
 
-{% if ci.type_contains_unsigned_types(inner_type) %}@ExperimentalUnsignedTypes{% endif %}
+{% call kt::unsigned_types_annotation(inner_type) %}
 internal fun write{{ canonical_type_name }}(v: List<{{ inner_type_name }}>, buf: RustBufferBuilder) {
     buf.putInt(v.size)
     v.forEach {
@@ -454,14 +454,14 @@ internal fun write{{ canonical_type_name }}(v: List<{{ inner_type_name }}>, buf:
 
 // Helper functions for pasing values of type {{ typ|type_kt }}
 
-{% if ci.type_contains_unsigned_types(inner_type) %}@ExperimentalUnsignedTypes{% endif %}
+{% call kt::unsigned_types_annotation(inner_type) %}
 internal fun lift{{ canonical_type_name }}(rbuf: RustBuffer.ByValue): Map<String, {{ inner_type_name }}> {
     return liftFromRustBuffer(rbuf) { buf ->
         read{{ canonical_type_name }}(buf)
     }
 }
 
-{% if ci.type_contains_unsigned_types(inner_type) %}@ExperimentalUnsignedTypes{% endif %}
+{% call kt::unsigned_types_annotation(inner_type) %}
 internal fun read{{ canonical_type_name }}(buf: ByteBuffer): Map<String, {{ inner_type_name }}> {
     // TODO: Once Kotlin's `buildMap` API is stabilized we should use it here.
     val items : MutableMap<String, {{ inner_type_name }}> = mutableMapOf()
@@ -474,14 +474,14 @@ internal fun read{{ canonical_type_name }}(buf: ByteBuffer): Map<String, {{ inne
     return items
 }
 
-{% if ci.type_contains_unsigned_types(inner_type) %}@ExperimentalUnsignedTypes{% endif %}
+{% call kt::unsigned_types_annotation(inner_type) %}
 internal fun lower{{ canonical_type_name }}(m: Map<String, {{ inner_type_name }}>): RustBuffer.ByValue {
     return lowerIntoRustBuffer(m) { m, buf ->
         write{{ canonical_type_name }}(m, buf)
     }
 }
 
-{% if ci.type_contains_unsigned_types(inner_type) %}@ExperimentalUnsignedTypes{% endif %}
+{% call kt::unsigned_types_annotation(inner_type) %}
 internal fun write{{ canonical_type_name }}(v: Map<String, {{ inner_type_name }}>, buf: RustBufferBuilder) {
     buf.putInt(v.size)
     // The parens on `(k, v)` here ensure we're calling the right method,

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -70,5 +70,5 @@
 
 // Add annotation if there are unsigned types
 {%- macro unsigned_types_annotation(member) -%}
-{% if member.contains_unsigned_types(ci) %}@ExperimentalUnsignedTypes{% endif %}
+{% if ci.item_contains_unsigned_types(member) %}@ExperimentalUnsignedTypes{% endif %}
 {%- endmacro -%}

--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -40,6 +40,6 @@ extension {{ e.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi {
     }
 }
 
-{% if ! e.contains_object_references(ci) %}
+{% if ! ci.item_contains_object_references(e) %}
 extension {{ e.name()|class_name_swift }}: Equatable, Hashable {}
 {% endif %}

--- a/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
@@ -82,7 +82,7 @@ extension {{ e.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi {
     }
 }
 
-{% if !e.contains_object_references(ci) %}
+{% if !ci.item_contains_object_references(e) %}
 extension {{ e.name()|class_name_swift }}: Equatable, Hashable {}
 {% endif %}
 extension {{ e.name()|class_name_swift }}: Error { }

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -12,7 +12,7 @@ public struct {{ rec.name()|class_name_swift }} {
     }
 }
 
-{% if ! rec.contains_object_references(ci) %}
+{% if ! ci.item_contains_object_references(rec) %}
 extension {{ rec.name()|class_name_swift }}: Equatable, Hashable {
     public static func ==(lhs: {{ rec.name()|class_name_swift }}, rhs: {{ rec.name()|class_name_swift }}) -> Bool {
         {%- for field in rec.fields() %}

--- a/uniffi_bindgen/src/interface/callbacks.rs
+++ b/uniffi_bindgen/src/interface/callbacks.rs
@@ -39,7 +39,7 @@ use anyhow::{bail, Result};
 
 use super::ffi::{FFIArgument, FFIFunction, FFIType};
 use super::object::Method;
-use super::types::Type;
+use super::types::{IterTypes, Type, TypeIterator};
 use super::{APIConverter, ComponentInterface};
 
 #[derive(Debug, Clone)]
@@ -81,6 +81,12 @@ impl CallbackInterface {
             type_: FFIType::ForeignCallback,
         }];
         self.ffi_init_callback.return_type = None;
+    }
+}
+
+impl IterTypes for CallbackInterface {
+    fn iter_types(&self) -> TypeIterator<'_> {
+        Box::new(self.methods.iter().map(IterTypes::iter_types).flatten())
     }
 }
 

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -79,7 +79,7 @@
 use anyhow::{bail, Result};
 
 use super::record::Field;
-use super::types::Type;
+use super::types::{IterTypes, Type, TypeIterator};
 use super::{APIConverter, ComponentInterface};
 
 /// Represents an enum with named variants, each of which may have named
@@ -113,17 +113,11 @@ impl Enum {
     pub fn is_flat(&self) -> bool {
         self.flat
     }
+}
 
-    pub fn contains_object_references(&self, ci: &ComponentInterface) -> bool {
-        ci.type_contains_object_references(&self.type_())
-    }
-
-    pub fn contains_unsigned_types(&self, ci: &ComponentInterface) -> bool {
-        self.variants().iter().any(|v| {
-            v.fields()
-                .iter()
-                .any(|f| ci.type_contains_unsigned_types(&f.type_))
-        })
+impl IterTypes for Enum {
+    fn iter_types(&self) -> TypeIterator<'_> {
+        Box::new(self.variants.iter().map(IterTypes::iter_types).flatten())
     }
 }
 
@@ -196,6 +190,12 @@ impl Variant {
 
     pub fn has_fields(&self) -> bool {
         !self.fields.is_empty()
+    }
+}
+
+impl IterTypes for Variant {
+    fn iter_types(&self) -> TypeIterator<'_> {
+        Box::new(self.fields.iter().map(IterTypes::iter_types).flatten())
     }
 }
 

--- a/uniffi_bindgen/src/interface/error.rs
+++ b/uniffi_bindgen/src/interface/error.rs
@@ -85,7 +85,7 @@
 use anyhow::Result;
 
 use super::enum_::{Enum, Variant};
-use super::types::Type;
+use super::types::{IterTypes, Type, TypeIterator};
 use super::{APIConverter, ComponentInterface};
 
 /// Represents an Error that might be thrown by functions/methods in the component interface.
@@ -129,10 +129,11 @@ impl Error {
     pub fn is_flat(&self) -> bool {
         self.enum_.is_flat()
     }
+}
 
-    // For compatibility with the Enum interface
-    pub fn contains_object_references(&self, ci: &ComponentInterface) -> bool {
-        self.enum_.contains_object_references(ci)
+impl IterTypes for Error {
+    fn iter_types(&self) -> TypeIterator<'_> {
+        self.wrapped_enum().iter_types()
     }
 }
 

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -39,7 +39,7 @@ use anyhow::{bail, Result};
 use super::attributes::{ArgumentAttributes, FunctionAttributes};
 use super::ffi::{FFIArgument, FFIFunction};
 use super::literal::{convert_default_value, Literal};
-use super::types::Type;
+use super::types::{IterTypes, Type, TypeIterator};
 use super::{APIConverter, ComponentInterface};
 
 /// Represents a standalone function.
@@ -96,20 +96,17 @@ impl Function {
         self.ffi_func.return_type = self.return_type.as_ref().map(|rt| rt.into());
         Ok(())
     }
+}
 
-    // Intentionally exactly the same as the Method version
-    pub fn contains_unsigned_types(&self, ci: &ComponentInterface) -> bool {
-        let check_return_type = {
-            match self.return_type() {
-                None => false,
-                Some(t) => ci.type_contains_unsigned_types(t),
-            }
-        };
-        check_return_type
-            || self
-                .arguments()
+impl IterTypes for Function {
+    fn iter_types(&self) -> TypeIterator<'_> {
+        Box::new(
+            self.arguments
                 .iter()
-                .any(|&arg| ci.type_contains_unsigned_types(&arg.type_()))
+                .map(IterTypes::iter_types)
+                .flatten()
+                .chain(self.return_type.iter_types()),
+        )
     }
 }
 
@@ -177,6 +174,12 @@ impl Argument {
     }
     pub fn default_value(&self) -> Option<Literal> {
         self.default.clone()
+    }
+}
+
+impl IterTypes for Argument {
+    fn iter_types(&self) -> TypeIterator<'_> {
+        self.type_.iter_types()
     }
 }
 

--- a/uniffi_bindgen/src/interface/record.rs
+++ b/uniffi_bindgen/src/interface/record.rs
@@ -47,7 +47,7 @@
 use anyhow::{bail, Result};
 
 use super::literal::{convert_default_value, Literal};
-use super::types::Type;
+use super::types::{IterTypes, Type, TypeIterator};
 use super::{APIConverter, ComponentInterface};
 
 /// Represents a "data class" style object, for passing around complex values.
@@ -75,15 +75,11 @@ impl Record {
     pub fn fields(&self) -> Vec<&Field> {
         self.fields.iter().collect()
     }
+}
 
-    pub fn contains_object_references(&self, ci: &ComponentInterface) -> bool {
-        ci.type_contains_object_references(&self.type_())
-    }
-
-    pub fn contains_unsigned_types(&self, ci: &ComponentInterface) -> bool {
-        self.fields()
-            .iter()
-            .any(|f| ci.type_contains_unsigned_types(&f.type_))
+impl IterTypes for Record {
+    fn iter_types(&self) -> TypeIterator<'_> {
+        Box::new(self.fields.iter().map(IterTypes::iter_types).flatten())
     }
 }
 
@@ -120,6 +116,12 @@ impl Field {
     }
     pub fn default_value(&self) -> Option<Literal> {
         self.default.clone()
+    }
+}
+
+impl IterTypes for Field {
+    fn iter_types(&self) -> TypeIterator<'_> {
+        self.type_.iter_types()
     }
 }
 


### PR DESCRIPTION
We currently have several methods that want to be able to recurse
through all the types contained within a particular item, such as
`type_contains_object_references` and `type_contains_unsigned_types`.
These methods duplicate the logic for recursing into our various
types of struct and are a bit weird to use.

This commit proposes a cleanup to make these methods appear more
consistent to the caller, and reduce code duplication in their
implementation.

The core idea is a new trait `IterTypes`. It can be implemented by
anything that contains instances of the `Type` enum, and provides a
single method `iter_types` to iterate over the the contained types.
It's designed to encapsulate the recursion logic, e.g. the `IterTypes`
impl for `Object` knows that it needs to recurse into each of the
methods, the `IterTypes` impl for a `Method` knows that it needs
to recurse into each argument and return type, etc.

On top of this, the `CompontentInterface` can provide a generic
implementation of methods like `contains_object_references` and
`contains_unsigned_types` that will work for any `IterTypes`. I
think this provides a nice little increase in consistency with how
those methods are implemented and called.