### PR TITLE
Add top-level "C" functions for RustBuffer (#1153)

### DIFF
--- a/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
+++ b/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
@@ -1,19 +1,19 @@
 error[E0277]: `Cell<u32>` cannot be shared between threads safely
-   --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
-    |
-    | uniffi::deps::static_assertions::assert_impl_all!(Counter: Sync, Send);
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    | |
-    | `Cell<u32>` cannot be shared between threads safely
-    | required by this bound in `assert_impl_all`
-    |
-    = help: within `Counter`, the trait `Sync` is not implemented for `Cell<u32>`
+  --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
+   |
+   | uniffi::deps::static_assertions::assert_impl_all!(Counter: Sync, Send);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | `Cell<u32>` cannot be shared between threads safely
+   | required by this bound in `assert_impl_all`
+   |
+   = help: within `Counter`, the trait `Sync` is not implemented for `Cell<u32>`
 note: required because it appears within the type `Counter`
-   --> tests/ui/interface_not_sync_and_send.rs:9:12
-    |
-9   | pub struct Counter {
-    |            ^^^^^^^
-    = note: this error originates in the macro `uniffi::deps::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> tests/ui/interface_not_sync_and_send.rs:9:12
+   |
+9  | pub struct Counter {
+   |            ^^^^^^^
+   = note: this error originates in the macro `uniffi::deps::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
    --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs

--- a/uniffi_bindgen/src/scaffolding/templates/RustBuffer.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/RustBuffer.rs
@@ -1,71 +1,27 @@
 // Everybody gets basic buffer support, since it's needed for passing complex types over the FFI.
+//
+// See `uniffi/src/ffi/rustbuffer.rs` for documentation on these functions
 
-/// This helper allocates a new byte buffer owned by the Rust code, and returns it
-/// to the foreign-language code as a `RustBuffer` struct. Callers must eventually
-/// free the resulting buffer, either by explicitly calling the destructor defined below,
-/// or by passing ownership of the buffer back into Rust code.
-#[doc(hidden)]
+#[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub extern "C" fn {{ ci.ffi_rustbuffer_alloc().name() }}(size: i32, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
-    uniffi::call_with_output(call_status, || {
-        uniffi::RustBuffer::new_with_size(size.max(0) as usize)
-    })
+    uniffi::ffi::uniffi_rustbuffer_alloc(size, call_status)
 }
 
-/// This helper copies bytes owned by the foreign-language code into a new byte buffer owned
-/// by the Rust code, and returns it as a `RustBuffer` struct. Callers must eventually
-/// free the resulting buffer, either by explicitly calling the destructor defined below,
-/// or by passing ownership of the buffer back into Rust code.
-///
-/// # Safety
-/// This function will dereference a provided pointer in order to copy bytes from it, so
-/// make sure the `ForeignBytes` struct contains a valid pointer and length.
-#[doc(hidden)]
+#[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn {{ ci.ffi_rustbuffer_from_bytes().name() }}(bytes: uniffi::ForeignBytes, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
-    uniffi::call_with_output(call_status, || {
-        let bytes = bytes.as_slice();
-        uniffi::RustBuffer::from_vec(bytes.to_vec())
-    })
+    uniffi::ffi::uniffi_rustbuffer_from_bytes(bytes, call_status)
 }
 
-/// Free a byte buffer that had previously been passed to the foreign language code.
-///
-/// # Safety
-/// The argument *must* be a uniquely-owned `RustBuffer` previously obtained from a call
-/// into the Rust code that returned a buffer, or you'll risk freeing unowned memory or
-/// corrupting the allocator state.
-#[doc(hidden)]
+#[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn {{ ci.ffi_rustbuffer_free().name() }}(buf: uniffi::RustBuffer, call_status: &mut uniffi::RustCallStatus) {
-    uniffi::call_with_output(call_status, || {
-        uniffi::RustBuffer::destroy(buf)
-    })
+    uniffi::ffi::uniffi_rustbuffer_free(buf, call_status)
 }
 
-/// Reserve additional capacity in a byte buffer that had previously been passed to the
-/// foreign language code.
-///
-/// The first argument *must* be a uniquely-owned `RustBuffer` previously
-/// obtained from a call into the Rust code that returned a buffer. Its underlying data pointer
-/// will be reallocated if necessary and returned in a new `RustBuffer` struct.
-///
-/// The second argument must be the minimum number of *additional* bytes to reserve
-/// capacity for in the buffer; it is likely to reserve additional capacity in practice
-/// due to amortized growth strategy of Rust vectors.
-///
-/// # Safety
-/// The first argument *must* be a uniquely-owned `RustBuffer` previously obtained from a call
-/// into the Rust code that returned a buffer, or you'll risk freeing unowned memory or
-/// corrupting the allocator state.
-#[doc(hidden)]
+#[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn {{ ci.ffi_rustbuffer_reserve().name() }}(buf: uniffi::RustBuffer, additional: i32, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
-    uniffi::call_with_output(call_status, || {
-        use std::convert::TryInto;
-        let additional: usize = additional.try_into().expect("additional buffer length negative or overflowed");
-        let mut v = buf.destroy_into_vec();
-        v.reserve(additional);
-        uniffi::RustBuffer::from_vec(v)
-    })
+    uniffi::ffi::uniffi_rustbuffer_reserve(buf, additional, call_status)
 }


### PR DESCRIPTION
This is to help support the desktop JS bindings that we're currently working on.  See #1153 for more details.