### PR TITLE
Upgrade to a newer base docker image

### DIFF
--- a/docker/Dockerfile-build
+++ b/docker/Dockerfile-build
@@ -5,7 +5,7 @@
 # This builds a docker image containing all the tools we need to run our
 # test suite in CI, including rust, kotlin, and swift.
 
-FROM circleci/rust:buster
+FROM cimg/rust:1.52.1
 
 MAINTAINER Ryan Kelly "rfkelly@mozilla.com"
 
@@ -41,6 +41,7 @@ ADD rust-toolchain.toml rust-toolchain.toml
 RUN rustup self update
 RUN rustup update
 RUN rustup show
+RUN rm rust-toolchain.toml
 
 RUN mkdir -p /tmp/setup-swift \
     && cd /tmp/setup-swift \
@@ -74,4 +75,4 @@ RUN mkdir -p /tmp/setup-jna \
     && cd ../ \
     && rm -rf ./setup-jna
 
-RUN sudo gem install ffi --no-ri
+RUN sudo gem install ffi --no-document


### PR DESCRIPTION
This newer base image is positioned by CircleCI team as:
> This image is designed to supercede the legacy CircleCI Rust image, circleci/rust.

My original motivation was to bring a newer version of ruby into base image. I was working on #469 and found that base docker images includes ruby 2.5 which is [no longer maintated](https://www.ruby-lang.org/en/downloads/branches/).

AFAIK [all CI checks pass](https://app.circleci.com/pipelines/github/saks/uniffi-rs/57/workflows/2065fda0-5fc9-418a-b3de-13606e82ea98) when using updated docker image. And just in case you're wondering: new image is slightly smaller (4.65GB VS 4.78GB).

Please let me know if we need a changelog item for this PR.