### PR TITLE
Specifying $UNIFFI_TESTS_DISABLE_EXTENSIONS can skip foreign tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
     `private type <type-name> in public interface`
   or similar, please declare the types as `pub` in your Rust code.
 
+### What's Changed
+
+- An environment variable `UNIFFI_TESTS_DISABLE_EXTENSIONS` can disable foreign language bindings
+  when running tests. See [the contributing guide](./contributing.md) for more.
+
 ## v0.13.1 (_2021-08-09_)
 
 [All changes in v0.13.1](https://github.com/mozilla/uniffi-rs/compare/v0.13.0...v0.13.1).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -60,6 +60,10 @@ test suite you will need:
   * A `ruby` interpreter.
   * The [`FFI`](https://github.com/ffi/ffi) Ruby gem, installable via `gem install FFI`.
 
+We also support an environment variable `UNIFFI_TESTS_DISABLE_EXTENSIONS`;
+It is a set of file extensions, without a leading period and separated by commas.
+Eg, `UNIFFI_TESTS_DISABLE_EXTENSIONS=swift,rb cargo test` will skip test filenames ending in
+`.swift` or `.rb`
 
 ## Navigating the code
 

--- a/uniffi_build/src/lib.rs
+++ b/uniffi_build/src/lib.rs
@@ -27,6 +27,9 @@ use std::process::Command;
 /// itself and need to test out their changes to the bindings generator.
 pub fn generate_scaffolding(udl_file: &str) -> Result<()> {
     println!("cargo:rerun-if-changed={}", udl_file);
+    // The UNIFFI_TESTS_DISABLE_EXTENSIONS variable disables some bindings, but it is evaluated
+    // at *build* time, so we need to rebuild when it changes.
+    println!("cargo:rerun-if-env-changed=UNIFFI_TESTS_DISABLE_EXTENSIONS");
     // Why don't we just depend on uniffi-bindgen and call the public functions?
     // Calling the command line helps making sure that the generated swift/Kotlin/whatever
     // bindings were generated with the same version of uniffi as the Rust scaffolding code.


### PR DESCRIPTION
In my local environment I can execute:

```shell
UNIFFI_TESTS_DISABLE_EXTENSIONS=swift:rb cargo test
```

output is nicely:
```
test uniffi_foreign_language_testcase_test_chronological_swift ... ignored
   Compiling uniffi-fixture-time v0.13.1 (/mnt/c/src/moz/uniffi-rs/fixtures/uniffi-fixture-time)
    Finished dev [unoptimized + debuginfo] target(s) in 3.62s
test uniffi_foreign_language_testcase_test_chronological_kts ... ok
test uniffi_foreign_language_testcase_test_chronological_py ... ok

test result: ok. 2 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 12.16s
```

(as opposed to now, when it's lots of noise about failing to execute ruby and swift)

I think we can declare this as fixing #466 too - that suggests a more automated approach, but I'm not sure that will be necessary given @tarikeshaq's work splitting the bindings; this seems fine to me.