### PR TITLE
Re-write read and write Swift template calls to go through filters

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
@@ -31,7 +31,7 @@ data class {{ rec.name()|class_name_kt }} (
 
     internal fun write(buf: RustBufferBuilder) {
         {%- for field in rec.fields() %}
-            {{ "(this.{})"|format(field.name())|write_kt("buf", field.type_()) }}
+            {{ "this.{}"|format(field.name())|write_kt("buf", field.type_()) }}
         {% endfor %}
     }
 

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/compounds.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/compounds.rs
@@ -102,6 +102,6 @@ impl_code_type_for_compound!(
 impl_code_type_for_compound!(
     MapCodeType,
     "[String: {}]",
-    "Map{}",
+    "Dictionary{}",
     "DictionaryTemplate.swift"
 );

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/error.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/error.rs
@@ -5,7 +5,7 @@
 use std::fmt;
 
 use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
-use crate::interface::{ComponentInterface, Error};
+use crate::interface::{ComponentInterface, Error, Type};
 use askama::Template;
 
 use super::filters;

--- a/uniffi_bindgen/src/bindings/swift/templates/ArrayTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ArrayTemplate.swift
@@ -7,20 +7,14 @@ fileprivate enum FfiConverter{{ canonical_type_name }}: FfiConverterUsingByteBuf
     typealias SwiftType = {{ outer_type|type_swift }}
 
     static func write(_ value: SwiftType, into buf: Writer) {
-        let len = Int32(value.count)
-        buf.writeInt(len)
-        for item in value {
+        FfiConverterSequence.write(value, into: buf) { (item, buf) in
             {{ "item"|write_swift("buf", inner_type) }}
         }
     }
 
     static func read(from buf: Reader) throws -> SwiftType {
-        let len: Int32 = try buf.readInt()
-        var seq = SwiftType()
-        seq.reserveCapacity(Int(len))
-        for _ in 0..<len {
-            seq.append(try {{ "buf"|read_swift(inner_type) }})
+        try FfiConverterSequence.read(from: buf) { buf in
+            try {{ "buf"|read_swift(inner_type) }}
         }
-        return seq
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/ArrayTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ArrayTemplate.swift
@@ -1,0 +1,26 @@
+{%- import "macros.swift" as swift -%}
+{%- let inner_type = self.inner() %}
+{%- let outer_type = self.outer() %}
+{%- let inner_type_name = inner_type|type_swift %}
+{%- let canonical_type_name = outer_type|canonical_name %}
+fileprivate enum FfiConverter{{ canonical_type_name }}: FfiConverterUsingByteBuffer {
+    typealias SwiftType = {{ outer_type|type_swift }}
+
+    static func write(_ value: SwiftType, into buf: Writer) {
+        let len = Int32(value.count)
+        buf.writeInt(len)
+        for item in value {
+            {{ "item"|write_swift("buf", inner_type) }}
+        }
+    }
+
+    static func read(from buf: Reader) throws -> SwiftType {
+        let len: Int32 = try buf.readInt()
+        var seq = SwiftType()
+        seq.reserveCapacity(Int(len))
+        for _ in 0..<len {
+            seq.append(try {{ "buf"|read_swift(inner_type) }})
+        }
+        return seq
+    }
+}

--- a/uniffi_bindgen/src/bindings/swift/templates/DictionaryTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/DictionaryTemplate.swift
@@ -7,21 +7,16 @@ fileprivate enum FfiConverter{{ canonical_type_name }}: FfiConverterUsingByteBuf
     typealias SwiftType = {{ outer_type|type_swift }}
 
     static func write(_ value: SwiftType, into buf: Writer) {
-        let len = Int32(value.count)
-        buf.writeInt(len)
-        for (key, value) in value {
+        FfiConverterDictionary.write(value, into: buf) { (key, value, buf) in
             {{ "key"|write_swift("buf", Type::String) }}
             {{ "value"|write_swift("buf", inner_type) }}
         }
     }
 
     static func read(from buf: Reader) throws -> SwiftType {
-        let len: Int32 = try buf.readInt()
-        var dict = SwiftType()
-        dict.reserveCapacity(Int(len))
-        for _ in 0..<len {
-            dict[try {{ "buf"|read_swift(Type::String) }}] = try {{ "buf"|read_swift(inner_type) }}
+        try FfiConverterDictionary.read(from: buf) { buf in
+            (try {{ "buf"|read_swift(Type::String) }},
+            try {{ "buf"|read_swift(inner_type) }})
         }
-        return dict
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/DictionaryTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/DictionaryTemplate.swift
@@ -1,0 +1,27 @@
+{%- import "macros.swift" as swift -%}
+{%- let inner_type = self.inner() %}
+{%- let outer_type = self.outer() %}
+{%- let inner_type_name = inner_type|type_swift %}
+{%- let canonical_type_name = outer_type|canonical_name %}
+fileprivate enum FfiConverter{{ canonical_type_name }}: FfiConverterUsingByteBuffer {
+    typealias SwiftType = {{ outer_type|type_swift }}
+
+    static func write(_ value: SwiftType, into buf: Writer) {
+        let len = Int32(value.count)
+        buf.writeInt(len)
+        for (key, value) in value {
+            {{ "key"|write_swift("buf", Type::String) }}
+            {{ "value"|write_swift("buf", inner_type) }}
+        }
+    }
+
+    static func read(from buf: Reader) throws -> SwiftType {
+        let len: Int32 = try buf.readInt()
+        var dict = SwiftType()
+        dict.reserveCapacity(Int(len))
+        for _ in 0..<len {
+            dict[try {{ "buf"|read_swift(Type::String) }}] = try {{ "buf"|read_swift(inner_type) }}
+        }
+        return dict
+    }
+}

--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -31,7 +31,7 @@ extension {{ e.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi {
         case let .{{ variant.name()|enum_variant_swift }}({% for field in variant.fields() %}{{ field.name()|var_name_swift }}{%- if loop.last -%}{%- else -%},{%- endif -%}{% endfor %}):
             buf.writeInt(Int32({{ loop.index }}))
             {% for field in variant.fields() -%}
-            {{ field.name()|var_name_swift }}.write(into: buf)
+            {{ field.name()|write_swift("buf", field.type_()) }}
             {% endfor -%}
         {% else %}
         case .{{ variant.name()|enum_variant_swift }}:

--- a/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
@@ -25,7 +25,7 @@ extension {{ e.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi {
 
         {% for variant in e.variants() %}
         case {{ loop.index }}: return .{{ variant.name()|class_name_swift }}(
-            message: try String.read(from: buf)
+            message: try {{ "buf"|read_swift(Type::String) }}
         )
         {% endfor %}
 
@@ -52,7 +52,7 @@ extension {{ e.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi {
         {% for variant in e.variants() %}
         case let .{{ variant.name()|class_name_swift }}(message):
             buf.writeInt(Int32({{ loop.index }}))
-            message.write(into: buf)
+            {{ "message"|write_swift("buf", Type::String) }}
         {%- endfor %}
 
         {% else %}
@@ -62,7 +62,7 @@ extension {{ e.name()|class_name_swift }}: ViaFfiUsingByteBuffer, ViaFfi {
         case let .{{ variant.name()|class_name_swift }}({% for field in variant.fields() %}{{ field.name()|var_name_swift }}{%- if loop.last -%}{%- else -%},{%- endif -%}{% endfor %}):
             buf.writeInt(Int32({{ loop.index }}))
             {% for field in variant.fields() -%}
-            {{ field.name()|var_name_swift }}.write(into: buf)
+            {{ field.name()|write_swift("buf", field.type_()) }}
             {% endfor -%}
         {% else %}
         case .{{ variant.name()|class_name_swift }}:

--- a/uniffi_bindgen/src/bindings/swift/templates/OptionalTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/OptionalTemplate.swift
@@ -7,19 +7,14 @@ fileprivate enum FfiConverter{{ canonical_type_name }}: FfiConverterUsingByteBuf
     typealias SwiftType = {{ outer_type|type_swift }}
 
     static func write(_ value: SwiftType, into buf: Writer) {
-        guard let value = value else {
-            buf.writeInt(Int8(0))
-            return
+        FfiConverterOptional.write(value, into: buf) { item, buf in
+            {{ "item"|write_swift("buf", inner_type) }}
         }
-        buf.writeInt(Int8(1))
-        {{ "value"|write_swift("buf", inner_type) }}
     }
 
     static func read(from buf: Reader) throws -> SwiftType {
-        switch try buf.readInt() as Int8 {
-        case 0: return nil
-        case 1: return try {{ "buf"|read_swift(inner_type) }}
-        default: throw UniffiInternalError.unexpectedOptionalTag
+        try FfiConverterOptional.read(from: buf) { buf in
+            try {{ "buf"|read_swift(inner_type) }}
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/OptionalTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/OptionalTemplate.swift
@@ -1,0 +1,25 @@
+{%- import "macros.swift" as swift -%}
+{%- let inner_type = self.inner() %}
+{%- let outer_type = self.outer() %}
+{%- let inner_type_name = inner_type|type_swift %}
+{%- let canonical_type_name = outer_type|canonical_name %}
+fileprivate enum FfiConverter{{ canonical_type_name }}: FfiConverterUsingByteBuffer {
+    typealias SwiftType = {{ outer_type|type_swift }}
+
+    static func write(_ value: SwiftType, into buf: Writer) {
+        guard let value = value else {
+            buf.writeInt(Int8(0))
+            return
+        }
+        buf.writeInt(Int8(1))
+        {{ "value"|write_swift("buf", inner_type) }}
+    }
+
+    static func read(from buf: Reader) throws -> SwiftType {
+        switch try buf.readInt() as Int8 {
+        case 0: return nil
+        case 1: return try {{ "buf"|read_swift(inner_type) }}
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -44,7 +44,7 @@ fileprivate extension {{ rec.name()|class_name_swift }} {
 
     func write(into buf: Writer) {
         {%- for field in rec.fields() %}
-        {{ field.name()|var_name_swift }}.write(into: buf)
+        {{ "self.{}"|format(field.name())|write_swift("buf", field.type_()) }}
         {%- endfor %}
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/RustBufferHelper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RustBufferHelper.swift
@@ -1,60 +1,34 @@
-// Implement our protocols for the built-in types that we use.
-extension Optional: ViaFfiUsingByteBuffer, ViaFfi, Serializable where Wrapped: Serializable {
-    fileprivate static func read(from buf: Reader) throws -> Self {
-        switch try buf.readInt() as Int8 {
-        case 0: return nil
-        case 1: return try Wrapped.read(from: buf)
-        default: throw UniffiInternalError.unexpectedOptionalTag
-        }
-    }
+// Protocols for converters we'll implement in templates
 
-    fileprivate func write(into buf: Writer) {
-        guard let value = self else {
-            buf.writeInt(Int8(0))
-            return
-        }
-        buf.writeInt(Int8(1))
-        value.write(into: buf)
-    }
+fileprivate protocol FfiConverter {
+    associatedtype SwiftType
+    associatedtype FfiType
+
+    static func lift(_ ffiValue: FfiType) throws -> SwiftType
+    static func lower(_ value: SwiftType) -> FfiType
+
+    static func read(from: Reader) throws -> SwiftType
+    static func write(_ value: SwiftType, into: Writer)
 }
 
-extension Array: ViaFfiUsingByteBuffer, ViaFfi, Serializable where Element: Serializable {
-    fileprivate static func read(from buf: Reader) throws -> Self {
-        let len: Int32 = try buf.readInt()
-        var seq = [Element]()
-        seq.reserveCapacity(Int(len))
-        for _ in 0..<len {
-            seq.append(try Element.read(from: buf))
-        }
-        return seq
-    }
-
-    fileprivate func write(into buf: Writer) {
-        let len = Int32(self.count)
-        buf.writeInt(len)
-        for item in self {
-            item.write(into: buf)
-        }
-    }
+fileprivate protocol FfiConverterUsingByteBuffer: FfiConverter where FfiType == RustBuffer {
+    // Empty, because we want to declare some helper methods in the extension below.
 }
 
-extension Dictionary: ViaFfiUsingByteBuffer, ViaFfi, Serializable where Key == String, Value: Serializable {
-    fileprivate static func read(from buf: Reader) throws -> Self {
-        let len: Int32 = try buf.readInt()
-        var dict = [String: Value]()
-        dict.reserveCapacity(Int(len))
-        for _ in 0..<len {
-            dict[try String.read(from: buf)] = try Value.read(from: buf)
-        }
-        return dict
+extension FfiConverterUsingByteBuffer {
+    static func lower(_ value: SwiftType) -> FfiType {
+        let writer = Writer()
+        Self.write(value, into: writer)
+        return RustBuffer(bytes: writer.bytes)
     }
 
-    fileprivate func write(into buf: Writer) {
-        let len = Int32(self.count)
-        buf.writeInt(len)
-        for (key, value) in self {
-            key.write(into: buf)
-            value.write(into: buf)
+    static func lift(_ buf: FfiType) throws -> SwiftType {
+        let reader = Reader(data: Data(rustBuffer: buf))
+        let value = try Self.read(from: reader)
+        if reader.hasRemaining() {
+          throw UniffiInternalError.incompleteData
         }
+        buf.deallocate()
+        return value
     }
 }


### PR DESCRIPTION
Re-write read and write Swift template calls to go through filters:

* needed to make wrapped types possible in Swift
* needed to land the Callback Interfaces (#1045)

This necessitated moving the structural types to where they are unrolled
(as seen in Kotlin). This, in turn, meant making an `FfiConverter` enum for
each concrete implementation of the structural type declared in the UDL.

This is could also be seen as part of #1047, but not quite.