### PR TITLE
add `_` for local variables for kotlin template when necessary

### DIFF
--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -97,6 +97,9 @@ interface Coveralls {
 
     // can't name it `clone` as it conflicts with the Clone trait and ours has a different signature
     Coveralls clone_me();
+
+    // regression test: using a parameter name that was also used by UniFFI runtime code
+    string get_status(string status);
 };
 
 // All coveralls end up with a patch.

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -227,6 +227,10 @@ impl Coveralls {
             other: new_other,
         })
     }
+
+    fn get_status(&self, status: String) -> String {
+        format!("status: {}", status)
+    }
 }
 
 impl Drop for Coveralls {

--- a/fixtures/coverall/tests/bindings/test_coverall.kts
+++ b/fixtures/coverall/tests/bindings/test_coverall.kts
@@ -154,6 +154,10 @@ Coveralls("test_complex_errors").use { coveralls ->
     }
 }
 
+Coveralls("test_regressions").use { coveralls ->
+    assert(coveralls.getStatus("success") == "status: success")
+}
+
 // This tests that the UniFFI-generated scaffolding doesn't introduce any unexpected locking.
 // We have one thread busy-wait for a some period of time, while a second thread repeatedly
 // increments the counter and then checks if the object is still busy. The second thread should

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -10,8 +10,8 @@
     rustCallWithError({{ e|exception_name}})
     {%- else %}
     rustCall()
-    {%- endmatch %} { status ->
-    _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call _arg_list_ffi_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %}status)
+    {%- endmatch %} { _status ->
+    _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call _arg_list_ffi_call(func) -%}{% if func.arguments().len() > 0 %},{% endif %} _status)
 }
 {%- endmacro -%}
 
@@ -21,9 +21,9 @@
     rustCallWithError({{ e|exception_name}})
     {%- else %}
     rustCall()
-    {%- endmatch %} { status ->
+    {%- endmatch %} { _status ->
     _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}(
-        {{- prefix }}, {% call _arg_list_ffi_call(func) %}{% if func.arguments().len() > 0 %}, {% endif %}status)
+        {{- prefix }}, {% call _arg_list_ffi_call(func) %}{% if func.arguments().len() > 0 %}, {% endif %} _status)
 }
 {%- endmacro %}
 
@@ -64,7 +64,7 @@
     {%- for arg in func.arguments() %}
         {{- arg.name() }}: {{ arg.type_()|ffi_type_name -}},
     {%- endfor %}
-    uniffi_out_err: RustCallStatus
+    _uniffi_out_err: RustCallStatus
 {%- endmacro -%}
 
 // Macro for destroying fields


### PR DESCRIPTION
#1102 

...or we'd better pretend **ALL** local variables and paramaters with `_`?