### PR TITLE
Load Python library from absolute path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,11 @@ jobs:
       - run:
           name: "Set RUSTFLAGS to fail the build if there are warnings"
           command: echo 'export RUSTFLAGS="-D warnings"' >> $BASH_ENV
+      - run:
+          name: Build all code
+          command: |
+            # Ensures that all examples are built and avaiable
+            cargo build
       - run: cargo test
   Rust and Foreign Language tests - min supported rust:
     docker:
@@ -93,6 +98,11 @@ jobs:
       - run:
           name: "Print the Rust version, to help with debugging"
           command: rustc --version
+      - run:
+          name: Build all code
+          command: |
+            # Ensures that all examples are built and avaiable
+            cargo build
       # some tests fail on earlier rust versions and we want to ignore them:
       # * trybuild_ui_tests - error message had a comma inserted! Can probably
       #   be re-enabled after the next rust version bump.


### PR DESCRIPTION
First of the `*.so` file extension is valid on more than just Linux,
e.g. on BSD and Solaris too.
We can just consider it the default case and only change it for Windows
and macOS.

Next, for final deployment the compiled library can be placed next to
the Python code and that way the wrapper code can find it by its
absolute path.

---

this is what we currently [do support Glean Python](https://github.com/mozilla/glean/blob/b2f72f861f17339689f7c6881bd8471bbcd79b88/glean-core/python/glean/_ffi.py#L21-L36).