### PR TITLE
Update FFI Ruby gem install command

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -58,7 +58,7 @@ test suite you will need:
   * A `python3` interpreter.
 * Ruby:
   * A `ruby` interpreter.
-  * The [`FFI`](https://github.com/ffi/ffi) Ruby gem, installable via `gem install FFI`.
+  * The [`FFI`](https://github.com/ffi/ffi) Ruby gem, installable via `gem install ffi`.
 
 We also support an environment variable `UNIFFI_TESTS_DISABLE_EXTENSIONS`;
 It is a set of file extensions, without a leading period and separated by commas.


### PR DESCRIPTION
`gem install FFI` doesn't work, the gem should install via `gem install ffi` according to [here](https://github.com/ffi/ffi).

```
➜  uniffi-rs gem install FFI
Ignoring iStats-1.6.1 because its extensions are not built. Try: gem pristine iStats --version 1.6.1
ERROR:  Could not find a valid gem 'FFI' (>= 0) in any repository
```