### PR TITLE
Update to new version of cargo release which has better workspace support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,6 @@
-<!-- The sections in this file are intended to be managed automatically by `cargo release` -->
-<!-- See https://github.com/sunng87/cargo-release/blob/master/docs/faq.md#maintaining-changelog for details -->
-<!-- Unfortunately that doesn't currently work in a workspace, so for now we update it by hand: -->
-<!--   * Replace `[[UnreleasedVersion]]` with `vX.Y.Z` -->
-<!--   * Replace `[[ReleaseDate]]` with `YYYY-MM-DD` -->
-<!--   * Replace `...HEAD` with `...vX.Y.Z` -->
-<!--   * Insert a fresh copy of the templated bits under the `next-header` comment  -->
+<!-- The sections in this file are managed automatically by `cargo release` -->
+<!-- See our [internal release process docs](docs/release-process.md) and for more general -->
+<!-- guidance, see https://github.com/sunng87/cargo-release/blob/master/docs/faq.md#maintaining-changelog -->
 
 <!-- next-header -->
 
@@ -18,7 +14,7 @@
 ### What's Changed
 - Kotlin and Swift, like Python, now support [simple "wrapped" types](https://mozilla.github.io/uniffi-rs/udl/ext_types_wrapped.html).
 
-[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.14.1...main).
+[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.14.1...HEAD).
 
 ## v0.14.1 (_2021-10-27_)
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -2,6 +2,8 @@
 ## Release Process
 
 We use [cargo-release](https://crates.io/crates/cargo-release) to simplify the release process.
+(We rely on v0.18 or later because it has support for workspaces. Install this with
+`cargo install cargo-release`, not to be confused with the different `cargo install release`!)
 It's not (yet) quite an ideal fit for our workflow, but it helps! Steps:
 
 1. Take a look over `CHANGELOG.md` and make sure the "unreleased" section accurately reflects the
@@ -16,18 +18,8 @@ It's not (yet) quite an ideal fit for our workflow, but it helps! Steps:
 1. Run `cargo release {MAJOR}.{MINOR}.{PATCH}` to perform a dry-run and check that the things
    it is proposing to do seem reasonable.
 1. Run `cargo release -x {MAJOR}.{MINOR}.{PATCH}` to perform real run and to
-   bump version numbers and publish the release to crates.io.
-1. Manually update the section header in `CHANGELOG.md` following the instructions
-   at the top of the file.
-    * This is a limitation of using `cargo release` in a workspace, possibly related
-      to [sunng87/cargo-release#222](https://github.com/sunng87/cargo-release/issues/222)
-1. Run `git commit -a --amend` to include the changelog fixes and fix up the version number
-   in the commit message.
-    * Manually replace `{{version}}` with `v{MAJOR}.{MINOR}.{PATCH}`.
-    * This is a limitation of using `cargo release` in a workspace,
-      ref [sunng87/cargo-release#222](https://github.com/sunng87/cargo-release/issues/222)
-1. Tag the release commit in github.
-    * `git tag v{MAJOR}.{MINOR}.{PATCH}`
-    * `git push origin v{MAJOR}.{MINOR}.{PATCH}`
+   bump version numbers and *publish the release to crates.io* and *create the tag*.
+   It does not push the tag or branch to github, but it will publish to crates.io, so
+   take care!
 1. Push your branch, and make a PR to request it be merged to the main branch.
-    * `git push origin`
+    * `git push origin --tags`

--- a/release.toml
+++ b/release.toml
@@ -1,18 +1,16 @@
 tag-name = "v{{version}}"
-no-dev-version = true
+dev-version = false
 consolidate-commits = true
+consolidate-pushes = true
 
-# Our branching/tagging setup isn't supported by the tool just yet.
-# It wants to do one tag per crate, whereas we want a single unified tag.
-# So we have to tag manually for now.
-disable-tag = true
-disable-push = true
+shared-version=true
 
-# This is how we'd *like* to manage the sections in CHANGELOG.md, but it doesn't
-# currently work that way when doing a consolidated commit in a workspace.
-#pre-release-replacements = [
-#  {file="CHANGELOG.md", search="\\[\\[UnreleasedVersion\\]\\]", replace="v{{version}}", exactly=2},
-#  {file="CHANGELOG.md", search="\\[\\[ReleaseDate\\]\\]", replace="{{date}}", exactly=1},
-#  {file="CHANGELOG.md", search="\\.\\.\\.HEAD)", replace="...{{tag_name}})", exactly=1},
-#  {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [[UnreleasedVersion]] - (_[[ReleaseDate]]_)\n\n[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.9.0...HEAD).", exactly=1},
-#]
+# Disabling auto pushing for now to avoid accidents (although we can still "accidentally" publish
+# to crates.io, so it's not clear this is saving us anything?)
+push = false
+
+# Note that some things need to be done exactly once for the workspace.
+# This includes updating CHANGELOG.md and creating the .git tag.
+# So we arrange for the `uniffi` crate to do this work, and disable it here.
+tag = false
+# Note that `pre-release-replacements` is also in [uniffi/release.toml](uniffi/release.toml)

--- a/uniffi/release.toml
+++ b/uniffi/release.toml
@@ -1,0 +1,12 @@
+# Note that this `release.toml` exists to capture things that must only be
+# done once per workspace - but all other config exists in [../release.toml](../release.toml).
+
+tag = true
+
+# This is how we manage the sections in CHANGELOG.md
+pre-release-replacements = [
+  {file="../CHANGELOG.md", search="\\[\\[UnreleasedVersion\\]\\]", replace="v{{version}}", exactly=2},
+  {file="../CHANGELOG.md", search="\\[\\[ReleaseDate\\]\\]", replace="{{date}}", exactly=1},
+  {file="../CHANGELOG.md", search="\\.\\.\\.HEAD\\)", replace="...{{tag_name}})", exactly=1},
+  {file="../CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [[UnreleasedVersion]] - (_[[ReleaseDate]]_)\n\n[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.9.0...HEAD).", exactly=1},
+]


### PR DESCRIPTION
This seems to work well with a newer `cargo-release` - so well I accidentally published 0.15.0 to crates.io 😅 which I've since yanked.

(I'd like to make a new 0.15.1 for use by app-services, so after approval and landing, feel free to test it out! Otherwise I'll cut a new release tomorrow.)