### PR TITLE
Split buffer from the type reader/writer for python.

### DIFF
--- a/uniffi_bindgen/src/bindings/python/templates/ErrorTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ErrorTemplate.py
@@ -51,12 +51,12 @@ class {{ e.name()|class_name_py }}:
     {%- endfor %}
 {%- endfor %}
 
-# Map error classes to the RustBufferStream method to read them
+# Map error classes to the RustBufferTypeBuilder method to read them
 _error_class_to_reader_method = {
 {%- for e in ci.iter_error_definitions() %}
 {%- let typ=ci.get_type(e.name()).unwrap() %}
 {%- let canonical_type_name = typ.canonical_name()|class_name_py %}
-    {{ e.name()|class_name_py }}: RustBufferStream.read{{ canonical_type_name }},
+    {{ e.name()|class_name_py }}: RustBufferTypeReader.read{{ canonical_type_name }},
 {%- endfor %}
 }
 

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferBuilder.py
@@ -1,6 +1,6 @@
 
 class RustBufferBuilder(object):
-    """Helper for structured writing of values into a RustBuffer."""
+    # Helper for structured writing of bytes into a RustBuffer.
 
     def __init__(self):
         self.rbuf = RustBuffer.alloc(16)
@@ -34,11 +34,14 @@ class RustBufferBuilder(object):
             for i, byte in enumerate(value):
                 self.rbuf.data[self.rbuf.len + i] = byte
 
+class RustBufferTypeBuilder(object):
     # For every type used in the interface, we provide helper methods for conveniently
     # writing values of that type in a buffer. Putting them on this internal helper object
     # (rather than, say, as methods on the public classes) makes it easier for us to hide
     # these implementation details from consumers, in the face of python's free-for-all
     # type system.
+    # This class holds the logic for *how* to write the types to a buffer - the buffer itself is
+    # always passed in, because the actual buffer might be owned by a different crate/module.
 
     {%- for typ in ci.iter_types() -%}
     {%- let canonical_type_name = typ.canonical_name()|class_name_py -%}
@@ -46,69 +49,82 @@ class RustBufferBuilder(object):
 
     {% when Type::Int8 -%}
 
-    def writeI8(self, v):
-        self._pack_into(1, ">b", v)
+    @staticmethod
+    def writeI8(builder, v):
+        builder._pack_into(1, ">b", v)
 
     {% when Type::UInt8 -%}
 
-    def writeU8(self, v):
-        self._pack_into(1, ">B", v)
+    @staticmethod
+    def writeU8(builder, v):
+        builder._pack_into(1, ">B", v)
 
     {% when Type::Int16 -%}
 
-    def writeI16(self, v):
-        self._pack_into(2, ">h", v)
+    @staticmethod
+    def writeI16(builder, v):
+        builder._pack_into(2, ">h", v)
 
     {% when Type::UInt16 -%}
 
-    def writeU16(self, v):
-        self._pack_into(2, ">H", v)
+    @staticmethod
+    def writeU16(builder, v):
+        builder._pack_into(2, ">H", v)
 
     {% when Type::Int32 -%}
 
-    def writeI32(self, v):
-        self._pack_into(4, ">i", v)
+    @staticmethod
+    def writeI32(builder, v):
+        builder._pack_into(4, ">i", v)
 
     {% when Type::UInt32 -%}
 
-    def writeU32(self, v):
-        self._pack_into(4, ">I", v)
+    @staticmethod
+    def writeU32(builder, v):
+        builder._pack_into(4, ">I", v)
 
     {% when Type::Int64 -%}
 
-    def writeI64(self, v):
-        self._pack_into(8, ">q", v)
+    @staticmethod
+    def writeI64(builder, v):
+        builder._pack_into(8, ">q", v)
 
     {% when Type::UInt64 -%}
 
-    def writeU64(self, v):
-        self._pack_into(8, ">Q", v)
+    @staticmethod
+    def writeU64(builder, v):
+        builder._pack_into(8, ">Q", v)
 
     {% when Type::Float32 -%}
 
-    def writeF32(self, v):
-        self._pack_into(4, ">f", v)
+    @staticmethod
+    def writeF32(builder, v):
+        builder._pack_into(4, ">f", v)
 
     {% when Type::Float64 -%}
 
-    def writeF64(self, v):
-        self._pack_into(8, ">d", v)
+    @staticmethod
+    def writeF64(builder, v):
+        builder._pack_into(8, ">d", v)
 
     {% when Type::Boolean -%}
 
-    def writeBool(self, v):
-        self._pack_into(1, ">b", 1 if v else 0)
+    @staticmethod
+    def writeBool(builder, v):
+        builder._pack_into(1, ">b", 1 if v else 0)
 
     {% when Type::String -%}
 
-    def writeString(self, v):
+    @staticmethod
+    def writeString(builder, v):
         utf8Bytes = v.encode("utf-8")
-        self._pack_into(4, ">i", len(utf8Bytes))
-        self.write(utf8Bytes)
+        builder._pack_into(4, ">i", len(utf8Bytes))
+        builder.write(utf8Bytes)
 
     {% when Type::Timestamp -%}
 
-    def write{{ canonical_type_name }}(self, v):
+    @staticmethod
+    def write{{ canonical_type_name }}(builder, v):
         if v >= datetime.datetime.fromtimestamp(0, datetime.timezone.utc):
             sign = 1
             delta = v - datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
@@ -118,43 +134,46 @@ class RustBufferBuilder(object):
 
         seconds = delta.seconds + delta.days * 24 * 3600
         nanoseconds = delta.microseconds * 1000
-        self._pack_into(8, ">q", sign * seconds)
-        self._pack_into(4, ">I", nanoseconds)
+        builder._pack_into(8, ">q", sign * seconds)
+        builder._pack_into(4, ">I", nanoseconds)
 
     {% when Type::Duration -%}
 
-    def write{{ canonical_type_name }}(self, v):
+    @staticmethod
+    def write{{ canonical_type_name }}(builder, v):
         seconds = v.seconds + v.days * 24 * 3600
         nanoseconds = v.microseconds * 1000
         if seconds < 0:
             raise ValueError("Invalid duration, must be non-negative")
-        self._pack_into(8, ">Q", seconds)
-        self._pack_into(4, ">I", nanoseconds)
+        builder._pack_into(8, ">Q", seconds)
+        builder._pack_into(4, ">I", nanoseconds)
 
     {% when Type::Object with (object_name) -%}
     # The Object type {{ object_name }}.
     # We write the pointer value directly - what could possibly go wrong?
 
-    def write{{ canonical_type_name }}(self, v):
+    @classmethod
+    def write{{ canonical_type_name }}(cls, builder, v):
         if not isinstance(v, {{ object_name|class_name_py }}):
             raise TypeError("Expected {{ object_name|class_name_py }} instance, {} found".format(v.__class__.__name__))
         # The Rust code always expects pointers written as 8 bytes,
         # and will fail to compile if they don't fit in that size.
-        self.writeU64(v._pointer)
+        cls.writeU64(builder, v._pointer)
 
     {% when Type::Enum with (enum_name) -%}
     {%- let e = ci.get_enum_definition(enum_name).unwrap() -%}
     # The Enum type {{ enum_name }}.
 
-    def write{{ canonical_type_name }}(self, v):
+    @classmethod
+    def write{{ canonical_type_name }}(cls, builder, v):
         {%- if e.is_flat() %}
-        self._pack_into(4, ">i", v.value)
+        builder._pack_into(4, ">i", v.value)
         {%- else -%}
         {%- for variant in e.variants() %}
         if v.is_{{ variant.name()|var_name_py }}():
-            self._pack_into(4, ">i", {{ loop.index }})
+            builder._pack_into(4, ">i", {{ loop.index }})
             {%- for field in variant.fields() %}
-            self.write{{ field.type_().canonical_name()|class_name_py }}(v.{{ field.name() }})
+            cls.write{{ field.type_().canonical_name()|class_name_py }}(builder, v.{{ field.name() }})
             {%- endfor %}
         {%- endfor %}
         {%- endif %}
@@ -163,42 +182,47 @@ class RustBufferBuilder(object):
     {%- let rec = ci.get_record_definition(record_name).unwrap() -%}
     # The Record type {{ record_name }}.
 
-    def write{{ canonical_type_name }}(self, v):
+    @classmethod
+    def write{{ canonical_type_name }}(cls, builder, v):
         {%- for field in rec.fields() %}
-        self.write{{ field.type_().canonical_name()|class_name_py }}(v.{{ field.name() }})
+        cls.write{{ field.type_().canonical_name()|class_name_py }}(builder, v.{{ field.name() }})
         {%- endfor %}
 
     {% when Type::Optional with (inner_type) -%}
     # The Optional<T> type for {{ inner_type.canonical_name() }}.
 
-    def write{{ canonical_type_name }}(self, v):
+    @classmethod
+    def write{{ canonical_type_name }}(cls, builder, v):
         if v is None:
-            self._pack_into(1, ">b", 0)
+            builder._pack_into(1, ">b", 0)
         else:
-            self._pack_into(1, ">b", 1)
-            self.write{{ inner_type.canonical_name()|class_name_py }}(v)
+            builder._pack_into(1, ">b", 1)
+            cls.write{{ inner_type.canonical_name()|class_name_py }}(builder, v)
 
     {% when Type::Sequence with (inner_type) -%}
     # The Sequence<T> type for {{ inner_type.canonical_name() }}.
 
-    def write{{ canonical_type_name }}(self, items):
-        self._pack_into(4, ">i", len(items))
+    @classmethod
+    def write{{ canonical_type_name }}(cls, builder, items):
+        builder._pack_into(4, ">i", len(items))
         for item in items:
-            self.write{{ inner_type.canonical_name()|class_name_py }}(item)
+            cls.write{{ inner_type.canonical_name()|class_name_py }}(builder, item)
 
     {% when Type::Map with (inner_type) -%}
     # The Map<T> type for {{ inner_type.canonical_name() }}.
 
-    def write{{ canonical_type_name }}(self, items):
-        self._pack_into(4, ">i", len(items))
+    @classmethod
+    def write{{ canonical_type_name }}(cls, builder, items):
+        builder._pack_into(4, ">i", len(items))
         for (k, v) in items.items():
-            self.writeString(k)
-            self.write{{ inner_type.canonical_name()|class_name_py }}(v)
+            cls.writeString(builder, k)
+            cls.write{{ inner_type.canonical_name()|class_name_py }}(builder, v)
 
     {%- else -%}
     # This type cannot currently be serialized, but we can produce a helpful error.
 
-    def write{{ canonical_type_name }}(self, value):
+    @staticmethod
+    def write{{ canonical_type_name }}(self, builder):
         raise InternalError("RustBufferStream.write() not implemented yet for {{ canonical_type_name }}")
 
     {%- endmatch -%}

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
@@ -1,6 +1,6 @@
 
 class RustBufferStream(object):
-    """Helper for structured reading of values from a RustBuffer."""
+    # Helper for structured reading of bytes from a RustBuffer
 
     def __init__(self, rbuf):
         self.rbuf = rbuf
@@ -23,11 +23,14 @@ class RustBufferStream(object):
         self.offset += size
         return data
 
+class RustBufferTypeReader(object):
     # For every type used in the interface, we provide helper methods for conveniently
     # reading that type in a buffer. Putting them on this internal helper object (rather
     # than, say, as methods on the public classes) makes it easier for us to hide these
     # implementation details from consumers, in the face of python's free-for-all type
     # system.
+    # This class holds the logic for *how* to read the types from a buffer - the buffer itself is
+    # always passed in, because the actual buffer might be owned by a different crate/module.
 
     {%- for typ in ci.iter_types() -%}
     {%- let canonical_type_name = typ.canonical_name()|class_name_py -%}
@@ -35,59 +38,70 @@ class RustBufferStream(object):
 
     {% when Type::Int8 -%}
 
-    def readI8(self):
-        return self._unpack_from(1, ">b")
+    @staticmethod
+    def readI8(stream):
+        return stream._unpack_from(1, ">b")
 
     {% when Type::UInt8 -%}
 
-    def readU8(self):
-        return self._unpack_from(1, ">B")
+    @staticmethod
+    def readU8(stream):
+        return stream._unpack_from(1, ">B")
 
     {% when Type::Int16 -%}
 
-    def readI16(self):
-        return self._unpack_from(2, ">h")
+    @staticmethod
+    def readI16(stream):
+        return stream._unpack_from(2, ">h")
 
     {% when Type::UInt16 -%}
 
-    def readU16(self):
-        return self._unpack_from(2, ">H")
+    @staticmethod
+    def readU16(stream):
+        return stream._unpack_from(2, ">H")
 
     {% when Type::Int32 -%}
 
-    def readI32(self):
-        return self._unpack_from(4, ">i")
+    @staticmethod
+    def readI32(stream):
+        return stream._unpack_from(4, ">i")
 
     {% when Type::UInt32 -%}
 
-    def readU32(self):
-        return self._unpack_from(4, ">I")
+    @staticmethod
+    def readU32(stream):
+        return stream._unpack_from(4, ">I")
 
     {% when Type::Int64 -%}
 
-    def readI64(self):
-        return self._unpack_from(8, ">q")
+    @staticmethod
+    def readI64(stream):
+        return stream._unpack_from(8, ">q")
 
     {% when Type::UInt64 -%}
 
-    def readU64(self):
-        return self._unpack_from(8, ">Q")
+    @staticmethod
+    def readU64(stream):
+        return stream._unpack_from(8, ">Q")
 
     {% when Type::Float32 -%}
 
-    def readF32(self):
-        v = self._unpack_from(4, ">f")
+    @staticmethod
+    def readF32(stream):
+        v = stream._unpack_from(4, ">f")
         return v
 
     {% when Type::Float64 -%}
 
-    def readF64(self):
-        return self._unpack_from(8, ">d")
+    @staticmethod
+    def readF64(stream):
+        return stream._unpack_from(8, ">d")
 
     {% when Type::Boolean -%}
 
-    def readBool(self):
-        v = self._unpack_from(1, ">b")
+    @staticmethod
+    def readBool(stream):
+        v = stream._unpack_from(1, ">b")
         if v == 0:
             return False
         if v == 1:
@@ -96,11 +110,12 @@ class RustBufferStream(object):
 
     {% when Type::String -%}
 
-    def readString(self):
-        size = self._unpack_from(4, ">i")
+    @staticmethod
+    def readString(stream):
+        size = stream._unpack_from(4, ">i")
         if size < 0:
             raise InternalError("Unexpected negative string length")
-        utf8Bytes = self.read(size)
+        utf8Bytes = stream.read(size)
         return utf8Bytes.decode("utf-8")
 
 
@@ -110,9 +125,10 @@ class RustBufferStream(object):
     # which are accurate to the nanosecond,to Python datetimes which have
     # a variable precision due to the use of float as representation.
 
-    def read{{ canonical_type_name }}(self):
-        seconds = self._unpack_from(8, ">q")
-        microseconds = self._unpack_from(4, ">I") / 1000
+    @staticmethod
+    def read{{ canonical_type_name }}(stream):
+        seconds = stream._unpack_from(8, ">q")
+        microseconds = stream._unpack_from(4, ">I") / 1000
         # Use fromtimestamp(0) then add the seconds using a timedelta.  This
         # ensures that we get OverflowError rather than ValueError when
         # seconds is too large.
@@ -127,24 +143,27 @@ class RustBufferStream(object):
     # which are accurate to the nanosecond,to Python durations which have
     # are only accurate to the microsecond.
 
-    def read{{ canonical_type_name }}(self):
-        return datetime.timedelta(seconds=self._unpack_from(8, ">Q"), microseconds=(self._unpack_from(4, ">I") / 1.0e3))
+    @staticmethod
+    def read{{ canonical_type_name }}(stream):
+        return datetime.timedelta(seconds=stream._unpack_from(8, ">Q"), microseconds=(stream._unpack_from(4, ">I") / 1.0e3))
 
     {% when Type::Object with (object_name) -%}
     # The Object type {{ object_name }}.
 
-    def read{{ canonical_type_name }}(self):
+    @staticmethod
+    def read{{ canonical_type_name }}(stream):
         # The Rust code always expects pointers written as 8 bytes,
         # and will fail to compile if they don't fit in that size.
-        pointer = self._unpack_from(8, ">Q")
+        pointer = stream._unpack_from(8, ">Q")
         return {{ object_name|class_name_py }}._make_instance_(pointer)
 
     {% when Type::Enum with (enum_name) -%}
     {%- let e = ci.get_enum_definition(enum_name).unwrap() -%}
     # The Enum type {{ enum_name }}.
 
-    def read{{ canonical_type_name }}(self):
-        variant = self._unpack_from(4, ">i")
+    @classmethod
+    def read{{ canonical_type_name }}(cls, stream):
+        variant = stream._unpack_from(4, ">i")
         {% if e.is_flat() -%}
         return {{ enum_name|class_name_py }}(variant)
         {%- else -%}
@@ -153,7 +172,7 @@ class RustBufferStream(object):
             {%- if variant.has_fields() %}
             return {{ enum_name|class_name_py }}.{{ variant.name()|enum_name_py }}(
                 {%- for field in variant.fields() %}
-                self.read{{ field.type_().canonical_name()|class_name_py }}(){% if loop.last %}{% else %},{% endif %}
+                cls.read{{ field.type_().canonical_name()|class_name_py }}(stream){% if loop.last %}{% else %},{% endif %}
                 {%- endfor %}
             )
             {%- else %}
@@ -169,22 +188,24 @@ class RustBufferStream(object):
     # The Error type {{ error_name }}
 
     # Top-level read method
-    def read{{ canonical_type_name }}(self):
-        variant = self._unpack_from(4, ">i")
+    @classmethod
+    def read{{ canonical_type_name }}(cls, stream):
+        variant = stream._unpack_from(4, ">i")
         try:
-            read_variant_method = getattr(self, 'readVariant{}Of{{canonical_type_name}}'.format(variant))
+            read_variant_method = getattr(cls, 'readVariant{}Of{{canonical_type_name}}'.format(variant))
         except AttributeError:
             raise InternalError("Unexpected variant value for error {{ canonical_type_name }} ({})".format(variant))
-        return read_variant_method()
+        return read_variant_method(stream)
 
     # Read methods for each individual variants
     {%- for variant in e.variants() %}
 
-    def readVariant{{ loop.index}}Of{{ canonical_type_name }}(self):
+    @classmethod
+    def readVariant{{ loop.index}}Of{{ canonical_type_name }}(cls, stream):
         {%- if variant.has_fields() %}
         return {{ error_name|class_name_py }}.{{ variant.name()|class_name_py }}(
             {%- for field in variant.fields() %}
-            self.read{{ field.type_().canonical_name()|class_name_py }}(),
+            cls.read{{ field.type_().canonical_name()|class_name_py }}(stream),
             {%- endfor %}
         )
         {%- else %}
@@ -196,55 +217,60 @@ class RustBufferStream(object):
     {%- let rec = ci.get_record_definition(record_name).unwrap() -%}
     # The Record type {{ record_name }}.
 
-    def read{{ canonical_type_name }}(self):
+    @classmethod
+    def read{{ canonical_type_name }}(cls, stream):
         return {{ rec.name()|class_name_py }}(
             {%- for field in rec.fields() %}
-            self.read{{ field.type_().canonical_name()|class_name_py }}(){% if loop.last %}{% else %},{% endif %}
+            cls.read{{ field.type_().canonical_name()|class_name_py }}(stream){% if loop.last %}{% else %},{% endif %}
             {%- endfor %}
         )
 
     {% when Type::Optional with (inner_type) -%}
     # The Optional<T> type for {{ inner_type.canonical_name() }}.
 
-    def read{{ canonical_type_name }}(self):
-        flag = self._unpack_from(1, ">b")
+    @classmethod
+    def read{{ canonical_type_name }}(cls, stream):
+        flag = stream._unpack_from(1, ">b")
         if flag == 0:
             return None
         elif flag == 1:
-            return self.read{{ inner_type.canonical_name()|class_name_py }}()
+            return cls.read{{ inner_type.canonical_name()|class_name_py }}(stream)
         else:
             raise InternalError("Unexpected flag byte for {{ canonical_type_name }}")
 
     {% when Type::Sequence with (inner_type) -%}
     # The Sequence<T> type for {{ inner_type.canonical_name() }}.
 
-    def read{{ canonical_type_name }}(self):
-        count = self._unpack_from(4, ">i")
+    @classmethod
+    def read{{ canonical_type_name }}(cls, stream):
+        count = stream._unpack_from(4, ">i")
         if count < 0:
             raise InternalError("Unexpected negative sequence length")
         items = []
         while count > 0:
-            items.append(self.read{{ inner_type.canonical_name()|class_name_py }}())
+            items.append(cls.read{{ inner_type.canonical_name()|class_name_py }}(stream))
             count -= 1
         return items
 
     {% when Type::Map with (inner_type) -%}
     # The Map<T> type for {{ inner_type.canonical_name() }}.
 
-    def read{{ canonical_type_name }}(self):
-        count = self._unpack_from(4, ">i")
+    @classmethod
+    def read{{ canonical_type_name }}(cls, stream):
+        count = stream._unpack_from(4, ">i")
         if count < 0:
             raise InternalError("Unexpected negative map size")
         items = {}
         while count > 0:
-            key = self.readString()
-            items[key] = self.read{{ inner_type.canonical_name()|class_name_py }}()
+            key = cls.readString(stream)
+            items[key] = cls.read{{ inner_type.canonical_name()|class_name_py }}(stream)
             count -= 1
         return items
 
     {%- else -%}
     # This type cannot currently be serialized, but we can produce a helpful error.
-    def read{{ canonical_type_name }}(self):
+    @staticmethod
+    def read{{ canonical_type_name }}(stream):
         raise InternalError("RustBufferStream.read not implemented yet for {{ canonical_type_name }}")
 
     {%- endmatch -%}

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
@@ -81,24 +81,24 @@ class RustBuffer(ctypes.Structure):
     @staticmethod
     def allocFrom{{ canonical_type_name }}(v):
         with RustBuffer.allocWithBuilder() as builder:
-            builder.write{{ canonical_type_name }}(v)
+            RustBufferTypeBuilder.write{{ canonical_type_name }}(builder, v)
             return builder.finalize()
 
     def consumeInto{{ canonical_type_name }}(self):
         with self.consumeWithStream() as stream:
-            return stream.read{{ canonical_type_name }}()
+            return RustBufferTypeReader.read{{ canonical_type_name }}(stream)
 
     {% when Type::Duration -%}
 
     @staticmethod
     def allocFrom{{ canonical_type_name }}(v):
         with RustBuffer.allocWithBuilder() as builder:
-            builder.write{{ canonical_type_name }}(v)
+            RustBufferTypeBuilder.write{{ canonical_type_name }}(builder, v)
             return builder.finalize()
 
     def consumeInto{{ canonical_type_name }}(self):
         with self.consumeWithStream() as stream:
-            return stream.read{{ canonical_type_name }}()
+            return RustBufferTypeReader.read{{ canonical_type_name }}(stream)
 
     {% when Type::Record with (record_name) -%}
     {%- let rec = ci.get_record_definition(record_name).unwrap() -%}
@@ -107,12 +107,12 @@ class RustBuffer(ctypes.Structure):
     @staticmethod
     def allocFrom{{ canonical_type_name }}(v):
         with RustBuffer.allocWithBuilder() as builder:
-            builder.write{{ canonical_type_name }}(v)
+            RustBufferTypeBuilder.write{{ canonical_type_name }}(builder, v)
             return builder.finalize()
 
     def consumeInto{{ canonical_type_name }}(self):
         with self.consumeWithStream() as stream:
-            return stream.read{{ canonical_type_name }}()
+            return RustBufferTypeReader.read{{ canonical_type_name }}(stream)
 
     {% when Type::Enum with (enum_name) -%}
     {%- let e = ci.get_enum_definition(enum_name).unwrap() -%}
@@ -121,12 +121,12 @@ class RustBuffer(ctypes.Structure):
     @staticmethod
     def allocFrom{{ canonical_type_name }}(v):
         with RustBuffer.allocWithBuilder() as builder:
-            builder.write{{ canonical_type_name }}(v)
+            RustBufferTypeBuilder.write{{ canonical_type_name }}(builder, v)
             return builder.finalize()
 
     def consumeInto{{ canonical_type_name }}(self):
         with self.consumeWithStream() as stream:
-            return stream.read{{ canonical_type_name }}()
+            return RustBufferTypeReader.read{{ canonical_type_name }}(stream)
 
     {% when Type::Optional with (inner_type) -%}
     # The Optional<T> type for {{ inner_type.canonical_name() }}.
@@ -134,12 +134,12 @@ class RustBuffer(ctypes.Structure):
     @staticmethod
     def allocFrom{{ canonical_type_name }}(v):
         with RustBuffer.allocWithBuilder() as builder:
-            builder.write{{ canonical_type_name }}(v)
+            RustBufferTypeBuilder.write{{ canonical_type_name }}(builder, v)
             return builder.finalize()
 
     def consumeInto{{ canonical_type_name }}(self):
         with self.consumeWithStream() as stream:
-            return stream.read{{ canonical_type_name }}()
+            return RustBufferTypeReader.read{{ canonical_type_name }}(stream)
 
     {% when Type::Sequence with (inner_type) -%}
     # The Sequence<T> type for {{ inner_type.canonical_name() }}.
@@ -147,12 +147,12 @@ class RustBuffer(ctypes.Structure):
     @staticmethod
     def allocFrom{{ canonical_type_name }}(v):
         with RustBuffer.allocWithBuilder() as builder:
-            builder.write{{ canonical_type_name }}(v)
+            RustBufferTypeBuilder.write{{ canonical_type_name }}(builder, v)
             return builder.finalize()
 
     def consumeInto{{ canonical_type_name }}(self):
         with self.consumeWithStream() as stream:
-            return stream.read{{ canonical_type_name }}()
+            return RustBufferTypeReader.read{{ canonical_type_name }}(stream)
 
     {% when Type::Map with (inner_type) -%}
     # The Map<T> type for {{ inner_type.canonical_name() }}.
@@ -160,12 +160,12 @@ class RustBuffer(ctypes.Structure):
     @staticmethod
     def allocFrom{{ canonical_type_name }}(v):
         with RustBuffer.allocWithBuilder() as builder:
-            builder.write{{ canonical_type_name }}(v)
+            RustBufferTypeBuilder.write{{ canonical_type_name }}(builder, v)
             return builder.finalize()
 
     def consumeInto{{ canonical_type_name }}(self):
         with self.consumeWithStream() as stream:
-            return stream.read{{ canonical_type_name }}()
+            return RustBufferTypeReader.read{{ canonical_type_name }}(stream)
 
     {%- else -%}
     {#- No code emitted for types that don't lower into a RustBuffer -#}

--- a/uniffi_bindgen/src/bindings/python/templates/wrapper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/wrapper.py
@@ -6,7 +6,7 @@
 # Ideally this would live in a separate .py file where it can be unittested etc
 # in isolation, and perhaps even published as a re-useable package.
 #
-# However, it's important that the detils of how this helper code works (e.g. the
+# However, it's important that the details of how this helper code works (e.g. the
 # way that different builtin types are passed across the FFI) exactly match what's
 # expected by the rust code on the other side of the interface. In practice right
 # now that means coming from the exact some version of `uniffi` that was used to


### PR DESCRIPTION
This came out of a discussion Ryan and I had last week for external types. The idea is that by splitting the "type reader/writer" from the buffer ownership we can support external types in our buffers. For example, external types will end up generating code that looks like:

```python
    @staticmethod
    def readSomeExternalType(stream):
        from some_module import RustBufferTypeReader;
        return RustBufferTypeReader.readSomeExternalType(stream)
```
ie, uses the reader from a different module with a stream that we own.