### PR TITLE
(cargo-release) version 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ## [[UnreleasedVersion]] - (_[[ReleaseDate]]_)
 
-[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.9.0...HEAD)
+[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.9.0...HEAD).
+
+## v0.16.0 - (_2021-12-15_)
+
+[All changes in v0.16.0](https://github.com/mozilla/uniffi-rs/compare/v0.9.0...v0.16.0)
 
 ### ⚠️ Breaking Changes ⚠️
 

--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-arithmetic"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/callbacks/Cargo.toml
+++ b/examples/callbacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-callbacks"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/geometry/Cargo.toml
+++ b/examples/geometry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-geometry"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/rondpoint/Cargo.toml
+++ b/examples/rondpoint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-rondpoint"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/sprites/Cargo.toml
+++ b/examples/sprites/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-sprites"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/todolist/Cargo.toml
+++ b/examples/todolist/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-todolist"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/wrapper-types/Cargo.toml
+++ b/examples/wrapper-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wrapper-types"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/callbacks/Cargo.toml
+++ b/fixtures/callbacks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "callbacks"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 publish = false

--- a/fixtures/coverall/Cargo.toml
+++ b/fixtures/coverall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coverall"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 publish = false

--- a/fixtures/ext-types/guid/Cargo.toml
+++ b/fixtures/ext-types/guid/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ext-types-guid"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/ext-types/lib/Cargo.toml
+++ b/fixtures/ext-types/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ext-types-lib"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/ext-types/uniffi-one/Cargo.toml
+++ b/fixtures/ext-types/uniffi-one/Cargo.toml
@@ -2,7 +2,7 @@
 # TODO: modify the crate name to test non-default names.
 name = "uniffi-one"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/external-types/crate-one/Cargo.toml
+++ b/fixtures/external-types/crate-one/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crate_one"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/external-types/crate-two/Cargo.toml
+++ b/fixtures/external-types/crate-two/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crate_two"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/external-types/lib/Cargo.toml
+++ b/fixtures/external-types/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "external_types_lib"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency/Cargo.toml
+++ b/fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cdylib-dependency"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["king6cong <king6cong@gmail.com>"]
 edition = "2018"
 publish = false

--- a/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
+++ b/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ffi-crate"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
+++ b/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "i356-enum-without-int-helpers"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/fully-qualified-types/Cargo.toml
+++ b/fixtures/regressions/fully-qualified-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "i1015-fully-qualified-types"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
+++ b/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kotlin-experimental-unsigned-types"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/swift-omit-labels/Cargo.toml
+++ b/fixtures/swift-omit-labels/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omit_argument_labels"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 publish = false

--- a/fixtures/uitests/Cargo.toml
+++ b/fixtures/uitests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_uitests"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 publish = false

--- a/fixtures/uniffi-fixture-time/Cargo.toml
+++ b/fixtures/uniffi-fixture-time/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-time"
 edition = "2018"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -4,7 +4,7 @@ description = "a multi-language bindings generator for rust (runtime support cod
 documentation = "https://mozilla.github.io/uniffi-rs"
 homepage = "https://mozilla.github.io/uniffi-rs"
 repository = "https://github.com/mozilla/uniffi-rs"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 edition = "2018"
@@ -19,7 +19,7 @@ log = "0.4"
 # Regular dependencies
 cargo_metadata = "0.13"
 paste = "1.0"
-uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "=0.15.2"}
+uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "=0.16.0"}
 static_assertions = "1.1.0"
 
 [features]

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_bindgen"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (codegen and cli tooling)"
 documentation = "https://mozilla.github.io/uniffi-rs"

--- a/uniffi_build/Cargo.toml
+++ b/uniffi_build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_build"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (build script helpers)"
 documentation = "https://mozilla.github.io/uniffi-rs"
@@ -12,7 +12,7 @@ keywords = ["ffi", "bindgen"]
 
 [dependencies]
 anyhow = "1"
-uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "=0.15.2"}
+uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "=0.16.0"}
 
 [features]
 default = []

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_macros"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (convenience macros)"
 documentation = "https://mozilla.github.io/uniffi-rs"
@@ -18,7 +18,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["extra-traits"] }
 glob = "0.3"
-uniffi_build = { path = "../uniffi_build", version = "=0.15.2"}
+uniffi_build = { path = "../uniffi_build", version = "=0.16.0"}
 
 [features]
 default = []


### PR DESCRIPTION
Releases version 0.16.0, versions already pushed to crate.io