### PR TITLE
Added external type support for Kotlin

### DIFF
--- a/fixtures/ext-types/guid/src/guid.udl
+++ b/fixtures/ext-types/guid/src/guid.udl
@@ -15,12 +15,12 @@ dictionary GuidHelper {
 namespace ext_types_guid {
     // Note this intentionally does not throw an error - uniffi will panic if
     // a Guid can't be converted.
-    Guid get_guid(optional Guid? val);
+    Guid get_guid(optional Guid? value);
 
     // Uniffi will handle failure converting a string to a Guid correctly if
     // the conversion returns `Err(GuidError)`, or panic otherwise.
     [Throws=GuidError]
-    Guid try_get_guid(optional Guid? val);
+    Guid try_get_guid(optional Guid? value);
 
-    GuidHelper get_guid_helper(optional GuidHelper? vals);
+    GuidHelper get_guid_helper(optional GuidHelper? values);
 };

--- a/fixtures/ext-types/guid/tests/bindings/test_guid.py
+++ b/fixtures/ext-types/guid/tests/bindings/test_guid.py
@@ -20,10 +20,10 @@ class TestGuid(unittest.TestCase):
         # This is testing `get_guid` which never returns a result, so everything
         # is InternalError representing a panic.
         # The fixture hard-codes some Guid strings to return specific errors.
-        with self.assertRaisesRegex(InternalError, "Failed to convert arg 'val': The Guid is too short"):
+        with self.assertRaisesRegex(InternalError, "Failed to convert arg 'value': The Guid is too short"):
             get_guid("")
 
-        with self.assertRaisesRegex(InternalError, "Failed to convert arg 'val': Something unexpected went wrong"):
+        with self.assertRaisesRegex(InternalError, "Failed to convert arg 'value': Something unexpected went wrong"):
             get_guid("unexpected")
 
         with self.assertRaisesRegex(InternalError, "guid value caused a panic!"):
@@ -35,7 +35,7 @@ class TestGuid(unittest.TestCase):
         with self.assertRaises(GuidError.TooShort):
             try_get_guid("")
 
-        with self.assertRaisesRegex(InternalError, "Failed to convert arg 'val': Something unexpected went wrong"):
+        with self.assertRaisesRegex(InternalError, "Failed to convert arg 'value': Something unexpected went wrong"):
             try_get_guid("unexpected")
 
         with self.assertRaisesRegex(InternalError, "guid value caused a panic!"):

--- a/fixtures/ext-types/lib/src/ext-types-lib.udl
+++ b/fixtures/ext-types/lib/src/ext-types-lib.udl
@@ -1,5 +1,5 @@
 namespace imported_types_lib {
-    CombinedType get_combined_type(optional CombinedType? val);
+    CombinedType get_combined_type(optional CombinedType? value);
 };
 
 // A type defined in a .udl file in the `uniffi-one` crate (ie, in

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.kts
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.kts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import uniffi.imported_types_lib.*
+
+val ct = getCombinedType(null)
+assert(ct.uot.sval == "hello")
+assert(ct.guid ==  "a-guid")
+assert(ct.url ==  java.net.URL("http://example.com/"))
+
+val ct2 = getCombinedType(ct)
+assert(ct == ct2)

--- a/fixtures/ext-types/lib/tests/test_generated_bindings.rs
+++ b/fixtures/ext-types/lib/tests/test_generated_bindings.rs
@@ -1,10 +1,9 @@
-// TODO: fix external types on Python and implement them on other languages
-// uniffi_macros::build_foreign_language_testcases!(
-//     [
-//         "../guid/src/guid.udl",
-//         "../../../examples/custom-types/src/custom-types.udl",
-//         "../uniffi-one/src/uniffi-one.udl",
-//         "src/ext-types-lib.udl",
-//     ],
-//     ["tests/bindings/test_imported_types.py",]
-// );
+uniffi_macros::build_foreign_language_testcases!(
+    [
+        "../guid/src/guid.udl",
+        "../../../examples/custom-types/src/custom-types.udl",
+        "../uniffi-one/src/uniffi-one.udl",
+        "src/ext-types-lib.udl",
+    ],
+    ["tests/bindings/test_imported_types.kts",]
+);

--- a/fixtures/ext-types/lib/uniffi.toml
+++ b/fixtures/ext-types/lib/uniffi.toml
@@ -1,2 +1,11 @@
 [bindings.python]
 cdylib_name = "uniffi_ext_types_lib"
+
+[bindings.kotlin]
+cdylib_name = "uniffi_ext_types_lib"
+
+[bindings.kotlin.external_packages]
+# Map the crate names from [External={name}] into Kotlin package names
+custom-types = "customtypes"
+ext-types-guid = "uniffi.ext_types_guid"
+uniffi-one = "uniffi.uniffi_one"

--- a/fixtures/ext-types/uniffi-one/uniffi.toml
+++ b/fixtures/ext-types/uniffi-one/uniffi.toml
@@ -1,3 +1,0 @@
-[bindings.python]
-# XXX - we need to use the "embedding" library name here. We can fix that, but haven't yet.
-cdylib_name = "uniffi_ext_types_lib"

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/external.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/external.rs
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::backend::{CodeOracle, CodeType, Literal};
+
+pub struct ExternalCodeType {
+    package_name: String,
+    name: String,
+}
+
+impl ExternalCodeType {
+    pub fn new(package_name: String, name: String) -> Self {
+        Self { package_name, name }
+    }
+}
+
+impl CodeType for ExternalCodeType {
+    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+        self.name.clone()
+    }
+
+    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+        format!("Type{}", self.name)
+    }
+
+    fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+        unreachable!("Can't have a literal of an external type");
+    }
+
+    /// A list of imports that are needed if this type is in use.
+    /// Classes are imported exactly once.
+    fn imports(&self, _oracle: &dyn CodeOracle) -> Option<Vec<String>> {
+        Some(vec![
+            format!("{}.{}", self.package_name, self.name),
+            format!("{}.FfiConverterType{}", self.package_name, self.name),
+        ])
+    }
+
+    fn helper_code(&self, _oracle: &dyn CodeOracle) -> Option<String> {
+        None
+    }
+}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/BooleanHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/BooleanHelper.kt
@@ -1,4 +1,4 @@
-internal object FfiConverterBoolean: FfiConverter<Boolean, Byte> {
+public object FfiConverterBoolean: FfiConverter<Boolean, Byte> {
     override fun lift(value: Byte): Boolean {
         return value.toInt() != 0
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceRuntime.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceRuntime.kt
@@ -42,14 +42,14 @@ interface ForeignCallback : com.sun.jna.Callback {
 // to free the callback once it's dropped by Rust.
 internal const val IDX_CALLBACK_FREE = 0
 
-internal abstract class FfiConverterCallbackInterface<CallbackInterface>(
+public abstract class FfiConverterCallbackInterface<CallbackInterface>(
     protected val foreignCallback: ForeignCallback
 ): FfiConverter<CallbackInterface, Handle> {
-    val handleMap = ConcurrentHandleMap<CallbackInterface>()
+    private val handleMap = ConcurrentHandleMap<CallbackInterface>()
 
     // Registers the foreign callback with the Rust side.
     // This method is generated for each callback interface.
-    abstract fun register(lib: _UniFFILib)
+    internal abstract fun register(lib: _UniFFILib)
 
     fun drop(handle: Handle): RustBuffer.ByValue {
         return handleMap.remove(handle).let { RustBuffer.ByValue() }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceTemplate.kt
@@ -87,7 +87,7 @@ internal class {{ foreign_callback }} : ForeignCallback {
 }
 
 // The ffiConverter which transforms the Callbacks in to Handles to pass to Rust.
-internal object {{ ffi_converter }}: FfiConverterCallbackInterface<{{ type_name }}>(
+public object {{ ffi_converter }}: FfiConverterCallbackInterface<{{ type_name }}>(
     foreignCallback = {{ foreign_callback }}()
 ) {
     override fun register(lib: _UniFFILib) {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CustomTypeTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CustomTypeTemplate.kt
@@ -1,12 +1,19 @@
 {%- match config %}
 {%- when None %}
 {#- No custom type config, just forward all methods to our builtin type #}
-internal typealias {{ outer|ffi_converter_name }} = {{ builtin|ffi_converter_name }}
+public typealias {{ outer|ffi_converter_name }} = {{ builtin|ffi_converter_name }}
+
+{#- Create a typealias so that this type can be imported when used as an external type #}
+public typealias {{ name }} = {{ builtin|type_name }}
 
 {%- when Some with (config) %}
 {%- let type_name=self.type_name(config) %}
 {%- let ffi_type_name=self.builtin_ffi_type()|ffi_type_name %}
-object {{ outer|ffi_converter_name }}: FfiConverter<{{ type_name }}, {{ffi_type_name }}> {
+
+{#- Create a typealias so that this type can be imported when used as an external type #}
+public typealias {{ name }} = {{ type_name }}
+
+public object {{ outer|ffi_converter_name }}: FfiConverter<{{ type_name }}, {{ ffi_type_name }}> {
     {#- Custom type config supplied, use it to convert the builtin type #}
     override fun lift(value: {{ ffi_type_name }}): {{ type_name }} {
         val builtinValue = {{ builtin|lift_fn }}(value)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/DurationHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/DurationHelper.kt
@@ -1,4 +1,4 @@
-internal object FfiConverterDuration: FfiConverterRustBuffer<java.time.Duration> {
+public object FfiConverterDuration: FfiConverterRustBuffer<java.time.Duration> {
     override fun read(buf: ByteBuffer): java.time.Duration {
         // Type mismatch (should be u64) but we check for overflow/underflow below
         val seconds = buf.getLong()

--- a/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
@@ -15,7 +15,7 @@ enum class {{ type_name }} {
     {%- endfor %}
 }
 
-internal object {{ e|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
+public object {{ e|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
     override fun read(buf: ByteBuffer) = try {
         {{ type_name }}.values()[buf.getInt() - 1]
     } catch (e: IndexOutOfBoundsException) {
@@ -62,7 +62,7 @@ sealed class {{ type_name }}{% if self.contains_object_references() %}: Disposab
     {% endif %}
 }
 
-internal object {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }}>{
+public object {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }}>{
     override fun read(buf: ByteBuffer): {{ type_name }} {
         return when(buf.getInt()) {
             {%- for variant in e.variants() %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
@@ -52,7 +52,7 @@ sealed class {{ type_name }}: Exception(){% if self.contains_object_references()
 }
 {%- endif %}
 
-internal object {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }}> {
+public object {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }}> {
     override fun read(buf: ByteBuffer): {{ type_name }} {
         {% if e.is_flat() %}
             return when(buf.getInt()) {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/FfiConverterTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/FfiConverterTemplate.kt
@@ -1,5 +1,8 @@
 // The FfiConverter interface handles converter types to and from the FFI
-interface FfiConverter<KotlinType, FfiType> {
+//
+// All implementing objects should be public to support external types.  When a
+// type is external we need to import it's FfiConverter.
+public interface FfiConverter<KotlinType, FfiType> {
     // Convert an FFI type to a Kotlin type
     fun lift(value: FfiType): KotlinType
 
@@ -62,7 +65,7 @@ interface FfiConverter<KotlinType, FfiType> {
 }
 
 // FfiConverter that uses `RustBuffer` as the FfiType
-interface FfiConverterRustBuffer<KotlinType>: FfiConverter<KotlinType, RustBuffer.ByValue> {
+public interface FfiConverterRustBuffer<KotlinType>: FfiConverter<KotlinType, RustBuffer.ByValue> {
     override fun lift(value: RustBuffer.ByValue) = liftFromRustBuffer(value)
     override fun lower(value: KotlinType) = lowerIntoRustBuffer(value)
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Float32Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Float32Helper.kt
@@ -1,4 +1,4 @@
-internal object FfiConverterFloat: FfiConverter<Float, Float> {
+public object FfiConverterFloat: FfiConverter<Float, Float> {
     override fun lift(value: Float): Float {
         return value
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Float64Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Float64Helper.kt
@@ -1,4 +1,4 @@
-internal object FfiConverterDouble: FfiConverter<Double, Double> {
+public object FfiConverterDouble: FfiConverter<Double, Double> {
     override fun lift(value: Double): Double {
         return value
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Int16Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Int16Helper.kt
@@ -1,4 +1,4 @@
-internal object FfiConverterShort: FfiConverter<Short, Short> {
+public object FfiConverterShort: FfiConverter<Short, Short> {
     override fun lift(value: Short): Short {
         return value
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Int32Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Int32Helper.kt
@@ -1,4 +1,4 @@
-internal object FfiConverterInt: FfiConverter<Int, Int> {
+public object FfiConverterInt: FfiConverter<Int, Int> {
     override fun lift(value: Int): Int {
         return value
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Int64Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Int64Helper.kt
@@ -1,4 +1,4 @@
-internal object FfiConverterLong: FfiConverter<Long, Long> {
+public object FfiConverterLong: FfiConverter<Long, Long> {
     override fun lift(value: Long): Long {
         return value
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Int8Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Int8Helper.kt
@@ -1,4 +1,4 @@
-internal object FfiConverterByte: FfiConverter<Byte, Byte> {
+public object FfiConverterByte: FfiConverter<Byte, Byte> {
     override fun lift(value: Byte): Byte {
         return value
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/MapTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/MapTemplate.kt
@@ -4,7 +4,7 @@
 {%- let inner_type_name = inner_type|type_name %}
 {%- let canonical_type_name = outer_type|canonical_name %}
 
-internal object {{ outer_type|ffi_converter_name }}: FfiConverterRustBuffer<Map<String, {{ inner_type_name }}>> {
+public object {{ outer_type|ffi_converter_name }}: FfiConverterRustBuffer<Map<String, {{ inner_type_name }}>> {
     override fun read(buf: ByteBuffer): Map<String, {{ inner_type_name }}> {
         // TODO: Once Kotlin's `buildMap` API is stabilized we should use it here.
         val items : MutableMap<String, {{ inner_type_name }}> = mutableMapOf()

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -76,7 +76,7 @@ class {{ type_name }}(
     {% endif %}
 }
 
-internal object {{ obj|ffi_converter_name }}: FfiConverter<{{ type_name }}, Pointer> {
+public object {{ obj|ffi_converter_name }}: FfiConverter<{{ type_name }}, Pointer> {
     override fun lower(value: {{ type_name }}): Pointer = value.callWithPointer { it }
 
     override fun lift(value: Pointer): {{ type_name }} {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/OptionalTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/OptionalTemplate.kt
@@ -4,7 +4,7 @@
 {%- let inner_type_name = inner_type|type_name %}
 {%- let canonical_type_name = outer_type|canonical_name %}
 
-internal object {{ outer_type|ffi_converter_name }}: FfiConverterRustBuffer<{{ inner_type_name }}?> {
+public object {{ outer_type|ffi_converter_name }}: FfiConverterRustBuffer<{{ inner_type_name }}?> {
     override fun read(buf: ByteBuffer): {{ inner_type_name }}? {
         if (buf.get().toInt() == 0) {
             return null

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
@@ -20,7 +20,7 @@ data class {{ type_name }} (
     {% endif %}
 }
 
-internal object {{ rec|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
+public object {{ rec|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
     override fun read(buf: ByteBuffer): {{ type_name }} {
         return {{ type_name }}(
         {%- for field in rec.fields() %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/SequenceTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/SequenceTemplate.kt
@@ -4,7 +4,7 @@
 {%- let inner_type_name = inner_type|type_name %}
 {%- let canonical_type_name = outer_type|canonical_name %}
 
-internal object {{ outer_type|ffi_converter_name }}: FfiConverterRustBuffer<List<{{ inner_type_name }}>> {
+public object {{ outer_type|ffi_converter_name }}: FfiConverterRustBuffer<List<{{ inner_type_name }}>> {
     override fun read(buf: ByteBuffer): List<{{ inner_type_name }}> {
         val len = buf.getInt()
         return List<{{ inner_type_name }}>(len) {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/StringHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/StringHelper.kt
@@ -1,4 +1,4 @@
-internal object FfiConverterString: FfiConverter<String, RustBuffer.ByValue> {
+public object FfiConverterString: FfiConverter<String, RustBuffer.ByValue> {
     // Note: we don't inherit from FfiConverterRustBuffer, because we use a
     // special encoding when lowering/lifting.  We can use `RustBuffer.len` to
     // store our length and avoid writing it out to the buffer.

--- a/uniffi_bindgen/src/bindings/kotlin/templates/TimestampHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/TimestampHelper.kt
@@ -1,4 +1,4 @@
-internal object FfiConverterTimestamp: FfiConverterRustBuffer<java.time.Instant> {
+public object FfiConverterTimestamp: FfiConverterRustBuffer<java.time.Instant> {
     override fun read(buf: ByteBuffer): java.time.Instant {
         val seconds = buf.getLong()
         // Type mismatch (should be u32) but we check for overflow/underflow below

--- a/uniffi_bindgen/src/bindings/kotlin/templates/UInt16Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/UInt16Helper.kt
@@ -1,4 +1,4 @@
-internal object FfiConverterUShort: FfiConverter<UShort, Short> {
+public object FfiConverterUShort: FfiConverter<UShort, Short> {
     override fun lift(value: Short): UShort {
         return value.toUShort()
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/UInt32Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/UInt32Helper.kt
@@ -1,4 +1,4 @@
-internal object FfiConverterUInt: FfiConverter<UInt, Int> {
+public object FfiConverterUInt: FfiConverter<UInt, Int> {
     override fun lift(value: Int): UInt {
         return value.toUInt()
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/UInt64Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/UInt64Helper.kt
@@ -1,4 +1,4 @@
-internal object FfiConverterULong: FfiConverter<ULong, Long> {
+public object FfiConverterULong: FfiConverter<ULong, Long> {
     override fun lift(value: Long): ULong {
         return value.toULong()
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/UInt8Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/UInt8Helper.kt
@@ -1,4 +1,4 @@
-internal object FfiConverterUByte: FfiConverter<UByte, Byte> {
+public object FfiConverterUByte: FfiConverter<UByte, Byte> {
     override fun lift(value: Byte): UByte {
         return value.toUByte()
     }

--- a/uniffi_bindgen/src/bindings/mod.rs
+++ b/uniffi_bindgen/src/bindings/mod.rs
@@ -126,6 +126,9 @@ where
 }
 
 /// Compile generated foreign language bindings so they're ready for use.
+///
+/// Note: This function is only used for compiling the unit tests. See #1169 for plans to refactor
+/// it.
 pub fn compile_bindings<P>(
     config: &Config,
     ci: &ComponentInterface,
@@ -146,6 +149,9 @@ where
 }
 
 /// Execute the given script via foreign language interpreter/shell.
+///
+/// Note: This function is only used for compiling the unit tests. See #1169 for plans to refactor
+/// it.
 pub fn run_script<P1, P2>(out_dir: P1, script_file: P2, language: TargetLanguage) -> Result<()>
 where
     P1: AsRef<Path>,


### PR DESCRIPTION
After #1144 and #1156, we're ready to implement external types on Kotlin.

- Updated `kotlin::compile_bindings()` so that uses the same classpath
  as `run_script()`.  This is needed to allow importing the external types.
- Made Kotlin `FfiConverter` objects public so that they can be imported
- Added a public typealias for Kotlin custom types so that they can be
  imported
- Changed ext_types fixture to not use `val` for argument names.

There are still a couple improvements to be done.  I'm thinking we can do a second pass for those.