### PR TITLE
WIP: Enhance external/wrapper types example and fixtures to show lack of l…

### DIFF
--- a/examples/wrapper-types/src/lib.rs
+++ b/examples/wrapper-types/src/lib.rs
@@ -14,8 +14,18 @@ impl UniffiCustomTypeWrapper for JsonObject {
     }
 }
 
+fn objectify(name: String, obj: serde_json::Value) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    map.insert(name, obj);
+    serde_json::Value::Object(map)
+}
+
 // And we also have a trivial "Handle" type which wraps an i64.
 pub struct Handle(pub i64);
+
+fn get_next_handle(handle: Handle) -> Handle {
+    Handle(handle.0 + 1)
+}
 
 impl UniffiCustomTypeWrapper for Handle {
     type Wrapped = i64;

--- a/examples/wrapper-types/src/wrapper-types.udl
+++ b/examples/wrapper-types/src/wrapper-types.udl
@@ -11,4 +11,6 @@ dictionary WrappedTypesDemo {
 
 namespace wrapper_types {
     WrappedTypesDemo get_wrapped_types_demo(WrappedTypesDemo? demo);
+    Handle get_next_handle(Handle handle);
+    JsonObject objectify(string name, JsonObject json);
 };

--- a/examples/wrapper-types/tests/bindings/test_wrapper_types.py
+++ b/examples/wrapper-types/tests/bindings/test_wrapper_types.py
@@ -6,5 +6,7 @@ assert(val.handle == 123)
 
 val = WrappedTypesDemo('{"foo":"bar"}', 456)
 val2 = get_wrapped_types_demo(val)
-print(val2)
 assert(val == val2)
+
+assert(get_next_handle(val.handle) == 457)
+assert(objectify("outer", '{"hello":"there"}') == '{"outer":{"hello":"there"}}')

--- a/fixtures/ext-types/lib/src/ext-types-lib.udl
+++ b/fixtures/ext-types/lib/src/ext-types-lib.udl
@@ -1,11 +1,22 @@
 namespace imported_types_lib {
+    UniffiOneType get_uniffi_one_type(UniffiOneType val);
+    Animal get_another_animal(Animal val);
+    IpAddr get_another_ip(IpAddr addr);
+
     CombinedType get_combined_type(optional CombinedType? val);
 };
 
-// A type defined in a .udl file in the `uniffi-one` crate (ie, in
+// Some types defined in a .udl file in the `uniffi-one` crate (ie, in
 // `../../uniffi-one/src/uniffi-one.udl`)
 [External="uniffi-one"]
 typedef extern UniffiOneType;
+
+[External="uniffi-one"]
+typedef extern Animal;
+
+[External="uniffi-one"]
+typedef extern IpAddr;
+
 
 // A "wrapped" type defined in the guid crate (ie, defined in `../../guid/src/lib.rs` and
 // "declared" in `../../guid/src/guid.udl`). But it's still "external" from our POV,
@@ -37,4 +48,8 @@ dictionary CombinedType {
     Handle handle;
     sequence<Handle> handles;
     Handle? maybe_handle;
+
+    Animal animal;
+    sequence<Animal> animals;
+    Animal? maybe_animal;
 };

--- a/fixtures/ext-types/lib/src/lib.rs
+++ b/fixtures/ext-types/lib/src/lib.rs
@@ -1,6 +1,24 @@
 use ext_types_guid::Guid;
-use uniffi_one::UniffiOneType;
+use uniffi_one::{Animal, IpAddr, UniffiOneType};
 use wrapper_types::Handle;
+
+fn get_uniffi_one_type(val: UniffiOneType) -> UniffiOneType {
+    UniffiOneType { sval: format!("{} - {}", val.sval, val.sval) }
+}
+
+fn get_another_animal(animal: Animal) -> Animal {
+    match animal {
+        Animal::Dog => Animal::Cat,
+        Animal::Cat => Animal::Dog,
+    }
+}
+
+fn get_another_ip(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V4 { .. } => IpAddr::V6 { addr: "1:2:3:4".to_string() },
+        IpAddr::V6 { .. } => IpAddr::V4 { q1: 127, q2: 0, q3: 0, q4: 1 },
+    }
+}
 
 pub struct CombinedType {
     pub uot: UniffiOneType,
@@ -18,6 +36,10 @@ pub struct CombinedType {
     pub handle: Handle,
     pub handles: Vec<Handle>,
     pub maybe_handle: Option<Handle>,
+
+    pub animal: Animal,
+    pub animals: Vec<Animal>,
+    pub maybe_animal: Option<Animal>,
 }
 
 fn get_combined_type(existing: Option<CombinedType>) -> CombinedType {
@@ -46,6 +68,10 @@ fn get_combined_type(existing: Option<CombinedType>) -> CombinedType {
         handle: Handle(123),
         handles: vec![Handle(1), Handle(2), Handle(3)],
         maybe_handle: Some(Handle(4)),
+
+        animal: Animal::Dog,
+        animals: vec![Animal::Cat, Animal::Dog],
+        maybe_animal: Some(Animal::Cat),
     })
 }
 

--- a/fixtures/ext-types/uniffi-one/src/lib.rs
+++ b/fixtures/ext-types/uniffi-one/src/lib.rs
@@ -1,5 +1,18 @@
+// We just expose types here - our fixtures 'lib' crate will reference them
+// and exposes functions to work with them.
+
 pub struct UniffiOneType {
     pub sval: String,
+}
+
+pub enum Animal {
+    Dog,
+    Cat,
+}
+
+pub enum IpAddr {
+    V4 {q1: u8, q2: u8, q3: u8, q4: u8},
+    V6 {addr: String},
 }
 
 include!(concat!(env!("OUT_DIR"), "/uniffi-one.uniffi.rs"));

--- a/fixtures/ext-types/uniffi-one/src/uniffi-one.udl
+++ b/fixtures/ext-types/uniffi-one/src/uniffi-one.udl
@@ -3,3 +3,14 @@ namespace uniffi_one {};
 dictionary UniffiOneType {
     string sval;
 };
+
+enum Animal {
+  "Dog",
+  "Cat",
+};
+
+[Enum]
+interface IpAddr {
+  V4(u8 q1, u8 q2, u8 q3, u8 q4);
+  V6(string addr);
+};


### PR DESCRIPTION
…ift/lower support

Just incase it helps.  As somewhat expected, tests fail with:

> thread 'test_exttypes_python' panicked at 'should not be necessary to coerce External types', uniffi_bindgen/src/bindings/python/gen_python.rs:164:38