### PR TITLE
Add some defensive programming to `RustBufferBuilder.discard()`

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
@@ -83,8 +83,12 @@ class RustBufferBuilder() {
     }
 
     fun discard() {
-        val rbuf = this.finalize()
-        RustBuffer.free(rbuf)
+        if(this.rbuf.data != null) {
+            // Free the current `RustBuffer`
+            RustBuffer.free(this.rbuf)
+            // Replace it with an empty RustBuffer.
+            this.setRustBuffer(RustBuffer.ByValue())
+        }
     }
 
     internal fun reserve(size: Int, write: (ByteBuffer) -> Unit) {


### PR DESCRIPTION
I tried to figure out how #1069 happened, but wasn't successful.  So,
let's just add some guards to `discard()` to avoid the NPE.

 - Don't call finalize(), which relies on bbuf being valid
 - Only call `RustBuffer.free()` if rbuf is non-null