### PR TITLE
Allow dictionaries to have fields which are interfaces

### DIFF
--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -115,6 +115,21 @@ interface Coveralls {
 
     /// integer->integer dictionary
     record<u32, u64> get_dict3(u32 key, u64 value);
+
+    /// Adds a new repair at the current time.
+    void add_patch(Patch patch);
+
+    /// Adds a new repair at the specified time.
+    void add_repair(Repair repair);
+
+    /// Returns all repairs made.
+    sequence<Repair> get_repairs();
+};
+
+// coveralls keep track of their repairs (an interface in a dict)
+dictionary Repair {
+    timestamp when;
+    Patch patch;
 };
 
 // All coveralls end up with a patch.

--- a/fixtures/coverall/tests/bindings/test_coverall.kts
+++ b/fixtures/coverall/tests/bindings/test_coverall.kts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import java.time.Instant
 import java.util.concurrent.*
 
 import uniffi.coverall.*
@@ -152,6 +153,14 @@ Coveralls("test_complex_errors").use { coveralls ->
     } catch(e: InternalException) {
         // Expected result
     }
+}
+
+Coveralls("test_interfaces_in_dicts").use { coveralls ->
+    coveralls.addPatch(Patch(Color.RED))
+    coveralls.addRepair(
+            Repair(`when`=Instant.now(), patch=Patch(Color.BLUE))
+        )
+    assert(coveralls.getRepairs().size == 2)
 }
 
 Coveralls("test_regressions").use { coveralls ->

--- a/fixtures/coverall/tests/bindings/test_coverall.py
+++ b/fixtures/coverall/tests/bindings/test_coverall.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import unittest
+from datetime import datetime, timezone
 from coverall import *
 
 class TestCoverall(unittest.TestCase):
@@ -168,6 +169,12 @@ class TestCoverall(unittest.TestCase):
         # be dropped as coveralls hold an `Arc<>` to it.
         c2 = None
         self.assertEqual(get_num_alive(), 2)
+
+        coveralls.add_patch(Patch(Color.RED))
+        coveralls.add_repair(
+            Repair(when=datetime.now(timezone.utc), patch=Patch(Color.BLUE))
+        )
+        self.assertEqual(len(coveralls.get_repairs()), 2)
 
         # Dropping `coveralls` will kill both.
         coveralls = None

--- a/fixtures/coverall/tests/bindings/test_coverall.swift
+++ b/fixtures/coverall/tests/bindings/test_coverall.swift
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import Foundation
 import coverall
 
 // TODO: use an actual test runner.
@@ -182,4 +183,12 @@ do {
 
     let dict3 = coveralls.getDict3(key: 31, value: 42)
     assert(dict3[31] == 42)
+}
+
+// Test interfaces as dict members
+do {
+    let coveralls = Coveralls(name: "test_interfaces_in_dicts")
+    coveralls.addPatch(patch: Patch(color: Color.red))
+    coveralls.addRepair(repair: Repair(when: Date.init(), patch: Patch(color: Color.blue)))
+    assert(coveralls.getRepairs().count == 2)
 }

--- a/uniffi_bindgen/src/interface/record.rs
+++ b/uniffi_bindgen/src/interface/record.rs
@@ -129,9 +129,6 @@ impl APIConverter<Field> for weedle::dictionary::DictionaryMember<'_> {
             bail!("dictionary member attributes are not supported yet");
         }
         let type_ = ci.resolve_type_expression(&self.type_)?;
-        if let Type::Object(_) = type_ {
-            bail!("Objects cannot currently appear in record fields");
-        }
         let default = match self.default {
             None => None,
             Some(v) => Some(convert_default_value(&v.value, &type_)?),


### PR DESCRIPTION
As noted in #1058, our [documentation](https://mozilla.github.io/uniffi-rs/udl/structs.html) promises dictionaries can have fields which are interfaces, so long as they are behind an `Arc`. It turns out this works fine in the scaffolding and even in all the bindings [edit: removed references to "bindings generate invalid code" - turns out I used a kotlin keyword - that's now supported!]

Fixes #1058