### PR TITLE
Hides FFIConverterTypes from cargo doc

### DIFF
--- a/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
@@ -7,6 +7,7 @@
 // public so other crates can refer to it via an `[External='crate'] typedef`
 #}
 
+#[doc(hidden)]
 pub struct {{ e.type_()|ffi_converter_name }};
 
 #[doc(hidden)]

--- a/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
@@ -7,6 +7,7 @@
 // public so other crates can refer to it via an `[External='crate'] typedef`
 #}
 
+#[doc(hidden)]
 pub struct {{ e.type_()|ffi_converter_name }};
 
 #[doc(hidden)]

--- a/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
@@ -21,6 +21,7 @@ trait UniffiCustomTypeWrapper {
 {%- endif -%}
 
 // Type `{{ name }}` wraps a `{{ prim.canonical_name() }}`
+#[doc(hidden)]
 pub struct FfiConverterType{{ name }};
 
 unsafe impl uniffi::FfiConverter for FfiConverterType{{ name }} {

--- a/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
@@ -7,6 +7,8 @@
 // We define a unit-struct to implement the trait to sidestep Rust's orphan rule (ADR-0006). It's
 // public so other crates can refer to it via an `[External='crate'] typedef`
 #}
+
+#[doc(hidden)]
 pub struct {{ rec.type_()|ffi_converter_name }};
 
 #[doc(hidden)]


### PR DESCRIPTION
fixes #1123 

Noticed that a bunch of the FfiConverterTypes sneak their way into the `cargo doc` of the consumer, eg: https://mozilla.github.io/application-services/book/rust-docs/fxa_client/index.html#structs

Consumers of libraries that use `uniffi` shouldn't need to know about those structs and can cause some mild confusion 