### PR TITLE
swift: surround identifiers with backticks to avoid reserved word conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 [All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.17.0...HEAD).
 
+### What's Changed
+
+- Identifiers in generated Swift code are automatically surrounded by backticks (`) when they are
+  the same as Swift reserved words.
+
 ## v0.17.0 - (_2022-02-03_)
 
 [All changes in v0.17.0](https://github.com/mozilla/uniffi-rs/compare/v0.16.0...v0.17.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
 
 ### What's Changed
 
-- Identifiers in generated Swift code are automatically surrounded by backticks (`) when they are
-  the same as Swift reserved words.
+- Identifiers in generated Swift code are automatically surrounded by backticks (`). This is
+  required to handle conflicts with reserved words.
 
 ## v0.17.0 - (_2022-02-03_)
 

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -424,6 +424,28 @@ impl CodeOracle for SwiftCodeOracle {
     }
 }
 
+/// When using a Swift reserved word as an identifier, one needs to add a backtick (`) before and
+/// after it. This function checks if the given identifier is a reserved word and adds backticks if
+/// necessary.
+pub fn escape_reserved_word_identifier(identifier: String) -> String {
+    match identifier.as_str() {
+        "associatedtype" | "class" | "deinit" | "enum" | "extension" | "fileprivate" | "func"
+        | "import" | "init" | "inout" | "internal" | "let" | "open" | "operator" | "private"
+        | "precedencegroup" | "protocol" | "public" | "rethrows" | "static" | "struct"
+        | "subscript" | "typealias" | "var" | "break" | "case" | "catch" | "continue"
+        | "default" | "defer" | "do" | "else" | "fallthrough" | "for" | "guard" | "if" | "in"
+        | "repeat" | "return" | "throw" | "switch" | "where" | "while" | "Any" | "as" | "false"
+        | "nil" | "self" | "Self" | "super" | "throws" | "true" | "try" | "associativity"
+        | "convenience" | "didSet" | "dynamic" | "final" | "get" | "indirect" | "infix"
+        | "lazy" | "left" | "mutating" | "none" | "nonmutating" | "optional" | "override"
+        | "postfix" | "precedence" | "prefix" | "Protocol" | "required" | "right" | "set"
+        | "some" | "Type" | "unowned" | "weak" | "willSet" => {
+            format!("`{}`", identifier)
+        }
+        _ => identifier,
+    }
+}
+
 pub mod filters {
     use super::*;
     use std::fmt;
@@ -449,7 +471,7 @@ pub mod filters {
 
     pub fn type_name(codetype: &impl CodeType) -> Result<String, askama::Error> {
         let oracle = oracle();
-        Ok(codetype.type_label(oracle))
+        Ok(escape_reserved_word_identifier(codetype.type_label(oracle)))
     }
 
     pub fn canonical_name(codetype: &impl CodeType) -> Result<String, askama::Error> {
@@ -526,22 +548,24 @@ pub mod filters {
 
     /// Get the idiomatic Swift rendering of a class name (for enums, records, errors, etc).
     pub fn class_name(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
-        Ok(oracle().class_name(nm))
+        Ok(escape_reserved_word_identifier(oracle().class_name(nm)))
     }
 
     /// Get the idiomatic Swift rendering of a function name.
     pub fn fn_name(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
-        Ok(oracle().fn_name(nm))
+        Ok(escape_reserved_word_identifier(oracle().fn_name(nm)))
     }
 
     /// Get the idiomatic Swift rendering of a variable name.
     pub fn var_name(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
-        Ok(oracle().var_name(nm))
+        Ok(escape_reserved_word_identifier(oracle().var_name(nm)))
     }
 
     /// Get the idiomatic Swift rendering of an individual enum variant.
     pub fn enum_variant_swift(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
-        Ok(oracle().enum_variant_name(nm))
+        Ok(escape_reserved_word_identifier(
+            oracle().enum_variant_name(nm),
+        ))
     }
 
     /// Get the idiomatic Swift rendering of an exception name
@@ -550,6 +574,6 @@ pub mod filters {
     /// "Error" for any type of error but in the Java world, "Error" means a non-recoverable error
     /// and is distinguished from an "Exception".
     pub fn exception_name(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
-        Ok(oracle().error_name(nm))
+        Ok(escape_reserved_word_identifier(oracle().error_name(nm)))
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -425,25 +425,10 @@ impl CodeOracle for SwiftCodeOracle {
 }
 
 /// When using a Swift reserved word as an identifier, one needs to add a backtick (`) before and
-/// after it. This function checks if the given identifier is a reserved word and adds backticks if
-/// necessary.
+/// after it. This function adds backticks around an identifier. The intention is to add backticks
+/// around all identifiers. Unnecessary backticks can be removed by `swiftformat` later.
 pub fn escape_reserved_word_identifier(identifier: String) -> String {
-    match identifier.as_str() {
-        "associatedtype" | "class" | "deinit" | "enum" | "extension" | "fileprivate" | "func"
-        | "import" | "init" | "inout" | "internal" | "let" | "open" | "operator" | "private"
-        | "precedencegroup" | "protocol" | "public" | "rethrows" | "static" | "struct"
-        | "subscript" | "typealias" | "var" | "break" | "case" | "catch" | "continue"
-        | "default" | "defer" | "do" | "else" | "fallthrough" | "for" | "guard" | "if" | "in"
-        | "repeat" | "return" | "throw" | "switch" | "where" | "while" | "Any" | "as" | "false"
-        | "nil" | "self" | "Self" | "super" | "throws" | "true" | "try" | "associativity"
-        | "convenience" | "didSet" | "dynamic" | "final" | "get" | "indirect" | "infix"
-        | "lazy" | "left" | "mutating" | "none" | "nonmutating" | "optional" | "override"
-        | "postfix" | "precedence" | "prefix" | "Protocol" | "required" | "right" | "set"
-        | "some" | "Type" | "unowned" | "weak" | "willSet" => {
-            format!("`{}`", identifier)
-        }
-        _ => identifier,
-    }
+    format!("`{}`", identifier)
 }
 
 pub mod filters {


### PR DESCRIPTION
Sometimes identifiers from a UDL file may conflict with Swift reserved words. Swift allows to resolve such conflicts by surrounding an identifier with backticks (`). For example:

    var private: Bool

is not a valid expression, but

    var `private`: Bool

is.

This pull request adds backticks automatically when required. Sometimes they may be redundant, but this does not trigger a compilation error and is a purely stylistic issue, so we rely on `swiftformat` to remove them when they are unnecessary.

The list of keywords was taken from [Swift documentation](https://docs.swift.org/swift-book/ReferenceManual/LexicalStructure.html#ID413). I skipped keywords that I think are not valid UDL identifiers.