### PR TITLE
[discuss] Decorator methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 [All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.9.0...HEAD).
 
+### What's New
+
+- [Decorator objects](docs/manual/src/udl/decorators.md) reduce boiler plate in Foreign Language bindings.
+
 ## v0.16.0 - (_2021-12-15_)
 
 [All changes in v0.16.0](https://github.com/mozilla/uniffi-rs/compare/v0.9.0...v0.16.0)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
 
   "fixtures/coverall",
   "fixtures/callbacks",
+  "fixtures/decorators",
 
   "fixtures/ext-types/guid",
   "fixtures/ext-types/uniffi-one",

--- a/docs/manual/src/udl/decorators.md
+++ b/docs/manual/src/udl/decorators.md
@@ -1,0 +1,242 @@
+# Decorator objects
+
+We'll be considering the UDL for an object called `DemoRustObject`:
+
+```webidl
+interface DemoRustObject {
+    void do_expensive_thing();
+    [Throws=RustyError]
+    void do_crashy_thing();
+    void do_consequential_thing();
+}
+```
+
+`DemoRustObject` is a `struct` written in Rust, and uniffi generates a class of that name in the foreign languages which forward method calls to the Rust implementation.
+
+## Problem
+
+Just by the names of these methods, we can see that the application might not want to deal with the `DemoRustObject` by itself, without some proper care taken while calling its methods:
+
+* it may want to run `do_expensive_thing()` off the main thread
+* it may want to catch and report errors from `do_crashy_thing()`.
+* it may want to inform the rest of the application each time `do_consequential_thing()` is called.
+
+A common pattern when using uniffied code is to run some common, but app-specific, code before or after calling the Rust code.
+
+```kotlin
+class DemoLib(
+    val backgroundScope: CoroutineContext,
+    val errorReporter: (e: Exception) -> Unit,
+    val listener: () -> Void
+) {
+    val demoRustObject = new DemoRustObject()
+
+    fun doExpensiveThing() {
+        backgroundScope.launch {
+            demoRustObject.doExpensiveThing()
+        }
+    }
+
+    fun doCrashyThing() {
+        try {
+            demoRustObject.doCrashyThing()
+        } catch (e: Exception) {
+            errorReporter(e)
+        }
+    }
+
+    fun doConsequentialThing() {
+        demoRustObject.doConsequentialThing()
+        listener()
+    }
+}
+```
+
+This causes a proliferation of boiler plate code. Worse, everytime we add a new method to the `DemoRustObject`, handwritten foreign language code needs to be written to expose it safely.
+
+The more methods that want to do similar things, the more repetitive this gets.
+
+We could isolate the repeated code into a decorator class with `onBackgroundThread`, `withErrorReporter` and `thenNotifyListeners` methods.
+
+```kotlin
+class MyDemoDecorator(
+    val backgroundScope: CoroutineContext,
+    val errorReporter: (e: Exception) -> Unit,
+    val listener: () -> Void
+) {
+    fun onBackgroundThread(rustCall: () -> Unit) {
+        backgroundScope.launch {
+            rustCall()
+        }
+    }
+
+    fun <T> withErrorReporter(rustCall: () -> T) =
+        try {
+            rustCall()
+        } catch (e: Exception) {
+            errorReporter(e)
+        }
+
+    fun thenNotifyListeners(rustCall: () -> T) {
+        try {
+            rustCall()
+        } finally {
+            listener()
+        }
+    }
+}
+```
+
+Then, we can re-write the `DemoLib` as:
+
+```kotlin
+class DemoLib(
+    val demoRustObject: DemoRustObject,
+    val decorator: MyDemoDecorator,
+) {
+    fun doExpensiveThing() = decorator.onBackgroundThread {
+        demoRustObject.doExpensiveThing()
+    }
+
+    fun doCrashyThing() = decorator.withErrorReporter {
+        demoRustObject.doCrashyThing()
+    }
+
+    fun doConsequentialThing() = decorator.thenNotifyListeners() {
+        demoRustObject.doConsequentialThing()
+    }
+}
+```
+
+This is much better, but it's still looking a bit cut and pasty. Enter decorator objects.
+
+## Decorators to the rescue
+
+> Decorator objects take their name from [Python's decorator methods][py-decorators].
+>
+> In Pythonic terms, Uniffi's decorator objects are a collection of decorator functions.
+>
+> Swift and Kotlin don't provide functionality to capture arbitrary `*args` and call a function with those same `*args`, so
+> at this time, decorator objects aren't as powerful as Python decorators. Nevertheless, they can be still quite useful.
+
+[py-decorators]: https://www.python.org/dev/peps/pep-0318/#on-the-name-decorator
+
+### UDL
+
+In the UDL we:
+
+* Specify that `DemoLib` should be a decorated version of `DemoRustObject` using the `[Decorated=`] annotation
+* Specify how methods should by decorated using the `[CallsWith=]` annotation
+* Don't specify the class that holds the decorator functions.  This is done on a per-app basis in `uniffi.toml`.
+
+```webidl
+namespace demo {}
+
+[Decorated=DemoLib]
+interface DemoRustObject {
+    [CallsWith=onBackgroundThread]
+    void do_expensive_thing();
+
+    [Throws=RustyError, CallsWith=withErrorReporter]
+    void do_crashy_thing();
+
+    [CallsWith=thenNotifyListeners]
+    void do_consequential_thing();
+}
+```
+
+### Write your decorator class
+
+```kotlin
+package my.uniffi.bindings.package
+
+class MyDemoDecorator(
+    val backgroundScope: CoroutineContext,
+    val errorReporter: (e: Exception) -> Unit,
+    val listener: () -> Void
+) {
+    fun <T> onBackgroundThread(rustCall: () -> T) {
+        backgroundScope.launch {
+            rustCall()
+        }
+    }
+
+    fun <T> withErrorReporter(rustCall: () -> T) =
+        try {
+            rustCall()
+        } catch (e: Exception) {
+            errorReporter(e)
+        }
+
+    fun thenNotifyListeners(rustCall: () -> T) {
+        try {
+            rustCall()
+        } finally {
+            listener()
+        }
+    }
+}
+```
+
+### Specify the decorator class in your uniffi.toml
+
+```toml
+
+[bindings.kotlin.decorators.DemoRustObject]
+class_name = MyDemoDecorator
+```
+
+### Use the decorator
+
+The above code will make UniFFI define a `DemoLib` class that uses
+`MyDemoDecorator` to decorate calls to `DemoRustObject`.  The `DemoLib`
+constructor will input a `DemoRustObject` and `MyDemoDecorator`.
+
+For example:
+
+```kotlin
+val demoLib = DemoLib(
+   DemoRustObject(),
+   MyDemoDecorator(backgroundScope, errorReporter, listener))
+
+// This will call MyDemoDecorator.stateChange { DemoRustObject.doConsequentialThing() }
+demoLib.doConsequentialThing()
+```
+
+This is a considerable improvement! Now the decorator methods can be specified by the app, and the UDL uses them. Each time the UDL changes, the foreign language bindings keeps up.
+
+### Re-writing the wrapper
+
+This would happen differently than the original proposal, but I'm not sure
+exactly what to suggest because I don't understand the issue so well.  If the
+point is to avoid changes to the code that constructs DemoLib/DemoRustObject,
+then what about one of these?
+
+  - Making DemoRustObject an open class and DemoLib a subclass whose constructor inputs the args you want
+  - A factory function that inputs the args you want and returns a DemoRustObject
+
+## Specification
+
+### UDL
+
+* Specify that an interface can be decorated by using the `[Decorated={class_name}]` attribute
+  * `{class_name}` specifies that UniFFI should define a class named `class_name` where methods of the interface are called through decorators
+* Specify how each method will be decorated in the decorator class using the `[CallsWith={decorator_name}]` attribute
+  * This specifies that this method should be called with function named `decorator_name`
+  * Methods that don't have the `CallsWith` attribute will be called directly
+
+### uniffi.toml
+
+* To enable a decorated class for a specific bindings language, add a table named `[bindings.{language}.decorators.{interface_name}]` with the following keys:
+  * `class_name`: name of the decorator implementation class
+  * `import` (optional): import line to add at the top of the file.  Use this to import your decorator class if needed.
+  * `return_types` (swift only): Table that maps decorator names to the return type for the decorator function.
+* If this table is not present, then UniFFI will not generate the decoratored class definition.
+
+### Decorator classes
+
+* Decorator classes must have a method corresponding to each `CallsWith` name.  This method will be used to decorate the interface's method.
+  * It inputs a zero-argument closure that invokes the original method call.
+  * It should arrange for that closure to be called somehow, not necessarily immediately.
+  * It can return any type it wants -- often decoraters will transform the original return type.
+  * For typed languages, it must be generic on the return value of the original method.

--- a/fixtures/decorators/Cargo.toml
+++ b/fixtures/decorators/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "decorators"
+version = "0.14.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+edition = "2018"
+publish = false
+
+[lib]
+crate-type = ["staticlib", "cdylib"]
+name = "uniffi_decorators"
+
+[dependencies]
+uniffi_macros = {path = "../../uniffi_macros"}
+uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
+thiserror = "1.0"
+lazy_static = "1.4"
+
+[build-dependencies]
+uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/decorators/README.md
+++ b/fixtures/decorators/README.md
@@ -1,0 +1,11 @@
+# A "Decorators" test for uniffi components
+
+This is similar to the `decorators` example, but it's intended to be contrived and to
+ensure we get good test coverage of all possible options.
+
+It's here so it doesn't even need to make a cursory effort to be a "good"
+example; it intentionally panics, asserts params are certain values, has
+no-op methods etc. If you're trying to get your head around uniffi then the
+"examples" directory will be a much better bet.
+
+This is its own crate, because the decorator mechanism is not implemented for all backends yet.

--- a/fixtures/decorators/build.rs
+++ b/fixtures/decorators/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/decorators.udl").unwrap();
+}

--- a/fixtures/decorators/src/decorators.kt
+++ b/fixtures/decorators/src/decorators.kt
@@ -1,0 +1,17 @@
+package my.decorator;
+
+/// MyDecorator is defined in the UDL file. It generates an interface.
+/// Implementations of the interface never cross the FFI boundary, and so
+/// can contain arbitrary Kotlin.
+///
+/// Note: MyDecorator must be in the same package as the generated bindings in order for UniFFI to see it.
+class MyDecorator {
+    var count = 0
+    var lastString: String? = null
+
+    fun <T> withReturn(thunk: () -> T): T = thunk()
+    fun <T> stringSaver(thunk: () -> T) {
+        lastString = thunk() as? String
+    }
+    fun <T> withCounter(thunk: () -> T): Int = thunk().let { ++count }
+}

--- a/fixtures/decorators/src/decorators.udl
+++ b/fixtures/decorators/src/decorators.udl
@@ -1,0 +1,18 @@
+namespace decorators {};
+
+[Decorated=DecoratedRustObject]
+interface RustObject {
+  constructor();
+
+  [Name=from_string]
+  constructor(string string);
+
+  [CallsWith=string_saver]
+  string identity_string(string s);
+
+  [CallsWith=with_counter]
+  string get_string();
+
+  [CallsWith=with_return]
+  i32 length();
+};

--- a/fixtures/decorators/src/lib.rs
+++ b/fixtures/decorators/src/lib.rs
@@ -1,0 +1,34 @@
+use std::convert::TryInto;
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#[derive(Debug, Clone)]
+pub struct RustObject {
+    string: String,
+}
+
+impl RustObject {
+    fn new() -> Self {
+        Self { string: "".into() }
+    }
+
+    fn from_string(string: String) -> Self {
+        Self { string }
+    }
+
+    fn identity_string(&self, s: String) -> String {
+        s
+    }
+
+    fn get_string(&self) -> String {
+        self.string.clone()
+    }
+
+    fn length(&self) -> i32 {
+        self.string.len().try_into().unwrap()
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/decorators.uniffi.rs"));

--- a/fixtures/decorators/tests/bindings/test_decorators.kts
+++ b/fixtures/decorators/tests/bindings/test_decorators.kts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import uniffi.decorators.*
+import my.decorator.MyDecorator
+
+// Create an instance of an interface
+val rustObj = RustObject()
+// Create a decorator for the interface
+val decorator = MyDecorator()
+// Create a decorated version of it
+val decorated = DecoratedRustObject(rustObj, decorator)
+// Decorate an object created with the secondary constructor
+val string1 = "placeholder string"
+val decorated2 = DecoratedRustObject(RustObject.fromString(string1), decorator)
+
+assert(decorated.length() == 0) { "generic return" }
+assert(decorated2.length() == string1.length) { "generic return" }
+
+assert(decorated.getString() == 1) { "different return type from method's own" }
+assert(decorated.getString() == 2) { "code is run each time the method is run" }
+assert(decorated2.getString() == 3) { "decorator is shared between objects" }
+
+val string2 = "meta-syntactic variable values"
+assert(decorated.identityString(string2) == Unit) { "void return" }
+assert(decorator.lastString == string2) { "Decorator is actually called" }

--- a/fixtures/decorators/tests/test_generated_bindings.rs
+++ b/fixtures/decorators/tests/test_generated_bindings.rs
@@ -1,0 +1,4 @@
+uniffi_macros::build_foreign_language_testcases!(
+    ["src/decorators.udl"],
+    ["tests/bindings/test_decorators.kts"]
+);

--- a/fixtures/decorators/uniffi.toml
+++ b/fixtures/decorators/uniffi.toml
@@ -1,0 +1,3 @@
+[bindings.kotlin.decorators.RustObject]
+import = "my.decorator.MyDecorator"
+class_name = "MyDecorator"

--- a/uniffi_bindgen/src/bindings/kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/mod.rs
@@ -51,7 +51,12 @@ fn full_bindings_path(config: &Config, out_dir: &Path) -> Result<PathBuf> {
 
 /// Generate kotlin bindings for the given namespace, then use the kotlin
 /// command-line tools to compile them into a .jar file.
-pub fn compile_bindings(config: &Config, ci: &ComponentInterface, out_dir: &Path) -> Result<()> {
+pub fn compile_bindings(
+    config: &Config,
+    ci: &ComponentInterface,
+    out_dir: &Path,
+    extra_files: &[PathBuf],
+) -> Result<()> {
     let mut kt_file = full_bindings_path(config, out_dir)?;
     kt_file.push(format!("{}.kt", ci.namespace()));
     let mut jar_file = PathBuf::from(out_dir);
@@ -63,6 +68,7 @@ pub fn compile_bindings(config: &Config, ci: &ComponentInterface, out_dir: &Path
         .arg("-classpath")
         .arg(env::var("CLASSPATH").unwrap_or_else(|_| "".to_string()))
         .arg(&kt_file)
+        .args(extra_files)
         .arg("-d")
         .arg(jar_file)
         .spawn()

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -89,3 +89,32 @@ class {{ obj|type_name }}(
         {% endfor %}
     }
 }
+
+{%- match decorator_info %}
+{%- when Some with (decorator_info) -%}
+class {{ decorator_info.decorated_class }}(
+    val obj: {{ obj|type_name }},
+    val decorator: {{ decorator_info.decorator_class}}
+) {
+    {% for meth in obj.methods() -%}
+    fun {{ meth.name()|fn_name }}({% call kt::arg_list_decl(meth) %}) =
+        {%- match meth.decorator_method_name() %}
+        {%- when Some with (decorator_method) -%}
+            decorator.{{ decorator_method|fn_name }} {
+                obj.{{ meth.name()|fn_name }}(
+                    {%- for arg in meth.arguments() %}
+                        {{- arg.name() }},
+                    {%- endfor %}
+                )
+            }
+        {%- else %}
+        obj.{{ meth.name()|fn_name }}(
+            {%- for arg in meth.arguments() %}
+                {{- arg.name() }},
+            {%- endfor %}
+        )
+        {%- endmatch %}
+    {% endfor %}
+}
+{%- else %}
+{%- endmatch %}

--- a/uniffi_bindgen/src/bindings/mod.rs
+++ b/uniffi_bindgen/src/bindings/mod.rs
@@ -10,7 +10,7 @@
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::interface::ComponentInterface;
 use crate::MergeWith;
@@ -131,13 +131,16 @@ pub fn compile_bindings<P>(
     ci: &ComponentInterface,
     out_dir: P,
     language: TargetLanguage,
+    extra_files: &[PathBuf],
 ) -> Result<()>
 where
     P: AsRef<Path>,
 {
     let out_dir = out_dir.as_ref();
     match language {
-        TargetLanguage::Kotlin => kotlin::compile_bindings(&config.kotlin, ci, out_dir)?,
+        TargetLanguage::Kotlin => {
+            kotlin::compile_bindings(&config.kotlin, ci, out_dir, extra_files)?
+        }
         TargetLanguage::Swift => swift::compile_bindings(&config.swift, ci, out_dir)?,
         TargetLanguage::Python => (),
         TargetLanguage::Ruby => (),

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -539,6 +539,22 @@ impl<'ci> ComponentInterface {
                 }
             }
         }
+
+        // For each object not using a decorator object: no method should use a decorator method.
+        for obj in self.objects.iter() {
+            if obj.decorated_class.is_none() {
+                for method in obj.methods.iter() {
+                    if let Some(dm) = &method.decorator_method_name() {
+                        bail!("Object method '{}.{}' calls with a decorator method '{}', but no decorated class specified",
+                            obj.name(),
+                            method.name(),
+                            dm,
+                        );
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 

--- a/uniffi_bindgen/src/interface/types/finder.rs
+++ b/uniffi_bindgen/src/interface/types/finder.rs
@@ -59,9 +59,10 @@ impl TypeFinder for weedle::InterfaceDefinition<'_> {
     fn add_type_definitions_to(&self, types: &mut TypeUniverse) -> Result<()> {
         let name = self.identifier.0.to_string();
         // Some enum types are defined using an `interface` with a special attribute.
-        if InterfaceAttributes::try_from(self.attributes.as_ref())?.contains_enum_attr() {
+        let attrs = InterfaceAttributes::try_from(self.attributes.as_ref())?;
+        if attrs.contains_enum_attr() {
             types.add_type_definition(self.identifier.0, Type::Enum(name))
-        } else if InterfaceAttributes::try_from(self.attributes.as_ref())?.contains_error_attr() {
+        } else if attrs.contains_error_attr() {
             types.add_type_definition(self.identifier.0, Type::Error(name))
         } else {
             types.add_type_definition(self.identifier.0, Type::Object(name))


### PR DESCRIPTION
This is a rebase of the branch I shared in #1051.  @mhammond and I have been talking about how decorators may be a big part in getting more components on desktop, so I thought it would be good to have something for him to look at.  I think @jhugman is working on a second try at these too, so let's not merge until that's out and we can compare and contrast.

TODO:
  - Remove the hack for adding extra scripts.  I have the code for this in another branch, just need to merge it in.
  - Add back the Kotlin interface so that that you can use code completion when defining the decorator.  I think this means the type names need to be specified in the Kotlin config, but that's not too bad.