### PR TITLE
Implementing type_rs for custom types (#1178)

### DIFF
--- a/fixtures/ext-types/guid/src/guid.udl
+++ b/fixtures/ext-types/guid/src/guid.udl
@@ -12,6 +12,10 @@ dictionary GuidHelper {
     Guid? maybe_guid;
 };
 
+callback interface GuidCallback {
+   Guid run(Guid arg);
+};
+
 namespace ext_types_guid {
     // Note this intentionally does not throw an error - uniffi will panic if
     // a Guid can't be converted.
@@ -23,4 +27,5 @@ namespace ext_types_guid {
     Guid try_get_guid(optional Guid? value);
 
     GuidHelper get_guid_helper(optional GuidHelper? values);
+    Guid run_callback(GuidCallback callback);
 };

--- a/fixtures/ext-types/guid/src/lib.rs
+++ b/fixtures/ext-types/guid/src/lib.rs
@@ -66,6 +66,14 @@ fn get_guid_helper(vals: Option<GuidHelper>) -> GuidHelper {
     }
 }
 
+pub trait GuidCallback {
+    fn run(&self, arg: Guid) -> Guid;
+}
+
+pub fn run_callback(callback: Box<dyn GuidCallback>) -> Guid {
+    callback.run(Guid("callback-test-payload".into()))
+}
+
 impl UniffiCustomTypeConverter for Guid {
     type Builtin = String;
 

--- a/fixtures/ext-types/guid/tests/bindings/test_guid.py
+++ b/fixtures/ext-types/guid/tests/bindings/test_guid.py
@@ -5,6 +5,11 @@
 import unittest
 from ext_types_guid import *
 
+class TestCallback(GuidCallback):
+    def run(self, guid):
+        self.saw_guid = guid
+        return guid
+
 class TestGuid(unittest.TestCase):
     def test_get_guid(self):
         self.assertEqual(get_guid(None), "NewGuid")
@@ -41,10 +46,13 @@ class TestGuid(unittest.TestCase):
         with self.assertRaisesRegex(InternalError, "guid value caused a panic!"):
             try_get_guid("panic")
 
-    # def test_round_trip(self):
-    #     ct = get_combined_type(None)
-    #     self.assertEqual(ct.cot.sval, "hello")
-    #     self.assertEqual(ct.ctt.ival, 1)
+    def test_guid_callback(self):
+        # Test that we can passing a guid from run_callback() to TestCallback.run() then back out
+
+        test_callback = TestCallback()
+        guid = run_callback(test_callback)
+        self.assertEquals(guid, "callback-test-payload")
+        self.assertEquals(test_callback.saw_guid, "callback-test-payload")
 
 if __name__=='__main__':
     unittest.main()

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -48,8 +48,8 @@ mod filters {
             Type::Optional(t) => format!("std::option::Option<{}>", type_rs(t)?),
             Type::Sequence(t) => format!("std::vec::Vec<{}>", type_rs(t)?),
             Type::Map(t) => format!("std::collections::HashMap<String, {}>", type_rs(t)?),
+            Type::Custom { name, .. } => name.clone(),
             Type::External { .. } => panic!("External types coming to a uniffi near you soon!"),
-            Type::Custom { .. } => panic!("Wrapped types coming to a uniffi near you soon!"),
         })
     }
 


### PR DESCRIPTION
It's kind of amazing that we didn't need this before, but I guess the scaffolding code doesn't really need to know the type name for custom types, until you start using it in a `CallbackInterface`.