### PR TITLE
Remove periods in the canonical type name for Timestamps and Duration…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## [[UnreleasedVersion]] - (_[[ReleaseDate]]_)
 
+### What's Changed
+- Kotlin now generates valid code for optional timestamps/durations.
+
 [All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.9.0...HEAD).
 
 ## v0.15.1 (_2021-11-23_)

--- a/fixtures/uniffi-fixture-time/src/chronological.udl
+++ b/fixtures/uniffi-fixture-time/src/chronological.udl
@@ -14,4 +14,6 @@ namespace chronological {
   timestamp now();
 
   boolean equal(timestamp a, timestamp b);
+
+  boolean optional(timestamp? a, duration? b);
 };

--- a/fixtures/uniffi-fixture-time/src/lib.rs
+++ b/fixtures/uniffi-fixture-time/src/lib.rs
@@ -30,6 +30,10 @@ fn equal(a: SystemTime, b: SystemTime) -> bool {
     a == b
 }
 
+fn optional(a: Option<SystemTime>, b: Option<Duration>) -> bool {
+    a.is_some() && b.is_some()
+}
+
 type Result<T, E = ChronologicalError> = std::result::Result<T, E>;
 
 include!(concat!(env!("OUT_DIR"), "/chronological.uniffi.rs"));

--- a/fixtures/uniffi-fixture-time/tests/bindings/test_chronological.kts
+++ b/fixtures/uniffi-fixture-time/tests/bindings/test_chronological.kts
@@ -45,3 +45,8 @@ Thread.sleep(10)
 val kotlinAfter = Instant.now()
 assert(kotlinBefore.isBefore(rustNow))
 assert(kotlinAfter.isAfter(rustNow))
+
+// Test optional values work
+assert(optional(Instant.MAX, Duration.ofSeconds(0)))
+assert(optional(null, Duration.ofSeconds(0)) == false)
+assert(optional(Instant.MAX, null) == false)

--- a/fixtures/uniffi-fixture-time/tests/bindings/test_chronological.py
+++ b/fixtures/uniffi-fixture-time/tests/bindings/test_chronological.py
@@ -40,3 +40,8 @@ assert pythonBefore <= rustNow <= pythonAfter
 # Test that uniffi returns UTC times
 assert now().tzinfo is timezone.utc
 assert abs(datetime.now(timezone.utc) - now()) <= timedelta(seconds=1)
+
+# Test that optionals work.
+assert(optional(now(), timedelta(seconds=0)))
+assert(not optional(None, timedelta(seconds=0)))
+assert(not optional(now(), None))

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/miscellany.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/miscellany.rs
@@ -58,7 +58,7 @@ macro_rules! impl_code_type_for_miscellany {
 
 impl_code_type_for_miscellany!(
     TimestampCodeType,
-    "java.time.Instant",
+    "Instant",
     "Timestamp",
     vec!["java.time.Instant", "java.time.DateTimeException"],
     "TimestampHelper.kt"
@@ -66,7 +66,7 @@ impl_code_type_for_miscellany!(
 
 impl_code_type_for_miscellany!(
     DurationCodeType,
-    "java.time.Duration",
+    "Duration",
     "Duration",
     vec!["java.time.Duration", "java.time.DateTimeException"],
     "DurationHelper.kt"


### PR DESCRIPTION
… in Kotlin.

Previously, optional timestamps would generate, eg:

`internal fun writeOptionaljava.time.Instant(v: java.time.Instant?, buf: RustBufferBuilder) ...`

and code which calls it:

`writeOptionaljava.time.Instant(v, buf)`

which upset the Kotlin compiler, causing errors like:

`Unresolved reference: writeOptionaljava`

(as found in app-services!)