### PR TITLE
Use fully-qualified type names in generated scaffolding code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,15 @@
 
 [All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.13.0...HEAD).
 
-
 ### What's Changed
 
 - Fixed an accidental regression in v0.13.0 where errors were no longer being coerced
   to the correct type via `Into`. If the UDL declares a `[Throws=ExampleError]` function
   or method, the underlying implementation can now return anything that is `Into<ExampleError>`,
   matching the implicit `Into` behavoir of Rust's `?` operator.
-
+- Fixed an accidental regression in v0.13.0 where the generated Rust scaffolding assumed
+  that the `HashMap` type would be in scope. It now uses fully-qualified type names in order
+  to be more robust.
 
 ## v0.13.0 (_2021-08-09_)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "fixtures/external-types/crate-two",
   "fixtures/external-types/lib",
   "fixtures/regressions/enum-without-i32-helpers",
+  "fixtures/regressions/fully-qualified-types",
   "fixtures/regressions/kotlin-experimental-unsigned-types",
   "fixtures/regressions/cdylib-crate-type-dependency/ffi-crate",
   "fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency",

--- a/fixtures/regressions/fully-qualified-types/Cargo.toml
+++ b/fixtures/regressions/fully-qualified-types/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "i1015-fully-qualified-types"
+edition = "2018"
+version = "0.13.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+name = "uniffi_regression_test_i1015"
+
+[dependencies]
+uniffi_macros = {path = "../../../uniffi_macros"}
+uniffi = {path = "../../../uniffi", features=["builtin-bindgen"]}
+
+[build-dependencies]
+uniffi_build = {path = "../../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/regressions/fully-qualified-types/README.md
+++ b/fixtures/regressions/fully-qualified-types/README.md
@@ -1,0 +1,18 @@
+# Regression test for issue #1015
+
+In issue [#1015](https://github.com/mozilla/uniffi-rs/issues/1015)
+we discovered that the generated scaffolding code was assuming that
+some std types were in scope, which makes it fragile to changes in
+the containing crate's Rust code. The scaffolding should instead
+use fully-qualified type names.
+
+This crate is a minimal reproduction of the issue, which will fail
+to compile if the scaffolding depends on particular types being
+in scope.
+
+There deliberately aren't any tests in this crate; the test is
+whether or not it compiles successully. If you find that this crate
+no longer compiles, you've probably added some generated scaffolding
+code that is depending on a particular type name being in scope.
+Change it to use a fully-qualified name, e.g. `std::collections::HashMap`
+instead of just `HashMap`.

--- a/fixtures/regressions/fully-qualified-types/build.rs
+++ b/fixtures/regressions/fully-qualified-types/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/test.udl").unwrap();
+}

--- a/fixtures/regressions/fully-qualified-types/src/lib.rs
+++ b/fixtures/regressions/fully-qualified-types/src/lib.rs
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// The point of this test is that we don't have any of the used Rust types
+// in scope under their usual names, so we don't import the ones that aren't
+// in the prelude, and we overrwrite the ones that are.
+//
+// Real Rust code wouldn't do this of course, but it's nice to be robust
+// against it.
+//
+// We could consider giving `String` and `Box` similar treatment in future,
+// but our use of those as unqualified names is not a recent regression,
+// so that's for follow-up work.
+
+#[allow(dead_code)]
+type Vec = ();
+
+#[allow(dead_code)]
+type Option = ();
+
+mod t {
+    pub use std::collections::HashMap;
+    pub use std::option::Option;
+    pub use std::time::{Duration, SystemTime};
+    pub use std::vec::Vec;
+}
+
+pub struct Values {
+    d: t::Duration,
+    t: t::SystemTime,
+}
+
+pub fn test() -> t::Option<t::HashMap<String, t::Vec<Values>>> {
+    None
+}
+
+include!(concat!(env!("OUT_DIR"), "/test.uniffi.rs"));

--- a/fixtures/regressions/fully-qualified-types/src/test.udl
+++ b/fixtures/regressions/fully-qualified-types/src/test.udl
@@ -1,0 +1,13 @@
+// We use a bunch of special built-in types, but the underlying Rust
+// code does not have the corresponding types in scope. This will fail
+// to compile if the generated Rust scaffolding incorrectly assumes that
+// they are in scope, ref https://github.com/mozilla/uniffi-rs/issues/1015.
+
+dictionary Values {
+  duration d;
+  timestamp t;
+};
+
+namespace regression_test_i1015 {
+  record<DOMString, sequence<Values>>? test();
+};

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -43,8 +43,8 @@ mod filters {
             Type::Enum(name) | Type::Record(name) | Type::Error(name) => name.clone(),
             Type::Object(name) => format!("std::sync::Arc<{}>", name),
             Type::CallbackInterface(name) => format!("Box<dyn {}>", name),
-            Type::Optional(t) => format!("Option<{}>", type_rs(t)?),
-            Type::Sequence(t) => format!("Vec<{}>", type_rs(t)?),
+            Type::Optional(t) => format!("std::option::Option<{}>", type_rs(t)?),
+            Type::Sequence(t) => format!("std::vec::Vec<{}>", type_rs(t)?),
             Type::Map(t) => format!("std::collections::HashMap<String, {}>", type_rs(t)?),
         })
     }
@@ -92,9 +92,12 @@ mod filters {
             }
             // Wrapper types are implemented by generics that wrap the FfiConverter implementation of the
             // inner type.
-            Type::Optional(inner) => format!("Option<{}>", ffi_converter_name(inner)?),
-            Type::Sequence(inner) => format!("Vec<{}>", ffi_converter_name(inner)?),
-            Type::Map(inner) => format!("HashMap<String, {}>", ffi_converter_name(inner)?),
+            Type::Optional(inner) => format!("std::option::Option<{}>", ffi_converter_name(inner)?),
+            Type::Sequence(inner) => format!("std::vec::Vec<{}>", ffi_converter_name(inner)?),
+            Type::Map(inner) => format!(
+                "std::collections::HashMap<String, {}>",
+                ffi_converter_name(inner)?
+            ),
             // Primitive types / strings are implemented by their rust type
             Type::Int8 => "i8".into(),
             Type::UInt8 => "u8".into(),

--- a/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
@@ -99,7 +99,7 @@ unsafe impl uniffi::FfiConverter for {{ trait_impl }} {
         panic!("Lowering CallbackInterface not supported")
     }
 
-    fn write(_obj: Self::RustType, _buf: &mut Vec<u8>) {
+    fn write(_obj: Self::RustType, _buf: &mut std::vec::Vec<u8>) {
         panic!("Writing CallbackInterface not supported")
     }
 

--- a/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
@@ -12,7 +12,7 @@ struct {{ e.type_()|ffi_converter_name }};
 impl uniffi::RustBufferFfiConverter for {{ e.type_()|ffi_converter_name }} {
     type RustType = {{ e.name() }};
 
-    fn write(obj: Self::RustType, buf: &mut Vec<u8>) {
+    fn write(obj: Self::RustType, buf: &mut std::vec::Vec<u8>) {
         use uniffi::deps::bytes::BufMut;
         match obj {
             {%- for variant in e.variants() %}

--- a/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
@@ -12,7 +12,7 @@ struct {{ e.type_()|ffi_converter_name }};
 impl uniffi::RustBufferFfiConverter for {{ e.type_()|ffi_converter_name }} {
     type RustType = {{ e.name() }};
 
-    fn write(obj: {{ e.name() }}, buf: &mut Vec<u8>) {
+    fn write(obj: {{ e.name() }}, buf: &mut std::vec::Vec<u8>) {
         use uniffi::deps::bytes::BufMut;
         match obj {
             {%- for variant in e.variants() %}

--- a/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
@@ -12,7 +12,7 @@ struct {{ rec.type_()|ffi_converter_name }};
 impl uniffi::RustBufferFfiConverter for {{ rec.type_()|ffi_converter_name }} {
     type RustType = {{ rec.name() }};
 
-    fn write(obj: {{ rec.name() }}, buf: &mut Vec<u8>) {
+    fn write(obj: {{ rec.name() }}, buf: &mut std::vec::Vec<u8>) {
         // If the provided struct doesn't match the fields declared in the UDL, then
         // the generated code here will fail to compile with somewhat helpful error.
         {%- for field in rec.fields() %}


### PR DESCRIPTION
This fixes #1015, which was a regression in the v0.13.0 release.

Where possible we should be robust against changes in the details of
the Rust code that implements a UniFFI component, but the generated
Rust scaffolding accidentally started assuming that the `HashMap` type
would be in scope for any interface using a map. This turned out not
to be true in practice.

To improve things, this commit makes the generated scaffolding use
fully-qualified type names for `HashMap`, `Vec` and `Option`. There
is probably more we could do on this front (e.g. the `String` type)
but these were low-hanging fruit that fixed a concrete regression,
so that's where I started.