### PR TITLE
Drop ffi-support dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 [All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.12.0...HEAD).
 
 ### ⚠️ Breaking Changes ⚠️
+- UniFFI no longer has ffi-support as a dependency.  This means it handles
+  panic logging on its own.  If you previously enabled the `log_panics` feature
+  for `ffi-support`, now you should enable it for `uniffi`.
 - The Swift bindings now explicitly generate two separate Swift modules, one for
   the high-level Swift code and one for the low-level C FFI. This change is intended
   to simplify distribution of the bindings via Swift packages, but brings with it

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -14,7 +14,6 @@ keywords = ["ffi", "bindgen"]
 # Re-exported dependencies used in generated Rust scaffolding files.
 anyhow = "1"
 bytes = "1.0"
-ffi-support = "~0.4.4"
 lazy_static = "1.4"
 log = "0.4"
 # Regular dependencies

--- a/uniffi/src/ffi/ffidefault.rs
+++ b/uniffi/src/ffi/ffidefault.rs
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! FfiDefault trait
+//!
+//! When we make a FFI call into Rust we always need to return a value, even if that value will be
+//! ignored because we're flagging an exception.  This trait defines what that value is for our
+//! supported FFI types.
+
+use paste::paste;
+
+pub trait FfiDefault {
+    fn ffi_default() -> Self;
+}
+
+// Most types can be handled by delegating to Default
+macro_rules! impl_ffi_default_with_default {
+    ($($T:ty,)+) => { impl_ffi_default_with_default!($($T),+); };
+    ($($T:ty),*) => {
+            $(
+                paste! {
+                    impl FfiDefault for $T {
+                        fn ffi_default() -> Self {
+                            $T::default()
+                        }
+                    }
+                }
+            )*
+    };
+}
+
+impl_ffi_default_with_default! {
+    i8, u8, i16, u16, i32, u32, i64, u64, f32, f64
+}
+
+// Implement FfiDefault for the remaining types
+impl FfiDefault for () {
+    fn ffi_default() {}
+}
+
+impl FfiDefault for *const std::ffi::c_void {
+    fn ffi_default() -> Self {
+        std::ptr::null()
+    }
+}
+
+impl FfiDefault for crate::RustBuffer {
+    fn ffi_default() -> Self {
+        unsafe { Self::from_raw_parts(std::ptr::null_mut(), 0, 0) }
+    }
+}

--- a/uniffi/src/ffi/foreigncallbacks.rs
+++ b/uniffi/src/ffi/foreigncallbacks.rs
@@ -139,15 +139,8 @@ pub const IDX_CALLBACK_FREE: u32 = 0;
 // Note that these are guaranteed by
 // https://rust-lang.github.io/unsafe-code-guidelines/layout/function-pointers.html
 // and thus this is a little paranoid.
-ffi_support::static_assert!(
-    STATIC_ASSERT_USIZE_EQ_FUNC_SIZE,
-    std::mem::size_of::<usize>() == std::mem::size_of::<ForeignCallback>()
-);
-
-ffi_support::static_assert!(
-    STATIC_ASSERT_USIZE_EQ_OPT_FUNC_SIZE,
-    std::mem::size_of::<usize>() == std::mem::size_of::<Option<ForeignCallback>>()
-);
+static_assertions::assert_eq_size!(usize, ForeignCallback);
+static_assertions::assert_eq_size!(usize, Option<ForeignCallback>);
 
 /// Struct to hold a foreign callback.
 pub struct ForeignCallbackInternals {

--- a/uniffi/src/ffi/mod.rs
+++ b/uniffi/src/ffi/mod.rs
@@ -2,11 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+pub mod ffidefault;
 pub mod foreignbytes;
 pub mod foreigncallbacks;
 pub mod rustbuffer;
 pub mod rustcalls;
 
+use ffidefault::FfiDefault;
 pub use foreignbytes::*;
 pub use foreigncallbacks::*;
 pub use rustbuffer::*;

--- a/uniffi/src/ffi/rustbuffer.rs
+++ b/uniffi/src/ffi/rustbuffer.rs
@@ -186,16 +186,6 @@ impl Default for RustBuffer {
     }
 }
 
-unsafe impl crate::deps::ffi_support::IntoFfi for RustBuffer {
-    type Value = Self;
-    fn ffi_default() -> Self {
-        unsafe { Self::from_raw_parts(std::ptr::null_mut(), 0, 0) }
-    }
-    fn into_ffi_value(self) -> Self::Value {
-        self
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -48,10 +48,11 @@ pub mod testing;
 pub mod deps {
     pub use anyhow;
     pub use bytes;
-    pub use ffi_support;
     pub use log;
     pub use static_assertions;
 }
+
+mod panichook;
 
 const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/uniffi/src/panichook.rs
+++ b/uniffi/src/panichook.rs
@@ -1,0 +1,34 @@
+/// Initialize our panic handling hook to optionally log panics
+#[cfg(feature = "log_panics")]
+pub fn ensure_setup() {
+    use std::sync::Once;
+    static INIT_BACKTRACES: Once = Once::new();
+    INIT_BACKTRACES.call_once(move || {
+        #[cfg(all(feature = "log_backtraces", not(target_os = "android")))]
+        {
+            std::env::set_var("RUST_BACKTRACE", "1");
+        }
+        // Turn on a panic hook which logs both backtraces and the panic
+        // "Location" (file/line). We do both in case we've been stripped,
+        // ).
+        std::panic::set_hook(Box::new(move |panic_info| {
+            let (file, line) = if let Some(loc) = panic_info.location() {
+                (loc.file(), loc.line())
+            } else {
+                // Apparently this won't happen but rust has reserved the
+                // ability to start returning None from location in some cases
+                // in the future.
+                ("<unknown>", 0)
+            };
+            log::error!("### Rust `panic!` hit at file '{}', line {}", file, line);
+            #[cfg(all(feature = "log_backtraces", not(target_os = "android")))]
+            {
+                log::error!("  Complete stack trace:\n{:?}", backtrace::Backtrace::new());
+            }
+        }));
+    });
+}
+
+/// Initialize our panic handling hook to optionally log panics
+#[cfg(not(feature = "log_panics"))]
+pub fn ensure_setup() {}


### PR DESCRIPTION
This seems like a nice little cleanup.  The `rustcalls` mod was importing
`IntoFfi`, but only using a trivial part of the interface.  Now we just
define our own trait to do that.

I was a slightly worried about this when I initially implemented the
`rustcalls` module, because I was concenced about uniffi consumers defining their own
`ViaFfi` implementation with some other `FfiType`.  However I now realize
this is impossible, we have a `FfiType` enum in the scaffolding code that
spells out the possible types.

The last bit of functionality was the panic handling hook, I just copied
the code for that.