### PR TITLE
Update default Rust version to 1.56.

### DIFF
--- a/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
+++ b/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
@@ -2,10 +2,7 @@ error[E0277]: `Cell<u32>` cannot be shared between threads safely
    --> $DIR/counter.uniffi.rs:119:1
     |
 119 | uniffi::deps::static_assertions::assert_impl_all!(Counter: Sync, Send);
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    | |
-    | `Cell<u32>` cannot be shared between threads safely
-    | required by this bound in `assert_impl_all`
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
     |
     = help: within `Counter`, the trait `Sync` is not implemented for `Cell<u32>`
 note: required because it appears within the type `Counter`
@@ -13,6 +10,11 @@ note: required because it appears within the type `Counter`
     |
 9   | pub struct Counter {
     |            ^^^^^^^
+note: required by a bound in `assert_impl_all`
+   --> $DIR/counter.uniffi.rs:119:1
+    |
+119 | uniffi::deps::static_assertions::assert_impl_all!(Counter: Sync, Send);
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
     = note: this error originates in the macro `uniffi::deps::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
@@ -23,7 +25,11 @@ error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
     |
     = help: the following implementations were found:
               <Arc<T> as FfiConverter>
-    = note: required by `lower`
+note: required by `lower`
+   --> $DIR/lib.rs:177:5
+    |
+177 |     fn lower(obj: Self::RustType) -> Self::FfiType;
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
    --> $DIR/counter.uniffi.rs:160:14
@@ -33,4 +39,8 @@ error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
     |
     = help: the following implementations were found:
               <Arc<T> as FfiConverter>
-    = note: required by `try_lift`
+note: required by `try_lift`
+   --> $DIR/lib.rs:187:5
+    |
+187 |     fn try_lift(v: Self::FfiType) -> Result<Self::RustType>;
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # * ./.circleci/config.yml which also specifies the rust versions used in CI.
 
 [toolchain]
-channel = "1.54.0"
+channel = "1.56.0"
 targets = [
     "aarch64-linux-android",
     "armv7-linux-androideabi",


### PR DESCRIPTION
As per our Rust policy, we track mozilla-central, and that bumped to
1.56 in bug 1736459.

Note that CI is currently broken by 9a1c543b08c874edef09629bf77f528d315a00e6 - rather than fix that I just bumped Rust even further, which also has some clippy related fallout.