### PR TITLE
Add `[Export]` attribute, which makes the generated FfiConverter for some types `pub`

### DIFF
--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -216,6 +216,11 @@ impl<'ci> ComponentInterface {
         self.types.get_type_definition(name)
     }
 
+    /// Returns true if the specified type has been marked as being exported.
+    pub fn is_name_exported(&self, name: &str) -> bool {
+        self.types.is_exported(name)
+    }
+
     /// Iterate over all types contained in the given item.
     ///
     /// This method uses `IterTypes::iter_types` to iterate over the types contained within the

--- a/uniffi_bindgen/src/interface/record.rs
+++ b/uniffi_bindgen/src/interface/record.rs
@@ -85,9 +85,6 @@ impl IterTypes for Record {
 
 impl APIConverter<Record> for weedle::DictionaryDefinition<'_> {
     fn convert(&self, ci: &mut ComponentInterface) -> Result<Record> {
-        if self.attributes.is_some() {
-            bail!("dictionary attributes are not supported yet");
-        }
         if self.inheritance.is_some() {
             bail!("dictionary inheritence is not supported");
         }

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -21,7 +21,11 @@
 //! about how these API-level types map into the lower-level types of the FFI layer as represented
 //! by the [`ffi::FFIType`](super::ffi::FFIType) enum, but that's a detail that is invisible to end users.
 
-use std::{collections::hash_map::Entry, collections::BTreeSet, collections::HashMap};
+use std::{
+    collections::hash_map::Entry,
+    collections::BTreeSet,
+    collections::{HashMap, HashSet},
+};
 
 use anyhow::{bail, Result};
 
@@ -168,6 +172,8 @@ pub(crate) struct TypeUniverse {
     type_definitions: HashMap<String, Type>,
     // All the types in the universe, by canonical type name, in a well-defined order.
     all_known_types: BTreeSet<Type>,
+    // All types in the universe declared as `Export`
+    exported_names: HashSet<String>,
 }
 
 impl TypeUniverse {
@@ -227,6 +233,16 @@ impl TypeUniverse {
     /// Iterator over all the known types in this universe.
     pub fn iter_known_types(&self) -> impl Iterator<Item = Type> + '_ {
         self.all_known_types.iter().cloned()
+    }
+
+    /// Mark the specified type name as being exported.
+    pub fn mark_as_exported(&mut self, name: &str) {
+        self.exported_names.insert(name.to_string());
+    }
+
+    /// Returns whether the specified type name is marked as exported.
+    pub fn is_exported(&self, name: &str) -> bool {
+        self.exported_names.contains(name)
     }
 }
 

--- a/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
@@ -6,6 +6,9 @@
 // We define a unit-struct to implement the trait to sidestep Rust's orphan rule (ADR-0006).
 #}
 
+{%- if ci.is_name_exported(e.name()) -%}
+pub
+{%- endif %}
 struct {{ e.type_()|ffi_converter_name }};
 
 #[doc(hidden)]

--- a/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
@@ -6,6 +6,9 @@
 // We define a unit-struct to implement the trait to sidestep Rust's orphan rule (ADR-0006).
 #}
 
+{%- if ci.is_name_exported(e.name()) -%}
+pub
+{%- endif %}
 struct {{ e.type_()|ffi_converter_name }};
 
 #[doc(hidden)]

--- a/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
@@ -6,6 +6,10 @@
 //
 // We define a unit-struct to implement the trait to sidestep Rust's orphan rule (ADR-0006)
 #}
+
+{%- if ci.is_name_exported(rec.name()) -%}
+pub
+{%- endif %}
 struct {{ rec.type_()|ffi_converter_name }};
 
 #[doc(hidden)]


### PR DESCRIPTION
This is on the path to the external types work and seems clear and stand-alone enough that we can consider merging it before the external types work is actually ready to land. Landing this now avoids rebase pain for the other attributes external-types would like, but they are still in more of a state of flux.

WDYT about landing this now, or would you prefer to wait for the external types work to solidify?