### PR TITLE
Use CIString for `ComponentInterface` strings

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/callback_interface.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/callback_interface.rs
@@ -6,15 +6,16 @@ use std::fmt;
 
 use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
 use crate::interface::{CallbackInterface, ComponentInterface};
+use crate::CIString;
 use askama::Template;
 
 use super::filters;
 pub struct CallbackInterfaceCodeType {
-    id: String,
+    id: CIString,
 }
 
 impl CallbackInterfaceCodeType {
-    pub fn new(id: String) -> Self {
+    pub fn new(id: CIString) -> Self {
         Self { id }
     }
 

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/enum_.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/enum_.rs
@@ -6,15 +6,16 @@ use std::fmt;
 
 use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
 use crate::interface::{ComponentInterface, Enum};
+use crate::CIString;
 use askama::Template;
 
 use super::filters;
 pub struct EnumCodeType {
-    id: String,
+    id: CIString,
 }
 
 impl EnumCodeType {
-    pub fn new(id: String) -> Self {
+    pub fn new(id: CIString) -> Self {
         Self { id }
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/error.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/error.rs
@@ -6,15 +6,16 @@ use std::fmt;
 
 use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
 use crate::interface::{ComponentInterface, Error};
+use crate::CIString;
 use askama::Template;
 
 use super::filters;
 pub struct ErrorCodeType {
-    id: String,
+    id: CIString,
 }
 
 impl ErrorCodeType {
-    pub fn new(id: String) -> Self {
+    pub fn new(id: CIString) -> Self {
         Self { id }
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/object.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/object.rs
@@ -6,16 +6,17 @@ use std::fmt;
 
 use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
 use crate::interface::{ComponentInterface, Object};
+use crate::CIString;
 use askama::Template;
 
 // Filters is used by ObjectTemplate.kt, which looks for the filters module here.
 use super::filters;
 pub struct ObjectCodeType {
-    id: String,
+    id: CIString,
 }
 
 impl ObjectCodeType {
-    pub fn new(id: String) -> Self {
+    pub fn new(id: CIString) -> Self {
         Self { id }
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/record.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/record.rs
@@ -6,15 +6,16 @@ use std::fmt;
 
 use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
 use crate::interface::{ComponentInterface, Record};
+use crate::CIString;
 use askama::Template;
 
 use super::filters;
 pub struct RecordCodeType {
-    id: String,
+    id: CIString,
 }
 
 impl RecordCodeType {
-    pub fn new(id: String) -> Self {
+    pub fn new(id: CIString) -> Self {
         Self { id }
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/callback_interface.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/callback_interface.rs
@@ -6,15 +6,16 @@ use std::fmt;
 
 use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
 use crate::interface::{CallbackInterface, ComponentInterface};
+use crate::CIString;
 use askama::Template;
 
 use super::filters;
 pub struct CallbackInterfaceCodeType {
-    id: String,
+    id: CIString,
 }
 
 impl CallbackInterfaceCodeType {
-    pub fn new(id: String) -> Self {
+    pub fn new(id: CIString) -> Self {
         Self { id }
     }
 

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/enum_.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/enum_.rs
@@ -6,15 +6,16 @@ use std::fmt;
 
 use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
 use crate::interface::{ComponentInterface, Enum};
+use crate::CIString;
 use askama::Template;
 
 use super::filters;
 pub struct EnumCodeType {
-    id: String,
+    id: CIString,
 }
 
 impl EnumCodeType {
-    pub fn new(id: String) -> Self {
+    pub fn new(id: CIString) -> Self {
         Self { id }
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/error.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/error.rs
@@ -6,15 +6,16 @@ use std::fmt;
 
 use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
 use crate::interface::{ComponentInterface, Error, Type};
+use crate::CIString;
 use askama::Template;
 
 use super::filters;
 pub struct ErrorCodeType {
-    id: String,
+    id: CIString,
 }
 
 impl ErrorCodeType {
-    pub fn new(id: String) -> Self {
+    pub fn new(id: CIString) -> Self {
         Self { id }
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/object.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/object.rs
@@ -6,15 +6,16 @@ use std::fmt;
 
 use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
 use crate::interface::{ComponentInterface, Object};
+use crate::CIString;
 use askama::Template;
 
 use super::filters;
 pub struct ObjectCodeType {
-    id: String,
+    id: CIString,
 }
 
 impl ObjectCodeType {
-    pub fn new(id: String) -> Self {
+    pub fn new(id: CIString) -> Self {
         Self { id }
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/record.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/record.rs
@@ -6,15 +6,16 @@ use std::fmt;
 
 use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
 use crate::interface::{ComponentInterface, Record};
+use crate::CIString;
 use askama::Template;
 
 use super::filters;
 pub struct RecordCodeType {
-    id: String,
+    id: CIString,
 }
 
 impl RecordCodeType {
-    pub fn new(id: String) -> Self {
+    pub fn new(id: CIString) -> Self {
         Self { id }
     }
 }

--- a/uniffi_bindgen/src/interface/cistring.rs
+++ b/uniffi_bindgen/src/interface/cistring.rs
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::rc::Rc;
+
+/// String struct for ComponentInterface items
+///
+/// This struct has a few advantages over the `String`:
+///   - Fast to clone, which we do a lot of
+///   - Has convenience methods for commonly used operations
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CIString(Rc<String>);
+
+impl CIString {
+    //! Join multiple parts into a CIString with underscores
+    pub fn from_parts(parts: Vec<&str>) -> Self {
+        parts.join("_").into()
+    }
+}
+
+impl<'a> From<&'a str> for CIString {
+    fn from(val: &'a str) -> CIString {
+        CIString(val.to_string().into())
+    }
+}
+
+impl From<String> for CIString {
+    fn from(val: String) -> CIString {
+        CIString(val.into())
+    }
+}
+
+impl From<CIString> for String {
+    fn from(val: CIString) -> String {
+        val.0.to_string()
+    }
+}
+
+impl std::fmt::Display for CIString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self)
+    }
+}
+
+impl std::cmp::PartialEq<str> for CIString {
+    fn eq(&self, other: &str) -> bool {
+        self.0.as_ref() == other
+    }
+}
+
+impl std::cmp::PartialEq<CIString> for str {
+    fn eq(&self, other: &CIString) -> bool {
+        other.0.as_ref() == self
+    }
+}
+
+impl std::cmp::PartialEq<&str> for CIString {
+    fn eq(&self, other: &&str) -> bool {
+        self.0.as_ref() == other
+    }
+}
+
+impl std::cmp::PartialEq<CIString> for &str {
+    fn eq(&self, other: &CIString) -> bool {
+        other.0.as_ref() == self
+    }
+}
+
+impl std::ops::Deref for CIString {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -81,6 +81,7 @@ use anyhow::{bail, Result};
 use super::record::Field;
 use super::types::{IterTypes, Type, TypeIterator};
 use super::{APIConverter, ComponentInterface};
+use crate::CIString;
 
 /// Represents an enum with named variants, each of which may have named
 /// and typed fields.
@@ -89,7 +90,7 @@ use super::{APIConverter, ComponentInterface};
 /// i32 indicating the variant followed by the serialization of each field.
 #[derive(Debug, Clone, Hash)]
 pub struct Enum {
-    pub(super) name: String,
+    pub(super) name: CIString,
     pub(super) variants: Vec<Variant>,
     // "Flat" enums do not have, and will never have, variants with associated data.
     pub(super) flat: bool,
@@ -127,7 +128,7 @@ impl IterTypes for Enum {
 impl APIConverter<Enum> for weedle::EnumDefinition<'_> {
     fn convert(&self, _ci: &mut ComponentInterface) -> Result<Enum> {
         Ok(Enum {
-            name: self.identifier.0.to_string(),
+            name: self.identifier.0.into(),
             variants: self
                 .values
                 .body
@@ -135,7 +136,7 @@ impl APIConverter<Enum> for weedle::EnumDefinition<'_> {
                 .iter()
                 .map::<Result<_>, _>(|v| {
                     Ok(Variant {
-                        name: v.0.to_string(),
+                        name: v.0.into(),
                         ..Default::default()
                     })
                 })
@@ -154,7 +155,7 @@ impl APIConverter<Enum> for weedle::InterfaceDefinition<'_> {
         // We don't need to check `self.attributes` here; if calling code has dispatched
         // to this impl then we already know there was an `[Enum]` attribute.
         Ok(Enum {
-            name: self.identifier.0.to_string(),
+            name: self.identifier.0.into(),
             variants: self
                 .members
                 .body
@@ -178,7 +179,7 @@ impl APIConverter<Enum> for weedle::InterfaceDefinition<'_> {
 /// Each variant has a name and zero or more fields.
 #[derive(Debug, Clone, Default, Hash)]
 pub struct Variant {
-    pub(super) name: String,
+    pub(super) name: CIString,
     pub(super) fields: Vec<Field>,
 }
 
@@ -226,7 +227,7 @@ impl APIConverter<Variant> for weedle::interface::OperationInterfaceMember<'_> {
             }
         };
         Ok(Variant {
-            name,
+            name: name.into(),
             fields: self
                 .args
                 .body
@@ -262,7 +263,7 @@ impl APIConverter<Field> for weedle::argument::SingleArgument<'_> {
         // TODO: maybe we should use our own `Field` type here with just name and type,
         // rather than appropriating record::Field..?
         Ok(Field {
-            name: self.identifier.0.to_string(),
+            name: self.identifier.0.into(),
             type_,
             required: false,
             default: None,

--- a/uniffi_bindgen/src/interface/error.rs
+++ b/uniffi_bindgen/src/interface/error.rs
@@ -87,6 +87,7 @@ use anyhow::Result;
 use super::enum_::{Enum, Variant};
 use super::types::{IterTypes, Type, TypeIterator};
 use super::{APIConverter, ComponentInterface};
+use crate::CIString;
 
 /// Represents an Error that might be thrown by functions/methods in the component interface.
 ///
@@ -96,7 +97,7 @@ use super::{APIConverter, ComponentInterface};
 /// struct and assign an integer error code to each variant.
 #[derive(Debug, Clone, Hash)]
 pub struct Error {
-    pub name: String,
+    pub name: CIString,
     enum_: Enum,
 }
 

--- a/uniffi_bindgen/src/interface/ffi.rs
+++ b/uniffi_bindgen/src/interface/ffi.rs
@@ -18,6 +18,8 @@
 /// For the types that involve memory allocation, we make a distinction between
 /// "owned" types (the recipient must free it, or pass it to someone else) and
 /// "borrowed" types (the sender must keep it alive for the duration of the call).
+use crate::CIString;
+
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum FFIType {
     // N.B. there are no booleans at this layer, since they cause problems for JNA.
@@ -57,7 +59,7 @@ pub enum FFIType {
 /// some built-in `FFIFunction` helpers for use in the foreign language bindings.
 #[derive(Debug, Default, Clone)]
 pub struct FFIFunction {
-    pub(super) name: String,
+    pub(super) name: CIString,
     pub(super) arguments: Vec<FFIArgument>,
     pub(super) return_type: Option<FFIType>,
 }
@@ -79,7 +81,7 @@ impl FFIFunction {
 /// Each argument has a name and a type.
 #[derive(Debug, Clone)]
 pub struct FFIArgument {
-    pub(super) name: String,
+    pub(super) name: CIString,
     pub(super) type_: FFIType,
 }
 

--- a/uniffi_bindgen/src/interface/record.rs
+++ b/uniffi_bindgen/src/interface/record.rs
@@ -49,6 +49,7 @@ use anyhow::{bail, Result};
 use super::literal::{convert_default_value, Literal};
 use super::types::{IterTypes, Type, TypeIterator};
 use super::{APIConverter, ComponentInterface};
+use crate::CIString;
 
 /// Represents a "data class" style object, for passing around complex values.
 ///
@@ -57,7 +58,7 @@ use super::{APIConverter, ComponentInterface};
 /// kind of like "pass by clone" values.
 #[derive(Debug, Clone, Hash)]
 pub struct Record {
-    pub(super) name: String,
+    pub(super) name: CIString,
     pub(super) fields: Vec<Field>,
 }
 
@@ -92,7 +93,7 @@ impl APIConverter<Record> for weedle::DictionaryDefinition<'_> {
             bail!("dictionary inheritence is not supported");
         }
         Ok(Record {
-            name: self.identifier.0.to_string(),
+            name: self.identifier.0.into(),
             fields: self.members.body.convert(ci)?,
         })
     }
@@ -101,7 +102,7 @@ impl APIConverter<Record> for weedle::DictionaryDefinition<'_> {
 // Represents an individual field on a Record.
 #[derive(Debug, Clone, Hash)]
 pub struct Field {
-    pub(super) name: String,
+    pub(super) name: CIString,
     pub(super) type_: Type,
     pub(super) required: bool,
     pub(super) default: Option<Literal>,
@@ -139,7 +140,7 @@ impl APIConverter<Field> for weedle::dictionary::DictionaryMember<'_> {
             Some(v) => Some(convert_default_value(&v.value, &type_)?),
         };
         Ok(Field {
-            name: self.identifier.0.to_string(),
+            name: self.identifier.0.into(),
             type_,
             required: self.required.is_some(),
             default,

--- a/uniffi_bindgen/src/interface/types/finder.rs
+++ b/uniffi_bindgen/src/interface/types/finder.rs
@@ -60,11 +60,11 @@ impl TypeFinder for weedle::InterfaceDefinition<'_> {
         let name = self.identifier.0.to_string();
         // Some enum types are defined using an `interface` with a special attribute.
         if InterfaceAttributes::try_from(self.attributes.as_ref())?.contains_enum_attr() {
-            types.add_type_definition(self.identifier.0, Type::Enum(name))
+            types.add_type_definition(self.identifier.0, Type::Enum(name.into()))
         } else if InterfaceAttributes::try_from(self.attributes.as_ref())?.contains_error_attr() {
-            types.add_type_definition(self.identifier.0, Type::Error(name))
+            types.add_type_definition(self.identifier.0, Type::Error(name.into()))
         } else {
-            types.add_type_definition(self.identifier.0, Type::Object(name))
+            types.add_type_definition(self.identifier.0, Type::Object(name.into()))
         }
     }
 }
@@ -72,7 +72,7 @@ impl TypeFinder for weedle::InterfaceDefinition<'_> {
 impl TypeFinder for weedle::DictionaryDefinition<'_> {
     fn add_type_definitions_to(&self, types: &mut TypeUniverse) -> Result<()> {
         let name = self.identifier.0.to_string();
-        types.add_type_definition(self.identifier.0, Type::Record(name))
+        types.add_type_definition(self.identifier.0, Type::Record(name.into()))
     }
 }
 
@@ -81,9 +81,9 @@ impl TypeFinder for weedle::EnumDefinition<'_> {
         let name = self.identifier.0.to_string();
         // Our error types are defined using an `enum` with a special attribute.
         if EnumAttributes::try_from(self.attributes.as_ref())?.contains_error_attr() {
-            types.add_type_definition(self.identifier.0, Type::Error(name))
+            types.add_type_definition(self.identifier.0, Type::Error(name.into()))
         } else {
-            types.add_type_definition(self.identifier.0, Type::Enum(name))
+            types.add_type_definition(self.identifier.0, Type::Enum(name.into()))
         }
     }
 }
@@ -103,7 +103,7 @@ impl TypeFinder for weedle::TypedefDefinition<'_> {
             types.add_type_definition(
                 name,
                 Type::Wrapped {
-                    name: name.to_string(),
+                    name: name.into(),
                     prim: prim.into(),
                 },
             )
@@ -114,8 +114,8 @@ impl TypeFinder for weedle::TypedefDefinition<'_> {
             types.add_type_definition(
                 name,
                 Type::External {
-                    name: name.to_string(),
-                    crate_name: attrs.get_crate_name(),
+                    name: name.into(),
+                    crate_name: attrs.get_crate_name().into(),
                 },
             )
         }
@@ -128,7 +128,7 @@ impl TypeFinder for weedle::CallbackInterfaceDefinition<'_> {
             bail!("no typedef attributes are currently supported");
         }
         let name = self.identifier.0.to_string();
-        types.add_type_definition(self.identifier.0, Type::CallbackInterface(name))
+        types.add_type_definition(self.identifier.0, Type::CallbackInterface(name.into()))
     }
 }
 

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -26,6 +26,7 @@ use std::{collections::hash_map::Entry, collections::BTreeSet, collections::Hash
 use anyhow::{bail, Result};
 
 use super::ffi::FFIType;
+use crate::CIString;
 
 mod finder;
 pub(super) use finder::TypeFinder;
@@ -53,19 +54,25 @@ pub enum Type {
     Timestamp,
     Duration,
     // Types defined in the component API, each of which has a string name.
-    Object(String),
-    Record(String),
-    Enum(String),
-    Error(String),
-    CallbackInterface(String),
+    Object(CIString),
+    Record(CIString),
+    Enum(CIString),
+    Error(CIString),
+    CallbackInterface(CIString),
     // Structurally recursive types.
     Optional(Box<Type>),
     Sequence(Box<Type>),
     Map(/* String, */ Box<Type>),
     // An FfiConverter we `use` from an external crate
-    External { name: String, crate_name: String },
+    External {
+        name: CIString,
+        crate_name: CIString,
+    },
     // A local type we will generate an FfiConverter via wrapping a primitive.
-    Wrapped { name: String, prim: Box<Type> },
+    Wrapped {
+        name: CIString,
+        prim: Box<Type>,
+    },
 }
 
 impl Type {

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -111,7 +111,7 @@ pub mod interface;
 pub mod scaffolding;
 
 use bindings::TargetLanguage;
-use interface::ComponentInterface;
+use interface::{CIString, ComponentInterface};
 use scaffolding::RustScaffolding;
 
 // Generate the infrastructural Rust code for implementing the UDL interface,

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -42,7 +42,7 @@ mod filters {
             Type::String => "String".into(),
             Type::Timestamp => "std::time::SystemTime".into(),
             Type::Duration => "std::time::Duration".into(),
-            Type::Enum(name) | Type::Record(name) | Type::Error(name) => name.clone(),
+            Type::Enum(name) | Type::Record(name) | Type::Error(name) => name.to_string(),
             Type::Object(name) => format!("std::sync::Arc<{}>", name),
             Type::CallbackInterface(name) => format!("Box<dyn {}>", name),
             Type::Optional(t) => format!("std::option::Option<{}>", type_rs(t)?),


### PR DESCRIPTION
The reason to do this is it makes clone() fast, which we call all the time.  Performance is not really that important, but there's also not many downsides to doing it this way.

I think the main benefit is developer piece of mind.  I personally can't stop myself from pausing every time I use `String::clone()` and thinking if there's a better way.

One goal I had was to make use this to implement `AsRef<Type>` for `Record`, `Enum`, etc.  But now that I think about it more, I don't think that's possible in any case.

I'm open to suggestions for a better name than "CIString".