### PR TITLE
Improve error reporting when an object impl isn't Sync+Send.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,6 @@ members = [
   "fixtures/regressions/kotlin-experimental-unsigned-types",
   "fixtures/regressions/cdylib-crate-type-dependency/ffi-crate",
   "fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency",
+  "fixtures/uitests",
   "fixtures/uniffi-fixture-time",
 ]

--- a/examples/sprites/src/lib.rs
+++ b/examples/sprites/src/lib.rs
@@ -31,8 +31,7 @@ pub fn translate(p: &Point, v: Vector) -> Point {
 // and which can move about over time.
 #[derive(Debug)]
 pub struct Sprite {
-    // All interfaces must be `Send+Sync`, and our naive `Point` struct
-    // isn't, so we wrap it in a `RwLock` to make it so.
+    // We must use interior mutability for managing mutable state, hence the `RwLock`.
     current_position: RwLock<Point>,
 }
 

--- a/examples/todolist/src/lib.rs
+++ b/examples/todolist/src/lib.rs
@@ -60,8 +60,8 @@ fn create_entry_with<S: Into<String>>(item: S) -> Result<TodoEntry> {
 type Result<T, E = TodoError> = std::result::Result<T, E>;
 
 // A simple Todolist.
-// UniFFI requires all objects to be `Send + Sync`, so we wrap our `Vec` in a RwLock
-// (a Mutex would also work, but a RwLock is more appropriate for this use-case, so we use it).
+// UniFFI requires that we use interior mutability for managing mutable state, so we wrap our `Vec` in a RwLock.
+// (A Mutex would also work, but a RwLock is more appropriate for this use-case, so we use it).
 #[derive(Debug)]
 pub struct TodoList {
     items: RwLock<Vec<String>>,

--- a/fixtures/uitests/Cargo.toml
+++ b/fixtures/uitests/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "uniffi_uitests"
+version = "0.14.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+edition = "2018"
+publish = false
+
+[lib]
+name = "uniffi_uitests"
+
+[dependencies]
+uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
+uniffi_macros = {path = "../../uniffi_macros", features=["builtin-bindgen"]}
+
+[build-dependencies]
+uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}
+
+[dev-dependencies]
+trybuild = "1"

--- a/fixtures/uitests/README.md
+++ b/fixtures/uitests/README.md
@@ -1,0 +1,11 @@
+# A suite of "user interface" tests for UniFFI.
+
+This crate uses [trybuild](https://docs.rs/trybuild) to automate tests for the compiler
+output of UniFFI-generated code. This helps us ensure that we're generatuing useful
+error messages in cases where the user's Rust code and `.udl` file to not match
+up correctly.
+
+Ideally these tests would be part of the `uniffi_bindgen` crate, but factoring it out
+into a separate crate has made it easier to integrate with `trybuild`. In particular
+it lets us use convenience macros from `uniffi_macros` when writing the tests, without
+having to deal with a circular dependency between `uniffi_macros` and `uniffi_bindgen`.

--- a/fixtures/uitests/build.rs
+++ b/fixtures/uitests/build.rs
@@ -1,0 +1,4 @@
+// This crate doesn't *actually* have any build logic, we just want
+// cargo to make `$OUT_DIR` for us so we can use it in the tests.
+
+fn main() {}

--- a/fixtures/uitests/src/counter.udl
+++ b/fixtures/uitests/src/counter.udl
@@ -1,0 +1,5 @@
+namespace uitests {};
+
+interface Counter {
+  u32 increment();
+};

--- a/fixtures/uitests/src/lib.rs
+++ b/fixtures/uitests/src/lib.rs
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/// This crate only exists for its tests.
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn trybuild_ui_tests() {
+        let t = trybuild::TestCases::new();
+        t.compile_fail("tests/ui/*.rs");
+    }
+}

--- a/fixtures/uitests/tests/ui/interface_cannot_use_mut_self.rs
+++ b/fixtures/uitests/tests/ui/interface_cannot_use_mut_self.rs
@@ -1,0 +1,22 @@
+
+// Unfortunately, path is relative to a temporary build directory :-/
+uniffi_macros::generate_and_include_scaffolding!("../../../fixtures/uitests/src/counter.udl");
+
+fn main() { /* empty main required by `trybuild` */}
+
+pub struct Counter {
+    value: u32,
+}
+
+impl Counter {
+    pub fn new() -> Self {
+        Self { value: 0 }
+    }
+
+    // This will fail to compile due to `&mut self` receiver.
+    pub fn increment(&mut self) -> u32 {
+        self.value = self.value + 1;
+        self.value
+    }
+}
+

--- a/fixtures/uitests/tests/ui/interface_cannot_use_mut_self.stderr
+++ b/fixtures/uitests/tests/ui/interface_cannot_use_mut_self.stderr
@@ -1,0 +1,8 @@
+error[E0308]: mismatched types
+   --> $DIR/counter.uniffi.rs:160:13
+    |
+160 |             &<std::sync::Arc<Counter> as uniffi::FfiConverter>::try_lift(ptr).unwrap(),
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+    |
+    = note: expected mutable reference `&mut Counter`
+                       found reference `&Arc<Counter>`

--- a/fixtures/uitests/tests/ui/interface_not_sync_and_send.rs
+++ b/fixtures/uitests/tests/ui/interface_not_sync_and_send.rs
@@ -1,0 +1,24 @@
+
+use std::cell::Cell;
+
+// Unfortunately, path is relative to a temporary build directory :-/
+uniffi_macros::generate_and_include_scaffolding!("../../../fixtures/uitests/src/counter.udl");
+
+fn main() { /* empty main required by `trybuild` */}
+
+pub struct Counter {
+    // This will fail to compile, because `Cell` is not `Sync`.
+    value: Cell<u32>,
+}
+
+impl Counter {
+    pub fn new() -> Self {
+        Self { value: Cell::new(0) }
+    }
+
+    pub fn increment(&self) -> u32 {
+        let new_value = self.value.get() + 1;
+        self.value.set(new_value);
+        new_value
+    }
+}

--- a/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
+++ b/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
@@ -1,0 +1,32 @@
+error[E0277]: `Cell<u32>` cannot be shared between threads safely
+   --> $DIR/counter.uniffi.rs:119:1
+    |
+119 | uniffi::deps::static_assertions::assert_impl_all!(Counter: Sync, Send);
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    | |
+    | `Cell<u32>` cannot be shared between threads safely
+    | required by this bound in `assert_impl_all`
+    |
+    = help: within `Counter`, the trait `Sync` is not implemented for `Cell<u32>`
+    = note: required because it appears within the type `Counter`
+    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
+   --> $DIR/counter.uniffi.rs:145:9
+    |
+145 |         <std::sync::Arc<Counter> as uniffi::FfiConverter>::lower(_arc)
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FfiConverter` is not implemented for `Arc<Counter>`
+    |
+    = help: the following implementations were found:
+              <Arc<T> as FfiConverter>
+    = note: required by `lower`
+
+error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
+   --> $DIR/counter.uniffi.rs:160:14
+    |
+160 |             &<std::sync::Arc<Counter> as uniffi::FfiConverter>::try_lift(ptr).unwrap(),
+    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FfiConverter` is not implemented for `Arc<Counter>`
+    |
+    = help: the following implementations were found:
+              <Arc<T> as FfiConverter>
+    = note: required by `try_lift`

--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -24,6 +24,13 @@
 fn uniffi_note_threadsafe_deprecation_{{ obj.name() }}() {}
 {% endif %}
 
+
+// All Object structs must be `Sync + Send`. The generated scaffolding will fail to compile
+// if they are not, but unfortunately it fails with an unactionably obscure error message.
+// By asserting the requirement explicitly, we help Rust produce a more scrutable error message
+// and thus help the user debug why the requirement isn't being met.
+uniffi::deps::static_assertions::assert_impl_all!({{ obj.name() }}: Sync, Send);
+
 {% let ffi_free = obj.ffi_object_free() -%}
 #[doc(hidden)]
 #[no_mangle]

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -18,3 +18,10 @@ proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["extra-traits"] }
 glob = "0.3"
+uniffi_build = { path = "../uniffi_build", version = "= 0.14.0"}
+
+[features]
+default = []
+# Use the `uniffi_bindgen` from this workspace instead of the one installed on your system.
+# You probably only want to enable this feature if you're working on uniffi itself.
+builtin-bindgen = ["uniffi_build/builtin-bindgen"]


### PR DESCRIPTION
We require the implementation of all object structs to be Sync+Send,
and the generated Rust scaffolding will fail to compile if this
requirement is not met. Unfortunately, the failure is currently
triggered via some trait bounds on `FfiConverter` for `Arc<T>`,
so the error message it produces is quite inscrutable and doesn't
help the user debug the underlying issue.

This commit adds an explicit static assertion about the Sync+Send
requirement, which helps the Rust compiler to emit the proper diagnostic
about why the underlying struct is not `Sync` or `Send`. It also has
the added benefit of guarding against any future refactor of the
code that might accidentally factor away the Sync+Send requirement.

Fixes #1048. (Well, not really *fixes* I guess because the code in
experience of debugging such cases much better).