### PR TITLE
[WIP] Type wrappers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "examples/todolist",
   "fixtures/coverall",
   "fixtures/callbacks",
+  "fixtures/ext-types/guid",
   "fixtures/external-types/crate-one",
   "fixtures/external-types/crate-two",
   "fixtures/external-types/lib",

--- a/fixtures/ext-types/guid/Cargo.toml
+++ b/fixtures/ext-types/guid/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "ext-types-guid"
+edition = "2018"
+version = "0.11.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["staticlib", "cdylib"]
+name = "uniffi_ext_types_guid"
+
+[dependencies]
+anyhow = "1"
+bytes = "1.0"
+serde_json = "1"
+uniffi_macros = {path = "../../../uniffi_macros"}
+uniffi = {path = "../../../uniffi", features=["builtin-bindgen"]}
+
+[build-dependencies]
+uniffi_build = {path = "../../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/ext-types/guid/build.rs
+++ b/fixtures/ext-types/guid/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/guid.udl").unwrap();
+}

--- a/fixtures/ext-types/guid/src/guid.udl
+++ b/fixtures/ext-types/guid/src/guid.udl
@@ -1,0 +1,12 @@
+[ExternalWrapping]
+typedef string Guid;
+
+dictionary GuidHelper {
+    Guid guid;
+    sequence<Guid> guids;
+};
+
+namespace ext_types_guid {
+    Guid get_guid(optional Guid? val);
+    GuidHelper get_guid_helper(optional GuidHelper? vals);
+};

--- a/fixtures/ext-types/guid/src/lib.rs
+++ b/fixtures/ext-types/guid/src/lib.rs
@@ -1,0 +1,68 @@
+use uniffi::FfiConverter;
+
+// A trivial guid.
+pub struct Guid(pub String);
+
+fn get_guid(guid: Option<Guid>) -> Guid {
+    match guid {
+        Some(guid) => guid,
+        None => Guid("NewGuid".to_string()),
+    }
+}
+
+pub struct GuidHelper {
+    pub guid: Guid,
+    pub guids: Vec<Guid>,
+}
+
+fn get_guid_helper(vals: Option<GuidHelper>) -> GuidHelper {
+    match vals {
+        None => GuidHelper {
+            guid: Guid("first-guid".to_string()),
+            guids: vec![
+                Guid("second-guid".to_string()),
+                Guid("third-guid".to_string()),
+            ],
+        },
+        Some(vals) => vals,
+    }
+}
+
+// The name is hard-coded based on the 2 types involved.  Definitely open to a suggestions for how
+// we generate the name.
+struct FFIConverterWrappingGuidString;
+
+impl FFIConverterWrappingGuidString {
+    pub fn to_wrapper(guid: Guid) -> String {
+        guid.0
+    }
+
+    pub fn from_wrapper(string: String) -> uniffi::Result<Guid> {
+        Ok(Guid(string))
+    }
+}
+
+// Imagine this being created by a derive macro
+unsafe impl FfiConverter for FFIConverterWrappingGuidString {
+    type RustType = Guid;
+    type FfiType = uniffi::RustBuffer;
+
+    fn lower(obj: Guid) -> uniffi::RustBuffer {
+        <String as FfiConverter>::lower(Self::to_wrapper(obj))
+    }
+
+    fn try_lift(v: uniffi::RustBuffer) -> uniffi::Result<Guid> {
+        Self::from_wrapper(<String as FfiConverter>::try_lift(v)?)
+    }
+
+    fn write(obj: Guid, buf: &mut Vec<u8>) {
+        <String as FfiConverter>::write(Self::to_wrapper(obj), buf);
+    }
+
+    fn try_read(buf: &mut &[u8]) -> uniffi::Result<Guid> {
+        Self::from_wrapper(<String as FfiConverter>::try_read(buf)?)
+    }
+}
+
+
+include!(concat!(env!("OUT_DIR"), "/guid.uniffi.rs"));

--- a/fixtures/ext-types/guid/tests/bindings/test_guid.py
+++ b/fixtures/ext-types/guid/tests/bindings/test_guid.py
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import unittest
+from ext_types_guid import *
+
+class TestGuid(unittest.TestCase):
+    def test_get_guid(self):
+        self.assertEqual(get_guid(None), "NewGuid")
+        self.assertEqual(get_guid("SomeGuid"), "SomeGuid")
+
+    # def test_round_trip(self):
+    #     ct = get_combined_type(None)
+    #     self.assertEqual(ct.cot.sval, "hello")
+    #     self.assertEqual(ct.ctt.ival, 1)
+
+if __name__=='__main__':
+    unittest.main()

--- a/fixtures/ext-types/guid/tests/test_generated_bindings.rs
+++ b/fixtures/ext-types/guid/tests/test_generated_bindings.rs
@@ -1,0 +1,6 @@
+uniffi_macros::build_foreign_language_testcases!(
+    "src/guid.udl",
+    [
+        "tests/bindings/test_guid.py",
+    ]
+);

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -28,7 +28,7 @@
 //! In addition to the core` FfiConverter` trait, we provide a handful of struct definitions useful
 //! for passing core rust types over the FFI, such as [`RustBuffer`].
 
-use anyhow::{bail, Result};
+use anyhow::bail;
 use bytes::buf::{Buf, BufMut};
 use paste::paste;
 use std::{
@@ -36,6 +36,9 @@ use std::{
     convert::TryFrom,
     time::{Duration, SystemTime},
 };
+
+// Make Result<> public to support external impls of FfiConverter
+pub use anyhow::Result;
 
 pub mod ffi;
 pub use ffi::*;

--- a/uniffi_bindgen/src/bindings/python/gen_python.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python.rs
@@ -156,7 +156,7 @@ mod filters {
                 coerce_py(&"v", t)?,
                 nm
             ),
-            Type::Custom { .. } => panic!("No support for coercing external types yet"),
+            Type::Custom { primitive, .. } => coerce_py(nm, primitive.as_ref())?,
         })
     }
 
@@ -188,7 +188,7 @@ mod filters {
                 class_name_py(&type_.canonical_name())?,
                 nm
             ),
-            Type::Custom { .. } => panic!("No support for lowering external types yet"),
+            Type::Custom { primitive, .. } => lower_py(nm, primitive.as_ref())?,
         })
     }
 
@@ -219,7 +219,7 @@ mod filters {
                 nm,
                 class_name_py(&type_.canonical_name())?
             ),
-            Type::Custom { .. } => panic!("No support for lowering external types, yet"),
+            Type::Custom { primitive, .. } => lift_py(nm, primitive.as_ref())?,
         })
     }
 }

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
@@ -195,6 +195,11 @@ class RustBufferBuilder(object):
             self.writeString(k)
             self.write{{ inner_type.canonical_name()|class_name_py }}(v)
 
+    {% when Type::Custom with { primitive, name, ffi_converter_name, bindings_kind } -%}
+
+    def write{{ canonical_type_name }}(self, items):
+        return self.write{{ primitive.canonical_name()|class_name_py }}(items)
+
     {%- else -%}
     # This type cannot currently be serialized, but we can produce a helpful error.
 

--- a/uniffi_bindgen/src/interface/types/finder.rs
+++ b/uniffi_bindgen/src/interface/types/finder.rs
@@ -19,6 +19,7 @@
 
 use std::convert::TryFrom;
 
+use heck::CamelCase;
 use anyhow::{bail, Result};
 
 use super::super::attributes::{EnumAttributes, InterfaceAttributes, TypedefAttributes};
@@ -106,7 +107,7 @@ impl TypeFinder for weedle::TypedefDefinition<'_> {
                 Type::Custom {
                     name: name.to_string(),
                     primitive: wrapped_type.clone().into(),
-                    ffi_converter_name: "TODO".into(),
+                    ffi_converter_name: format!("FFIConverterWrapping{}{}", name, wrapped_type.canonical_name().to_camel_case()),
                     bindings_kind: CustomTypeBindingsKind::Primitive(wrapped_type.into()),
                 }
             )


### PR DESCRIPTION
I wish I had another half hour to polish this some more, but it seems like this approach would be doable to me.  The python tests are currently passing.  I haven't tested GuidHelper yet, but I don't see why it wouldn't work.

I feel like the scaffolding side of things is makes it much easier to implement new types, I would love to refactor the bindings templates to put the FfiConverter code for a type all in 1 place.  Right now it feels like to add a type you need to make changes in a bunch of random files.  On that topic, I saw an crash in the `RustBuffer` code and fixed that to make the tests pass, but I suspect that different primitives would cause a failure (like a `Timestamp` type that wrapped `u64`).