### PR TITLE
Callbacks in swift

### DIFF
--- a/uniffi/src/testing.rs
+++ b/uniffi/src/testing.rs
@@ -139,9 +139,9 @@ pub fn ensure_compiled_cdylib(pkg_dir: &str) -> Result<String> {
 /// who are working on uniffi itself and want to test out their changes to the bindings generator.
 #[cfg(not(feature = "builtin-bindgen"))]
 fn run_uniffi_bindgen_test(out_dir: &str, udl_files: &[&str], test_file: &str) -> Result<()> {
-    let udl_files = udl_files.map(|&x| x).collect::<Vec<&str>>().join("\n");
+    let udl_files = udl_files.join("\n");
     let status = Command::new("uniffi-bindgen")
-        .args(&["test", out_dir, udl_files, test_file])
+        .args(&["test", out_dir, &udl_files, test_file])
         .status()?;
     if !status.success() {
         bail!("Error while running tests: {}",);

--- a/uniffi_bindgen/src/bindings/swift/gen_swift.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift.rs
@@ -210,7 +210,7 @@ mod filters {
             FFIType::RustArcPtr => "void*_Nonnull".into(),
             FFIType::RustBuffer => "RustBuffer".into(),
             FFIType::ForeignBytes => "ForeignBytes".into(),
-            FFIType::ForeignCallback => unimplemented!("Callback interfaces are not implemented"),
+            FFIType::ForeignCallback => "ForeignCallback".to_string(),
         })
     }
 
@@ -266,6 +266,11 @@ mod filters {
     /// This is used to pass arguments over the FFI, from Swift to Rust.
     pub fn lower_swift(name: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
         match type_ {
+            Type::CallbackInterface(_) => Ok(format!(
+                "{}Internals.lower({})",
+                class_name_swift(&type_.canonical_name())?,
+                name,
+            )),
             Type::Duration => Ok(format!(
                 "{}.lower{}()",
                 var_name_swift(name)?,
@@ -280,6 +285,11 @@ mod filters {
     /// This is used to receive values over the FFI, from Rust to Swift.
     pub fn lift_swift(name: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
         match type_ {
+            Type::CallbackInterface(_) => Ok(format!(
+                "{}Internals.lift({})",
+                class_name_swift(&type_.canonical_name())?,
+                name,
+            )),
             Type::Duration => Ok(format!(
                 "{}.lift{}({})",
                 type_swift(type_)?,
@@ -296,6 +306,12 @@ mod filters {
     /// that is passed by serializing into bytes.
     pub fn read_swift(name: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
         match type_ {
+            // Type::CallbackInterface(_) => format!(
+            //     "{}Internals.read({})",
+            //     class_name_swift(&type_.canonical_name())?,
+            //     name,
+            // ),
+            Type::CallbackInterface(_) => panic!(),
             Type::Duration => Ok(format!(
                 "{}.read{}(from: {})",
                 type_swift(type_)?,

--- a/uniffi_bindgen/src/bindings/swift/templates/BridgingHeaderTemplate.h
+++ b/uniffi_bindgen/src/bindings/swift/templates/BridgingHeaderTemplate.h
@@ -28,6 +28,8 @@ typedef struct RustBuffer
     uint8_t *_Nullable data;
 } RustBuffer;
 
+typedef RustBuffer (*ForeignCallback)(uint64_t, int32_t, RustBuffer);
+
 typedef struct ForeignBytes
 {
     int32_t len;

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
@@ -1,0 +1,81 @@
+{% let type_name = cbi.name()|class_name_swift %}
+public protocol {{ type_name }} : AnyObject {
+    {% for meth in cbi.methods() -%}
+    func {{ meth.name()|fn_name_swift }}({% call swift::arg_list_protocol(meth) %}) {% call swift::throws(meth) -%}
+    {%- match meth.return_type() -%}
+    {%- when Some with (return_type) %} -> {{ return_type|type_swift -}}
+    {%- else -%}
+    {%- endmatch %}
+    {% endfor %}
+}
+
+{% let canonical_type_name = cbi.type_().canonical_name()|class_name_swift %}
+{% let callback_internals = format!("{}Internals", canonical_type_name) -%}
+{% let callback_interface_impl = format!("{}FFI", canonical_type_name) -%}
+
+let {{ callback_interface_impl }} : ForeignCallback = 
+    { (handle: UInt64, method: Int32, args: RustBuffer) -> RustBuffer in
+
+        {% for meth in cbi.methods() -%}
+    {% let method_name = format!("invoke_{}", meth.name())|fn_name_swift %}
+
+    func {{ method_name }}(_ swiftCallbackInterface: {{ type_name }}, _ args: RustBuffer) throws -> RustBuffer {
+        defer { args.deallocate() }
+        {#- Unpacking args from the RustBuffer #}
+            {%- if meth.arguments().len() != 0 -%}
+            {#- Calling the concrete callback object #}
+            
+            let reader = Reader(data: Data(rustBuffer: args))
+            let result = swiftCallbackInterface.{{ meth.name()|fn_name_swift }}(
+                    {% for arg in meth.arguments() -%}
+                    {{ arg.name() }}: try {{ "reader"|read_swift(arg.type_()) }}
+                    {%- if !loop.last %}, {% endif %}
+                    {% endfor -%}
+                )
+            {% else %}
+            let result = swiftCallbackInterface.{{ meth.name()|fn_name_swift }}()
+            {% endif -%}
+            
+        {#- Packing up the return value into a RustBuffer #}
+                {%- match meth.return_type() -%}
+                {%- when Some with (return_type) -%}
+                let writer = Writer()
+                result.write(into: writer)
+                return RustBuffer(bytes: writer.bytes)
+                {%- else -%}
+                return RustBuffer()
+                {% endmatch -%}
+                // TODO catch errors and report them back to Rust. 
+                // https://github.com/mozilla/uniffi-rs/issues/351
+        
+    }
+    {% endfor %}
+
+        return {{ callback_internals }}.handleMap.callWithResult(handle: handle) { cb -> RustBuffer in 
+            switch method {
+                case IDX_CALLBACK_FREE: return {{ callback_internals }}.drop(handle: handle)
+                {% for meth in cbi.methods() -%}
+                {% let method_name = format!("invoke_{}", meth.name())|fn_name_swift -%}
+                case {{ loop.index }}: return try! {{ method_name }}(cb, args)
+                {% endfor %}
+                // This should never happen, because an out of bounds method index won't
+                // ever be used. Once we can catch errors, we should return an InternalError.
+                // https://github.com/mozilla/uniffi-rs/issues/351
+                default: return RustBuffer()
+            }
+        }
+    }
+
+let {{ callback_internals }} = _{{ callback_internals }}()
+class _{{ callback_internals }}<T: {{ type_name }}>: CallbackInternals<T> {
+
+    init() {
+        super.init(foreignCallback: {{ callback_interface_impl }})
+        register()
+    }
+    func register() {
+        try? rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
+            {{ cbi.ffi_init_callback().name() }}(self.foreignCallback, err)
+        }
+    }
+}

--- a/uniffi_bindgen/src/bindings/swift/templates/Helpers.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Helpers.swift
@@ -1,0 +1,102 @@
+
+
+{% if ci.iter_callback_interface_definitions().len() > 0 %}
+
+class Lock {
+    init(){}
+    func withLock<T>(f: () throws -> T ) rethrows -> T {
+        objc_sync_enter(self)
+        defer { objc_sync_exit(self) }
+        return try f()
+    }
+}
+
+typealias Handle = UInt64
+class ConcurrentHandleMap<T: AnyObject> {
+    private var leftMap: [Handle: T] = [:]
+    private var rightMap: [ObjectIdentifier: Handle] = [:]
+
+    private let lock = Lock()
+    private var currentHandle: Handle = 0
+    private let stride: Handle = 1
+
+    func insert(obj: T) -> Handle {
+        lock.withLock {
+            rightMap[ObjectIdentifier(obj)] ?? {
+                currentHandle += stride
+                let handle = currentHandle
+                leftMap[handle] = obj
+                rightMap[ObjectIdentifier(obj)] = handle
+                return handle
+            }()
+        }
+    }
+
+    func callWithResult<R>(handle: Handle, fn: (T) -> R) -> R {
+        guard let obj = lock.withLock(f: { leftMap[handle] })
+        else { fatalError("Panic: handle not in handlemap") }
+        return fn(obj)
+    }
+
+    func get(handle: Handle) -> T? {
+        lock.withLock {
+            leftMap[handle]
+        }
+    }
+
+    func delete(handle: Handle) {
+        remove(handle: handle)
+    }
+
+    @discardableResult
+    func remove(handle: Handle) -> T? {
+        lock.withLock {
+            let obj = leftMap.removeValue(forKey: handle)
+             if let obj = obj {
+                 rightMap.removeValue(forKey:  ObjectIdentifier(obj))
+             }
+            return obj
+        }
+    }
+}
+
+// Magic number for the Rust proxy to call using the same mechanism as every other method,
+// to free the callback once it's dropped by Rust.
+private let IDX_CALLBACK_FREE: Int32 = 0
+
+class CallbackInternals<CallbackInterface: AnyObject> {
+
+    let foreignCallback: ForeignCallback
+
+    init(foreignCallback: @escaping ForeignCallback) {
+        self.foreignCallback = foreignCallback
+    }
+
+    let handleMap = ConcurrentHandleMap<CallbackInterface>()
+
+    func drop(handle: Handle) -> RustBuffer {
+        handleMap.remove(handle: handle)
+        return RustBuffer()
+    }
+
+    func lift(n handle: Handle) -> CallbackInterface? {
+        handleMap.get(handle: handle)
+    }
+
+    fileprivate func read(from buf: Reader) throws -> CallbackInterface? {
+        let handle: UInt64 = try buf.readInt()
+        return lift(n: handle)
+    }
+
+    func lower(_ v: CallbackInterface) -> Handle {
+        let handle = handleMap.insert(obj: v)
+        return handle
+        // assert(handleMap.get(handle: obj) == v, "Handle map is not returning the object we just placed there. This is a bug in the HandleMap.")
+    }
+
+    fileprivate func write(v: CallbackInterface, into buf: Writer) {
+        buf.writeInt(lower(v))
+    }
+}
+
+{% endif %}

--- a/uniffi_bindgen/src/bindings/swift/templates/RustBufferTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RustBufferTemplate.swift
@@ -14,6 +14,17 @@ fileprivate extension RustBuffer {
     }
 }
 
+public extension RustBuffer {
+    // Allocate a new buffer, copying the contents of a `UInt8` array.
+    static var empty: RustBuffer {
+        return RustBuffer.init(
+                capacity: 0,
+                len: 0,
+                data: nil
+            )
+    }
+}
+
 fileprivate extension ForeignBytes {
     init(bufferPointer: UnsafeBufferPointer<UInt8>) {
         self.init(len: Int32(bufferPointer.count), data: bufferPointer.baseAddress)

--- a/uniffi_bindgen/src/bindings/swift/templates/macros.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/macros.swift
@@ -32,7 +32,7 @@
 
 {%- macro _arg_list_ffi_call(func) %}
     {%- for arg in func.arguments() %}
-        {{- arg.name()|lower_swift(arg.type_()) }}
+        {{- arg.name()|var_name_swift|lower_swift(arg.type_()) }}
         {%- if !loop.last %}, {% endif -%}
     {%- endfor %}
 {%- endmacro -%}

--- a/uniffi_bindgen/src/bindings/swift/templates/wrapper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/wrapper.swift
@@ -11,6 +11,7 @@ import {{ config.ffi_module_name() }}
 #endif
 
 {% include "RustBufferTemplate.swift" %}
+{% include "Helpers.swift" %}
 {% include "RustBufferHelper.swift" %}
 
 // Public interface members begin here.
@@ -33,4 +34,10 @@ import {{ config.ffi_module_name() }}
 {% include "ObjectTemplate.swift" %}
 {% endfor %}
 
+// Callback Interfaces
+{% for cbi in ci.iter_callback_interface_definitions() %}
+{% include "CallbackInterfaceTemplate.swift" %}
+{% endfor %}
+
 {% import "macros.swift" as swift %}
+


### PR DESCRIPTION
Add support for callbacks in swift. Basically a copy of how it is done for Kotlin, except that reference counting is only implemented for callbacks and not for classes. Im not sure if it is needed in swift.