### PR TITLE
Implement the core support for defining external types via a typedef

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin.rs
@@ -98,6 +98,7 @@ mod filters {
             Type::Optional(t) => format!("{}?", type_kt(t)?),
             Type::Sequence(t) => format!("List<{}>", type_kt(t)?),
             Type::Map(t) => format!("Map<String, {}>", type_kt(t)?),
+            Type::External { .. } => panic!("no support for external types yet"),
         })
     }
 

--- a/uniffi_bindgen/src/bindings/python/gen_python.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python.rs
@@ -156,6 +156,7 @@ mod filters {
                 coerce_py(&"v", t)?,
                 nm
             ),
+            Type::External { .. } => panic!("No support for coercing external types yet"),
         })
     }
 
@@ -187,6 +188,7 @@ mod filters {
                 class_name_py(&type_.canonical_name())?,
                 nm
             ),
+            Type::External { .. } => panic!("No support for lowering external types yet"),
         })
     }
 
@@ -217,6 +219,7 @@ mod filters {
                 nm,
                 class_name_py(&type_.canonical_name())?
             ),
+            Type::External { .. } => panic!("No support for lowering external types, yet"),
         })
     }
 }

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby.rs
@@ -190,6 +190,7 @@ mod filters {
                     )
                 }
             }
+            Type::External { .. } => panic!("No support for external types in Ruby, yet"),
         })
     }
 
@@ -221,6 +222,7 @@ mod filters {
                 class_name_rb(&type_.canonical_name())?,
                 nm
             ),
+            Type::External { .. } => panic!("No support for lowering external types, yet"),
         })
     }
 
@@ -251,6 +253,7 @@ mod filters {
                 nm,
                 class_name_rb(&type_.canonical_name())?
             ),
+            Type::External { .. } => panic!("No support for lifting external types, yet"),
         })
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift.rs
@@ -190,6 +190,7 @@ mod filters {
             Type::Optional(type_) => format!("{}?", type_swift(type_)?),
             Type::Sequence(type_) => format!("[{}]", type_swift(type_)?),
             Type::Map(type_) => format!("[String:{}]", type_swift(type_)?),
+            Type::External { .. } => panic!("no support for external types in swift, yet"),
         })
     }
 

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -648,6 +648,8 @@ impl APIBuilder for weedle::Definition<'_> {
                 let obj = d.convert(ci)?;
                 ci.add_callback_interface_definition(obj);
             }
+            // everything needed for typedefs is done in finder.rs.
+            weedle::Definition::Typedef(_) => {}
             _ => bail!("don't know how to deal with {:?}", self),
         }
         Ok(())

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -48,6 +48,7 @@ mod filters {
             Type::Optional(t) => format!("Option<{}>", type_rs(t)?),
             Type::Sequence(t) => format!("Vec<{}>", type_rs(t)?),
             Type::Map(t) => format!("std::collections::HashMap<String, {}>", type_rs(t)?),
+            Type::External { name, .. } => name.clone(),
         })
     }
 


### PR DESCRIPTION
Because @bendk and I are both working towaards what can be broadly described as "external types", I thought I'd put up for review the support for defining these types via `typedef`s in the UDL. Because all bindings bail when this is seen, it doesn't actually enable any new functionality, so there should not be any backwards compatibility issues should we need to tweak things later.

I ended up with a single new type - `Type::External`, but that holds a new enum `ExternalTypeKind`, supporting both `Uniffi` (ie, what I've previously been calling "imported" and `Wrapping` (ie, what I've been previously calling just "external".)

I'm open to all bikeshed, including 2 new types and dropping the new enum, and all the names I've used - but they do seem reasonable to me. I've landed on fairly verbose attribute names in the UDL, but it should avoid confusion if I used plain old "imported" (which could mean anything!)

I see no reason to not land this as soon as both Ben and I need it, but we could also consider just basing our branches on this branch and land as soon as we have actual functionality to land.

WDYT?