### PR TITLE
Use a predictable canonical_name for types which support being imported

### DIFF
--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -259,7 +259,7 @@ mod test {
         assert_eq!(func2.arguments()[1].name(), "arg2");
         assert_eq!(
             func2.arguments()[1].type_().canonical_name(),
-            "RecordTestDict"
+            "TypeTestDict"
         );
         Ok(())
     }

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -479,7 +479,7 @@ mod test {
         assert!(ci
             .iter_types()
             .iter()
-            .any(|t| t.canonical_name() == "ObjectTesting"));
+            .any(|t| t.canonical_name() == "TypeTesting"));
     }
 
     #[test]

--- a/uniffi_bindgen/src/interface/record.rs
+++ b/uniffi_bindgen/src/interface/record.rs
@@ -233,6 +233,6 @@ mod test {
         assert!(ci
             .iter_types()
             .iter()
-            .any(|t| t.canonical_name() == "RecordTesting"));
+            .any(|t| t.canonical_name() == "TypeTesting"));
     }
 }

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -89,11 +89,13 @@ impl Type {
             // API defined types.
             // Note that these all get unique names, and the parser ensures that the names do not
             // conflict with a builtin type. We add a prefix to the name to guard against pathological
-            // cases like a record named `SequenceRecord` interfering with `sequence<Record>`
-            Type::Object(nm) => format!("Object{}", nm),
-            Type::Error(nm) => format!("Error{}", nm),
-            Type::Enum(nm) => format!("Enum{}", nm),
-            Type::Record(nm) => format!("Record{}", nm),
+            // cases like a record named `SequenceRecord` interfering with `sequence<Record>`.
+            // However, types that support importing all end up with the same prefix of "Type", so
+            // that the import handling code knows how to find the remote reference.
+            Type::Object(nm) => format!("Type{}", nm),
+            Type::Error(nm) => format!("Type{}", nm),
+            Type::Enum(nm) => format!("Type{}", nm),
+            Type::Record(nm) => format!("Type{}", nm),
             Type::CallbackInterface(nm) => format!("CallbackInterface{}", nm),
             Type::Timestamp => "Timestamp".into(),
             Type::Duration => "Duration".into(),
@@ -303,7 +305,7 @@ mod test_type {
                 "Example".into()
             )))))
             .canonical_name(),
-            "OptionalSequenceObjectExample"
+            "OptionalSequenceTypeExample"
         );
     }
 }

--- a/uniffi_bindgen/src/interface/types/resolver.rs
+++ b/uniffi_bindgen/src/interface/types/resolver.rs
@@ -207,7 +207,7 @@ mod test {
         let t = types.resolve_type_expression(expr).unwrap();
         assert!(matches!(t, Type::Optional(_)));
         // Matching the Box<T> is hard, use names as a convenient workaround.
-        assert_eq!(t.canonical_name(), "OptionalRecordTestRecord");
+        assert_eq!(t.canonical_name(), "OptionalTypeTestRecord");
         assert_eq!(types.iter_known_types().count(), 2);
 
         Ok(())


### PR DESCRIPTION
This seems required in every iteration of the "external types" effort and can't cause harm, so here I am. Flagging Ryan as he suggested adding `Error` etc in another WIP patch, so is somewhat familiar.