### PR TITLE
Make "flat" error enums carry a stringified error message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
     `private type <type-name> in public interface`
   or similar, please declare the types as `pub` in your Rust code.
 
+- Errors declared using the `[Error] enum` syntax will now expose the error string from
+  Rust to the foreign language bindings. This reverts an unintended change in behaviour
+  from the v0.13 release which made the error message inaccessible.
+
 ### What's Changed
 
 - You can now use external types of various flavours - see

--- a/fixtures/coverall/tests/bindings/test_coverall.kts
+++ b/fixtures/coverall/tests/bindings/test_coverall.kts
@@ -109,6 +109,7 @@ Coveralls("test_simple_errors").use { coveralls ->
         throw RuntimeException("Expected method to throw exception")
     } catch(e: CoverallException.TooManyHoles) {
         // Expected result
+        assert(e.message == "The coverall has too many holes")
     }
 
     try {

--- a/fixtures/coverall/tests/bindings/test_coverall.py
+++ b/fixtures/coverall/tests/bindings/test_coverall.py
@@ -89,7 +89,7 @@ class TestCoverall(unittest.TestCase):
         coveralls = Coveralls("test_errors")
         self.assertEqual(coveralls.get_name(), "test_errors")
 
-        with self.assertRaises(CoverallError.TooManyHoles):
+        with self.assertRaisesRegex(CoverallError.TooManyHoles, "The coverall has too many holes"):
             coveralls.maybe_throw(True)
 
         with self.assertRaises(CoverallError.TooManyHoles):

--- a/fixtures/coverall/tests/bindings/test_coverall.rb
+++ b/fixtures/coverall/tests/bindings/test_coverall.rb
@@ -98,17 +98,19 @@ class TestCoverall < Test::Unit::TestCase
     coveralls = Coverall::Coveralls.new 'test_simple_errors'
     assert_equal coveralls.get_name, 'test_simple_errors'
 
-    assert_raise Coverall::CoverallError::TooManyHoles do
+    err = assert_raise Coverall::CoverallError::TooManyHoles do
       coveralls.maybe_throw true
     end
+    assert_equal err.message, 'The coverall has too many holes'
 
     assert_raise Coverall::CoverallError::TooManyHoles do
       coveralls.maybe_throw_into true
     end
 
-    assert_raise Coverall::InternalError, 'expected panic: oh no' do
+    err = assert_raise Coverall::InternalError do
       coveralls.panic 'expected panic: oh no'
     end
+    assert_equal err.message, 'expected panic: oh no'
 
     assert_raise_message /expected panic: oh no/ do
       coveralls.panic 'expected panic: oh no'

--- a/fixtures/coverall/tests/bindings/test_coverall.swift
+++ b/fixtures/coverall/tests/bindings/test_coverall.swift
@@ -84,8 +84,9 @@ do {
     do {
         let _ = try coveralls.maybeThrow(shouldThrow: true)
         fatalError("Should have thrown")
-    } catch CoverallError.TooManyHoles {
+    } catch CoverallError.TooManyHoles(message) {
         // It's okay!
+        assert(message == "The coverall has too many holes")
     }
 
     do {

--- a/fixtures/coverall/tests/bindings/test_coverall.swift
+++ b/fixtures/coverall/tests/bindings/test_coverall.swift
@@ -84,7 +84,7 @@ do {
     do {
         let _ = try coveralls.maybeThrow(shouldThrow: true)
         fatalError("Should have thrown")
-    } catch CoverallError.TooManyHoles(message) {
+    } catch CoverallError.TooManyHoles(let message) {
         // It's okay!
         assert(message == "The coverall has too many holes")
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
@@ -27,16 +27,16 @@ interface CallStatusErrorHandler<E> {
 
 // Error {{ e.name() }}
 {%- let toplevel_name=e.name()|exception_name_kt %}
-sealed class {{ toplevel_name }}: Exception(){% if ci.item_contains_object_references(e) %}, Disposable {% endif %} {
-
-    {% if e.is_flat() %}
+{% if e.is_flat() %}
+sealed class {{ toplevel_name }}(message: String): Exception(message){% if ci.item_contains_object_references(e) %}, Disposable {% endif %} {
         // Each variant is a nested class
         // Flat enums carries a string error message, so no special implementation is necessary.
         {% for variant in e.variants() -%}
-        class {{ variant.name()|exception_name_kt }}() : {{ toplevel_name }}()
+        class {{ variant.name()|exception_name_kt }}(message: String) : {{ toplevel_name }}(message)
         {% endfor %}
 
-    {%- else %}
+{%- else %}
+sealed class {{ toplevel_name }}(): Exception(){% if ci.item_contains_object_references(e) %}, Disposable {% endif %} {
 
     // Each variant is a nested class
     {% for variant in e.variants() -%}
@@ -51,7 +51,7 @@ sealed class {{ toplevel_name }}: Exception(){% if ci.item_contains_object_refer
     {%- endif %}
     {% endfor %}
 
-    {%- endif %}
+{%- endif %}
 
     companion object ErrorHandler : CallStatusErrorHandler<{{ toplevel_name }}> {
         override fun lift(error_buf: RustBuffer.ByValue): {{ toplevel_name }} {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
@@ -28,6 +28,16 @@ interface CallStatusErrorHandler<E> {
 // Error {{ e.name() }}
 {%- let toplevel_name=e.name()|exception_name_kt %}
 sealed class {{ toplevel_name }}: Exception(){% if ci.item_contains_object_references(e) %}, Disposable {% endif %} {
+
+    {% if e.is_flat() %}
+        // Each variant is a nested class
+        // Flat enums carries a string error message, so no special implementation is necessary.
+        {% for variant in e.variants() -%}
+        class {{ variant.name()|exception_name_kt }}() : {{ toplevel_name }}()
+        {% endfor %}
+
+    {%- else %}
+
     // Each variant is a nested class
     {% for variant in e.variants() -%}
     {% if !variant.has_fields() -%}
@@ -41,12 +51,23 @@ sealed class {{ toplevel_name }}: Exception(){% if ci.item_contains_object_refer
     {%- endif %}
     {% endfor %}
 
+    {%- endif %}
+
     companion object ErrorHandler : CallStatusErrorHandler<{{ toplevel_name }}> {
         override fun lift(error_buf: RustBuffer.ByValue): {{ toplevel_name }} {
             return liftFromRustBuffer(error_buf) { error_buf -> read(error_buf) }
         }
 
         fun read(error_buf: ByteBuffer): {{ toplevel_name }} {
+            {% if e.is_flat() %}
+                return when(error_buf.getInt()) {
+                {%- for variant in e.variants() %}
+                {{ loop.index }} -> {{ toplevel_name }}.{{ variant.name()|exception_name_kt }}(String.read(error_buf))
+                {%- endfor %}
+                else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
+            }
+            {% else %}
+
             return when(error_buf.getInt()) {
                 {%- for variant in e.variants() %}
                 {{ loop.index }} -> {{ toplevel_name }}.{{ variant.name()|exception_name_kt }}({% if variant.has_fields() %}
@@ -57,6 +78,7 @@ sealed class {{ toplevel_name }}: Exception(){% if ci.item_contains_object_refer
                 {%- endfor %}
                 else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
             }
+            {%- endif %}
         }
     }
 

--- a/uniffi_bindgen/src/bindings/python/templates/ErrorTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ErrorTemplate.py
@@ -24,9 +24,20 @@ class RustCallStatus(ctypes.Structure):
 {%- for e in ci.iter_error_definitions() %}
 
 class {{ e.name()|class_name_py }}:
+
+    {%- if e.is_flat() %}
+
+    # Each variant is a nested class of the error itself.
+    # It just carries a string error message, so no special implementation is necessary.
+    {%- for variant in e.variants() %}
+    class {{ variant.name()|class_name_py }}(Exception):
+        pass
+    {%- endfor %}
+
+    {%- else %}
+
     # Each variant is a nested class of the error itself.
     {%- for variant in e.variants() %}
-
     class {{ variant.name()|class_name_py }}(Exception):
         def __init__(self{% for field in variant.fields() %}, {{ field.name()|var_name_py }}{% endfor %}):
             {%- if variant.has_fields() %}
@@ -49,6 +60,8 @@ class {{ e.name()|class_name_py }}:
             return "{{ e.name()|class_name_py }}.{{ variant.name()|class_name_py }}"
             {%- endif %}
     {%- endfor %}
+
+    {%- endif %}
 {%- endfor %}
 
 # Map error classes to the RustBufferTypeBuilder method to read them

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
@@ -203,7 +203,7 @@ class RustBufferTypeReader(object):
     @classmethod
     def readVariant{{ loop.index}}Of{{ canonical_type_name }}(cls, stream):
         {%- if e.is_flat() %}
-        return {{ error_name|class_name_py }}.{{ variant.name()|class_name_py }}(self.readString())
+        return {{ error_name|class_name_py }}.{{ variant.name()|class_name_py }}(cls.readString(stream))
         {%- else %}
         {%- if variant.has_fields() %}
         return {{ error_name|class_name_py }}.{{ variant.name()|class_name_py }}(

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
@@ -202,6 +202,9 @@ class RustBufferTypeReader(object):
 
     @classmethod
     def readVariant{{ loop.index}}Of{{ canonical_type_name }}(cls, stream):
+        {%- if e.is_flat() %}
+        return {{ error_name|class_name_py }}.{{ variant.name()|class_name_py }}(self.readString())
+        {%- else %}
         {%- if variant.has_fields() %}
         return {{ error_name|class_name_py }}.{{ variant.name()|class_name_py }}(
             {%- for field in variant.fields() %}
@@ -210,6 +213,7 @@ class RustBufferTypeReader(object):
         )
         {%- else %}
         return {{ error_name|class_name_py }}.{{ variant.name()|class_name_py }}()
+        {%- endif %}
         {%- endif %}
     {%- endfor %}
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/ErrorTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/ErrorTemplate.rb
@@ -20,6 +20,12 @@ CALL_SUCCESS = 0
 CALL_ERROR = 1
 CALL_PANIC = 2
 {%- for e in ci.iter_error_definitions() %}
+{% if e.is_flat() %}
+class {{ e.name()|class_name_rb }}
+    {%- for variant in e.variants() %}
+    {{ variant.name()|class_name_rb }} = Class.new StandardError
+    {%- endfor %}
+{% else %}
 module {{ e.name()|class_name_rb }}
   {%- for variant in e.variants() %}
   class {{ variant.name()|class_name_rb }} < StandardError
@@ -35,6 +41,7 @@ module {{ e.name()|class_name_rb }}
     {% endif %}
   end
   {%- endfor %}
+{% endif %}
 end
 {%- endfor %}
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
@@ -156,7 +156,9 @@ class RustBufferStream
     {% if e.is_flat() -%}
     {%- for variant in e.variants() %}
     if variant == {{ loop.index }}
-      return {{ error_name|class_name_rb }}::{{ variant.name()|class_name_rb }}
+      return {{ error_name|class_name_rb }}::{{ variant.name()|class_name_rb }}.new(
+        readString()
+      )
     end
     {%- endfor %}
 

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -140,6 +140,7 @@ impl APIConverter<Enum> for weedle::EnumDefinition<'_> {
                     })
                 })
                 .collect::<Result<Vec<_>>>()?,
+            // Enums declared using the `enum` syntax can never have variants with fields.
             flat: true,
         })
     }
@@ -166,6 +167,7 @@ impl APIConverter<Enum> for weedle::InterfaceDefinition<'_> {
                     ),
                 })
                 .collect::<Result<Vec<_>>>()?,
+            // Enums declared using the `[Enum] interface` syntax might have variants with fields.
             flat: false,
         })
     }


### PR DESCRIPTION
Sam Edit: Taken over by @skhamis (but don't want to make a new PR for now). Continuing the work Ryan did on this after having a sync before he left. The current best plan is to leverage the `is_flat()` to determine if it's a simple enum vs the new complex error handling. Issue linked below has more details on the matter:


Fixes #1024 by restoring the behaviour of "flat" error enums declared
with the `[Error] enum` syntax. The generated bindings of these errors
will now carry a single `message` field giving the stringified Rust
error.
