### PR TITLE
Allow errors converting custom types to propagate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@
 
 ## [[UnreleasedVersion]] - (_[[ReleaseDate]]_)
 
-[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.9.0...HEAD).
+[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.9.0...HEAD)
+
+### ⚠️ Breaking Changes ⚠️
+
+- Error handling when converting custom types has been updated. If your `wrap()`
+  function returns an `Err`, in some cases it now [may not panic but instead
+  return the error declared by the function](https://mozilla.github.io/uniffi-rs/udl/ext_types_wrapped.html#error-handling-during-conversion).
 
 ## v0.15.2 - (_2021-11-25_)
 

--- a/fixtures/ext-types/guid/Cargo.toml
+++ b/fixtures/ext-types/guid/Cargo.toml
@@ -14,6 +14,7 @@ name = "ext_types_guid"
 anyhow = "1"
 bytes = "1.0"
 serde_json = "1"
+thiserror = "1.0"
 uniffi_macros = {path = "../../../uniffi_macros"}
 uniffi = {path = "../../../uniffi", features=["builtin-bindgen"]}
 

--- a/fixtures/ext-types/guid/src/guid.udl
+++ b/fixtures/ext-types/guid/src/guid.udl
@@ -1,6 +1,11 @@
 [Wrapped]
 typedef string Guid;
 
+[Error]
+enum GuidError {
+    "TooShort"
+};
+
 dictionary GuidHelper {
     Guid guid;
     sequence<Guid> guids;
@@ -8,6 +13,9 @@ dictionary GuidHelper {
 };
 
 namespace ext_types_guid {
+    [Throws=GuidError]
     Guid get_guid(optional Guid? val);
+
+    // Note this intentionally does not throw an error - uniffi will need to `unwrap` here.
     GuidHelper get_guid_helper(optional GuidHelper? vals);
 };

--- a/fixtures/ext-types/guid/src/guid.udl
+++ b/fixtures/ext-types/guid/src/guid.udl
@@ -18,7 +18,7 @@ namespace ext_types_guid {
     Guid get_guid(optional Guid? val);
 
     // Uniffi will handle failure converting a string to a Guid correctly if
-    // the conversion returns `Err<GuidError>`, or panic otherwise.
+    // the conversion returns `Err(GuidError)`, or panic otherwise.
     [Throws=GuidError]
     Guid try_get_guid(optional Guid? val);
 

--- a/fixtures/ext-types/guid/src/guid.udl
+++ b/fixtures/ext-types/guid/src/guid.udl
@@ -13,9 +13,14 @@ dictionary GuidHelper {
 };
 
 namespace ext_types_guid {
-    [Throws=GuidError]
+    // Note this intentionally does not throw an error - uniffi will panic if
+    // a Guid can't be converted.
     Guid get_guid(optional Guid? val);
 
-    // Note this intentionally does not throw an error - uniffi will need to `unwrap` here.
+    // Uniffi will handle failure converting a string to a Guid correctly if
+    // the conversion returns `Err<GuidError>`, or panic otherwise.
+    [Throws=GuidError]
+    Guid try_get_guid(optional Guid? val);
+
     GuidHelper get_guid_helper(optional GuidHelper? vals);
 };

--- a/fixtures/ext-types/guid/src/lib.rs
+++ b/fixtures/ext-types/guid/src/lib.rs
@@ -1,11 +1,23 @@
 // A trivial guid.
 pub struct Guid(pub String);
 
-fn get_guid(guid: Option<Guid>) -> Guid {
-    match guid {
-        Some(guid) => guid,
+#[derive(Debug, thiserror::Error)]
+pub enum GuidError {
+    #[error("The Guid is too short")]
+    TooShort,
+}
+
+fn get_guid(guid: Option<Guid>) -> std::result::Result<Guid, GuidError> {
+    // This function itself always returns Ok - but it's declared as a Result
+    // because the UniffiCustomTypeWrapper might return the Err as part of
+    // turning the string into the Guid.
+    Ok(match guid {
+        Some(guid) => {
+            assert!(!guid.0.is_empty(), "our UniffiCustomTypeWrapper already checked!");
+            guid
+        },
         None => Guid("NewGuid".to_string()),
-    }
+    })
 }
 
 pub struct GuidHelper {
@@ -32,7 +44,11 @@ impl UniffiCustomTypeWrapper for Guid {
     type Wrapped = String;
 
     fn wrap(val: Self::Wrapped) -> uniffi::Result<Self> {
-        Ok(Guid(val))
+        if val.is_empty() {
+            Err(GuidError::TooShort.into())
+        } else {
+            Ok(Guid(val))
+        }
     }
 
     fn unwrap(obj: Self) -> Self::Wrapped {

--- a/fixtures/ext-types/guid/src/lib.rs
+++ b/fixtures/ext-types/guid/src/lib.rs
@@ -38,7 +38,7 @@ fn try_get_guid(guid: Option<Guid>) -> std::result::Result<Guid, GuidError> {
         Some(guid) => {
             assert!(
                 !guid.0.is_empty(),
-                "our UniffiCustomTypeWrapper already checked!"
+                "our UniffiCustomTypeWrapper failed to check for an empty GUID"
             );
             guid
         }

--- a/fixtures/ext-types/guid/src/lib.rs
+++ b/fixtures/ext-types/guid/src/lib.rs
@@ -1,21 +1,47 @@
 // A trivial guid.
 pub struct Guid(pub String);
 
+// This error is represented in the UDL.
 #[derive(Debug, thiserror::Error)]
 pub enum GuidError {
     #[error("The Guid is too short")]
     TooShort,
 }
 
-fn get_guid(guid: Option<Guid>) -> std::result::Result<Guid, GuidError> {
+// This error is not represented in the UDL - it's only to be used internally (although
+// for test purposes, we do allow this to leak out below.)
+#[derive(Debug, thiserror::Error)]
+pub enum InternalError {
+    #[error("Something unexpected went wrong")]
+    Unexpected,
+}
+
+fn get_guid(guid: Option<Guid>) -> Guid {
+    // This function doesn't return a Result, so all conversion errors are panics
+    match guid {
+        Some(guid) => {
+            assert!(
+                !guid.0.is_empty(),
+                "our UniffiCustomTypeWrapper already checked!"
+            );
+            guid
+        }
+        None => Guid("NewGuid".to_string()),
+    }
+}
+
+fn try_get_guid(guid: Option<Guid>) -> std::result::Result<Guid, GuidError> {
     // This function itself always returns Ok - but it's declared as a Result
     // because the UniffiCustomTypeWrapper might return the Err as part of
     // turning the string into the Guid.
     Ok(match guid {
         Some(guid) => {
-            assert!(!guid.0.is_empty(), "our UniffiCustomTypeWrapper already checked!");
+            assert!(
+                !guid.0.is_empty(),
+                "our UniffiCustomTypeWrapper already checked!"
+            );
             guid
-        },
+        }
         None => Guid("NewGuid".to_string()),
     })
 }
@@ -43,9 +69,15 @@ fn get_guid_helper(vals: Option<GuidHelper>) -> GuidHelper {
 impl UniffiCustomTypeWrapper for Guid {
     type Wrapped = String;
 
+    // This is a "fixture" rather than an "example", so we are free to do things that don't really
+    // make sense for real apps.
     fn wrap(val: Self::Wrapped) -> uniffi::Result<Self> {
         if val.is_empty() {
             Err(GuidError::TooShort.into())
+        } else if val == "unexpected" {
+            Err(InternalError::Unexpected.into())
+        } else if val == "panic" {
+            panic!("guid value caused a panic!");
         } else {
             Ok(Guid(val))
         }

--- a/fixtures/ext-types/guid/src/lib.rs
+++ b/fixtures/ext-types/guid/src/lib.rs
@@ -13,9 +13,12 @@ fn get_guid(guid: Option<Guid>) -> std::result::Result<Guid, GuidError> {
     // turning the string into the Guid.
     Ok(match guid {
         Some(guid) => {
-            assert!(!guid.0.is_empty(), "our UniffiCustomTypeWrapper already checked!");
+            assert!(
+                !guid.0.is_empty(),
+                "our UniffiCustomTypeWrapper already checked!"
+            );
             guid
-        },
+        }
         None => Guid("NewGuid".to_string()),
     })
 }
@@ -42,8 +45,9 @@ fn get_guid_helper(vals: Option<GuidHelper>) -> GuidHelper {
 
 impl UniffiCustomTypeWrapper for Guid {
     type Wrapped = String;
+    type Error = GuidError;
 
-    fn wrap(val: Self::Wrapped) -> uniffi::Result<Self> {
+    fn wrap(val: Self::Wrapped) -> std::result::Result<Self, Self::Error> {
         if val.is_empty() {
             Err(GuidError::TooShort.into())
         } else {

--- a/fixtures/ext-types/guid/src/lib.rs
+++ b/fixtures/ext-types/guid/src/lib.rs
@@ -13,12 +13,9 @@ fn get_guid(guid: Option<Guid>) -> std::result::Result<Guid, GuidError> {
     // turning the string into the Guid.
     Ok(match guid {
         Some(guid) => {
-            assert!(
-                !guid.0.is_empty(),
-                "our UniffiCustomTypeWrapper already checked!"
-            );
+            assert!(!guid.0.is_empty(), "our UniffiCustomTypeWrapper already checked!");
             guid
-        }
+        },
         None => Guid("NewGuid".to_string()),
     })
 }
@@ -45,9 +42,8 @@ fn get_guid_helper(vals: Option<GuidHelper>) -> GuidHelper {
 
 impl UniffiCustomTypeWrapper for Guid {
     type Wrapped = String;
-    type Error = GuidError;
 
-    fn wrap(val: Self::Wrapped) -> std::result::Result<Self, Self::Error> {
+    fn wrap(val: Self::Wrapped) -> uniffi::Result<Self> {
         if val.is_empty() {
             Err(GuidError::TooShort.into())
         } else {

--- a/fixtures/ext-types/guid/tests/bindings/test_guid.py
+++ b/fixtures/ext-types/guid/tests/bindings/test_guid.py
@@ -16,6 +16,8 @@ class TestGuid(unittest.TestCase):
         self.assertEqual(helper.guids, ["second-guid", "third-guid"])
         self.assertEqual(helper.maybe_guid, None)
 
+    def test_guid_errors(self):
+        self.assertRaises(GuidError.TooShort, get_guid(""))
 
     # def test_round_trip(self):
     #     ct = get_combined_type(None)

--- a/fixtures/ext-types/guid/tests/bindings/test_guid.py
+++ b/fixtures/ext-types/guid/tests/bindings/test_guid.py
@@ -16,8 +16,30 @@ class TestGuid(unittest.TestCase):
         self.assertEqual(helper.guids, ["second-guid", "third-guid"])
         self.assertEqual(helper.maybe_guid, None)
 
-    def test_guid_errors(self):
-        self.assertRaises(GuidError.TooShort, get_guid, "")
+    def test_get_guid_errors(self):
+        # This is testing `get_guid` which never returns a result, so everything
+        # is InternalError representing a panic.
+        # The fixture hard-codes some Guid strings to return specific errors.
+        with self.assertRaisesRegex(InternalError, "Failed to convert arg 'val': The Guid is too short"):
+            get_guid("")
+
+        with self.assertRaisesRegex(InternalError, "Failed to convert arg 'val': Something unexpected went wrong"):
+            get_guid("unexpected")
+
+        with self.assertRaisesRegex(InternalError, "guid value caused a panic!"):
+            get_guid("panic")
+
+    def test_try_get_guid_errors(self):
+        # This is testing `try_get_guid()` which says it returns a result, so we
+        # will get a mix of "expected" errors and panics.
+        with self.assertRaises(GuidError.TooShort):
+            try_get_guid("")
+
+        with self.assertRaisesRegex(InternalError, "Failed to convert arg 'val': Something unexpected went wrong"):
+            try_get_guid("unexpected")
+
+        with self.assertRaisesRegex(InternalError, "guid value caused a panic!"):
+            try_get_guid("panic")
 
     # def test_round_trip(self):
     #     ct = get_combined_type(None)

--- a/fixtures/ext-types/guid/tests/bindings/test_guid.py
+++ b/fixtures/ext-types/guid/tests/bindings/test_guid.py
@@ -17,7 +17,7 @@ class TestGuid(unittest.TestCase):
         self.assertEqual(helper.maybe_guid, None)
 
     def test_guid_errors(self):
-        self.assertRaises(GuidError.TooShort, get_guid(""))
+        self.assertRaises(GuidError.TooShort, get_guid, "")
 
     # def test_round_trip(self):
     #     ct = get_combined_type(None)

--- a/fixtures/uitests/tests/ui/interface_cannot_use_mut_self.stderr
+++ b/fixtures/uitests/tests/ui/interface_cannot_use_mut_self.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
-   --> $DIR/counter.uniffi.rs:160:13
+   --> $DIR/counter.uniffi.rs:161:32
     |
-160 |             &<std::sync::Arc<Counter> as uniffi::FfiConverter>::try_lift(ptr).unwrap(),
-    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+161 |                 Ok(ref val) => val,
+    |                                ^^^ types differ in mutability
     |
     = note: expected mutable reference `&mut Counter`
                        found reference `&Arc<Counter>`

--- a/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
+++ b/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
@@ -26,10 +26,10 @@ error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
     = note: required by `lower`
 
 error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
-   --> $DIR/counter.uniffi.rs:160:14
+   --> $DIR/counter.uniffi.rs:160:19
     |
-160 |             &<std::sync::Arc<Counter> as uniffi::FfiConverter>::try_lift(ptr).unwrap(),
-    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FfiConverter` is not implemented for `Arc<Counter>`
+160 |             match <std::sync::Arc<Counter> as uniffi::FfiConverter>::try_lift(ptr) {
+    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FfiConverter` is not implemented for `Arc<Counter>`
     |
     = help: the following implementations were found:
               <Arc<T> as FfiConverter>

--- a/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
@@ -13,8 +13,9 @@ use {{ crate_name|crate_name_rs }}::FfiConverterType{{ name }};
 // A trait that's in our crate for our external wrapped types to implement.
 trait UniffiCustomTypeWrapper {
     type Wrapped;
+    type Error: Into<anyhow::Error>;
 
-    fn wrap(val: Self::Wrapped) -> uniffi::Result<Self> where Self: Sized;
+    fn wrap(val: Self::Wrapped) -> std::result::Result<Self, Self::Error> where Self: Sized;
     fn unwrap(obj: Self) -> Self::Wrapped;
 }
 
@@ -33,7 +34,7 @@ unsafe impl uniffi::FfiConverter for FfiConverterType{{ name }} {
     }
 
     fn try_lift(v: Self::FfiType) -> uniffi::Result<{{ name }}> {
-        <{{ name }} as UniffiCustomTypeWrapper>::wrap(<{{ prim|type_rs }} as uniffi::FfiConverter>::try_lift(v)?)
+        <{{ name }} as UniffiCustomTypeWrapper>::wrap(<{{ prim|type_rs }} as uniffi::FfiConverter>::try_lift(v)?).map_err(Into::into)
     }
 
     fn write(obj: {{ name }}, buf: &mut Vec<u8>) {
@@ -41,7 +42,7 @@ unsafe impl uniffi::FfiConverter for FfiConverterType{{ name }} {
     }
 
     fn try_read(buf: &mut &[u8]) -> uniffi::Result<{{ name }}> {
-        <{{ name }} as UniffiCustomTypeWrapper>::wrap(<{{ prim|type_rs }} as uniffi::FfiConverter>::try_read(buf)?)
+        <{{ name }} as UniffiCustomTypeWrapper>::wrap(<{{ prim|type_rs }} as uniffi::FfiConverter>::try_read(buf)?).map_err(Into::into)
     }
 }
 {%- endfor -%}

--- a/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
@@ -13,9 +13,8 @@ use {{ crate_name|crate_name_rs }}::FfiConverterType{{ name }};
 // A trait that's in our crate for our external wrapped types to implement.
 trait UniffiCustomTypeWrapper {
     type Wrapped;
-    type Error: Into<anyhow::Error>;
 
-    fn wrap(val: Self::Wrapped) -> std::result::Result<Self, Self::Error> where Self: Sized;
+    fn wrap(val: Self::Wrapped) -> uniffi::Result<Self> where Self: Sized;
     fn unwrap(obj: Self) -> Self::Wrapped;
 }
 
@@ -34,7 +33,7 @@ unsafe impl uniffi::FfiConverter for FfiConverterType{{ name }} {
     }
 
     fn try_lift(v: Self::FfiType) -> uniffi::Result<{{ name }}> {
-        <{{ name }} as UniffiCustomTypeWrapper>::wrap(<{{ prim|type_rs }} as uniffi::FfiConverter>::try_lift(v)?).map_err(Into::into)
+        <{{ name }} as UniffiCustomTypeWrapper>::wrap(<{{ prim|type_rs }} as uniffi::FfiConverter>::try_lift(v)?)
     }
 
     fn write(obj: {{ name }}, buf: &mut Vec<u8>) {
@@ -42,7 +41,7 @@ unsafe impl uniffi::FfiConverter for FfiConverterType{{ name }} {
     }
 
     fn try_read(buf: &mut &[u8]) -> uniffi::Result<{{ name }}> {
-        <{{ name }} as UniffiCustomTypeWrapper>::wrap(<{{ prim|type_rs }} as uniffi::FfiConverter>::try_read(buf)?).map_err(Into::into)
+        <{{ name }} as UniffiCustomTypeWrapper>::wrap(<{{ prim|type_rs }} as uniffi::FfiConverter>::try_read(buf)?)
     }
 }
 {%- endfor -%}

--- a/uniffi_bindgen/src/scaffolding/templates/macros.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/macros.rs
@@ -24,11 +24,11 @@
             Err(err) => {
                 match err.downcast::<{{ e }}>() {
                     Ok(actual_error) => return Err({{ func.throws_type().unwrap()|ffi_converter }}::lower(actual_error)),
-                    Err(ohno) => panic!("Failed to convert arg '{{ arg.name() }}': {}", ohno),
+                    Err(ohno) => panic!("Failed to convert arg '{}': {}", "{{ arg.name() }}", ohno),
                 }
             }
         {% else %}
-            Err(err) => panic!("Failed to convert arg '{{ arg.name() }}': {}", err),
+            Err(err) => panic!("Failed to convert arg '{}': {}", "{{ arg.name() }}", err),
         {% endmatch %}
         }
         {%- if !loop.last %}, {% endif %}

--- a/uniffi_bindgen/src/scaffolding/templates/macros.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/macros.rs
@@ -16,8 +16,8 @@
         #}
         {%- match func.throws_type() -%}
         {% when Some with (e) %}
-            // XXX - this is wrong and is still failing - need to work out how to lower the error
-            .map_err(Into::into)?
+            // XXX - this is wrong - can't go from anyhow back to the actual error :(
+            .map_err(Into::into).map_err({{ e|ffi_converter }}::lower)?
         {% else %}
             .unwrap()
         {% endmatch %}

--- a/uniffi_bindgen/src/scaffolding/templates/macros.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/macros.rs
@@ -16,8 +16,8 @@
         #}
         {%- match func.throws_type() -%}
         {% when Some with (e) %}
-            // XXX - this is wrong - can't go from anyhow back to the actual error :(
-            .map_err(Into::into).map_err({{ e|ffi_converter }}::lower)?
+            // XXX - this is wrong and is still failing - need to work out how to lower the error
+            .map_err(Into::into)?
         {% else %}
             .unwrap()
         {% endmatch %}

--- a/uniffi_bindgen/src/scaffolding/templates/macros.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/macros.rs
@@ -8,19 +8,29 @@
 
 {%- macro _arg_list_rs_call(func) %}
     {%- for arg in func.full_arguments() %}
-        {%- if arg.by_ref() %}&{% endif %}
-        {{- arg.type_()|ffi_converter }}::try_lift({{ arg.name() }})
-        {# If this function returns an error, then we assume the UniffiCustomTypeWrapper
-           implementation returns a compatible result. If this function does not return
-           an error, we unwrap the conversion, so will panic if it fails.
-        #}
-        {%- match func.throws_type() -%}
-        {% when Some with (e) %}
-            // XXX - this is wrong - can't go from anyhow back to the actual error :(
-            .map_err(Into::into).map_err({{ e|ffi_converter }}::lower)?
+        match {{- arg.type_()|ffi_converter }}::try_lift({{ arg.name() }}) {
+        {%- if arg.by_ref() %}
+            Ok(ref val) => val,
         {% else %}
-            .unwrap()
+            Ok(val) => val,
+        {% endif %}
+
+        {# If this function returns an error, we attempt to downcast errors doing arg
+            conversions to this error. If the downcast fails or the function doesn't
+            return an error, we just panic.
+        #}
+        {%- match func.throws() -%}
+        {% when Some with (e) %}
+            Err(err) => {
+                match err.downcast::<{{ e }}>() {
+                    Ok(actual_error) => return Err({{ func.throws_type().unwrap()|ffi_converter }}::lower(actual_error)),
+                    Err(ohno) => panic!("Failed to convert arg '{{ arg.name() }}': {}", ohno),
+                }
+            }
+        {% else %}
+            Err(err) => panic!("Failed to convert arg '{{ arg.name() }}': {}", err),
         {% endmatch %}
+        }
         {%- if !loop.last %}, {% endif %}
     {%- endfor %}
 {%- endmacro -%}


### PR DESCRIPTION
This gets close, but strikes a mismatch between the `Err` types.