### PR TITLE
Change scaffold logs to trace level

### DIFF
--- a/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
@@ -52,7 +52,7 @@ impl {{ trait_name }} for {{ trait_impl }} {
     {% else -%}
     {%- endmatch -%} {
     {#- Method body #}
-        uniffi::deps::log::debug!("{{ cbi.name() }}.{{ meth.name() }}");
+        uniffi::deps::log::trace!("{{ cbi.name() }}.{{ meth.name() }}");
 
     {#- Packing args into a RustBuffer #}
         {% if meth.arguments().len() == 0 -%}

--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -47,7 +47,7 @@ pub extern "C" fn {{ ffi_free.name() }}(ptr: *const std::os::raw::c_void, call_s
     #[no_mangle]
     pub extern "C" fn {{ cons.ffi_func().name() }}(
         {%- call rs::arg_list_ffi_decl(cons.ffi_func()) %}) -> *const std::os::raw::c_void /* *const {{ obj.name() }} */ {
-        uniffi::deps::log::debug!("{{ cons.ffi_func().name() }}");
+        uniffi::deps::log::trace!("{{ cons.ffi_func().name() }}");
         {% if obj.uses_deprecated_threadsafe_attribute() %}
         uniffi_note_threadsafe_deprecation_{{ obj.name() }}();
         {% endif %}
@@ -64,7 +64,7 @@ pub extern "C" fn {{ ffi_free.name() }}(ptr: *const std::os::raw::c_void, call_s
     pub extern "C" fn {{ meth.ffi_func().name() }}(
         {%- call rs::arg_list_ffi_decl(meth.ffi_func()) %}
     ) {% call rs::return_signature(meth) %} {
-        uniffi::deps::log::debug!("{{ meth.ffi_func().name() }}");
+        uniffi::deps::log::trace!("{{ meth.ffi_func().name() }}");
         // If the method does not have the same signature as declared in the UDL, then
         // this attempt to call it will fail with a (somewhat) helpful compiler error.
         {% call rs::to_rs_method_call(obj, meth) %}

--- a/uniffi_bindgen/src/scaffolding/templates/TopLevelFunctionTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/TopLevelFunctionTemplate.rs
@@ -11,6 +11,6 @@ pub extern "C" fn {{ func.ffi_func().name() }}(
 ) {% call rs::return_signature(func) %} {
     // If the provided function does not match the signature specified in the UDL
     // then this attempt to call it will not compile, and will give guidance as to why.
-    uniffi::deps::log::debug!("{{ func.ffi_func().name() }}");
+    uniffi::deps::log::trace!("{{ func.ffi_func().name() }}");
     {% call rs::to_rs_function_call(func) %}
 }


### PR DESCRIPTION
These can be very noisy when relying on other debug messaging from libraries.