### PR TITLE
Allow multiple .udl files in test fixtures

### DIFF
--- a/uniffi/src/testing.rs
+++ b/uniffi/src/testing.rs
@@ -35,7 +35,11 @@ lazy_static! {
 /// a foreign-language test file that exercises that component's bindings. It ensures that the
 /// component is compiled and available for use and then executes the foreign language script,
 /// returning successfully iff the script exits successfully.
-pub fn run_foreign_language_testcase(pkg_dir: &str, udl_file: &str, test_file: &str) -> Result<()> {
+pub fn run_foreign_language_testcase(
+    pkg_dir: &str,
+    udl_files: &[&str],
+    test_file: &str,
+) -> Result<()> {
     let cdylib_file = ensure_compiled_cdylib(pkg_dir)?;
     let out_dir = Path::new(cdylib_file.as_str())
         .parent()
@@ -43,7 +47,7 @@ pub fn run_foreign_language_testcase(pkg_dir: &str, udl_file: &str, test_file: &
         .to_str()
         .unwrap();
     let _lock = UNIFFI_BINDGEN.lock();
-    run_uniffi_bindgen_test(out_dir, udl_file, test_file)?;
+    run_uniffi_bindgen_test(out_dir, udl_files, test_file)?;
     Ok(())
 }
 
@@ -140,9 +144,10 @@ pub fn ensure_compiled_cdylib(pkg_dir: &str) -> Result<String> {
 /// on the `uniffi_bindgen` crate and execute its methods in-process. This is useful for folks
 /// who are working on uniffi itself and want to test out their changes to the bindings generator.
 #[cfg(not(feature = "builtin-bindgen"))]
-fn run_uniffi_bindgen_test(out_dir: &str, udl_file: &str, test_file: &str) -> Result<()> {
+fn run_uniffi_bindgen_test(out_dir: &str, udl_files: &[&str], test_file: &str) -> Result<()> {
+    let udl_files = udl_files.map(|&x| x).collect::<Vec<&str>>().join("\n");
     let status = Command::new("uniffi-bindgen")
-        .args(&["test", out_dir, udl_file, test_file])
+        .args(&["test", out_dir, udl_files, test_file])
         .status()?;
     if !status.success() {
         bail!("Error while running tests: {}",);
@@ -151,6 +156,6 @@ fn run_uniffi_bindgen_test(out_dir: &str, udl_file: &str, test_file: &str) -> Re
 }
 
 #[cfg(feature = "builtin-bindgen")]
-fn run_uniffi_bindgen_test(out_dir: &str, udl_file: &str, test_file: &str) -> Result<()> {
-    uniffi_bindgen::run_tests(out_dir, udl_file, vec![test_file], None)
+fn run_uniffi_bindgen_test(out_dir: &str, udl_files: &[&str], test_file: &str) -> Result<()> {
+    uniffi_bindgen::run_tests(out_dir, udl_files, vec![test_file], None)
 }

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -126,7 +126,11 @@ pub fn generate_component_scaffolding<P: AsRef<Path>>(
     let out_dir_override = out_dir_override.as_ref().map(|p| p.as_ref());
     let udl_file = udl_file.as_ref();
     let component = parse_udl(udl_file)?;
-    let _config = get_config(&component, udl_file, config_file_override);
+    let _config = get_config(
+        &component,
+        guess_crate_root(udl_file)?,
+        config_file_override,
+    );
     let mut filename = Path::new(&udl_file)
         .file_stem()
         .ok_or_else(|| anyhow!("not a file"))?
@@ -158,8 +162,12 @@ pub fn generate_bindings<P: AsRef<Path>>(
     let udl_file = udl_file.as_ref();
 
     let component = parse_udl(udl_file)?;
-    let config = get_config(&component, udl_file, config_file_override)?;
-    let out_dir = get_out_dir(udl_file, out_dir_override)?;
+    let config = get_config(
+        &component,
+        guess_crate_root(udl_file)?,
+        config_file_override,
+    )?;
+    let out_dir = get_out_dir(&udl_file, out_dir_override)?;
     for language in target_languages {
         bindings::write_bindings(
             &config.bindings,
@@ -176,19 +184,22 @@ pub fn generate_bindings<P: AsRef<Path>>(
 // Note that the cdylib we're testing against must be built already.
 pub fn run_tests<P: AsRef<Path>>(
     cdylib_dir: P,
-    udl_file: P,
+    udl_files: &[&str],
     test_scripts: Vec<&str>,
     config_file_override: Option<P>,
 ) -> Result<()> {
-    let cdylib_dir = cdylib_dir.as_ref();
-    let udl_file = udl_file.as_ref();
-    let config_file_override = config_file_override.as_ref().map(|p| p.as_ref());
+    // XXX - this is just for tests, so one config_file_override for all .udl files doesn't really
+    // make sense, so we don't let tests do this.
+    // "Real" apps will build the .udl files one at a file and can therefore do whatever they want
+    // with overrides, so don't have this problem.
+    assert!(udl_files.len() == 1 || config_file_override.is_none());
 
-    let component = parse_udl(udl_file)?;
-    let config = get_config(&component, udl_file, config_file_override)?;
+    let cdylib_dir = cdylib_dir.as_ref();
+    let config_file_override = config_file_override.as_ref().map(|p| p.as_ref());
 
     // Group the test scripts by language first.
     let mut language_tests: HashMap<TargetLanguage, Vec<String>> = HashMap::new();
+
     for test_script in test_scripts {
         let lang: TargetLanguage = PathBuf::from(test_script)
             .extension()
@@ -201,8 +212,13 @@ pub fn run_tests<P: AsRef<Path>>(
     }
 
     for (lang, test_scripts) in language_tests {
-        bindings::write_bindings(&config.bindings, &component, &cdylib_dir, lang, true)?;
-        bindings::compile_bindings(&config.bindings, &component, &cdylib_dir, lang)?;
+        for udl_file in udl_files {
+            let crate_root = guess_crate_root(Path::new(udl_file))?;
+            let component = parse_udl(Path::new(udl_file))?;
+            let config = get_config(&component, crate_root, config_file_override)?;
+            bindings::write_bindings(&config.bindings, &component, &cdylib_dir, lang, true)?;
+            bindings::compile_bindings(&config.bindings, &component, &cdylib_dir, lang)?;
+        }
         for test_script in test_scripts {
             bindings::run_script(cdylib_dir, &test_script, lang)?;
         }
@@ -229,20 +245,14 @@ fn guess_crate_root(udl_file: &Path) -> Result<&Path> {
 
 fn get_config(
     component: &ComponentInterface,
-    udl_file: &Path,
+    crate_root: &Path,
     config_file_override: Option<&Path>,
 ) -> Result<Config> {
     let default_config: Config = component.into();
 
     let config_file: Option<PathBuf> = match config_file_override {
         Some(cfg) => Some(PathBuf::from(cfg)),
-        None => {
-            let crate_root = guess_crate_root(udl_file)?.join("uniffi.toml");
-            match crate_root.canonicalize() {
-                Ok(f) => Some(f),
-                Err(_) => None,
-            }
-        }
+        None => crate_root.join("uniffi.toml").canonicalize().ok(),
     };
 
     match config_file {
@@ -418,12 +428,14 @@ pub fn run_main() -> Result<()> {
             m.value_of_os("out_dir"),
             !m.is_present("no_format"),
         )?,
-        ("test", Some(m)) => crate::run_tests(
-            m.value_of_os("cdylib_dir").unwrap(),           // Required
-            m.value_of_os("udl_file").unwrap(),             // Required
-            m.values_of("test_scripts").unwrap().collect(), // Required
-            m.value_of_os("config"),
-        )?,
+        ("test", Some(m)) => {
+            crate::run_tests(
+                m.value_of_os("cdylib_dir").unwrap(), // Required
+                &[&m.value_of_os("udl_file").unwrap().to_string_lossy()], // Required
+                m.values_of("test_scripts").unwrap().collect(), // Required
+                m.value_of_os("config"),
+            )?
+        }
         _ => bail!("No command specified; try `--help` for some help."),
     }
     Ok(())

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -50,7 +50,7 @@ pub fn build_foreign_language_testcases(paths: proc_macro::TokenStream) -> proc_
             quote! {
                 #[test]
                 fn #test_name () -> uniffi::deps::anyhow::Result<()> {
-                    uniffi::testing::run_foreign_language_testcase(#pkg_dir, #udl_file, #test_file_path)
+                    uniffi::testing::run_foreign_language_testcase(#pkg_dir, &[#udl_file], #test_file_path)
                 }
             }
         })


### PR DESCRIPTION
This is a change only for the test runners. It's not clear the semantics are quite correct yet in terms of config file overrides etc, but it should help the "external types" effort keep moving.