### PR TITLE
The Rust impls of all `dictionary`, `enum` or `error` types must be pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - The Rust implementations of all `dictionary`, `enum` or `error` types defined in UDL must be
   public. If you see errors like:
     `private type <type-name> in public interface`
-  or similar, please declare the types as `pub` in your Rust.
+  or similar, please declare the types as `pub` in your Rust code.
 
 ## v0.13.1 (_2021-08-09_)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 [All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.13.1...HEAD).
 
+### ⚠️ Breaking Changes ⚠️
+- The Rust implementations of all `dictionary`, `enum` or `error` types defined in UDL must be
+  public. If you see errors like:
+    `private type <type-name> in public interface`
+  or similar, please declare the types as `pub` in your Rust.
+
 ## v0.13.1 (_2021-08-09_)
 
 [All changes in v0.13.1](https://github.com/mozilla/uniffi-rs/compare/v0.13.0...v0.13.1).

--- a/examples/arithmetic/src/lib.rs
+++ b/examples/arithmetic/src/lib.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #[derive(Debug, thiserror::Error)]
-enum ArithmeticError {
+pub enum ArithmeticError {
     #[error("Integer overflow on an operation with {a} and {b}")]
     IntegerOverflow { a: u64, b: u64 },
 }

--- a/examples/rondpoint/src/lib.rs
+++ b/examples/rondpoint/src/lib.rs
@@ -49,7 +49,7 @@ pub struct minusculeMAJUSCULEDict {
 }
 
 #[allow(non_camel_case_types)]
-enum minusculeMAJUSCULEEnum {
+pub enum minusculeMAJUSCULEEnum {
     minusculeMAJUSCULEVariant,
 }
 
@@ -272,7 +272,7 @@ impl Optionneur {
     }
 }
 
-struct OptionneurDictionnaire {
+pub struct OptionneurDictionnaire {
     i8_var: i8,
     u8_var: u8,
     i16_var: i16,

--- a/examples/todolist/src/lib.rs
+++ b/examples/todolist/src/lib.rs
@@ -18,7 +18,7 @@ lazy_static::lazy_static! {
 }
 
 #[derive(Debug, thiserror::Error)]
-enum TodoError {
+pub enum TodoError {
     #[error("The todo does not exist!")]
     TodoDoesNotExist,
     #[error("The todolist is empty!")]

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -12,7 +12,7 @@ lazy_static::lazy_static! {
 }
 
 #[derive(Debug, thiserror::Error)]
-enum CoverallError {
+pub enum CoverallError {
     #[error("The coverall has too many holes")]
     TooManyHoles,
 }
@@ -20,7 +20,7 @@ enum CoverallError {
 /// This error doesn't appear in the interface, instead
 /// we rely on an `Into<CoverallError>` impl to surface it to consumers.
 #[derive(Debug, thiserror::Error)]
-enum InternalCoverallError {
+pub enum InternalCoverallError {
     #[error("The coverall has an excess of holes")]
     ExcessiveHoles,
 }
@@ -34,7 +34,7 @@ impl From<InternalCoverallError> for CoverallError {
 }
 
 #[derive(Debug, thiserror::Error)]
-enum ComplexError {
+pub enum ComplexError {
     #[error("OsError: {code} ({extended_code})")]
     OsError { code: i16, extended_code: i16 },
     #[error("PermissionDenied: {reason}")]
@@ -235,7 +235,7 @@ impl Drop for Coveralls {
     }
 }
 #[derive(Debug, Clone, Copy)]
-enum Color {
+pub enum Color {
     Red,
     Blue,
     Green,

--- a/fixtures/uniffi-fixture-time/src/lib.rs
+++ b/fixtures/uniffi-fixture-time/src/lib.rs
@@ -5,7 +5,7 @@
 use std::time::{Duration, SystemTime};
 
 #[derive(Debug, thiserror::Error)]
-enum ChronologicalError {
+pub enum ChronologicalError {
     #[error("Time overflow on an operation with {a:?} and {b:?}")]
     TimeOverflow { a: SystemTime, b: Duration },
     #[error("Time difference error {a:?} is before {b:?}")]


### PR DESCRIPTION
The "external types" effort will cause us to generate code that will fail
to build if they aren't, and over #1023 @rfk and I agreed this was a
reasonable requirement.

Note this patch doesn't actually enforce the new rule - it was
generated by sprinkling

```
pub struct {{ e.name() }}Wrapper(pub {{ e.name() }});
```

around scaffolding_template.rs and fixing the build errors.