### PR TITLE
Decorator objects for decorating foreign language method calls in to Rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@
 
 [All changes in v0.14.1](https://github.com/mozilla/uniffi-rs/compare/v0.14.0...v0.14.1).
 
+### What's Changed
+
+- [Decorator objects](docs/manual/src/udl/decorators.md) reduce boiler plate in Foreign Language bindings.
+  - `[Decorator]` declares an `interface` of decorator functions
+  - `[Decorator=]` adds a decorator to an `interface`
+  - `[CallsWith=]` directs method calls through a decorator function.
+
 ## v0.14.0 (_2021-08-17_)
 
 [All changes in v0.14.0](https://github.com/mozilla/uniffi-rs/compare/v0.13.1...v0.14.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,15 @@
   constructor, you must add one explicitly.
 
 ### What's Changed
+
 - Kotlin and Swift, like Python, now support [simple "wrapped" types](https://mozilla.github.io/uniffi-rs/udl/ext_types_wrapped.html).
+
+### What's New
+
+- [Decorator objects](docs/manual/src/udl/decorators.md) reduce boiler plate in Foreign Language bindings.
+  - `[Decorator]` declares an `interface` of decorator functions
+  - `[Decorator=]` adds a decorator to an `interface`
+  - `[CallsWith=]` directs method calls through a decorator function.
 
 [All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.14.1...main).
 
@@ -33,13 +41,6 @@
 - Kotlin: Added some defensive programming around `RustBufferBuilder.discard()`
 
 [All changes in v0.14.1](https://github.com/mozilla/uniffi-rs/compare/v0.14.0...v0.14.1).
-
-### What's Changed
-
-- [Decorator objects](docs/manual/src/udl/decorators.md) reduce boiler plate in Foreign Language bindings.
-  - `[Decorator]` declares an `interface` of decorator functions
-  - `[Decorator=]` adds a decorator to an `interface`
-  - `[CallsWith=]` directs method calls through a decorator function.
 
 ## v0.14.0 (_2021-08-17_)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
 
   "fixtures/coverall",
   "fixtures/callbacks",
+  "fixtures/decorators",
 
   "fixtures/ext-types/guid",
   "fixtures/ext-types/uniffi-one",

--- a/docs/manual/src/udl/decorators.md
+++ b/docs/manual/src/udl/decorators.md
@@ -1,0 +1,240 @@
+# Decorator objects
+
+We'll be considering the UDL for an object called `DemoRustObject`:
+
+```webidl
+interface DemoRustObject {
+    void do_expensive_thing();
+    [Throws=RustyError]
+    void do_crashy_thing();
+    void do_consequential_thing();
+}
+```
+
+`DemoRustObject` is a `struct` written in Rust, and uniffi generates a class of that name in the foreign languages which forward method calls to the Rust implementation.
+
+## Problem
+
+Just by the names of these methods, we can see that the application might not want to deal with the `DemoRustObject` by itself, without some proper care taken while calling its methods:
+
+* it may want to run `do_expensive_thing()` off the main thread
+* it may want to catch and report errors from `do_crashy_thing()`.
+* it may want to inform the rest of the application each time `do_consequential_thing()` is called.
+
+A common pattern when using uniffied code is to run some common, but app-specific, code before or after calling the Rust code.
+
+```kotlin
+class DemoLib(
+    val backgroundScope: CoroutineContext,
+    val errorReporter: (e: Exception) -> Unit,
+    val listener: () -> Void
+) {
+    val demoRustObject = new DemoRustObject()
+
+    fun doExpensiveThing() {
+        backgroundScope.launch {
+            demoRustObject.doExpensiveThing()
+        }
+    }
+
+    fun doCrashyThing() {
+        try {
+            demoRustObject.doCrashyThing()
+        } catch (e: Exception) {
+            errorReporter(e)
+        }
+    }
+
+    fun doConsequentialThing() {
+        demoRustObject.doConsequentialThing()
+        listener()
+    }
+}
+```
+
+This causes a proliferation of boiler plate code. Worse, everytime we add a new method to the `DemoRustObject`, handwritten foreign language code needs to be written to expose it safely.
+
+The more methods that want to do similar things, the more repetitive this gets.
+
+We could isolate the repeated code into a decorator class with `onBackgroundThread`, `withErrorReporter` and `thenNotifyListeners` methods.
+
+We'll handwrite a little decorator interface, then write an implementation that we pass the thread pool/coroutine context/whatever, and the error reporter.
+
+```kotlin
+interface DemoDecorator {
+    fun onBackgroundThread(rustCall: () -> Unit)
+    fun <T> withErrorReporter(rustCall: () -> T): T
+    fun thenNotifyListeners(obj: DemoLib, rustCall: () -> T)
+}
+
+class MyDemoDecorator(
+    val backgroundScope: CoroutineContext,
+    val errorReporter: (e: Exception) -> Unit,
+    val listener: () -> Void
+) : DemoDecorator {
+    fun onBackgroundThread(rustCall: () -> Unit) {
+        backgroundScope.launch {
+            rustCall()
+        }
+    }
+
+    fun <T> withErrorReporter(rustCall: () -> T) =
+        try {
+            rustCall()
+        } catch (e: Exception) {
+            errorReporter(e)
+        }
+
+    fun thenNotifyListeners(obj: DemoLib, rustCall: () -> T) {
+        try {
+            rustCall()
+        } finally {
+            listener()
+        }
+    }
+}
+```
+
+Then, we can re-write the `DemoLib` as:
+
+```kotlin
+class DemoLib(
+    val decorator: DemoDecorator = MyDemoDecorator()
+) {
+    val demoRustObject = new DemoRustObject()
+
+    fun doExpensiveThing() = decorator.onBackgroundThread {
+        demoRustObject.doExpensiveThing()
+    }
+
+    fun doCrashyThing() = decorator.withErrorReporter {
+        demoRustObject.doCrashyThing()
+    }
+
+    fun doConsequentialThing() = decorator.thenNotifyListeners(this) {
+        demoRustObject.doConsequentialThing()
+    }
+}
+```
+
+This is much better, but it's still looking a bit cut and pasty. Enter decorator objects.
+
+## Solution
+
+```webidl
+namespace demo {}
+
+[Decorator]
+interface DemoDecorator {
+    Any? with_error_reporter();
+    void on_background_thread();
+    Any  then_notify_listeners();
+}
+
+[Decorator=DemoDecorator]
+interface DemoRustObject {
+    [CallsWith=on_background_thread]
+    void do_expensive_thing();
+
+    [Throws=RustyError, CallsWith=with_error_reporter]
+    void do_crashy_thing();
+
+    [CallsWith=then_notify_listeners]
+    void do_consequential_thing();
+}
+```
+
+With this UDL: the `[Decorator]` annotation declares an `DemoDecorator` as a decorator object. Decorator objects never cross the FFI.
+
+> Decorator objects take their name from [Python's decorator methods][py-decorators].
+>
+> In Pythonic terms, Uniffi's decorator objects are a collection of decorator functions.
+>
+> Swift and Kotlin don't provide functionality to capture arbitrary `*args` and call a function with those same `*args`, so
+> at this time, decorator objects aren't as powerful as Python decorators. Nevertheless, they can be still quite useful.
+
+[py-decorators]: https://www.python.org/dev/peps/pep-0318/#on-the-name-decorator
+
+They are implemented as a `protocol` in Swift, and `interface` in Kotlin.
+
+They declare zero argument methods, but can return an arbitrary concrete type, `void` or the generic `Any` type. The `DemoDecorator` interface is now generated,
+and each method accepts the decorated object and a generic closure which will call the Rust code.
+
+```kotlin
+// generated by uniffi
+interface DemoDecorator<ObjectType> {
+    fun <ReturnType> onBackgroundThread(obj: ObjectType, rustCall: () -> ReturnType)
+    fun <ReturnType> withErrorReporter(obj: ObjectType, rustCall: () -> ReturnType): ReturnType?
+    fun <ReturnType> thenNotifyListeners(obj: ObjectType, rustCall: () -> ReturnType)
+}
+```
+
+The `[Decorator=DemoDecorator]` annotation above the `DemoRustObject` `interface` declaration ties the decorator object to our original `DemoRustObject` class.
+
+This changes the generated API of `DemoRustObject`:
+
+* it adds a `DemoDecorator` argument to every constructor.
+* it changes the return types and throws types for each method called with a decorator method to match the decorator method. Where the decorator method returns `Any`, the original return type remains.
+
+Now the generated Rust calls go through the app-specific decorator methods, we could more safely hand the rust object to the application to use directly.
+
+```kotlin
+val decorator = MyDemoDecorator(backgroundScope, errorReporter, listener)
+val demoRustObject = DemoRustObject(decorator)
+```
+
+This is a considerable improvement! Now the decorator methods can be specified by the app, and the UDL uses them. Each time the UDL changes, the foreign language bindings keeps up.
+
+### Re-writing the wrapper
+
+In our example above, we had a handwritten `DemoLib` which had all the methods of the `DemoRustObject` but did all error catching and launching on a background thread. It was also a good place to put additional handwritten code. With decorator objects, the need for `DemoLib` all but disappears.
+
+However, there may already be a considerable amount of application code pointing to it, which we don't want to change.
+
+Uniffi generates a Kotlin `interface` or Swift `protocol` for each `Object` in the UDL. In this case, `DemoRustObject` is the class, and `DemoRustObjectInterface` is the interface.
+
+#### Kotlin
+
+We can use this and [Kotlin's Interface delegation features][1] to re-write `DemoLib` so that it too keeps up and in sync with the UDL.
+
+[1]: https://kotlinlang.org/docs/delegation.html
+
+```kotlin
+class DemoLib private constructor(
+    demoRustObject: DemoRustObject
+) : DemoRustObjectInterface by demoRustObject {
+
+    constructor(decorator: DemoDecorator) = this(DemoRustObject(decorator))
+
+    constructor(
+        backgroundScope: CoroutineContext,
+        errorReporter: (e: Exception) -> Unit,
+        listener: () -> Unit
+    ) = this(MyDemoDecorator(backgroundScope, errorReporter, listener))
+}
+```
+
+We can then add hand-written code to this class.
+
+#### Swift
+
+In Swift, we can't get `DemoLib` to implement `DemoRustObjectProtocol`, and automatically implement the methods with `DemoRustObject`. Instead we literally replace it with a `typealias` and add a convenience constructor to take the original arguments. Handwritten code can then be added to this extension.
+
+```swift
+typealias DemoLib = DemoRustObject
+extension DemoLib {
+    convenience init(
+        backgroundQueue: OperationQueue,
+        errorReporter: @escaping (Error) -> Void,
+        listener: @escaping () -> Void
+    ) {
+        self.init(
+            MyDemoDecorator(
+                backgroundQueue: backgroundQueue,
+                errorReporter: errorReporter,
+                listener: listener
+            )
+        )
+    }
+}
+```

--- a/examples/todolist/src/lib.rs
+++ b/examples/todolist/src/lib.rs
@@ -27,7 +27,7 @@ pub enum TodoError {
     DuplicateTodo,
     #[error("Empty String error!: {0}")]
     EmptyString(String),
-    #[error("I am a delegated Error: {0}")]
+    #[error("I am a decorated Error: {0}")]
     DeligatedError(#[from] std::io::Error),
 }
 

--- a/fixtures/decorators/Cargo.toml
+++ b/fixtures/decorators/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "decorators"
+version = "0.14.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+edition = "2018"
+publish = false
+
+[lib]
+crate-type = ["staticlib", "cdylib"]
+name = "uniffi_decorators"
+
+[dependencies]
+uniffi_macros = {path = "../../uniffi_macros"}
+uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
+thiserror = "1.0"
+lazy_static = "1.4"
+
+[build-dependencies]
+uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/decorators/README.md
+++ b/fixtures/decorators/README.md
@@ -1,0 +1,11 @@
+# A "Decorators" test for uniffi components
+
+This is similar to the `decorators` example, but it's intended to be contrived and to
+ensure we get good test coverage of all possible options.
+
+It's here so it doesn't even need to make a cursory effort to be a "good"
+example; it intentionally panics, asserts params are certain values, has
+no-op methods etc. If you're trying to get your head around uniffi then the
+"examples" directory will be a much better bet.
+
+This is its own crate, because the decorator mechanism is not implemented for all backends yet.

--- a/fixtures/decorators/build.rs
+++ b/fixtures/decorators/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/decorators.udl").unwrap();
+}

--- a/fixtures/decorators/src/decorators.udl
+++ b/fixtures/decorators/src/decorators.udl
@@ -1,0 +1,25 @@
+namespace decorators {};
+
+[Decorator]
+interface MyDecorator {
+  Any? with_return();
+  void string_saver();
+  i32  with_counter();
+};
+
+[Decorator=MyDecorator]
+interface RustObject {
+  constructor();
+
+  [Name=from_string]
+  constructor(string string);
+
+  [CallsWith=string_saver]
+  string identity_string(string s);
+
+  [CallsWith=with_counter]
+  string get_string();
+
+  [CallsWith=with_return]
+  i32 length();
+};

--- a/fixtures/decorators/src/lib.rs
+++ b/fixtures/decorators/src/lib.rs
@@ -1,0 +1,34 @@
+use std::convert::TryInto;
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#[derive(Debug, Clone)]
+pub struct RustObject {
+    string: String,
+}
+
+impl RustObject {
+    fn new() -> Self {
+        Self { string: "".into() }
+    }
+
+    fn from_string(string: String) -> Self {
+        Self { string }
+    }
+
+    fn identity_string(&self, s: String) -> String {
+        s
+    }
+
+    fn get_string(&self) -> String {
+        self.string.clone()
+    }
+
+    fn length(&self) -> i32 {
+        self.string.len().try_into().unwrap()
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/decorators.uniffi.rs"));

--- a/fixtures/decorators/tests/bindings/test_decorators.kts
+++ b/fixtures/decorators/tests/bindings/test_decorators.kts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import uniffi.decorators.*
+
+/// MyDecorator is defined in the UDL file. It generates an interface.
+/// Implementations of the interface never cross the FFI boundary, and so
+/// can contain arbitrary Kotlin.
+class Decorator : MyDecorator<RustObject> {
+    var count = 0
+    var lastString: String? = null
+
+    override fun <T> withReturn(obj: RustObject, thunk: () -> T): T = thunk()
+    override fun <T> stringSaver(obj: RustObject, thunk: () -> T) {
+        lastString = thunk() as? String
+    }
+    override fun <T> withCounter(obj: RustObject, thunk: () -> T): Int = thunk().let { ++count }
+}
+
+val decorator = Decorator()
+// Decorators are given to the rust object via a constructor.
+val rustObj0 = RustObject(decorator)
+
+val string1 = "placeholder string"
+// Alternative constructors take the decorator as the first argument.
+// The argument name is a mixed case version of the decorator interface name.
+val rustObj1 = RustObject.fromString(string = string1, myDecorator = decorator)
+
+assert(rustObj0.length() == 0) { "generic return" }
+assert(rustObj1.length() == string1.length) { "generic return" }
+
+assert(rustObj0.getString() == 1) { "different return type from method's own" }
+assert(rustObj0.getString() == 2) { "code is run each time the method is run" }
+assert(rustObj1.getString() == 3) { "decorator can be shared between objects" }
+
+val string2 = "meta-syntactic variable values"
+assert(rustObj1.identityString(string2) == Unit) { "void return" }
+assert(decorator.lastString == string2) { "Decorator is actually called" }

--- a/fixtures/decorators/tests/test_generated_bindings.rs
+++ b/fixtures/decorators/tests/test_generated_bindings.rs
@@ -1,4 +1,4 @@
 uniffi_macros::build_foreign_language_testcases!(
-    "src/decorators.udl",
+    ["src/decorators.udl"],
     ["tests/bindings/test_decorators.kts"]
 );

--- a/fixtures/decorators/tests/test_generated_bindings.rs
+++ b/fixtures/decorators/tests/test_generated_bindings.rs
@@ -1,0 +1,4 @@
+uniffi_macros::build_foreign_language_testcases!(
+    "src/decorators.udl",
+    ["tests/bindings/test_decorators.kts"]
+);

--- a/uniffi_bindgen/src/backend/types.rs
+++ b/uniffi_bindgen/src/backend/types.rs
@@ -43,6 +43,12 @@ pub trait CodeType {
     /// method signatures and property declarations.
     fn type_label(&self, oracle: &dyn CodeOracle) -> String;
 
+    /// The language specific label used to reference this type. This will be used in
+    /// method signatures and property declarations.
+    fn type_t_label(&self, oracle: &dyn CodeOracle, _t: &str) -> String {
+        self.type_label(oracle)
+    }
+
     /// A representation of this type label that can be used as part of another
     /// identifier. e.g. `read_foo()`, or `FooInternals`.
     ///

--- a/uniffi_bindgen/src/backend/types.rs
+++ b/uniffi_bindgen/src/backend/types.rs
@@ -187,6 +187,10 @@ impl<T: CodeTypeDispatch> CodeType for T {
         self.code_type_impl(oracle).type_label(oracle)
     }
 
+    fn type_t_label(&self, oracle: &dyn CodeOracle, t: &str) -> String {
+        self.code_type_impl(oracle).type_t_label(oracle, t)
+    }
+
     fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
         self.code_type_impl(oracle).canonical_name(oracle)
     }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/compounds.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/compounds.rs
@@ -47,6 +47,10 @@ macro_rules! impl_code_type_for_compound {
                     format!($type_label_pattern, oracle.find(self.inner()).type_label(oracle))
                 }
 
+                fn type_t_label(&self, oracle: &dyn CodeOracle, t: &str) -> String {
+                    format!($type_label_pattern, oracle.find(self.inner()).type_t_label(oracle, t))
+                }
+
                 fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
                     format!($canonical_name_pattern, oracle.find(self.inner()).canonical_name(oracle))
                 }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/decorator.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/decorator.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType};
+use crate::backend::{CodeDeclaration, CodeOracle, CodeType};
 use crate::interface::{ComponentInterface, DecoratorObject};
 use askama::Template;
 

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/decorator.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/decorator.rs
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType};
+use crate::interface::{ComponentInterface, DecoratorObject};
+use askama::Template;
+
+use super::filters;
+pub struct DecoratorObjectCodeType {
+    id: String,
+}
+
+impl DecoratorObjectCodeType {
+    pub fn new(id: String) -> Self {
+        Self { id }
+    }
+}
+
+impl CodeType for DecoratorObjectCodeType {
+    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
+        oracle.class_name(&self.id)
+    }
+
+    fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
+        format!("Decorator{}", self.type_label(oracle))
+    }
+}
+
+#[derive(Template)]
+#[template(syntax = "kt", escape = "none", path = "DecoratorObjectTemplate.kt")]
+pub struct KotlinDecoratorObject {
+    inner: DecoratorObject,
+}
+
+impl KotlinDecoratorObject {
+    pub fn new(inner: DecoratorObject, _ci: &ComponentInterface) -> Self {
+        Self { inner }
+    }
+    pub fn inner(&self) -> &DecoratorObject {
+        &self.inner
+    }
+}
+
+impl CodeDeclaration for KotlinDecoratorObject {
+    fn definition_code(&self, _oracle: &dyn CodeOracle) -> Option<String> {
+        Some(self.render().unwrap())
+    }
+}

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/generic.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/generic.rs
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::bindings::backend::{CodeOracle, CodeType};
+pub struct GenericCodeType;
+
+impl GenericCodeType {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl CodeType for GenericCodeType {
+    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+        "T".to_string()
+    }
+
+    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+        "Generic".to_string()
+    }
+
+    fn type_t_label(&self, _oracle: &dyn CodeOracle, t: &str) -> String {
+        t.to_string()
+    }
+}

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/generic.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/generic.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bindings::backend::{CodeOracle, CodeType};
+use crate::backend::{CodeOracle, CodeType};
 pub struct GenericCodeType;
 
 impl GenericCodeType {

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -201,7 +201,6 @@ impl KotlinCodeOracle {
             Type::Duration => Box::new(miscellany::DurationCodeType),
 
             Type::Enum(id) => Box::new(enum_::EnumCodeType::new(id)),
-            Type::DecoratorObject(s) => Box::new(decorator::DecoratorObjectCodeType::new(s)),
             Type::Object(id) => Box::new(object::ObjectCodeType::new(id)),
             Type::Generic => Box::new(generic::GenericCodeType::new()),
             Type::Record(id) => Box::new(record::RecordCodeType::new(id)),
@@ -209,7 +208,7 @@ impl KotlinCodeOracle {
             Type::CallbackInterface(id) => {
                 Box::new(callback_interface::CallbackInterfaceCodeType::new(id))
             }
-
+            Type::DecoratorObject(s) => Box::new(decorator::DecoratorObjectCodeType::new(s)),
             Type::Optional(ref inner) => {
                 let outer = type_.clone();
                 let inner = *inner.to_owned();
@@ -230,7 +229,6 @@ impl KotlinCodeOracle {
                 name,
                 self.create_code_type(prim.as_ref().clone()),
             )),
-            Type::DelegateObject(s) => Box::new(delegate::DelegateObjectCodeType::new(s)),
         }
     }
 }
@@ -308,12 +306,14 @@ pub mod filters {
         Ok(codetype.type_label(&oracle()))
     }
 
-    pub fn type_t_kt(type_: &Type, t: &dyn fmt::Display) -> Result<String, askama::Error> {
-        let oracle = oracle();
-        Ok(oracle.find(type_).type_t_label(&oracle, &t.to_string()))
+    pub fn type_t_kt(
+        codetype: &impl CodeType,
+        t: &dyn fmt::Display,
+    ) -> Result<String, askama::Error> {
+        Ok(codetype.type_t_label(&oracle(), &t.to_string()))
     }
 
-    pub fn canonical_name(type_: &Type) -> Result<String, askama::Error> {
+    pub fn canonical_name(codetype: &impl CodeType) -> Result<String, askama::Error> {
         Ok(codetype.canonical_name(&oracle()))
     }
 

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/object.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/object.rs
@@ -5,7 +5,7 @@
 use std::fmt;
 
 use crate::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
-use crate::interface::{ComponentInterface, Object};
+use crate::interface::{ComponentInterface, DecoratorObject, Object, Type};
 use askama::Template;
 
 // Filters is used by ObjectTemplate.kt, which looks for the filters module here.
@@ -66,14 +66,25 @@ impl CodeType for ObjectCodeType {
 #[template(syntax = "kt", escape = "none", path = "ObjectTemplate.kt")]
 pub struct KotlinObject {
     inner: Object,
+    decorator_object: Option<DecoratorObject>,
 }
 
 impl KotlinObject {
-    pub fn new(inner: Object, _ci: &ComponentInterface) -> Self {
-        Self { inner }
+    pub fn new(inner: Object, ci: &ComponentInterface) -> Self {
+        let decorator_object = match inner.decorator_type() {
+            Some(Type::DecoratorObject(d)) => ci.get_decorator_definition(&d).cloned(),
+            _ => None,
+        };
+        Self {
+            inner,
+            decorator_object,
+        }
     }
     pub fn inner(&self) -> &Object {
         &self.inner
+    }
+    pub fn decorator_object(&self) -> Option<&DecoratorObject> {
+        self.decorator_object.as_ref()
     }
 }
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/DecoratorObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/DecoratorObjectTemplate.kt
@@ -1,0 +1,13 @@
+{% import "macros.kt" as kt %}
+{%- let obj = self.inner() %}
+{%- let generic_return_type = "ReturnType" %}
+{%- let generic_object_type = "ObjectType" %}
+public interface {{ obj.name()|class_name_kt }}<{{generic_object_type}}> {
+    {% for meth in obj.methods() -%}
+    fun <{{generic_return_type}}> {{ meth.name()|fn_name_kt }}(obj: {{generic_object_type}}, thunk: () -> {{generic_return_type}})
+        {%- match meth.return_type() -%}
+            {%- when Some with (return_type) %}: {{ return_type|type_t_kt(generic_return_type) -}}
+            {%- when None -%}
+        {%- endmatch %}
+    {% endfor %}
+}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -1,9 +1,10 @@
 {% import "macros.kt" as kt %}
 {%- let obj = self.inner() %}
+{%- let dobj = self.decorator_object() %}
 public interface {{ obj.name()|class_name_kt }}Interface {
     {% for meth in obj.methods() -%}
     fun {{ meth.name()|fn_name_kt }}({% call kt::arg_list_decl(meth) %})
-    {%- match meth.return_type() -%}
+    {%- match meth.decorated_return_type(dobj) -%}
     {%- when Some with (return_type) %}: {{ return_type|type_kt -}}
     {%- else -%}
     {%- endmatch %}
@@ -12,15 +13,18 @@ public interface {{ obj.name()|class_name_kt }}Interface {
 
 class {{ obj.name()|class_name_kt }}(
     pointer: Pointer
-) : FFIObject(pointer), {{ obj.name()|class_name_kt }}Interface {
-
-    {%- match obj.primary_constructor() %}
-    {%- when Some with (cons) %}
-    constructor({% call kt::arg_list_decl(cons) -%}) :
-        this({% call kt::to_ffi_call(cons) %})
-    {%- when None %}
+    {%- match inner.decorator_type() %}
+    {%- when Some with (d) %},
+    internal val {{ d|type_kt|var_name_kt }}: {{ d|type_kt }}<{{ obj.name()|class_name_kt }}>
+    {%- else %}
     {%- endmatch %}
-
+) : FFIObject(pointer), {{ obj.name()|class_name_kt }}Interface {
+        {%- match obj.primary_constructor() %}
+        {%- when Some with (cons) %}
+    constructor({% call constructor_args_decl(cons) -%}) :
+        this({% call super_constructor_args(cons) %})
+        {%- else %}
+        {%- endmatch %}
     /**
      * Disconnect the object from the underlying Rust object.
      *
@@ -44,25 +48,20 @@ class {{ obj.name()|class_name_kt }}(
     }
 
     {% for meth in obj.methods() -%}
-    {%- match meth.return_type() -%}
-
-    {%- when Some with (return_type) -%}
-    override fun {{ meth.name()|fn_name_kt }}({% call kt::arg_list_protocol(meth) %}): {{ return_type|type_kt }} =
-        callWithPointer {
-            {%- call kt::to_ffi_call_with_prefix("it", meth) %}
-        }.let {
-            {{ "it"|lift_kt(return_type) }}
-        }
-
-    {%- when None -%}
     override fun {{ meth.name()|fn_name_kt }}({% call kt::arg_list_protocol(meth) %}) =
-        callWithPointer {
-            {%- call kt::to_ffi_call_with_prefix("it", meth) %}
+        {%- match meth.decorator_method_name() -%}
+        {%- when Some with (nm) %}
+            {%- match obj.decorator_type() %}{%- when Some with (decorator_type) %}{{ decorator_type|type_kt|var_name_kt }}{% else %}{% endmatch -%}
+                .{{ nm|fn_name_kt }}(this) {
+            {% call method_body(meth) %}
         }
-    {% endmatch %}
+        {% else %}
+        {% call method_body(meth) %}
+        {% endmatch %}
     {% endfor %}
 
     companion object {
+        {%- if dobj.is_none() %}
         internal fun lift(ptr: Pointer): {{ obj.name()|class_name_kt }} {
             return {{ obj.name()|class_name_kt }}(ptr)
         }
@@ -72,10 +71,46 @@ class {{ obj.name()|class_name_kt }}(
             // fail to compile if they don't fit.
             return {{ obj.name()|class_name_kt }}.lift(Pointer(buf.getLong()))
         }
+        {% endif %}
 
-        {% for cons in obj.alternate_constructors() -%}
-        fun {{ cons.name()|fn_name_kt }}({% call kt::arg_list_decl(cons) %}): {{ obj.name()|class_name_kt }} =
-            {{ obj.name()|class_name_kt }}({% call kt::to_ffi_call(cons) %})
-        {% endfor %}
+        {%- for cons in obj.alternate_constructors() -%}
+        fun {{ cons.name()|fn_name_kt }}({% call constructor_args_decl(cons) %}): {{ obj.name()|class_name_kt }} =
+            {{ obj.name()|class_name_kt }}({% call super_constructor_args(cons) %})
+        {% endfor -%}
     }
 }
+
+{# Macros only used in objects -#}
+{% macro method_body(meth) -%}
+callWithPointer {
+    {%- call kt::to_ffi_call_with_prefix("it", meth) %}
+}
+{%- match meth.return_type() -%}
+{%- when Some with (return_type) -%}.let {
+    {{ "it"|lift_kt(return_type) }}
+}
+{%- when None -%}
+{%- endmatch %}
+{% endmacro -%}
+
+{% macro constructor_args_decl(cons) %}
+{% match obj.decorator_type() %}
+    {%- when Some with (decorator_type) %}
+        {%- let decorator_name = decorator_type|type_kt|var_name_kt %}
+        {{- decorator_name }}: {{ decorator_type|type_kt -}}<{{ obj.name()|class_name_kt }}>
+        {%- if cons.arguments().len() != 0 %}, {% endif %}
+        {%- call kt::arg_list_decl(cons) -%}
+    {%- else %}
+        {% call kt::arg_list_decl(cons) -%}
+    {%- endmatch %}
+{% endmacro %}
+
+{% macro super_constructor_args(cons) %}
+{% match obj.decorator_type() %}
+    {%- when Some with (decorator_type) %}
+        {%- let decorator_name = decorator_type|type_kt|var_name_kt %}
+        {%- call kt::to_ffi_call(cons) %}, {{ decorator_name }}
+    {%- else %}
+        {%- call kt::to_ffi_call(cons) %}
+    {%- endmatch %}
+{% endmacro %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -8,8 +8,8 @@
     {%- match func.throws() %}
     {%- when Some with (e) %}
     rustCallWithError({{ e|exception_name_kt}})
-    {%- else %}
-    rustCall()
+    {%- else -%}
+    rustCall
     {%- endmatch %} { status ->
     _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call _arg_list_ffi_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %}status)
 }

--- a/uniffi_bindgen/src/bindings/mod.rs
+++ b/uniffi_bindgen/src/bindings/mod.rs
@@ -22,7 +22,7 @@ pub mod swift;
 
 /// Enumeration of all foreign language targets currently supported by this crate.
 ///
-/// The functions in this module will delegate to a language-specific backend based
+/// The functions in this module will decorator to a language-specific backend based
 /// on the provided `TargetLanguage`. For convenience of calling code we also provide
 /// a few `TryFrom` implementations to help guess the correct target language from
 /// e.g. a file extension of command-line argument.

--- a/uniffi_bindgen/src/bindings/python/gen_python.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python.rs
@@ -162,6 +162,10 @@ mod filters {
             ),
             Type::Wrapped { prim, .. } => coerce_py(nm, prim.as_ref())?,
             Type::External { .. } => panic!("should not be necessary to coerce External types"),
+            Type::DecoratorObject(_) => {
+                unreachable!("Decorator objects should never cross the FFI")
+            }
+            Type::Generic => unreachable!("Generic types should never cross the FFI"),
         })
     }
 
@@ -195,6 +199,10 @@ mod filters {
             ),
             Type::Wrapped { prim, .. } => lower_py(nm, prim.as_ref())?,
             Type::External { .. } => panic!("should not be necessary to lower External types"),
+            Type::DecoratorObject(_) => {
+                unreachable!("Decorator objects should never cross the FFI")
+            }
+            Type::Generic => unreachable!("Generic types should never cross the FFI"),
         })
     }
 
@@ -227,6 +235,10 @@ mod filters {
             ),
             Type::Wrapped { prim, .. } => lift_py(nm, prim.as_ref())?,
             Type::External { .. } => panic!("should not be necessary to lift External types"),
+            Type::DecoratorObject(_) => {
+                unreachable!("Decorator objects should never cross the FFI")
+            }
+            Type::Generic => unreachable!("Generic types should never cross the FFI"),
         })
     }
 }

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -192,6 +192,10 @@ mod filters {
             }
             Type::External { .. } => panic!("No support for external types, yet"),
             Type::Wrapped { .. } => panic!("No support for wrapped types, yet"),
+            Type::DecoratorObject(_) => {
+                unreachable!("Decorator objects should never cross the FFI")
+            }
+            Type::Generic => unreachable!("Generic types should never cross the FFI"),
         })
     }
 
@@ -225,6 +229,10 @@ mod filters {
             ),
             Type::External { .. } => panic!("No support for lowering external types, yet"),
             Type::Wrapped { .. } => panic!("No support for lowering wrapped types, yet"),
+            Type::DecoratorObject(_) => {
+                unreachable!("Decorator objects should never cross the FFI")
+            }
+            Type::Generic => unreachable!("Generic types should never cross the FFI"),
         })
     }
 
@@ -257,6 +265,10 @@ mod filters {
             ),
             Type::External { .. } => panic!("No support for lifting external types, yet"),
             Type::Wrapped { .. } => panic!("No support for lifting wrapped types, yet"),
+            Type::DecoratorObject(_) => {
+                unreachable!("Decorator objects should never cross the FFI")
+            }
+            Type::Generic => unreachable!("Generic types should never cross the FFI"),
         })
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -311,6 +311,10 @@ impl SwiftCodeOracle {
                 name,
                 self.create_code_type(prim.as_ref().clone()),
             )),
+            Type::DecoratorObject(_) => {
+                unreachable!("Decorator objects should never cross the FFI")
+            }
+            Type::Generic => unreachable!("Generic types should never cross the FFI"),
         }
     }
 }

--- a/uniffi_bindgen/src/interface/decorator.rs
+++ b/uniffi_bindgen/src/interface/decorator.rs
@@ -1,0 +1,363 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! # Decorator object definitions for a `ComponentInterface`.
+//!
+//! This module converts "interface" definitions from UDL into [`DecoratorObject`] structures
+//! that can be added to a `ComponentInterface`.
+//!
+//! A [`DecoratorObject`] is a collection of methods defined by application code.
+//!
+//! A declaration in the UDL like this:
+//!
+//! ```
+//! # let ci = uniffi_bindgen::interface::ComponentInterface::from_webidl(r##"
+//! # namespace example {};
+//! [Decorator]
+//! interface ExampleDecorator {
+//!   void async_dispatch();
+//! };
+//! [Decorator=ExampleDecorator]
+//! interface Example {
+//!   [CallsWith=async_dispatch]
+//!   void long_running_method();
+//! };
+//!
+//! # "##)?;
+//! # Ok::<(), anyhow::Error>(())
+//! ```
+//!
+//! Will result in an [`DecoratorObject`] with one [`DecoratorMethod`] and a corresponding [`Object`](super::Object)
+//! which uses that decorator object.
+//!
+//! ```
+//! # let ci = uniffi_bindgen::interface::ComponentInterface::from_webidl(r##"
+//! # namespace example {};
+//! # [Decorator]
+//! # interface ExampleDecorator {
+//! #   void async_dispatch();
+//! # };
+//! # "##)?;
+//! let obj = ci.get_decorator_definition("ExampleDecorator").unwrap();
+//! assert_eq!(obj.name(), "ExampleDecorator");
+//! assert_eq!(obj.methods().len(),1 );
+//! assert_eq!(obj.methods()[0].name(), "async_dispatch");
+//! # Ok::<(), anyhow::Error>(())
+//! ```
+
+use crate::interface::Type;
+use std::collections::HashSet;
+use std::convert::TryFrom;
+use std::hash::{Hash, Hasher};
+
+use anyhow::{bail, Result};
+
+use super::attributes::MethodAttributes;
+use super::{APIConverter, ComponentInterface};
+
+/// An "object" is an opaque type that can be instantiated and passed around by reference,
+/// have methods called on it, and so on - basically your classic Object Oriented Programming
+/// type of deal, except without elaborate inheritence hierarchies.
+///
+/// In UDL these correspond to the `interface` keyword.
+///
+/// At the FFI layer, objects are represented by an opaque integer handle and a set of functions
+/// a common prefix. The object's constuctors are functions that return new objects by handle,
+/// and its methods are functions that take a handle as first argument. The foreign language
+/// binding code is expected to stitch these functions back together into an appropriate class
+/// definition (or that language's equivalent thereof).
+///
+/// TODO:
+///  - maybe "Class" would be a better name than "Object" here?
+#[derive(Debug, Clone)]
+pub struct DecoratorObject {
+    pub(super) name: String,
+    pub(super) methods: Vec<DecoratorMethod>,
+}
+
+impl DecoratorObject {
+    fn new(name: String) -> Self {
+        Self {
+            name,
+            methods: Default::default(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn type_(&self) -> Type {
+        Type::DecoratorObject(self.name.clone())
+    }
+
+    pub fn methods(&self) -> Vec<&DecoratorMethod> {
+        self.methods.iter().collect()
+    }
+
+    pub fn find_method(&self, nm: &str) -> Option<&DecoratorMethod> {
+        self.methods.iter().find(|m| m.name == nm)
+    }
+}
+
+impl Hash for DecoratorObject {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        self.methods.hash(state);
+    }
+}
+
+impl APIConverter<DecoratorObject> for weedle::InterfaceDefinition<'_> {
+    fn convert(&self, ci: &mut ComponentInterface) -> Result<DecoratorObject> {
+        if self.inheritance.is_some() {
+            bail!("interface inheritence is not supported");
+        }
+        let mut decorator = DecoratorObject::new(self.identifier.0.to_string());
+        // Convert each member into a constructor or method, guarding against duplicate names.
+        let mut member_names = HashSet::new();
+        for member in &self.members.body {
+            match member {
+                weedle::interface::InterfaceMember::Operation(t) => {
+                    let mut method: DecoratorMethod = t.convert(ci)?;
+                    if !member_names.insert(method.name.clone()) {
+                        bail!("Duplicate interface member name: \"{}\"", method.name())
+                    }
+                    method.object_name = decorator.name.clone();
+                    decorator.methods.push(method);
+                }
+                _ => bail!("no support for interface member type {:?} yet", member),
+            }
+        }
+        Ok(decorator)
+    }
+}
+
+// Represents an instance method for an object type.
+//
+// The FFI will represent this as a function whose first/self argument is a
+// `FFIType::RustArcPtr` to the instance.
+#[derive(Debug, Clone)]
+pub struct DecoratorMethod {
+    pub(super) name: String,
+    pub(super) object_name: String,
+    pub(super) return_type: Option<Type>,
+    pub(super) attributes: MethodAttributes,
+}
+
+impl DecoratorMethod {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn return_type(&self) -> Option<&Type> {
+        self.return_type.as_ref()
+    }
+
+    pub fn throws(&self) -> Option<&str> {
+        self.attributes.get_throws_err()
+    }
+
+    pub fn throws_type(&self) -> Option<Type> {
+        self.attributes
+            .get_throws_err()
+            .map(|name| Type::Error(name.to_owned()))
+    }
+}
+
+impl Hash for DecoratorMethod {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        self.return_type.hash(state);
+        self.attributes.hash(state);
+    }
+}
+
+impl APIConverter<DecoratorMethod> for weedle::interface::OperationInterfaceMember<'_> {
+    fn convert(&self, ci: &mut ComponentInterface) -> Result<DecoratorMethod> {
+        if self.special.is_some() {
+            bail!("special operations not supported");
+        }
+        if self.modifier.is_some() {
+            bail!("method modifiers are not supported")
+        }
+        if !self.args.body.list.is_empty() {
+            bail!("custom method arguments are not supported")
+        }
+        let return_type = ci.resolve_return_type_expression(&self.return_type)?;
+        Ok(DecoratorMethod {
+            name: match self.identifier {
+                None => bail!("anonymous methods are not supported {:?}", self),
+                Some(id) => {
+                    let name = id.0.to_string();
+                    if name == "new" {
+                        bail!("the method name \"new\" is reserved for the default constructor");
+                    }
+                    name
+                }
+            },
+            // We don't know the name of the containing `Object` at this point, fill it in later.
+            object_name: Default::default(),
+            return_type,
+            attributes: MethodAttributes::try_from(self.attributes.as_ref())?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::interface::Type;
+
+    use super::*;
+
+    use super::super::object::{Method, Object};
+
+    #[test]
+    fn test_decorator_attribute_makes_a_decorator_object() {
+        const UDL: &str = r#"
+            namespace test{};
+            [Decorator]
+            interface Testing {
+                sequence<u32> code_points_of_name();
+            };
+        "#;
+        let ci = ComponentInterface::from_webidl(UDL).unwrap();
+        assert_eq!(ci.iter_decorator_definitions().len(), 1);
+        ci.get_decorator_definition("Testing").unwrap();
+    }
+
+    #[test]
+    fn test_the_name_new_is_reserved_for_constructors() {
+        const UDL: &str = r#"
+            namespace test{};
+            [Decorator]
+            interface Testing {
+                void new();
+            };
+        "#;
+        let err = ComponentInterface::from_webidl(UDL).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "the method name \"new\" is reserved for the default constructor"
+        );
+    }
+
+    #[test]
+    fn test_methods_have_zero_args() {
+        const UDL: &str = r#"
+            namespace test{};
+            [Decorator]
+            interface Testing {
+                void method(u32 arg);
+            };
+        "#;
+        let err = ComponentInterface::from_webidl(UDL).unwrap_err();
+        assert_eq!(err.to_string(), "custom method arguments are not supported");
+    }
+
+    #[test]
+    fn test_decorator_methods_can_throw() {
+        const UDL: &str = r#"
+            namespace test{};
+            [Decorator]
+            interface Testing {
+                [Throws=Error]
+                void method();
+            };
+
+            [Error]
+            enum Error {
+                "LOLWUT"
+            };
+        "#;
+        let ci = ComponentInterface::from_webidl(UDL).unwrap();
+        let dobj = ci.get_decorator_definition("Testing").unwrap();
+        let m = dobj.find_method("method").unwrap();
+
+        assert_eq!(m.throws_type(), Some(Type::Error("Error".into())));
+    }
+
+    #[test]
+    fn test_decorator_methods_can_override_return_types_and_throw_types() {
+        const UDL: &str = r#"
+            namespace test{};
+            [Decorator]
+            interface TheDecorator {
+                [Throws=Error]
+                void it_throws();
+
+                Any? it_swallows();
+
+                i32 it_counts();
+
+                Any it_passes_through();
+            };
+
+            [Decorator=TheDecorator]
+            interface Testing {
+                [Throws=Error, CallsWith=it_swallows]
+                void thrower();
+
+                [CallsWith=it_throws]
+                void silent();
+
+                [CallsWith=it_swallows]
+                i32 silent_with_return();
+
+                [CallsWith=it_counts]
+                void counted();
+
+                [CallsWith=it_passes_through]
+                sequence<i32?> exotic();
+            };
+
+            [Error]
+            enum Error {
+                "LOLWUT"
+            };
+        "#;
+        let ci = ComponentInterface::from_webidl(UDL).unwrap();
+        let dobj = ci.get_decorator_definition("TheDecorator");
+        let obj = ci.get_object_definition("Testing").unwrap();
+
+        fn find_method<'a>(nm: &str, obj: &'a Object) -> &'a Method {
+            obj.methods.iter().find(|m| m.name() == nm).unwrap()
+        }
+
+        let m = find_method("thrower", obj);
+        // thrower decorators through it_swallows, which returns void and throws nothing
+        assert_eq!(m.decorated_return_type(&dobj), None);
+        assert_eq!(m.decorated_throws_type(&dobj), None);
+
+        let m = find_method("silent", obj);
+        // silent decorators through it_throws, which returns void and throws nothing
+        assert_eq!(m.decorated_return_type(&dobj), None);
+        assert_eq!(
+            m.decorated_throws_type(&dobj),
+            Some(Type::Error("Error".into()))
+        );
+
+        let m = find_method("silent_with_return", obj);
+        // silent decorators through it_throws, which returns void and throws nothing
+        assert_eq!(
+            m.decorated_return_type(&dobj),
+            Some(Type::Optional(Box::new(Type::Int32)))
+        );
+        assert_eq!(m.decorated_throws_type(&dobj), None);
+
+        let m = find_method("counted", obj);
+        // counted decorators through it_counts, which returns i32 and throws nothing
+        assert_eq!(m.decorated_return_type(&dobj), Some(Type::Int32));
+        assert_eq!(m.decorated_throws_type(&dobj), None);
+
+        let m = find_method("exotic", obj);
+        // exotic decorators through it_passes_through, which returns Sequence<Option<i32>> and throws nothing
+        assert_eq!(
+            m.decorated_return_type(&dobj),
+            Some(Type::Sequence(Box::new(Type::Optional(Box::new(
+                Type::Int32
+            )))))
+        );
+        assert_eq!(m.decorated_throws_type(&dobj), None);
+    }
+}

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -230,11 +230,6 @@ impl APIConverter<Object> for weedle::InterfaceDefinition<'_> {
                 _ => bail!("no support for interface member type {:?} yet", member),
             }
         }
-        // Everyone gets a primary constructor, even if not declared explicitly.
-        if object.primary_constructor().is_none() {
-            object.constructors.push(Default::default());
-        }
-
         // Finally, add the decorator object.
         if let Some(nm) = attributes.get_decorator_object() {
             object.decorator_type = ci
@@ -437,7 +432,7 @@ impl Method {
         &self,
         decorator_object: &Option<&DecoratorObject>,
     ) -> Option<Type> {
-        if let Some(dm) = self.decorator_method(&decorator_object) {
+        if let Some(dm) = self.decorator_method(decorator_object) {
             dm.throws_type()
         } else {
             self.throws_type()

--- a/uniffi_bindgen/src/interface/types/finder.rs
+++ b/uniffi_bindgen/src/interface/types/finder.rs
@@ -59,10 +59,13 @@ impl TypeFinder for weedle::InterfaceDefinition<'_> {
     fn add_type_definitions_to(&self, types: &mut TypeUniverse) -> Result<()> {
         let name = self.identifier.0.to_string();
         // Some enum types are defined using an `interface` with a special attribute.
-        if InterfaceAttributes::try_from(self.attributes.as_ref())?.contains_enum_attr() {
+        let attrs = InterfaceAttributes::try_from(self.attributes.as_ref())?;
+        if attrs.contains_enum_attr() {
             types.add_type_definition(self.identifier.0, Type::Enum(name))
-        } else if InterfaceAttributes::try_from(self.attributes.as_ref())?.contains_error_attr() {
+        } else if attrs.contains_error_attr() {
             types.add_type_definition(self.identifier.0, Type::Error(name))
+        } else if attrs.is_decorator() {
+            types.add_type_definition(self.identifier.0, Type::DecoratorObject(name))
         } else {
             types.add_type_definition(self.identifier.0, Type::Object(name))
         }

--- a/uniffi_bindgen/src/interface/types/resolver.rs
+++ b/uniffi_bindgen/src/interface/types/resolver.rs
@@ -183,6 +183,7 @@ pub(in super::super) fn resolve_builtin_type(name: &str) -> Option<Type> {
         "f64" => Some(Type::Float64),
         "timestamp" => Some(Type::Timestamp),
         "duration" => Some(Type::Duration),
+        "Any" => Some(Type::Generic),
         _ => None,
     }
 }

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -50,6 +50,10 @@ mod filters {
             Type::Map(t) => format!("std::collections::HashMap<String, {}>", type_rs(t)?),
             Type::External { .. } => panic!("External types coming to a uniffi near you soon!"),
             Type::Wrapped { .. } => panic!("Wrapped types coming to a uniffi near you soon!"),
+            Type::DecoratorObject(_) => {
+                unreachable!("Decorator objects should never cross the FFI")
+            }
+            Type::Generic => unreachable!("Generic types should never cross the FFI"),
         })
     }
 
@@ -119,6 +123,10 @@ mod filters {
             Type::Float64 => "f64".into(),
             Type::String => "String".into(),
             Type::Boolean => "bool".into(),
+            Type::DecoratorObject(_) => {
+                unreachable!("Decorator objects should never cross the FFI")
+            }
+            Type::Generic => unreachable!("Generic types should never cross the FFI"),
         })
     }
 


### PR DESCRIPTION
This PR introduces the concept of Delegate objects, for decorating method calls into Rust.

We add three annotations:

1. `[Delegate]`, to mark an `interface` as a Delegate object.
2. `[Delegate=]`, to specify a delegate object for the annotated `interface`. Such objects have a delegate argument added to each of its constructors.
3. `[CallsWith=]`, on methods of objects with delegate objects.

Delegate objects in Kotlin are `interface`s. Methods accept the delegated object and a closure representing the Rust call.

Examples are given in the [`docs/manual/src/udl/delegates.md` file][1]: error catching, launching on background threads, notifying a UI after a call.

This PR only includes a Kotlin implementation, so is *not* ready for prime time, but otherwise ready for review.

I'd like to get more feedback before adding a Swift implementation.

Feedback sought:

* is this a concept worth pursuing?
* are the names right; do the annotations do what you'd think, do they require much explanation?
* should delegates do more? or less? e.g. do they need to be more configurable with more annotations?

[1]: https://github.com/mozilla/uniffi-rs/blob/4ed0a731acf7411bbed260cffad768f3c47b7f8f/docs/manual/src/udl/delegates.md