### PR TITLE
Python: Extract type coercing into a `CodeType` method

### DIFF
--- a/uniffi_bindgen/src/backend/types.rs
+++ b/uniffi_bindgen/src/backend/types.rs
@@ -105,6 +105,11 @@ pub trait CodeType {
     fn imports(&self, _oracle: &dyn CodeOracle) -> Option<Vec<String>> {
         None
     }
+
+    /// An expression to coerce the given variable to the expected type.
+    fn coerce(&self, oracle: &dyn CodeOracle, _nm: &dyn fmt::Display) -> String {
+        panic!("Unimplemented for {}", self.type_label(oracle));
+    }
 }
 
 /// This trait is used to implement `CodeType` for `Type` and type-like structs (`Record`, `Enum`, `Field`,

--- a/uniffi_bindgen/src/bindings/python/gen_python/enum_.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/enum_.rs
@@ -67,6 +67,10 @@ impl CodeType for EnumCodeType {
             self.type_label(oracle)
         ))
     }
+
+    fn coerce(&self, _oracle: &dyn CodeOracle, nm: &dyn fmt::Display) -> String {
+        nm.to_string()
+    }
 }
 
 #[derive(Template)]

--- a/uniffi_bindgen/src/bindings/python/gen_python/error.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/error.rs
@@ -59,6 +59,10 @@ impl CodeType for ErrorCodeType {
             self.type_label(oracle)
         ))
     }
+
+    fn coerce(&self, _oracle: &dyn CodeOracle, nm: &dyn fmt::Display) -> String {
+        nm.to_string()
+    }
 }
 
 #[derive(Template)]

--- a/uniffi_bindgen/src/bindings/python/gen_python/external.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/external.rs
@@ -75,4 +75,8 @@ impl CodeType for ExternalCodeType {
     fn helper_code(&self, _oracle: &dyn CodeOracle) -> Option<String> {
         Some(self.render().unwrap())
     }
+
+    fn coerce(&self, _oracle: &dyn CodeOracle, _nm: &dyn fmt::Display) -> String {
+        panic!("should not be necessary to coerce External types");
+    }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/miscellany.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/miscellany.rs
@@ -52,9 +52,13 @@ macro_rules! impl_code_type_for_miscellany {
                     format!("{}._read({})", self.ffi_converter_name(oracle), nm)
                 }
 
-                 fn helper_code(&self, _oracle: &dyn CodeOracle) -> Option<String> {
-                     Some(self.render().unwrap())
-                 }
+                fn helper_code(&self, _oracle: &dyn CodeOracle) -> Option<String> {
+                    Some(self.render().unwrap())
+                }
+
+                fn coerce(&self, _oracle: &dyn CodeOracle, nm: &dyn fmt::Display) -> String {
+                    nm.to_string()
+                }
              }
          }
      }

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -359,35 +359,7 @@ pub mod filters {
     }
 
     pub fn coerce_py(nm: &dyn fmt::Display, type_: &Type) -> Result<String, askama::Error> {
-        Ok(match type_ {
-            Type::Int8
-            | Type::UInt8
-            | Type::Int16
-            | Type::UInt16
-            | Type::Int32
-            | Type::UInt32
-            | Type::Int64
-            | Type::UInt64 => format!("int({})", nm), // TODO: check max/min value
-            Type::Float32 | Type::Float64 => format!("float({})", nm),
-            Type::Boolean => format!("bool({})", nm),
-            Type::String
-            | Type::Object(_)
-            | Type::Enum(_)
-            | Type::Error(_)
-            | Type::Record(_)
-            | Type::Timestamp
-            | Type::Duration => nm.to_string(),
-            Type::CallbackInterface(_) => panic!("No support for coercing callback interfaces yet"),
-            Type::Optional(t) => format!("(None if {} is None else {})", nm, coerce_py(nm, t)?),
-            Type::Sequence(t) => format!("list({} for x in {})", coerce_py(&"x", t)?, nm),
-            Type::Map(t) => format!(
-                "dict(({},{}) for (k, v) in {}.items())",
-                coerce_py(&"k", &Type::String)?,
-                coerce_py(&"v", t)?,
-                nm
-            ),
-            Type::Wrapped { prim, .. } => coerce_py(nm, prim.as_ref())?,
-            Type::External { .. } => panic!("should not be necessary to coerce External types"),
-        })
+        let oracle = oracle();
+        Ok(oracle.find(type_).coerce(&oracle, nm))
     }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/object.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/object.rs
@@ -65,6 +65,10 @@ impl CodeType for ObjectCodeType {
             self.type_label(oracle)
         ))
     }
+
+    fn coerce(&self, _oracle: &dyn CodeOracle, nm: &dyn fmt::Display) -> String {
+        nm.to_string()
+    }
 }
 
 #[derive(Template)]

--- a/uniffi_bindgen/src/bindings/python/gen_python/primitives.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/primitives.rs
@@ -39,7 +39,7 @@ fn render_literal(_oracle: &dyn CodeOracle, literal: &Literal) -> String {
 }
 
 macro_rules! impl_code_type_for_primitive {
-    ($T:ty, $class_name:literal, $template_file:literal) => {
+    ($T:ty, $class_name:literal, $template_file:literal, $coerce_code:expr) => {
         paste! {
             #[derive(Template)]
             #[template(syntax = "py", escape = "none", path = $template_file)]
@@ -73,20 +73,24 @@ macro_rules! impl_code_type_for_primitive {
                 fn helper_code(&self, _oracle: &dyn CodeOracle) -> Option<String> {
                     Some(self.render().unwrap())
                 }
+
+                fn coerce(&self, _oracle: &dyn CodeOracle, nm: &dyn fmt::Display) -> String {
+                    format!($coerce_code, nm)
+                }
             }
         }
     }
 }
 
-impl_code_type_for_primitive!(BooleanCodeType, "Bool", "BooleanHelper.py");
-impl_code_type_for_primitive!(StringCodeType, "String", "StringHelper.py");
-impl_code_type_for_primitive!(Int8CodeType, "Int8", "Int8Helper.py");
-impl_code_type_for_primitive!(Int16CodeType, "Int16", "Int16Helper.py");
-impl_code_type_for_primitive!(Int32CodeType, "Int32", "Int32Helper.py");
-impl_code_type_for_primitive!(Int64CodeType, "Int64", "Int64Helper.py");
-impl_code_type_for_primitive!(UInt8CodeType, "UInt8", "UInt8Helper.py");
-impl_code_type_for_primitive!(UInt16CodeType, "UInt16", "UInt16Helper.py");
-impl_code_type_for_primitive!(UInt32CodeType, "UInt32", "UInt32Helper.py");
-impl_code_type_for_primitive!(UInt64CodeType, "UInt64", "UInt64Helper.py");
-impl_code_type_for_primitive!(Float32CodeType, "Float", "Float32Helper.py");
-impl_code_type_for_primitive!(Float64CodeType, "Double", "Float64Helper.py");
+impl_code_type_for_primitive!(BooleanCodeType, "Bool", "BooleanHelper.py", "bool({})");
+impl_code_type_for_primitive!(StringCodeType, "String", "StringHelper.py", "{}");
+impl_code_type_for_primitive!(Int8CodeType, "Int8", "Int8Helper.py", "int({})");
+impl_code_type_for_primitive!(Int16CodeType, "Int16", "Int16Helper.py", "int({})");
+impl_code_type_for_primitive!(Int32CodeType, "Int32", "Int32Helper.py", "int({})");
+impl_code_type_for_primitive!(Int64CodeType, "Int64", "Int64Helper.py", "int({})");
+impl_code_type_for_primitive!(UInt8CodeType, "UInt8", "UInt8Helper.py", "int({})");
+impl_code_type_for_primitive!(UInt16CodeType, "UInt16", "UInt16Helper.py", "int({})");
+impl_code_type_for_primitive!(UInt32CodeType, "UInt32", "UInt32Helper.py", "int({})");
+impl_code_type_for_primitive!(UInt64CodeType, "UInt64", "UInt64Helper.py", "int({})");
+impl_code_type_for_primitive!(Float32CodeType, "Float", "Float32Helper.py", "float({})");
+impl_code_type_for_primitive!(Float64CodeType, "Double", "Float64Helper.py", "float({})");

--- a/uniffi_bindgen/src/bindings/python/gen_python/record.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/record.rs
@@ -60,6 +60,10 @@ impl CodeType for RecordCodeType {
             self.type_label(oracle)
         ))
     }
+
+    fn coerce(&self, _oracle: &dyn CodeOracle, nm: &dyn fmt::Display) -> String {
+        nm.to_string()
+    }
 }
 
 #[derive(Template)]

--- a/uniffi_bindgen/src/bindings/python/gen_python/wrapped.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/wrapped.rs
@@ -71,4 +71,8 @@ impl CodeType for WrappedCodeType {
     fn helper_code(&self, _oracle: &dyn CodeOracle) -> Option<String> {
         Some(self.render().unwrap())
     }
+
+    fn coerce(&self, oracle: &dyn CodeOracle, nm: &dyn fmt::Display) -> String {
+        oracle.find(self.inner()).coerce(oracle, nm)
+    }
 }


### PR DESCRIPTION
Now every type knows how to coerce itself.
So far only Python needs that (Kotlin/Swift rely on the type system,
Ruby hasn't been migrated to UoC yet)

---

Follow up to #1081 