### PR TITLE
Naming refactor

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/error.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/error.rs
@@ -21,7 +21,7 @@ impl ErrorCodeType {
 
 impl CodeType for ErrorCodeType {
     fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.class_name(&self.id)
+        oracle.error_name(&self.id)
     }
 
     fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -340,7 +340,6 @@ pub mod filters {
         Ok(codetype.literal(&oracle(), literal))
     }
 
-
     /// Get the Kotlin syntax for representing a given low-level `FFIType`.
     pub fn ffi_type_name(type_: &FFIType) -> Result<String, askama::Error> {
         Ok(oracle().ffi_type_label(type_))

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -296,7 +296,7 @@ pub mod filters {
         KotlinCodeOracle
     }
 
-    pub fn type_kt(codetype: &impl CodeType) -> Result<String, askama::Error> {
+    pub fn type_name(codetype: &impl CodeType) -> Result<String, askama::Error> {
         Ok(codetype.type_label(&oracle()))
     }
 
@@ -304,14 +304,14 @@ pub mod filters {
         Ok(codetype.canonical_name(&oracle()))
     }
 
-    pub fn lower_kt(
+    pub fn lower_var(
         nm: &dyn fmt::Display,
         codetype: &impl CodeType,
     ) -> Result<String, askama::Error> {
         Ok(codetype.lower(&oracle(), nm))
     }
 
-    pub fn write_kt(
+    pub fn write_var(
         nm: &dyn fmt::Display,
         target: &dyn fmt::Display,
         codetype: &impl CodeType,
@@ -319,49 +319,50 @@ pub mod filters {
         Ok(codetype.write(&oracle(), nm, target))
     }
 
-    pub fn lift_kt(
+    pub fn lift_var(
         nm: &dyn fmt::Display,
         codetype: &impl CodeType,
     ) -> Result<String, askama::Error> {
         Ok(codetype.lift(&oracle(), nm))
     }
 
-    pub fn literal_kt(
-        literal: &Literal,
-        codetype: &impl CodeType,
-    ) -> Result<String, askama::Error> {
-        Ok(codetype.literal(&oracle(), literal))
-    }
-
-    pub fn read_kt(
+    pub fn read_var(
         nm: &dyn fmt::Display,
         codetype: &impl CodeType,
     ) -> Result<String, askama::Error> {
         Ok(codetype.read(&oracle(), nm))
     }
 
+    pub fn render_literal(
+        literal: &Literal,
+        codetype: &impl CodeType,
+    ) -> Result<String, askama::Error> {
+        Ok(codetype.literal(&oracle(), literal))
+    }
+
+
     /// Get the Kotlin syntax for representing a given low-level `FFIType`.
-    pub fn type_ffi(type_: &FFIType) -> Result<String, askama::Error> {
+    pub fn ffi_type_name(type_: &FFIType) -> Result<String, askama::Error> {
         Ok(oracle().ffi_type_label(type_))
     }
 
     /// Get the idiomatic Kotlin rendering of a class name (for enums, records, errors, etc).
-    pub fn class_name_kt(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+    pub fn class_name(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
         Ok(oracle().class_name(nm))
     }
 
     /// Get the idiomatic Kotlin rendering of a function name.
-    pub fn fn_name_kt(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+    pub fn fn_name(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
         Ok(oracle().fn_name(nm))
     }
 
     /// Get the idiomatic Kotlin rendering of a variable name.
-    pub fn var_name_kt(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+    pub fn var_name(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
         Ok(oracle().var_name(nm))
     }
 
     /// Get the idiomatic Kotlin rendering of an individual enum variant.
-    pub fn enum_variant_kt(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+    pub fn enum_variant(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
         Ok(oracle().enum_variant_name(nm))
     }
 
@@ -370,7 +371,7 @@ pub mod filters {
     /// This replaces "Error" at the end of the name with "Exception".  Rust code typically uses
     /// "Error" for any type of error but in the Java world, "Error" means a non-recoverable error
     /// and is distinguished from an "Exception".
-    pub fn exception_name_kt(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+    pub fn exception_name(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
         Ok(oracle().error_name(nm))
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
@@ -8,14 +8,14 @@
 {%- let e = self.inner() %}
 {%- if e.is_flat() %}
 
-enum class {{ e.name()|class_name_kt }} {
+enum class {{ e.name()|class_name }} {
     {% for variant in e.variants() -%}
-    {{ variant.name()|enum_variant_kt }}{% if loop.last %};{% else %},{% endif %}
+    {{ variant.name()|enum_variant }}{% if loop.last %};{% else %},{% endif %}
     {%- endfor %}
 
     companion object {
-        internal fun lift(rbuf: RustBuffer.ByValue): {{ e.name()|class_name_kt }} {
-            return liftFromRustBuffer(rbuf) { buf -> {{ e.name()|class_name_kt }}.read(buf) }
+        internal fun lift(rbuf: RustBuffer.ByValue): {{ e.name()|class_name }} {
+            return liftFromRustBuffer(rbuf) { buf -> {{ e.name()|class_name }}.read(buf) }
         }
 
         internal fun read(buf: ByteBuffer) =
@@ -36,30 +36,30 @@ enum class {{ e.name()|class_name_kt }} {
 
 {% else %}
 
-sealed class {{ e.name()|class_name_kt }}{% if self.contains_object_references() %}: Disposable {% endif %} {
+sealed class {{ e.name()|class_name }}{% if self.contains_object_references() %}: Disposable {% endif %} {
     {% for variant in e.variants() -%}
     {% if !variant.has_fields() -%}
-    object {{ variant.name()|class_name_kt }} : {{ e.name()|class_name_kt }}()
+    object {{ variant.name()|class_name }} : {{ e.name()|class_name }}()
     {% else -%}
-    data class {{ variant.name()|class_name_kt }}(
+    data class {{ variant.name()|class_name }}(
         {% for field in variant.fields() -%}
-        val {{ field.name()|var_name_kt }}: {{ field|type_kt}}{% if loop.last %}{% else %}, {% endif %}
+        val {{ field.name()|var_name }}: {{ field|type_name}}{% if loop.last %}{% else %}, {% endif %}
         {% endfor -%}
-    ) : {{ e.name()|class_name_kt }}()
+    ) : {{ e.name()|class_name }}()
     {%- endif %}
     {% endfor %}
 
     companion object {
-        internal fun lift(rbuf: RustBuffer.ByValue): {{ e.name()|class_name_kt }} {
-            return liftFromRustBuffer(rbuf) { buf -> {{ e.name()|class_name_kt }}.read(buf) }
+        internal fun lift(rbuf: RustBuffer.ByValue): {{ e.name()|class_name }} {
+            return liftFromRustBuffer(rbuf) { buf -> {{ e.name()|class_name }}.read(buf) }
         }
 
-        internal fun read(buf: ByteBuffer): {{ e.name()|class_name_kt }} {
+        internal fun read(buf: ByteBuffer): {{ e.name()|class_name }} {
             return when(buf.getInt()) {
                 {%- for variant in e.variants() %}
-                {{ loop.index }} -> {{ e.name()|class_name_kt }}.{{ variant.name()|class_name_kt }}{% if variant.has_fields() %}(
+                {{ loop.index }} -> {{ e.name()|class_name }}.{{ variant.name()|class_name }}{% if variant.has_fields() %}(
                     {% for field in variant.fields() -%}
-                    {{ "buf"|read_kt(field) }}{% if loop.last %}{% else %},{% endif %}
+                    {{ "buf"|read_var(field) }}{% if loop.last %}{% else %},{% endif %}
                     {% endfor -%}
                 ){%- endif -%}
                 {%- endfor %}
@@ -75,10 +75,10 @@ sealed class {{ e.name()|class_name_kt }}{% if self.contains_object_references()
     internal fun write(buf: RustBufferBuilder) {
         when(this) {
             {%- for variant in e.variants() %}
-            is {{ e.name()|class_name_kt }}.{{ variant.name()|class_name_kt }} -> {
+            is {{ e.name()|class_name }}.{{ variant.name()|class_name }} -> {
                 buf.putInt({{ loop.index }})
                 {% for field in variant.fields() -%}
-                {{ "(this.{})"|format(field.name())|write_kt("buf", field) }}
+                {{ "(this.{})"|format(field.name())|write_var("buf", field) }}
                 {% endfor %}
             }
             {%- endfor %}
@@ -90,7 +90,7 @@ sealed class {{ e.name()|class_name_kt }}{% if self.contains_object_references()
     override fun destroy() {
         when(this) {
             {%- for variant in e.variants() %}
-            is {{ e.name()|class_name_kt }}.{{ variant.name()|class_name_kt }} -> {
+            is {{ e.name()|class_name }}.{{ variant.name()|class_name }} -> {
                 {%- if variant.has_fields() %}
                 {% call kt::destroy_fields(variant) %}
                 {% else -%}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
@@ -8,14 +8,14 @@
 {%- let e = self.inner() %}
 {%- if e.is_flat() %}
 
-enum class {{ e.name()|class_name }} {
+enum class {{ e|type_name }} {
     {% for variant in e.variants() -%}
     {{ variant.name()|enum_variant }}{% if loop.last %};{% else %},{% endif %}
     {%- endfor %}
 
     companion object {
-        internal fun lift(rbuf: RustBuffer.ByValue): {{ e.name()|class_name }} {
-            return liftFromRustBuffer(rbuf) { buf -> {{ e.name()|class_name }}.read(buf) }
+        internal fun lift(rbuf: RustBuffer.ByValue): {{ e|type_name }} {
+            return liftFromRustBuffer(rbuf) { buf -> {{ e|type_name }}.read(buf) }
         }
 
         internal fun read(buf: ByteBuffer) =
@@ -36,28 +36,28 @@ enum class {{ e.name()|class_name }} {
 
 {% else %}
 
-sealed class {{ e.name()|class_name }}{% if self.contains_object_references() %}: Disposable {% endif %} {
+sealed class {{ e|type_name }}{% if self.contains_object_references() %}: Disposable {% endif %} {
     {% for variant in e.variants() -%}
     {% if !variant.has_fields() -%}
-    object {{ variant.name()|class_name }} : {{ e.name()|class_name }}()
+    object {{ variant.name()|class_name }} : {{ e|type_name }}()
     {% else -%}
     data class {{ variant.name()|class_name }}(
         {% for field in variant.fields() -%}
         val {{ field.name()|var_name }}: {{ field|type_name}}{% if loop.last %}{% else %}, {% endif %}
         {% endfor -%}
-    ) : {{ e.name()|class_name }}()
+    ) : {{ e|type_name }}()
     {%- endif %}
     {% endfor %}
 
     companion object {
-        internal fun lift(rbuf: RustBuffer.ByValue): {{ e.name()|class_name }} {
-            return liftFromRustBuffer(rbuf) { buf -> {{ e.name()|class_name }}.read(buf) }
+        internal fun lift(rbuf: RustBuffer.ByValue): {{ e|type_name }} {
+            return liftFromRustBuffer(rbuf) { buf -> {{ e|type_name }}.read(buf) }
         }
 
-        internal fun read(buf: ByteBuffer): {{ e.name()|class_name }} {
+        internal fun read(buf: ByteBuffer): {{ e|type_name }} {
             return when(buf.getInt()) {
                 {%- for variant in e.variants() %}
-                {{ loop.index }} -> {{ e.name()|class_name }}.{{ variant.name()|class_name }}{% if variant.has_fields() %}(
+                {{ loop.index }} -> {{ e|type_name }}.{{ variant.name()|class_name }}{% if variant.has_fields() %}(
                     {% for field in variant.fields() -%}
                     {{ "buf"|read_var(field) }}{% if loop.last %}{% else %},{% endif %}
                     {% endfor -%}
@@ -75,7 +75,7 @@ sealed class {{ e.name()|class_name }}{% if self.contains_object_references() %}
     internal fun write(buf: RustBufferBuilder) {
         when(this) {
             {%- for variant in e.variants() %}
-            is {{ e.name()|class_name }}.{{ variant.name()|class_name }} -> {
+            is {{ e|type_name }}.{{ variant.name()|class_name }} -> {
                 buf.putInt({{ loop.index }})
                 {% for field in variant.fields() -%}
                 {{ "(this.{})"|format(field.name())|write_var("buf", field) }}
@@ -90,7 +90,7 @@ sealed class {{ e.name()|class_name }}{% if self.contains_object_references() %}
     override fun destroy() {
         when(this) {
             {%- for variant in e.variants() %}
-            is {{ e.name()|class_name }}.{{ variant.name()|class_name }} -> {
+            is {{ e|type_name }}.{{ variant.name()|class_name }} -> {
                 {%- if variant.has_fields() %}
                 {% call kt::destroy_fields(variant) %}
                 {% else -%}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
@@ -1,43 +1,41 @@
 {% import "macros.kt" as kt %}
 {%- let e = self.inner() %}
 
-// Error {{ e.name() }}
-{%- let toplevel_name=e.name()|exception_name %}
 {% if e.is_flat() %}
-sealed class {{ toplevel_name }}(message: String): Exception(message){% if self.contains_object_references() %}, Disposable {% endif %} {
+sealed class {{ e|type_name }}(message: String): Exception(message){% if self.contains_object_references() %}, Disposable {% endif %} {
         // Each variant is a nested class
         // Flat enums carries a string error message, so no special implementation is necessary.
         {% for variant in e.variants() -%}
-        class {{ variant.name()|exception_name }}(message: String) : {{ toplevel_name }}(message)
+        class {{ variant.name()|exception_name }}(message: String) : {{ e|type_name }}(message)
         {% endfor %}
 
 {%- else %}
-sealed class {{ toplevel_name }}: Exception(){% if self.contains_object_references() %}, Disposable {% endif %} {
+sealed class {{ e|type_name }}: Exception(){% if self.contains_object_references() %}, Disposable {% endif %} {
     // Each variant is a nested class
     {% for variant in e.variants() -%}
     {% if !variant.has_fields() -%}
-    class {{ variant.name()|exception_name }} : {{ toplevel_name }}()
+    class {{ variant.name()|exception_name }} : {{ e|type_name }}()
     {% else %}
     class {{ variant.name()|exception_name }}(
         {% for field in variant.fields() -%}
         val {{ field.name()|var_name }}: {{ field|type_name}}{% if loop.last %}{% else %}, {% endif %}
         {% endfor -%}
-    ) : {{ toplevel_name }}()
+    ) : {{ e|type_name }}()
     {%- endif %}
     {% endfor %}
 
 {%- endif %}
 
-    companion object ErrorHandler : CallStatusErrorHandler<{{ toplevel_name }}> {
-        override fun lift(error_buf: RustBuffer.ByValue): {{ toplevel_name }} {
+    companion object ErrorHandler : CallStatusErrorHandler<{{ e|type_name }}> {
+        override fun lift(error_buf: RustBuffer.ByValue): {{ e|type_name }} {
             return liftFromRustBuffer(error_buf) { error_buf -> read(error_buf) }
         }
 
-        fun read(error_buf: ByteBuffer): {{ toplevel_name }} {
+        fun read(error_buf: ByteBuffer): {{ e|type_name }} {
             {% if e.is_flat() %}
                 return when(error_buf.getInt()) {
                 {%- for variant in e.variants() %}
-                {{ loop.index }} -> {{ toplevel_name }}.{{ variant.name()|exception_name }}(String.read(error_buf))
+                {{ loop.index }} -> {{ e|type_name }}.{{ variant.name()|exception_name }}(String.read(error_buf))
                 {%- endfor %}
                 else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
             }
@@ -45,7 +43,7 @@ sealed class {{ toplevel_name }}: Exception(){% if self.contains_object_referenc
 
             return when(error_buf.getInt()) {
                 {%- for variant in e.variants() %}
-                {{ loop.index }} -> {{ toplevel_name }}.{{ variant.name()|exception_name }}({% if variant.has_fields() %}
+                {{ loop.index }} -> {{ e|type_name }}.{{ variant.name()|exception_name }}({% if variant.has_fields() %}
                     {% for field in variant.fields() -%}
                     {{ "error_buf"|read_var(field) }}{% if loop.last %}{% else %},{% endif %}
                     {% endfor -%}
@@ -62,7 +60,7 @@ sealed class {{ toplevel_name }}: Exception(){% if self.contains_object_referenc
     override fun destroy() {
         when(this) {
             {%- for variant in e.variants() %}
-            is {{ e.name()|class_name }}.{{ variant.name()|class_name }} -> {
+            is {{ e|type_name }}.{{ variant.name()|class_name }} -> {
                 {%- if variant.has_fields() %}
                 {% call kt::destroy_fields(variant) %}
                 {% else -%}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
@@ -43,7 +43,7 @@ private inline fun <U, E: Exception> rustCallWithError(errorHandler: CallStatusE
         // with the message.  but if that code panics, then it just sends back
         // an empty buffer.
         if (status.error_buf.len > 0) {
-            throw InternalException({{ "status.error_buf"|lift_kt(Type::String) }})
+            throw InternalException({{ "status.error_buf"|lift_var(Type::String) }})
         } else {
             throw InternalException("Rust panic")
         }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/MapTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/MapTemplate.kt
@@ -1,10 +1,10 @@
 {%- import "macros.kt" as kt -%}
 {%- let inner_type = self.inner() %}
 {%- let outer_type = self.outer() %}
-{%- let inner_type_name = inner_type|type_kt %}
+{%- let inner_type_name = inner_type|type_name %}
 {%- let canonical_type_name = outer_type|canonical_name %}
 
-// Helper functions for passing values of type {{ outer_type|type_kt }}
+// Helper functions for passing values of type {{ outer_type|type_name }}
 internal fun lower{{ canonical_type_name }}(m: Map<String, {{ inner_type_name }}>): RustBuffer.ByValue {
     return lowerIntoRustBuffer(m) { m, buf ->
         write{{ canonical_type_name }}(m, buf)
@@ -17,8 +17,8 @@ internal fun write{{ canonical_type_name }}(v: Map<String, {{ inner_type_name }}
     // which is important for compatibility with older android devices.
     // Ref https://blog.danlew.net/2017/03/16/kotlin-puzzler-whose-line-is-it-anyways/
     v.forEach { (k, v) ->
-        {{ "k"|write_kt("buf", TypeIdentifier::String) }}
-        {{ "v"|write_kt("buf", inner_type) }}
+        {{ "k"|write_var("buf", TypeIdentifier::String) }}
+        {{ "v"|write_var("buf", inner_type) }}
     }
 }
 
@@ -33,8 +33,8 @@ internal fun read{{ canonical_type_name }}(buf: ByteBuffer): Map<String, {{ inne
     val items : MutableMap<String, {{ inner_type_name }}> = mutableMapOf()
     val len = buf.getInt()
     repeat(len) {
-        val k = {{ "buf"|read_kt(TypeIdentifier::String) }}
-        val v = {{ "buf"|read_kt(inner_type) }}
+        val k = {{ "buf"|read_var(TypeIdentifier::String) }}
+        val v = {{ "buf"|read_var(inner_type) }}
         items[k] = v
     }
     return items

--- a/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
@@ -34,7 +34,7 @@ internal interface _UniFFILib : Library {
     {% for func in ci.iter_ffi_function_definitions() -%}
     fun {{ func.name() }}(
         {%- call kt::arg_list_ffi_decl(func) %}
-    ){%- match func.return_type() -%}{%- when Some with (type_) %}: {{ type_|type_ffi }}{% when None %}: Unit{% endmatch %}
+    ){%- match func.return_type() -%}{%- when Some with (type_) %}: {{ type_|ffi_type_name }}{% when None %}: Unit{% endmatch %}
 
     {% endfor %}
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -1,18 +1,18 @@
 {% import "macros.kt" as kt %}
 {%- let obj = self.inner() %}
-public interface {{ obj.name()|class_name_kt }}Interface {
+public interface {{ obj.name()|class_name }}Interface {
     {% for meth in obj.methods() -%}
-    fun {{ meth.name()|fn_name_kt }}({% call kt::arg_list_decl(meth) %})
+    fun {{ meth.name()|fn_name }}({% call kt::arg_list_decl(meth) %})
     {%- match meth.return_type() -%}
-    {%- when Some with (return_type) %}: {{ return_type|type_kt -}}
+    {%- when Some with (return_type) %}: {{ return_type|type_name -}}
     {%- else -%}
     {%- endmatch %}
     {% endfor %}
 }
 
-class {{ obj.name()|class_name_kt }}(
+class {{ obj.name()|class_name }}(
     pointer: Pointer
-) : FFIObject(pointer), {{ obj.name()|class_name_kt }}Interface {
+) : FFIObject(pointer), {{ obj.name()|class_name }}Interface {
 
     {%- match obj.primary_constructor() %}
     {%- when Some with (cons) %}
@@ -47,15 +47,15 @@ class {{ obj.name()|class_name_kt }}(
     {%- match meth.return_type() -%}
 
     {%- when Some with (return_type) -%}
-    override fun {{ meth.name()|fn_name_kt }}({% call kt::arg_list_protocol(meth) %}): {{ return_type|type_kt }} =
+    override fun {{ meth.name()|fn_name }}({% call kt::arg_list_protocol(meth) %}): {{ return_type|type_name }} =
         callWithPointer {
             {%- call kt::to_ffi_call_with_prefix("it", meth) %}
         }.let {
-            {{ "it"|lift_kt(return_type) }}
+            {{ "it"|lift_var(return_type) }}
         }
 
     {%- when None -%}
-    override fun {{ meth.name()|fn_name_kt }}({% call kt::arg_list_protocol(meth) %}) =
+    override fun {{ meth.name()|fn_name }}({% call kt::arg_list_protocol(meth) %}) =
         callWithPointer {
             {%- call kt::to_ffi_call_with_prefix("it", meth) %}
         }
@@ -63,19 +63,19 @@ class {{ obj.name()|class_name_kt }}(
     {% endfor %}
 
     companion object {
-        internal fun lift(ptr: Pointer): {{ obj.name()|class_name_kt }} {
-            return {{ obj.name()|class_name_kt }}(ptr)
+        internal fun lift(ptr: Pointer): {{ obj.name()|class_name }} {
+            return {{ obj.name()|class_name }}(ptr)
         }
 
-        internal fun read(buf: ByteBuffer): {{ obj.name()|class_name_kt }} {
+        internal fun read(buf: ByteBuffer): {{ obj.name()|class_name }} {
             // The Rust code always writes pointers as 8 bytes, and will
             // fail to compile if they don't fit.
-            return {{ obj.name()|class_name_kt }}.lift(Pointer(buf.getLong()))
+            return {{ obj.name()|class_name }}.lift(Pointer(buf.getLong()))
         }
 
         {% for cons in obj.alternate_constructors() -%}
-        fun {{ cons.name()|fn_name_kt }}({% call kt::arg_list_decl(cons) %}): {{ obj.name()|class_name_kt }} =
-            {{ obj.name()|class_name_kt }}({% call kt::to_ffi_call(cons) %})
+        fun {{ cons.name()|fn_name }}({% call kt::arg_list_decl(cons) %}): {{ obj.name()|class_name }} =
+            {{ obj.name()|class_name }}({% call kt::to_ffi_call(cons) %})
         {% endfor %}
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -1,6 +1,6 @@
 {% import "macros.kt" as kt %}
 {%- let obj = self.inner() %}
-public interface {{ obj.name()|class_name }}Interface {
+public interface {{ obj|type_name }}Interface {
     {% for meth in obj.methods() -%}
     fun {{ meth.name()|fn_name }}({% call kt::arg_list_decl(meth) %})
     {%- match meth.return_type() -%}
@@ -10,9 +10,9 @@ public interface {{ obj.name()|class_name }}Interface {
     {% endfor %}
 }
 
-class {{ obj.name()|class_name }}(
+class {{ obj|type_name }}(
     pointer: Pointer
-) : FFIObject(pointer), {{ obj.name()|class_name }}Interface {
+) : FFIObject(pointer), {{ obj|type_name }}Interface {
 
     {%- match obj.primary_constructor() %}
     {%- when Some with (cons) %}
@@ -63,19 +63,19 @@ class {{ obj.name()|class_name }}(
     {% endfor %}
 
     companion object {
-        internal fun lift(ptr: Pointer): {{ obj.name()|class_name }} {
-            return {{ obj.name()|class_name }}(ptr)
+        internal fun lift(ptr: Pointer): {{ obj|type_name }} {
+            return {{ obj|type_name }}(ptr)
         }
 
-        internal fun read(buf: ByteBuffer): {{ obj.name()|class_name }} {
+        internal fun read(buf: ByteBuffer): {{ obj|type_name }} {
             // The Rust code always writes pointers as 8 bytes, and will
             // fail to compile if they don't fit.
-            return {{ obj.name()|class_name }}.lift(Pointer(buf.getLong()))
+            return {{ obj|type_name }}.lift(Pointer(buf.getLong()))
         }
 
         {% for cons in obj.alternate_constructors() -%}
-        fun {{ cons.name()|fn_name }}({% call kt::arg_list_decl(cons) %}): {{ obj.name()|class_name }} =
-            {{ obj.name()|class_name }}({% call kt::to_ffi_call(cons) %})
+        fun {{ cons.name()|fn_name }}({% call kt::arg_list_decl(cons) %}): {{ obj|type_name }} =
+            {{ obj|type_name }}({% call kt::to_ffi_call(cons) %})
         {% endfor %}
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/OptionalTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/OptionalTemplate.kt
@@ -1,10 +1,10 @@
 {%- import "macros.kt" as kt -%}
 {%- let inner_type = self.inner() %}
 {%- let outer_type = self.outer() %}
-{%- let inner_type_name = inner_type|type_kt %}
+{%- let inner_type_name = inner_type|type_name %}
 {%- let canonical_type_name = outer_type|canonical_name %}
 
-// Helper functions for passing values of type {{ outer_type|type_kt }}
+// Helper functions for passing values of type {{ outer_type|type_name }}
 internal fun lower{{ canonical_type_name }}(v: {{ inner_type_name }}?): RustBuffer.ByValue {
     return lowerIntoRustBuffer(v) { v, buf ->
         write{{ canonical_type_name }}(v, buf)
@@ -16,7 +16,7 @@ internal fun write{{ canonical_type_name }}(v: {{ inner_type_name }}?, buf: Rust
         buf.putByte(0)
     } else {
         buf.putByte(1)
-        {{ "v"|write_kt("buf", inner_type) }}
+        {{ "v"|write_var("buf", inner_type) }}
     }
 }
 
@@ -30,5 +30,5 @@ internal fun read{{ canonical_type_name }}(buf: ByteBuffer): {{ inner_type_name 
     if (buf.get().toInt() == 0) {
         return null
     }
-    return {{ "buf"|read_kt(inner_type) }}
+    return {{ "buf"|read_var(inner_type) }}
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
@@ -1,6 +1,6 @@
 {% import "macros.kt" as kt %}
 {%- let rec = self.inner() %}
-data class {{ rec.name()|class_name }} (
+data class {{ rec|type_name }} (
     {%- for field in rec.fields() %}
     var {{ field.name()|var_name }}: {{ field|type_name -}}
     {%- match field.default_value() %}
@@ -11,12 +11,12 @@ data class {{ rec.name()|class_name }} (
     {%- endfor %}
 ) {% if self.contains_object_references() %}: Disposable {% endif %}{
     companion object {
-        internal fun lift(rbuf: RustBuffer.ByValue): {{ rec.name()|class_name }} {
-            return liftFromRustBuffer(rbuf) { buf -> {{ rec.name()|class_name }}.read(buf) }
+        internal fun lift(rbuf: RustBuffer.ByValue): {{ rec|type_name }} {
+            return liftFromRustBuffer(rbuf) { buf -> {{ rec|type_name }}.read(buf) }
         }
 
-        internal fun read(buf: ByteBuffer): {{ rec.name()|class_name }} {
-            return {{ rec.name()|class_name }}(
+        internal fun read(buf: ByteBuffer): {{ rec|type_name }} {
+            return {{ rec|type_name }}(
             {%- for field in rec.fields() %}
             {{ "buf"|read_var(field) }}{% if loop.last %}{% else %},{% endif %}
             {%- endfor %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
@@ -1,24 +1,24 @@
 {% import "macros.kt" as kt %}
 {%- let rec = self.inner() %}
-data class {{ rec.name()|class_name_kt }} (
+data class {{ rec.name()|class_name }} (
     {%- for field in rec.fields() %}
-    var {{ field.name()|var_name_kt }}: {{ field|type_kt -}}
+    var {{ field.name()|var_name }}: {{ field|type_name -}}
     {%- match field.default_value() %}
-        {%- when Some with(literal) %} = {{ literal|literal_kt(field) }}
+        {%- when Some with(literal) %} = {{ literal|render_literal(field) }}
         {%- else %}
     {%- endmatch -%}
     {% if !loop.last %}, {% endif %}
     {%- endfor %}
 ) {% if self.contains_object_references() %}: Disposable {% endif %}{
     companion object {
-        internal fun lift(rbuf: RustBuffer.ByValue): {{ rec.name()|class_name_kt }} {
-            return liftFromRustBuffer(rbuf) { buf -> {{ rec.name()|class_name_kt }}.read(buf) }
+        internal fun lift(rbuf: RustBuffer.ByValue): {{ rec.name()|class_name }} {
+            return liftFromRustBuffer(rbuf) { buf -> {{ rec.name()|class_name }}.read(buf) }
         }
 
-        internal fun read(buf: ByteBuffer): {{ rec.name()|class_name_kt }} {
-            return {{ rec.name()|class_name_kt }}(
+        internal fun read(buf: ByteBuffer): {{ rec.name()|class_name }} {
+            return {{ rec.name()|class_name }}(
             {%- for field in rec.fields() %}
-            {{ "buf"|read_kt(field) }}{% if loop.last %}{% else %},{% endif %}
+            {{ "buf"|read_var(field) }}{% if loop.last %}{% else %},{% endif %}
             {%- endfor %}
             )
         }
@@ -30,7 +30,7 @@ data class {{ rec.name()|class_name_kt }} (
 
     internal fun write(buf: RustBufferBuilder) {
         {%- for field in rec.fields() %}
-            {{ "this.{}"|format(field.name())|write_kt("buf", field) }}
+            {{ "this.{}"|format(field.name())|write_var("buf", field) }}
         {% endfor %}
     }
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/SequenceTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/SequenceTemplate.kt
@@ -1,10 +1,10 @@
 {%- import "macros.kt" as kt -%}
 {%- let inner_type = self.inner() %}
 {%- let outer_type = self.outer() %}
-{%- let inner_type_name = inner_type|type_kt %}
+{%- let inner_type_name = inner_type|type_name %}
 {%- let canonical_type_name = outer_type|canonical_name %}
 
-// Helper functions for passing values of type {{ outer_type|type_kt }}
+// Helper functions for passing values of type {{ outer_type|type_name }}
 internal fun lower{{ canonical_type_name }}(v: List<{{ inner_type_name }}>): RustBuffer.ByValue {
     return lowerIntoRustBuffer(v) { v, buf ->
         write{{ canonical_type_name }}(v, buf)
@@ -14,7 +14,7 @@ internal fun lower{{ canonical_type_name }}(v: List<{{ inner_type_name }}>): Rus
 internal fun write{{ canonical_type_name }}(v: List<{{ inner_type_name }}>, buf: RustBufferBuilder) {
     buf.putInt(v.size)
     v.forEach {
-        {{ "it"|write_kt("buf", inner_type) }}
+        {{ "it"|write_var("buf", inner_type) }}
     }
 }
 
@@ -27,6 +27,6 @@ internal fun lift{{ canonical_type_name }}(rbuf: RustBuffer.ByValue): List<{{ in
 internal fun read{{ canonical_type_name }}(buf: ByteBuffer): List<{{ inner_type_name }}> {
     val len = buf.getInt()
     return List<{{ inner_type_name }}>(len) {
-        {{ "buf"|read_kt(inner_type) }}
+        {{ "buf"|read_var(inner_type) }}
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
@@ -3,13 +3,13 @@
 {%- match func.return_type() -%}
 {%- when Some with (return_type) %}
 
-fun {{ func.name()|fn_name_kt }}({%- call kt::arg_list_decl(func) -%}): {{ return_type|type_kt }} {
+fun {{ func.name()|fn_name }}({%- call kt::arg_list_decl(func) -%}): {{ return_type|type_name }} {
     val _retval = {% call kt::to_ffi_call(func) %}
-    return {{ "_retval"|lift_kt(return_type) }}
+    return {{ "_retval"|lift_var(return_type) }}
 }
 
 {% when None -%}
 
-fun {{ func.name()|fn_name_kt }}({% call kt::arg_list_decl(func) %}) =
+fun {{ func.name()|fn_name }}({% call kt::arg_list_decl(func) %}) =
     {% call kt::to_ffi_call(func) %}
 {% endmatch %}


### PR DESCRIPTION
More changes extracted out of the `uoc-macro-dispatch` PR.  These change how we name things on Kotlin.  If this seems good, then we can do something similar for Python/Swift.

There's a couple changes here.  The goal is to make generating names in the template code simple and consistent.

  - Use "name" in general rather than "label".  I'm definitely open to changing this one, but in my mind "label" to signifies something human to read rather than a machine name.
  - Remove the "_kt" suffix at the end of template function names.  This seems like extra typing without much benefit.
  - Added a `name` filter function.  The idea is that you send it some `ComponentInterface` item and it generates the proper name for it.  It works with `Record`, `Enum`, etc. as well as `Field` and `Argument`.  Added the `variant_name` filter for enum/error variants.