### PR TITLE
Add throws annotation to kotlin exceptions [originally 1099]

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -51,7 +51,7 @@ class {{ obj|type_name }}(
     {% for meth in obj.methods() -%}
     {%- match meth.throws() -%}
     {%- when Some with (throwable) %}
-    @Throws({{ throwable|exception_name_kt }}::class)
+    @Throws({{ throwable|exception_name }}::class)
     {%- else -%}
     {%- endmatch %}
     {%- match meth.return_type() -%}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -2,6 +2,11 @@
 {%- let obj = self.inner() %}
 public interface {{ obj|type_name }}Interface {
     {% for meth in obj.methods() -%}
+    {%- match meth.throws() -%}
+    {%- when Some with (throwable) %}
+    @Throws({{ throwable|exception_name }}::class)
+    {%- else -%}
+    {%- endmatch %}
     fun {{ meth.name()|fn_name }}({% call kt::arg_list_decl(meth) %})
     {%- match meth.return_type() -%}
     {%- when Some with (return_type) %}: {{ return_type|type_name -}}
@@ -44,6 +49,11 @@ class {{ obj|type_name }}(
     }
 
     {% for meth in obj.methods() -%}
+    {%- match meth.throws() -%}
+    {%- when Some with (throwable) %}
+    @Throws({{ throwable|exception_name_kt }}::class)
+    {%- else -%}
+    {%- endmatch %}
     {%- match meth.return_type() -%}
 
     {%- when Some with (return_type) -%}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
@@ -1,8 +1,8 @@
 {% import "macros.kt" as kt %}
 {%- let func = self.inner() %}
 {%- match func.throws() -%}
-{%- when Some with (throwable) %} 
-@Throws({{ throwable|exception_name_kt }}::class)
+{%- when Some with (throwable) %}
+@Throws({{ throwable|exception_name }}::class)
 {%- else -%}
 {%- endmatch %}
 {%- match func.return_type() -%}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
@@ -1,5 +1,10 @@
 {% import "macros.kt" as kt %}
 {%- let func = self.inner() %}
+{%- match func.throws() -%}
+{%- when Some with (throwable) %} 
+@Throws({{ throwable|exception_name_kt }}::class)
+{%- else -%}
+{%- endmatch %}
 {%- match func.return_type() -%}
 {%- when Some with (return_type) %}
 


### PR DESCRIPTION
Fixes #1098, closes #1099 to allow interop with Java.

This is really #1099 with some light rebasing. I've already asked external contributor @l-maia to rebase once, and I don't think it's fair to ask him a second time. I've approved his work already, so a rubber stamp approval is needed to make github happy.

