### PR TITLE
Restore implicit `Into` conversion when throwing errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@
 
 [All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.13.0...HEAD).
 
+
+### What's Changed
+
+- Fixed an accidental regression in v0.13.0 where errors were no longer being coerced
+  to the correct type via `Into`. If the UDL declares a `[Throws=ExampleError]` function
+  or method, the underlying implementation can now return anything that is `Into<ExampleError>`,
+  matching the implicit `Into` behavoir of Rust's `?` operator.
+
+
 ## v0.13.0 (_2021-08-09_)
 
 [All changes in v0.13.0](https://github.com/mozilla/uniffi-rs/compare/v0.12.0...v0.13.0).

--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -60,6 +60,11 @@ interface Coveralls {
     [Throws=CoverallError]
     boolean maybe_throw(boolean should_throw);
 
+    /// Throws something that impls `Into<CoverallError>`,
+    /// rather than directly throwing `CoverallError`.
+    [Throws=CoverallError]
+    boolean maybe_throw_into(boolean should_throw);
+
     [Throws=ComplexError]
     boolean maybe_throw_complex(i8 input);
 

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -17,6 +17,22 @@ enum CoverallError {
     TooManyHoles,
 }
 
+/// This error doesn't appear in the interface, instead
+/// we rely on an `Into<CoverallError>` impl to surface it to consumers.
+#[derive(Debug, thiserror::Error)]
+enum InternalCoverallError {
+    #[error("The coverall has an excess of holes")]
+    ExcessiveHoles,
+}
+
+impl From<InternalCoverallError> for CoverallError {
+    fn from(err: InternalCoverallError) -> CoverallError {
+        match err {
+            InternalCoverallError::ExcessiveHoles => CoverallError::TooManyHoles,
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 enum ComplexError {
     #[error("OsError: {code} ({extended_code})")]
@@ -149,6 +165,14 @@ impl Coveralls {
     fn maybe_throw(&self, should_throw: bool) -> Result<bool> {
         if should_throw {
             Err(CoverallError::TooManyHoles)
+        } else {
+            Ok(true)
+        }
+    }
+
+    fn maybe_throw_into(&self, should_throw: bool) -> Result<bool, InternalCoverallError> {
+        if should_throw {
+            Err(InternalCoverallError::ExcessiveHoles)
         } else {
             Ok(true)
         }

--- a/fixtures/coverall/tests/bindings/test_coverall.kts
+++ b/fixtures/coverall/tests/bindings/test_coverall.kts
@@ -112,6 +112,13 @@ Coveralls("test_simple_errors").use { coveralls ->
     }
 
     try {
+        coveralls.maybeThrowInto(true)
+        throw RuntimeException("Expected method to throw exception")
+    } catch(e: CoverallException.TooManyHoles) {
+        // Expected result
+    }
+
+    try {
         coveralls.panic("oops")
         throw RuntimeException("Expected method to throw exception")
     } catch(e: InternalException) {

--- a/fixtures/coverall/tests/bindings/test_coverall.py
+++ b/fixtures/coverall/tests/bindings/test_coverall.py
@@ -92,6 +92,9 @@ class TestCoverall(unittest.TestCase):
         with self.assertRaises(CoverallError.TooManyHoles):
             coveralls.maybe_throw(True)
 
+        with self.assertRaises(CoverallError.TooManyHoles):
+            coveralls.maybe_throw_into(True)
+
         with self.assertRaisesRegex(InternalError, "expected panic: oh no"):
             coveralls.panic("expected panic: oh no")
 

--- a/fixtures/coverall/tests/bindings/test_coverall.rb
+++ b/fixtures/coverall/tests/bindings/test_coverall.rb
@@ -102,6 +102,10 @@ class TestCoverall < Test::Unit::TestCase
       coveralls.maybe_throw true
     end
 
+    assert_raise Coverall::CoverallError::TooManyHoles do
+      coveralls.maybe_throw_into true
+    end
+
     assert_raise Coverall::InternalError, 'expected panic: oh no' do
       coveralls.panic 'expected panic: oh no'
     end

--- a/fixtures/coverall/tests/bindings/test_coverall.swift
+++ b/fixtures/coverall/tests/bindings/test_coverall.swift
@@ -88,6 +88,13 @@ do {
         // It's okay!
     }
 
+    do {
+        let _ = try coveralls.maybeThrowInto(shouldThrow: true)
+        fatalError("Should have thrown")
+    } catch CoverallError.TooManyHoles {
+        // It's okay!
+    }
+
     // Note: Can't test coveralls.panic() because rust panics trigger a fatal error in swift
 }
 

--- a/uniffi_bindgen/src/scaffolding/templates/macros.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/macros.rs
@@ -48,7 +48,7 @@
 {% match cons.throws_type() %}
 {% when Some with (e) %}
     uniffi::call_with_result(call_status, || {
-        let _new = {% call construct(obj, cons) %}.map_err({{ e|ffi_converter }}::lower)?;
+        let _new = {% call construct(obj, cons) %}.map_err(Into::into).map_err({{ e|ffi_converter }}::lower)?;
         let _arc = std::sync::Arc::new(_new);
         Ok({{ obj.type_()|ffi_converter }}::lower(_arc))
     })
@@ -65,7 +65,7 @@
 {% match meth.throws_type() -%}
 {% when Some with (e) -%}
 uniffi::call_with_result(call_status, || {
-    let _retval =  {{ obj.name() }}::{% call to_rs_call(meth) %}.map_err({{ e|ffi_converter }}::lower)?;
+    let _retval =  {{ obj.name() }}::{% call to_rs_call(meth) %}.map_err(Into::into).map_err({{ e|ffi_converter }}::lower)?;
     Ok({% call ret(meth) %})
 })
 {% else %}
@@ -85,7 +85,7 @@ uniffi::call_with_output(call_status, || {
 {% match func.throws_type() %}
 {% when Some with (e) %}
 uniffi::call_with_result(call_status, || {
-    let _retval = {% call to_rs_call(func) %}.map_err({{ e|ffi_converter }}::lower)?;
+    let _retval = {% call to_rs_call(func) %}.map_err(Into::into).map_err({{ e|ffi_converter }}::lower)?;
     Ok({% call ret(func) %})
 })
 {% else %}


### PR DESCRIPTION
This fixes a subtle regression from #983. Prior to that change, we
were returning errors using Rust's builtin `?` operator and thus
performing an implicit `Into::into` conversion on the error value.
This meant that the underlying implementation of a `[Throws=MyErr]`
function could return anything that was `Into<MyErr>` and our scaffolding
would do the right thing.

In #983 we switched to doing an explicit `.map_err` rather than using
the `?` operator, losing the implicit `Into::into` and causing a
subtle breaking change for any consumers that were relying on the
old behaviour. It turns out our Logins component was relying on it.

This commit restores the previous behaviour by adding an explicit
`Into::into`, and a coveralls testcase to prevent regressing it
in future. I think it's worth commiting to this being explicitly
intended semantics given that it matches the behaviour of the `?`
operator.