### PR TITLE
Move generated arg lowering/error code into a helper function

### DIFF
--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -625,6 +625,20 @@ unsafe impl<T: Sync + Send> FfiConverter for std::sync::Arc<T> {
     }
 }
 
+pub fn lower_anyhow_error_or_panic<ErrConverter>(
+    err: anyhow::Error,
+    arg_name: &str,
+) -> ErrConverter::FfiType
+where
+    ErrConverter: FfiConverter,
+    ErrConverter::RustType: 'static + Sync + Send + std::fmt::Debug + std::fmt::Display,
+{
+    match err.downcast::<ErrConverter::RustType>() {
+        Ok(actual_error) => ErrConverter::lower(actual_error),
+        Err(ohno) => panic!("Failed to convert arg '{}': {}", arg_name, ohno),
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/uniffi_bindgen/src/scaffolding/templates/macros.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/macros.rs
@@ -19,17 +19,12 @@
             conversions to this error. If the downcast fails or the function doesn't
             return an error, we just panic.
         #}
-        {%- match func.throws() -%}
-        {% when Some with (e) %}
-            Err(err) => {
-                match err.downcast::<{{ e }}>() {
-                    Ok(actual_error) => return Err({{ func.throws_type().unwrap()|ffi_converter }}::lower(actual_error)),
-                    Err(ohno) => panic!("Failed to convert arg '{}': {}", "{{ arg.name() }}", ohno),
-                }
-            }
-        {% else %}
+        {%- match func.throws_type() -%}
+        {%- when Some with (e) %}
+            Err(err) => return Err(uniffi::lower_anyhow_error_or_panic::<{{ e|ffi_converter_name }}>(err, "{{ arg.name() }}")),
+        {%- else %}
             Err(err) => panic!("Failed to convert arg '{}': {}", "{{ arg.name() }}", err),
-        {% endmatch %}
+        {%- endmatch %}
         }
         {%- if !loop.last %}, {% endif %}
     {%- endfor %}


### PR DESCRIPTION
As @bendk suggested in #1126, we can move lots of the generated boilerplate into the uniffi crate. This almost works - it's types all the way down and my brain is melting :)

I think the failure to handle `Arc` is tractable, but I guess my biggest concern are the `uitest` changes - it makes user-facing error messages intractable. I'll keep playing, but thoughts welcome about whether this is actually an improvement or not? The generated+formatted code without this patch isn't *that* bad - one `match` per arg still leaves it readable, just verbose. I'm on the fence.