### PR TITLE
Fix missing fmt argument in error message

### DIFF
--- a/uniffi/src/testing.rs
+++ b/uniffi/src/testing.rs
@@ -144,7 +144,7 @@ fn run_uniffi_bindgen_test(out_dir: &str, udl_files: &[&str], test_file: &str) -
         .args(&["test", out_dir, &udl_files, test_file])
         .status()?;
     if !status.success() {
-        bail!("Error while running tests: {}",);
+        bail!("Error while running tests: {}", status);
     }
     Ok(())
 }


### PR DESCRIPTION
Without this, the error message would literally be "Error while running tests: {}" with curly braces in it instead of the exit status.