### PR TITLE
[Swift] Omit argument labels in functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### What's Changed
 
 - Python: Added Callback Interface support
+- Swift bindings can now omit argument labels in generated functions using `omit_argument_labels = true` in the configuration.
 
 ## v0.15.2 - (_2021-11-25_)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,5 @@ members = [
   "fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency",
   "fixtures/uitests",
   "fixtures/uniffi-fixture-time",
+  "fixtures/swift-omit-labels",
 ]

--- a/docs/manual/src/SUMMARY.md
+++ b/docs/manual/src/SUMMARY.md
@@ -26,6 +26,7 @@
 # Swift
 
 - [Overview](./swift/overview.md)
+- [Configuration](./swift/configuration.md)
 - [Building a Swift module](./swift/module.md)
 - [Integrating with XCode](./swift/xcode.md)
 

--- a/docs/manual/src/swift/configuration.md
+++ b/docs/manual/src/swift/configuration.md
@@ -1,0 +1,24 @@
+# Configuration
+
+The generated Swift module can be configured using a `uniffi.toml` configuration file.
+
+## Available options
+
+| Configuration name | Default  | Description |
+| ------------------ | -------  |------------ |
+| `cdylib_name`      | `uniffi_{namespace}`[^1] | The name of the compiled Rust library containing the FFI implementation. |
+| `module_name`      | `{namespace}`[^1] | The name of the Swift module containing the high-level foreign-language bindings. |
+| `ffi_module_name`  | `{module_name}FFI` | The name of the lower-level C module containing the FFI declarations. |
+| `ffi_module_filename` | `{ffi_module_name}` | The filename stem for the lower-level C module containing the FFI declarations. |
+| `generate_module_map` | `true` | Whether to generate a `.modulemap` file for the lower-level C module with FFI declarations. |
+| `omit_argument_labels` | `false` | Whether to omit argument labels in Swift function definitions. |
+
+[^1]: `namespace` is the top-level namespace from your UDL file.
+
+## Example
+
+```toml
+[bindings.swift]
+cdylib_name = "mycrate_ffi"
+omit_argument_labels = true
+```

--- a/docs/manual/src/swift/overview.md
+++ b/docs/manual/src/swift/overview.md
@@ -41,4 +41,4 @@ in order to reduce the compiled code size, while distributing their Swift wrappe
 individual modules.
 
 For more technical details on how the bindings work internally, please see the
-[module documentation](./api/uniffi_bindgen/bindings/swift/index.html)
+[module documentation](../internals/api/uniffi_bindgen/bindings/swift/index.html)

--- a/fixtures/swift-omit-labels/Cargo.toml
+++ b/fixtures/swift-omit-labels/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "omit_argument_labels"
+version = "0.15.2"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+edition = "2018"
+publish = false
+
+[lib]
+crate-type = ["staticlib", "cdylib"]
+name = "uniffi_omit_argument_labels"
+
+[dependencies]
+uniffi_macros = {path = "../../uniffi_macros"}
+uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
+
+[build-dependencies]
+uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/swift-omit-labels/README.md
+++ b/fixtures/swift-omit-labels/README.md
@@ -1,0 +1,4 @@
+# A Swift-only test for uniffi components
+
+This tests that we can instruct UniFFI to define functions
+so that the caller can omit argument labels.

--- a/fixtures/swift-omit-labels/build.rs
+++ b/fixtures/swift-omit-labels/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/omit_argument_labels.udl").unwrap();
+}

--- a/fixtures/swift-omit-labels/src/lib.rs
+++ b/fixtures/swift-omit-labels/src/lib.rs
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn no_args() -> i32 {
+    31
+}
+
+fn one_arg(amount: i32) -> i32 {
+    amount
+}
+
+fn multiple_args(amount: i32, _msg: String) -> i32 {
+    amount
+}
+
+include!(concat!(env!("OUT_DIR"), "/omit_argument_labels.uniffi.rs"));

--- a/fixtures/swift-omit-labels/src/omit_argument_labels.udl
+++ b/fixtures/swift-omit-labels/src/omit_argument_labels.udl
@@ -1,0 +1,5 @@
+namespace omit_argument_labels {
+    i32 no_args();
+    i32 one_arg(i32 amount);
+    i32 multiple_args(i32 amount, string msg);
+};

--- a/fixtures/swift-omit-labels/tests/bindings/test_omit_argument_labels.swift
+++ b/fixtures/swift-omit-labels/tests/bindings/test_omit_argument_labels.swift
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import omit_argument_labels
+
+assert(31 == noArgs())
+assert(3 == oneArg(3))
+assert(7 == multipleArgs(7, "look, I can omit the labels"))

--- a/fixtures/swift-omit-labels/tests/test_generated_bindings.rs
+++ b/fixtures/swift-omit-labels/tests/test_generated_bindings.rs
@@ -1,0 +1,4 @@
+uniffi_macros::build_foreign_language_testcases!(
+    ["src/omit_argument_labels.udl",],
+    ["tests/bindings/test_omit_argument_labels.swift",]
+);

--- a/fixtures/swift-omit-labels/uniffi.toml
+++ b/fixtures/swift-omit-labels/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.swift]
+omit_argument_labels = true

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/callback_interface.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/callback_interface.rs
@@ -9,6 +9,8 @@ use crate::interface::{CallbackInterface, ComponentInterface};
 use askama::Template;
 
 use super::filters;
+use super::Config;
+
 pub struct CallbackInterfaceCodeType {
     id: String,
 }
@@ -79,11 +81,12 @@ impl CodeType for CallbackInterfaceCodeType {
 )]
 pub struct SwiftCallbackInterface {
     inner: CallbackInterface,
+    config: Config,
 }
 
 impl SwiftCallbackInterface {
-    pub fn new(inner: CallbackInterface, _ci: &ComponentInterface) -> Self {
-        Self { inner }
+    pub fn new(inner: CallbackInterface, _ci: &ComponentInterface, config: Config) -> Self {
+        Self { inner, config }
     }
     pub fn inner(&self) -> &CallbackInterface {
         &self.inner

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/function.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/function.rs
@@ -7,6 +7,7 @@ use crate::interface::{ComponentInterface, Function};
 use askama::Template;
 
 use super::filters;
+use super::Config;
 
 #[derive(Template)]
 #[template(
@@ -16,12 +17,14 @@ use super::filters;
 )]
 pub struct SwiftFunction {
     inner: Function,
+    config: Config,
 }
 
 impl SwiftFunction {
-    pub fn new(inner: Function, _ci: &ComponentInterface) -> Self {
-        Self { inner }
+    pub fn new(inner: Function, _ci: &ComponentInterface, config: Config) -> Self {
+        Self { inner, config }
     }
+
     pub fn inner(&self) -> &Function {
         &self.inner
     }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/object.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/object.rs
@@ -9,6 +9,8 @@ use crate::interface::{ComponentInterface, Object};
 use askama::Template;
 
 use super::filters;
+use super::Config;
+
 pub struct ObjectCodeType {
     id: String,
 }
@@ -64,13 +66,15 @@ impl CodeType for ObjectCodeType {
 #[derive(Template)]
 #[template(syntax = "swift", escape = "none", path = "ObjectTemplate.swift")]
 pub struct SwiftObject {
+    config: Config,
     inner: Object,
 }
 
 impl SwiftObject {
-    pub fn new(inner: Object, _ci: &ComponentInterface) -> Self {
-        Self { inner }
+    pub fn new(inner: Object, _ci: &ComponentInterface, config: Config) -> Self {
+        Self { inner, config }
     }
+
     pub fn inner(&self) -> &Object {
         &self.inner
     }

--- a/uniffi_bindgen/src/bindings/swift/templates/macros.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/macros.swift
@@ -44,7 +44,7 @@
 
 {% macro arg_list_decl(func) %}
     {%- for arg in func.arguments() -%}
-        {{ arg.name()|var_name }}: {{ arg|type_name -}}
+        {% if config.omit_argument_labels() %}_ {% endif %}{{ arg.name()|var_name }}: {{ arg|type_name -}}
         {%- match arg.default_value() %}
         {%- when Some with(literal) %} = {{ literal|literal_swift(arg) }}
         {%- else %}
@@ -71,7 +71,7 @@
 
 {% macro arg_list_protocol(func) %}
     {%- for arg in func.arguments() -%}
-        {{ arg.name()|var_name }}: {{ arg|type_name -}}
+        {% if config.omit_argument_labels() %}_ {% endif %}{{ arg.name()|var_name }}: {{ arg|type_name -}}
         {%- if !loop.last %}, {% endif -%}
     {%- endfor %}
 {%- endmacro %}


### PR DESCRIPTION
PR is a strawman. See the details first:

For the default function definition, e.g. `myfun(parameterName: Int)`, Swift requires passing in named parameters: `myfun(parameterName: 3)`.
This can be changed by either adding another label `myfun(newLabel parameterName: Int)` and be called like `myfun(newLabel: 3)`.
Or you can omit the label with `myfun(_ parameterName: Int)` and call it like `myfun(3)`.

Currently UniFFI always generates the first form.
Sometimes that makes the functions read better when called.
But for Glean's API it makes it slightly awkward because now these labels become required:

```swift
GleanMetrics.cat.myCounter.add(amount: 1)
```

It also means that the names we define in the UDL are part of the public API and so changing them will break users.

For Glean I now have 4 options:

1. Live with it and break users and force everyone to pass in values with labels
2. Write wrapper code around every metric type that allows to omit the label
3. Convince UniFFI folks that we don't need labels (basically what this PR starts)
4. Come up with a way to let me specify whether I want a label or not (same `_` syntax in UDL?)

What do the others think?