### PR TITLE
Allow integer keys in records (hashmaps)

### DIFF
--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -106,6 +106,15 @@ interface Coveralls {
 
     // regression test: using a parameter name that was also used by UniFFI runtime code
     string get_status(string status);
+
+    /// Simple string->integer dictionary, using the legacy `DOMString` type.
+    record<DOMString, u64> get_dict(string key, u64 value);
+
+    /// Simple string->integer dictionary, using the classic string type
+    record<string, u64> get_dict2(string key, u64 value);
+
+    /// integer->integer dictionary
+    record<u32, u64> get_dict3(u32 key, u64 value);
 };
 
 // All coveralls end up with a patch.

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -235,6 +236,24 @@ impl Coveralls {
 
     fn get_status(&self, status: String) -> String {
         format!("status: {}", status)
+    }
+
+    fn get_dict(&self, key: String, value: u64) -> HashMap<String, u64> {
+        let mut map = HashMap::new();
+        map.insert(key, value);
+        map
+    }
+
+    fn get_dict2(&self, key: String, value: u64) -> HashMap<String, u64> {
+        let mut map = HashMap::new();
+        map.insert(key, value);
+        map
+    }
+
+    fn get_dict3(&self, key: u32, value: u64) -> HashMap<u32, u64> {
+        let mut map = HashMap::new();
+        map.insert(key, value);
+        map
     }
 }
 

--- a/fixtures/coverall/tests/bindings/test_coverall.py
+++ b/fixtures/coverall/tests/bindings/test_coverall.py
@@ -193,5 +193,17 @@ class TestCoverall(unittest.TestCase):
         self.assertEqual("that", d.category)
         self.assertEqual(42, d.integer)
 
+    def test_dict_with_non_string_keys(self):
+        coveralls = Coveralls("test_dict")
+
+        dict1 = coveralls.get_dict(key="answer", value=42)
+        assert dict1["answer"] == 42
+
+        dict2 = coveralls.get_dict2(key="answer", value=42)
+        assert dict2["answer"] == 42
+
+        dict3 = coveralls.get_dict3(key=31, value=42)
+        assert dict3[31] == 42
+
 if __name__=='__main__':
     unittest.main()

--- a/fixtures/coverall/tests/bindings/test_coverall.swift
+++ b/fixtures/coverall/tests/bindings/test_coverall.swift
@@ -153,6 +153,7 @@ do {
     // be dropped as coveralls hold an `Arc<>` to it.
     assert(getNumAlive() == 2)
 }
+
 // Dropping `coveralls` will kill both.
 assert(getNumAlive() == 0)
 
@@ -168,4 +169,17 @@ do {
     assert(d2.name == "this")
     assert(d2.category == "that")
     assert(d2.integer == 42)
+}
+
+do {
+    let coveralls = Coveralls(name: "test_dicts")
+
+    let dict1 = coveralls.getDict(key: "answer", value: 42)
+    assert(dict1["answer"] == 42)
+
+    let dict2 = coveralls.getDict2(key: "answer", value: 42)
+    assert(dict2["answer"] == 42)
+
+    let dict3 = coveralls.getDict3(key: 31, value: 42)
+    assert(dict3[31] == 42)
 }

--- a/fixtures/uitests/src/records.udl
+++ b/fixtures/uitests/src/records.udl
@@ -1,0 +1,4 @@
+namespace uitests {
+    // f32 is not allowed as a key
+    record<f32, u64> get_dict();
+};

--- a/fixtures/uitests/tests/ui/non_hashable_record_key.rs
+++ b/fixtures/uitests/tests/ui/non_hashable_record_key.rs
@@ -1,0 +1,4 @@
+// Unfortunately, path is relative to a temporary build directory :-/
+uniffi_macros::generate_and_include_scaffolding!("../../../fixtures/uitests/src/records.udl");
+
+fn main() { /* empty main required by `trybuild` */}

--- a/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
+++ b/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
@@ -1,0 +1,7 @@
+error: Failed to generate scaffolding from UDL file at ../../../fixtures/uitests/src/records.udl
+ --> tests/ui/non_hashable_record_key.rs:2:1
+  |
+2 | uniffi_macros::generate_and_include_scaffolding!("../../../fixtures/uitests/src/records.udl");
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `uniffi_macros::generate_and_include_scaffolding` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 cargo_metadata = "0.13"
-weedle = "0.12"
+weedle2 = "2.0.0"
 anyhow = "1"
 askama = { version = "0.11", default-features = false, features = ["config"] }
 heck = "0.3"

--- a/uniffi_bindgen/src/backend/types.rs
+++ b/uniffi_bindgen/src/backend/types.rs
@@ -232,4 +232,8 @@ impl<T: CodeTypeDispatch> CodeType for T {
     fn initialization_fn(&self, oracle: &dyn CodeOracle) -> Option<String> {
         self.code_type_impl(oracle).initialization_fn(oracle)
     }
+
+    fn coerce(&self, oracle: &dyn CodeOracle, nm: &str) -> String {
+        self.code_type_impl(oracle).coerce(oracle, nm)
+    }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/compounds.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/compounds.rs
@@ -42,7 +42,7 @@ macro_rules! impl_code_type_for_compound {
                 }
 
                 fn literal(&self, oracle: &dyn CodeOracle, literal: &Literal) -> String {
-                    render_literal(oracle, &literal, self.inner())
+                    render_literal(oracle, literal, self.inner())
                 }
             }
         }
@@ -51,4 +51,44 @@ macro_rules! impl_code_type_for_compound {
 
 impl_code_type_for_compound!(OptionalCodeType, "{}?", "Optional{}");
 impl_code_type_for_compound!(SequenceCodeType, "List<{}>", "Sequence{}");
-impl_code_type_for_compound!(MapCodeType, "Map<String, {}>", "Map{}");
+
+pub struct MapCodeType {
+    key: TypeIdentifier,
+    value: TypeIdentifier,
+}
+
+impl MapCodeType {
+    pub fn new(key: TypeIdentifier, value: TypeIdentifier) -> Self {
+        Self { key, value }
+    }
+
+    fn key(&self) -> &TypeIdentifier {
+        &self.key
+    }
+
+    fn value(&self) -> &TypeIdentifier {
+        &self.value
+    }
+}
+
+impl CodeType for MapCodeType {
+    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
+        format!(
+            "Map<{}, {}>",
+            self.key().type_label(oracle),
+            self.value().type_label(oracle),
+        )
+    }
+
+    fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
+        format!(
+            "Map{}{}",
+            self.key().type_label(oracle),
+            self.value().type_label(oracle),
+        )
+    }
+
+    fn literal(&self, oracle: &dyn CodeOracle, literal: &Literal) -> String {
+        render_literal(oracle, literal, &self.value)
+    }
+}

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -222,7 +222,7 @@ impl KotlinCodeOracle {
             }
             Type::Optional(inner) => Box::new(compounds::OptionalCodeType::new(*inner)),
             Type::Sequence(inner) => Box::new(compounds::SequenceCodeType::new(*inner)),
-            Type::Map(inner) => Box::new(compounds::MapCodeType::new(*inner)),
+            Type::Map(key, value) => Box::new(compounds::MapCodeType::new(*key, *value)),
             Type::External { name, .. } => Box::new(external::ExternalCodeType::new(name)),
             Type::Custom { name, .. } => Box::new(custom::CustomCodeType::new(name)),
         }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/MapTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/MapTemplate.kt
@@ -1,35 +1,35 @@
-{%- let inner_type_name = inner_type|type_name %}
-
-public object {{ ffi_converter_name }}: FfiConverterRustBuffer<Map<String, {{ inner_type_name }}>> {
-    override fun read(buf: ByteBuffer): Map<String, {{ inner_type_name }}> {
+{%- let key_type_name = key_type|type_name %}
+{%- let value_type_name = value_type|type_name %}
+public object {{ ffi_converter_name }}: FfiConverterRustBuffer<Map<{{ key_type_name }}, {{ value_type_name }}>> {
+    override fun read(buf: ByteBuffer): Map<{{ key_type_name }}, {{ value_type_name }}> {
         // TODO: Once Kotlin's `buildMap` API is stabilized we should use it here.
-        val items : MutableMap<String, {{ inner_type_name }}> = mutableMapOf()
+        val items : MutableMap<{{ key_type_name }}, {{ value_type_name }}> = mutableMapOf()
         val len = buf.getInt()
         repeat(len) {
-            val k = {{ TypeIdentifier::String.borrow()|read_fn }}(buf)
-            val v = {{ inner_type|read_fn }}(buf)
+            val k = {{ key_type|read_fn }}(buf)
+            val v = {{ value_type|read_fn }}(buf)
             items[k] = v
         }
         return items
     }
 
-    override fun allocationSize(value: Map<String, {{ inner_type_name }}>): Int {
+    override fun allocationSize(value: Map<{{ key_type_name }}, {{ value_type_name }}>): Int {
         val spaceForMapSize = 4
         val spaceForChildren = value.map { (k, v) ->
-            {{ TypeIdentifier::String.borrow()|allocation_size_fn }}(k) +
-            {{ inner_type|allocation_size_fn }}(v)
+            {{ key_type|allocation_size_fn }}(k) +
+            {{ value_type|allocation_size_fn }}(v)
         }.sum()
         return spaceForMapSize + spaceForChildren
     }
 
-    override fun write(value: Map<String, {{ inner_type_name }}>, buf: ByteBuffer) {
+    override fun write(value: Map<{{ key_type_name }}, {{ value_type_name }}>, buf: ByteBuffer) {
         buf.putInt(value.size)
         // The parens on `(k, v)` here ensure we're calling the right method,
         // which is important for compatibility with older android devices.
         // Ref https://blog.danlew.net/2017/03/16/kotlin-puzzler-whose-line-is-it-anyways/
         value.forEach { (k, v) ->
-            {{ TypeIdentifier::String.borrow()|write_fn }}(k, buf)
-            {{ inner_type|write_fn }}(v, buf)
+            {{ key_type|write_fn }}(k, buf)
+            {{ value_type|write_fn }}(v, buf)
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
@@ -71,7 +71,7 @@
 {%- when Type::Sequence(inner_type) %}
 {% include "SequenceTemplate.kt" %}
 
-{%- when Type::Map(inner_type) %}
+{%- when Type::Map(key_type, value_type) %}
 {% include "MapTemplate.kt" %}
 
 {%- when Type::CallbackInterface(name) %}

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -219,7 +219,7 @@ impl PythonCodeOracle {
                 let inner = *inner.to_owned();
                 Box::new(compounds::SequenceCodeType::new(inner, outer))
             }
-            Type::Map(ref inner) => {
+            Type::Map(ref _key, ref inner) => {
                 let outer = type_.clone();
                 let inner = *inner.to_owned();
                 Box::new(compounds::MapCodeType::new(inner, outer))

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -219,10 +219,11 @@ impl PythonCodeOracle {
                 let inner = *inner.to_owned();
                 Box::new(compounds::SequenceCodeType::new(inner, outer))
             }
-            Type::Map(ref _key, ref inner) => {
+            Type::Map(ref key, ref value) => {
                 let outer = type_.clone();
-                let inner = *inner.to_owned();
-                Box::new(compounds::MapCodeType::new(inner, outer))
+                let key = *key.to_owned();
+                let value = *value.to_owned();
+                Box::new(compounds::MapCodeType::new(key, value, outer))
             }
             Type::External { name, crate_name } => {
                 Box::new(external::ExternalCodeType::new(name, crate_name))

--- a/uniffi_bindgen/src/bindings/python/templates/MapTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/MapTemplate.py
@@ -1,7 +1,8 @@
-{%- let inner_type = self.inner() %}
 {%- let outer_type = self.outer() %}
-{%- let key_ffi_converter = Type::String.borrow()|ffi_converter_name %}
-{%- let value_ffi_converter = inner_type|ffi_converter_name %}
+{%- let key_type = self.key() %}
+{%- let value_type = self.value() %}
+{%- let key_ffi_converter = key_type|ffi_converter_name %}
+{%- let value_ffi_converter = value_type|ffi_converter_name %}
 
 class {{ outer_type|ffi_converter_name }}(FfiConverterRustBuffer):
     @classmethod

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -177,7 +177,7 @@ mod filters {
                     format!("{}.map {{ |v| {} }}", nm, coerce_code)
                 }
             }
-            Type::Map(t) => {
+            Type::Map(_k, t) => {
                 let k_coerce_code = coerce_rb("k", &Type::String)?;
                 let v_coerce_code = coerce_rb("v", t)?;
 
@@ -218,7 +218,7 @@ mod filters {
             | Type::Record(_)
             | Type::Optional(_)
             | Type::Sequence(_)
-            | Type::Map(_) => format!(
+            | Type::Map(_, _) => format!(
                 "RustBuffer.alloc_from_{}({})",
                 class_name_rb(&type_.canonical_name())?,
                 nm
@@ -250,7 +250,7 @@ mod filters {
             | Type::Record(_)
             | Type::Optional(_)
             | Type::Sequence(_)
-            | Type::Map(_) => format!(
+            | Type::Map(_, _) => format!(
                 "{}.consumeInto{}",
                 nm,
                 class_name_rb(&type_.canonical_name())?

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -165,7 +165,7 @@ class RustBufferBuilder
     end
   end
 
-  {% when Type::Map with (inner_type) -%}
+  {% when Type::Map with (k, inner_type) -%}
   # The Map<T> type for {{ inner_type.canonical_name() }}.
 
   def write_{{ canonical_type_name }}(items)

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
@@ -226,7 +226,7 @@ class RustBufferStream
     items
   end
 
-  {% when Type::Map with (inner_type) -%}
+  {% when Type::Map with (k, inner_type) -%}
   # The Map<T> type for {{ inner_type.canonical_name() }}.
 
   def read{{ canonical_type_name }}

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
@@ -146,7 +146,7 @@ class RustBuffer < FFI::Struct
     end
   end
 
-  {% when Type::Map with (inner_type) -%}
+  {% when Type::Map with (k, inner_type) -%}
   # The Map<T> type for {{ inner_type.canonical_name() }}.
 
   def self.alloc_from_{{ canonical_type_name }}(v)

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -349,7 +349,7 @@ impl SwiftCodeOracle {
                 let inner = *inner.to_owned();
                 Box::new(compounds::SequenceCodeType::new(inner, outer))
             }
-            Type::Map(ref inner) => {
+            Type::Map(ref _key, ref inner) => {
                 let outer = type_.clone();
                 let inner = *inner.to_owned();
                 Box::new(compounds::MapCodeType::new(inner, outer))

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -349,10 +349,11 @@ impl SwiftCodeOracle {
                 let inner = *inner.to_owned();
                 Box::new(compounds::SequenceCodeType::new(inner, outer))
             }
-            Type::Map(ref _key, ref inner) => {
+            Type::Map(ref key, ref value) => {
                 let outer = type_.clone();
-                let inner = *inner.to_owned();
-                Box::new(compounds::MapCodeType::new(inner, outer))
+                let key = *key.to_owned();
+                let value = *value.to_owned();
+                Box::new(compounds::MapCodeType::new(key, value, outer))
             }
             Type::External { .. } => panic!("no support for external types yet"),
             Type::Custom { name, .. } => Box::new(custom::CustomCodeType::new(name)),

--- a/uniffi_bindgen/src/bindings/swift/templates/MapTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/MapTemplate.swift
@@ -1,8 +1,8 @@
 {%- import "macros.swift" as swift -%}
 {%- let outer_type = self.outer() %}
 {%- let dict_type = outer_type|type_name %}
-{%- let key_type = Type::String %}
-{%- let value_type = self.inner() %}
+{%- let key_type = self.key() %}
+{%- let value_type = self.value() %}
 
 fileprivate struct {{ outer_type|ffi_converter_name }}: FfiConverterRustBuffer {
     fileprivate static func write(_ value: {{ dict_type }}, into buf: Writer) {

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -967,7 +967,10 @@ mod test {
         // check that `contains_map_types` returns true when there is a Map type in the interface
         assert!(ci
             .types
-            .add_type_definition("Map{}", Type::Map(Box::new(Type::Boolean)))
+            .add_type_definition(
+                "Map{}",
+                Type::Map(Box::new(Type::String), Box::new(Type::Boolean))
+            )
             .is_ok());
         assert!(ci.contains_map_types());
     }

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -283,7 +283,7 @@ impl<'ci> ComponentInterface {
     pub fn contains_map_types(&self) -> bool {
         self.types
             .iter_known_types()
-            .any(|t| matches!(t, Type::Map(_)))
+            .any(|t| matches!(t, Type::Map(_, _)))
     }
 
     /// Calculate a numeric checksum for this ComponentInterface.

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -24,6 +24,7 @@
 use std::{collections::hash_map::Entry, collections::BTreeSet, collections::HashMap};
 
 use anyhow::{bail, Result};
+use heck::CamelCase;
 
 use super::ffi::FFIType;
 
@@ -110,7 +111,11 @@ impl Type {
             // acccidentally generating name collisions.
             Type::Optional(t) => format!("Optional{}", t.canonical_name()),
             Type::Sequence(t) => format!("Sequence{}", t.canonical_name()),
-            Type::Map(_k, t) => format!("Map{}", t.canonical_name()),
+            Type::Map(k, v) => format!(
+                "Map{}{}",
+                k.canonical_name().to_camel_case(),
+                v.canonical_name().to_camel_case()
+            ),
             // A type that exists externally.
             Type::External { name, .. } | Type::Custom { name, .. } => format!("Type{}", name),
         }

--- a/uniffi_bindgen/src/interface/types/resolver.rs
+++ b/uniffi_bindgen/src/interface/types/resolver.rs
@@ -261,11 +261,11 @@ mod test {
         assert_eq!(types.iter_known_types().count(), 0);
         let (_, expr) = weedle::types::Type::parse("record<DOMString, float>").unwrap();
         let t = types.resolve_type_expression(expr).unwrap();
-        assert_eq!(t.canonical_name(), "Mapf32");
+        assert_eq!(t.canonical_name(), "MapStringF32");
         assert_eq!(types.iter_known_types().count(), 3);
         assert!(types
             .iter_known_types()
-            .any(|t| t.canonical_name() == "Mapf32"));
+            .any(|t| t.canonical_name() == "MapStringF32"));
         assert!(types
             .iter_known_types()
             .any(|t| t.canonical_name() == "string"));
@@ -280,11 +280,11 @@ mod test {
         assert_eq!(types.iter_known_types().count(), 0);
         let (_, expr) = weedle::types::Type::parse("record<u64, float>").unwrap();
         let t = types.resolve_type_expression(expr).unwrap();
-        assert_eq!(t.canonical_name(), "Mapf32");
+        assert_eq!(t.canonical_name(), "MapU64F32");
         assert_eq!(types.iter_known_types().count(), 3);
         assert!(types
             .iter_known_types()
-            .any(|t| t.canonical_name() == "Mapf32"));
+            .any(|t| t.canonical_name() == "MapU64F32"));
         assert!(types
             .iter_known_types()
             .any(|t| t.canonical_name() == "u64"));

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -47,7 +47,11 @@ mod filters {
             Type::CallbackInterface(name) => format!("Box<dyn {}>", name),
             Type::Optional(t) => format!("std::option::Option<{}>", type_rs(t)?),
             Type::Sequence(t) => format!("std::vec::Vec<{}>", type_rs(t)?),
-            Type::Map(t) => format!("std::collections::HashMap<String, {}>", type_rs(t)?),
+            Type::Map(k, v) => format!(
+                "std::collections::HashMap<{}, {}>",
+                type_rs(k)?,
+                type_rs(v)?
+            ),
             Type::Custom { name, .. } => name.clone(),
             Type::External { .. } => panic!("External types coming to a uniffi near you soon!"),
         })
@@ -98,9 +102,10 @@ mod filters {
             // inner type.
             Type::Optional(inner) => format!("std::option::Option<{}>", ffi_converter_name(inner)?),
             Type::Sequence(inner) => format!("std::vec::Vec<{}>", ffi_converter_name(inner)?),
-            Type::Map(inner) => format!(
-                "std::collections::HashMap<String, {}>",
-                ffi_converter_name(inner)?
+            Type::Map(k, v) => format!(
+                "std::collections::HashMap<{}, {}>",
+                ffi_converter_name(k)?,
+                ffi_converter_name(v)?
             ),
             // External and Wrapped bytes have FfiConverters with a predictable name based on the type name.
             Type::Custom { name, .. } | Type::External { name, .. } => {


### PR DESCRIPTION
Right now UniFFI only supports `record<DOMString, T>`, that is maps with a string key.
These are expressed as `HashMap<String, T>` on the Rust side and `[String: T]` on the Swift side.
All languages we target can easily support non-string keys.
Only weedle (the UDL parser) has it hardcoded to `DOMString` (and 2 other string types). 
We could losen this restriction and allow arbitrary key types (as long as they can be hashed).
This requires a single extra commit in Weedle: https://github.com/badboy/weedle/commit/90031e37d491104b9cd9572e7c3d6d214da39fa0

~~The commits here are not perfect yet, so treat them as a prototype (they certainly lack tests for the other languages).~~
~~Right now it's also not doing any checks on the key type, so you could specify even floats or nested records as keys, which will only blow up once you try to implement it in Rust.~~
~~We would also need to use a weedle fork (for now, I can certainly send a PR upstream and see what they think about it).~~

What do you all think? Is this worth pursuing?
Glean certainly has a use case for it: Some of our test APIs return `[Int: Int]` maps.
I can work around that for now using `[String: Int]` and some wrapping to not break consumers (and as it's test-only APIs I'm not too afraid of really breaking it)

---

Update 2022-02-09 :

* I forked weedle into [weedle2](https://crates.io/crates/weedle2) with the only change being the commit to allow arbitrary types in record keys.
* The interface code now verifies it only sees integers, booleans or strings as the key type in records. All others are not allowed and lead to an error. This is ensured by a compile test as well.
* I added the implementation for Python as well

Given weedle is unchanged for a year now, I don't think there's much maintenance overhead on it with that one fix on top. It certainly is less than swapping out the full parser or switching away from it now.