### PR TITLE
Ignore clippy "redundant closure" warnings in our scaffolding.

### DIFF
--- a/uniffi_bindgen/src/scaffolding/templates/macros.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/macros.rs
@@ -94,6 +94,7 @@ uniffi::call_with_output(call_status, || {
     {% when Some with (return_type) -%}
     {{ return_type|ffi_converter }}::lower({% call to_rs_call(func) %})
     {% else -%}
+    {% if func.full_arguments().is_empty() %}#[allow(clippy::redundant_closure)]{% endif %}
     {% call to_rs_call(func) %}
     {% endmatch -%}
 })


### PR DESCRIPTION
Fixes #1018. I didn't make a regression test for this but I did
test it locally against a consume crate that was triggering this
warning.