### PR TITLE
Use correct path to backend module

### DIFF
--- a/uniffi_bindgen/src/bindings/python/gen_python/compounds.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/compounds.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bindings::backend::{CodeOracle, CodeType, Literal, TypeIdentifier};
+use crate::backend::{CodeOracle, CodeType, Literal, TypeIdentifier};
 use crate::interface::types::Type;
 use askama::Template;
 use paste::paste;

--- a/uniffi_bindgen/src/bindings/python/gen_python/enum_.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/enum_.rs
@@ -4,7 +4,7 @@
 
 use std::fmt;
 
-use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
+use crate::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
 use crate::interface::{ComponentInterface, Enum};
 use askama::Template;
 

--- a/uniffi_bindgen/src/bindings/python/gen_python/error.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/error.rs
@@ -4,7 +4,7 @@
 
 use std::fmt;
 
-use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
+use crate::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
 use crate::interface::{ComponentInterface, Error, Type};
 use askama::Template;
 

--- a/uniffi_bindgen/src/bindings/python/gen_python/external.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/external.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bindings::backend::{CodeOracle, CodeType};
+use crate::backend::{CodeOracle, CodeType};
 use askama::Template;
 use std::fmt;
 

--- a/uniffi_bindgen/src/bindings/python/gen_python/function.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/function.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bindings::backend::{CodeDeclaration, CodeOracle};
+use crate::backend::{CodeDeclaration, CodeOracle};
 use crate::interface::{ComponentInterface, Function};
 use askama::Template;
 

--- a/uniffi_bindgen/src/bindings/python/gen_python/miscellany.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/miscellany.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bindings::backend::{CodeOracle, CodeType, Literal};
+use crate::backend::{CodeOracle, CodeType, Literal};
 use askama::Template;
 use paste::paste;
 use std::fmt;

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -10,7 +10,7 @@ use askama::Template;
 use heck::{CamelCase, ShoutySnakeCase, SnakeCase};
 use serde::{Deserialize, Serialize};
 
-use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType, TypeIdentifier};
+use crate::backend::{CodeDeclaration, CodeOracle, CodeType, TypeIdentifier};
 use crate::interface::*;
 use crate::MergeWith;
 

--- a/uniffi_bindgen/src/bindings/python/gen_python/object.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/object.rs
@@ -4,7 +4,7 @@
 
 use std::fmt;
 
-use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
+use crate::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
 use crate::interface::{ComponentInterface, Object};
 use askama::Template;
 

--- a/uniffi_bindgen/src/bindings/python/gen_python/primitives.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/primitives.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bindings::backend::{CodeOracle, CodeType, Literal};
+use crate::backend::{CodeOracle, CodeType, Literal};
 use crate::interface::Radix;
 use askama::Template;
 use paste::paste;

--- a/uniffi_bindgen/src/bindings/python/gen_python/record.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/record.rs
@@ -4,7 +4,7 @@
 
 use std::fmt;
 
-use crate::bindings::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
+use crate::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
 use crate::interface::{ComponentInterface, Record};
 use askama::Template;
 

--- a/uniffi_bindgen/src/bindings/python/gen_python/wrapped.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/wrapped.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bindings::backend::{CodeOracle, CodeType, TypeIdentifier};
+use crate::backend::{CodeOracle, CodeType, TypeIdentifier};
 use askama::Template;
 use std::fmt;
 


### PR DESCRIPTION
This was done in #1091, but missed in the recent Python UoC work