### PR TITLE
RFC: example of how decorators could be specified in uniffi.toml

### DIFF
--- a/examples/decorators/src/decorators.udl
+++ b/examples/decorators/src/decorators.udl
@@ -1,0 +1,22 @@
+namespace decorators {
+    // The Decorator attribute says that this function may be wrapped by a
+    // decorator named "io".  We define what that means in uniffi.toml
+    [Decorator=io]
+    void sync_all_users();
+};
+
+record User {
+    id: string,
+    name: string,
+}
+
+interface UserDatabase {
+    // Another use of the decorator from above
+    [Decorator=io]
+    User lookup();
+
+    // A different decorator
+    [Decorator=log-errors]
+    [Throws=RustyError]
+    void import_legacy_data(string: data);
+}

--- a/examples/decorators/uniffi.toml
+++ b/examples/decorators/uniffi.toml
@@ -1,0 +1,43 @@
+[bindings.python]
+cdylib_name = "wrapper_types"
+
+[bindings.ruby]
+cdylib_name = "wrapper_types"
+
+[bindings.swift]
+cdylib_name = "wrapper_types"
+
+[bindings.kotlin]
+cdylib_name = "wrapper_types"
+
+# Defining the log-errors decorator for the Python bindings
+[decorators.log-errors.python]
+imports = ["logging"]
+code = """
+error_logger = logging.getLogger("errors")
+
+def logErrors(func):
+  try:
+    return func()
+  except:
+    error_logger.error("Error calling {}".format(func), exc_info=True)
+    raise
+"""
+decorator = "logErrors"
+
+# Defining the io decorator for the Python bindings
+[decorators.io.kotlin]
+imports = [
+    "kotlinx.coroutines.Dispatchers",
+    "kotlinx.coroutines.CoroutineScope"
+]
+code = """
+ioScope = CoroutineScope(Dispatchers.IO)
+"""
+decorator = "ioScope.launch"
+
+# I think the return type can be inferred and we don't need the next line.  But
+# this is an example of how the return type could be specified.  Swift might
+# need something like this.
+return_type = "Deferred<{}>" # "{}" will be replaced with the decorated function's return type
+


### PR DESCRIPTION
We've been discussing the concept of function decorators in mozilla/application-services#4595 and #1051.  One idea that's been thrown around a bit is defining the decorators outside of the UDL file.  Here's a proposal of how they could be defined in `uniffi.toml`.  It's hand-wavey, but hopefully it gives a good picture of the general approach.  I think there are a few nice things about this:
  - Decorators aren't tied to classes.  You can have a decorator that's shared by methods of different classes and top-level functions.
  - Consumer's don't need to implement the decorator if they don't want to.
  - It doesn't change the constructor signature.  This allows the objects to continue to work inside `Record` and other containers.
  - It seems to me that wrapper types and decorator functions should be defined in the same place.  If we're going to define wrapper types in `uniffi.toml` then that seems like a natural place for the decorators.
  - It supports all types of generics (this seems like more of an IDL-parsing issue than an issue of where the config should live though).
 
Side issue: I think we should lean towards names based on the decorated function (`io`) rather than the decorator (`on_db_thread`).  `io` would work with running the function in a coroutine, a thread pool, a separate process, etc.  `on_db_thread` implies that it's going to run on a dedicated thread.