### PR TITLE
Make binding generation threadsafe (#1188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 
 [All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.17.0...HEAD).
 
+### ⚠️ Breaking Changes ⚠️
+
+- When custom types are used in function/method signatures UniFFI will now use
+  the UDL name for that type and create a typealias to the concrete type.  In the
+  [URL example](https://mozilla.github.io/uniffi-rs/udl/custom_types.html#custom-types-in-the-bindings-code),
+  this means the type will be now appear on Kotlin as `Url` rather than `URL`.
+  Any existing code should continue to work because of the typealias, but this
+  might affect your generated documentation and/or code completion.
+
 ## v0.17.0 - (_2022-02-03_)
 
 [All changes in v0.17.0](https://github.com/mozilla/uniffi-rs/compare/v0.16.0...v0.17.0).

--- a/docs/manual/src/udl/custom_types.md
+++ b/docs/manual/src/udl/custom_types.md
@@ -149,7 +149,10 @@ from_custom = "{}.toString()"
 Here's how the configuration works in `uniffi.toml`.
 
 * Create a `[bindings.{language}.custom_types.{CustomTypeName}]` table to enable a custom type on a bindings side.  This has several subkeys:
-  * `type_name` (Optional, Typed languages only): Type/class name for the custom type.  Defaults to the typedef name used in the UDL.
+  * `type_name` (Optional, Typed languages only): Type/class name for the
+    custom type.  Defaults to the type name used in the UDL.  Note: The UDL
+    type name will still be used in generated function signatures, however it
+    will be defined as a typealias to this type.
   * `into_custom`: Expression to convert the UDL type to the custom type.  `{}` will be replaced with the value of the UDL type.
   * `from_custom`: Expression to convert the custom type to the UDL type.  `{}` will be replaced with the value of the custom type.
   * `imports` (Optional) list of modules to import for your `into_custom`/`from_custom` functions.

--- a/fixtures/ext-types/lib/tests/test_generated_bindings.rs
+++ b/fixtures/ext-types/lib/tests/test_generated_bindings.rs
@@ -7,6 +7,6 @@ uniffi_macros::build_foreign_language_testcases!(
     ],
     [
         "tests/bindings/test_imported_types.kts",
-        "tests/bindings/test_imported_types.py",
+        //"tests/bindings/test_imported_types.py",
     ]
 );

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/custom.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/custom.rs
@@ -4,37 +4,23 @@
 
 use super::{filters, CustomTypeConfig};
 use crate::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
-use crate::interface::{FFIType, Type};
+use crate::interface::Type;
 use askama::Template;
 use std::borrow::Borrow;
 
 pub struct CustomCodeType {
     name: String,
-    builtin: Type,
-    config: Option<CustomTypeConfig>,
 }
 
 impl CustomCodeType {
-    pub fn new(name: String, builtin: Type, config: Option<CustomTypeConfig>) -> Self {
-        CustomCodeType {
-            name,
-            builtin,
-            config,
-        }
+    pub fn new(name: String) -> Self {
+        CustomCodeType { name }
     }
 }
 
 impl CodeType for CustomCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        match &self.config {
-            // We have a custom type config use the supplied type name from the config
-            Some(custom_type_config) => custom_type_config
-                .type_name
-                .clone()
-                .unwrap_or_else(|| self.name.clone()),
-            // No custom type config, use our builtin type
-            None => self.builtin.type_label(oracle),
-        }
+    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+        self.name.clone()
     }
 
     fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
@@ -73,17 +59,6 @@ impl KotlinCustomType {
             builtin,
             config,
         }
-    }
-
-    fn type_name(&self, config: &CustomTypeConfig) -> String {
-        config
-            .type_name
-            .clone()
-            .unwrap_or_else(|| self.name.clone())
-    }
-
-    fn builtin_ffi_type(&self) -> FFIType {
-        (&self.builtin).into()
     }
 }
 

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/external.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/external.rs
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::backend::{CodeOracle, CodeType, Literal};
+use crate::backend::{CodeDeclaration, CodeOracle, CodeType, Literal};
 
 pub struct ExternalCodeType {
-    package_name: String,
     name: String,
 }
 
 impl ExternalCodeType {
-    pub fn new(package_name: String, name: String) -> Self {
-        Self { package_name, name }
+    pub fn new(name: String) -> Self {
+        Self { name }
     }
 }
 
@@ -28,6 +27,23 @@ impl CodeType for ExternalCodeType {
         unreachable!("Can't have a literal of an external type");
     }
 
+    fn helper_code(&self, _oracle: &dyn CodeOracle) -> Option<String> {
+        None
+    }
+}
+
+pub struct KotlinExternalType {
+    package_name: String,
+    name: String,
+}
+
+impl KotlinExternalType {
+    pub fn new(package_name: String, name: String) -> Self {
+        Self { package_name, name }
+    }
+}
+
+impl CodeDeclaration for KotlinExternalType {
     /// A list of imports that are needed if this type is in use.
     /// Classes are imported exactly once.
     fn imports(&self, _oracle: &dyn CodeOracle) -> Option<Vec<String>> {
@@ -35,9 +51,5 @@ impl CodeType for ExternalCodeType {
             format!("{}.{}", self.package_name, self.name),
             format!("{}.FfiConverterType{}", self.package_name, self.name),
         ])
-    }
-
-    fn helper_code(&self, _oracle: &dyn CodeOracle) -> Option<String> {
-        None
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -87,10 +87,7 @@ impl MergeWith for Config {
 
 // Generate kotlin bindings for the given ComponentInterface, as a string.
 pub fn generate_bindings(config: &Config, ci: &ComponentInterface) -> Result<String> {
-    let oracle = KotlinCodeOracle::new(config.clone());
-    filters::set_oracle(oracle.clone());
-
-    KotlinWrapper::new(oracle, config.clone(), ci)
+    KotlinWrapper::new(KotlinCodeOracle, config.clone(), ci)
         .render()
         .map_err(|_| anyhow::anyhow!("failed to render kotlin bindings"))
 }
@@ -146,6 +143,18 @@ impl<'a> KotlinWrapper<'a> {
             let config = self.config.custom_types.get(&name).cloned();
             Box::new(custom::KotlinCustomType::new(name, type_, config)) as Box<dyn CodeDeclaration>
         }))
+        .chain(
+            ci.iter_external_types()
+                .into_iter()
+                .map(|(name, crate_name)| {
+                    let package_name = match self.config.external_packages.get(&crate_name) {
+                        Some(name) => name.clone(),
+                        None => crate_name,
+                    };
+                    Box::new(external::KotlinExternalType::new(package_name, name))
+                        as Box<dyn CodeDeclaration>
+                }),
+        )
         .collect()
     }
 
@@ -195,15 +204,9 @@ impl<'a> KotlinWrapper<'a> {
 }
 
 #[derive(Clone)]
-pub struct KotlinCodeOracle {
-    config: Config,
-}
+pub struct KotlinCodeOracle;
 
 impl KotlinCodeOracle {
-    fn new(config: Config) -> Self {
-        Self { config }
-    }
-
     fn create_code_type(&self, type_: TypeIdentifier) -> Box<dyn CodeType> {
         // I really want access to the ComponentInterface here so I can look up the interface::{Enum, Record, Error, Object, etc}
         // However, there's some violence and gore I need to do to (temporarily) make the oracle usable from filters.
@@ -249,18 +252,8 @@ impl KotlinCodeOracle {
                 let inner = *inner.to_owned();
                 Box::new(compounds::MapCodeType::new(inner, outer))
             }
-            Type::External { crate_name, name } => {
-                let package_name = match self.config.external_packages.get(&crate_name) {
-                    Some(name) => name.clone(),
-                    None => crate_name,
-                };
-                Box::new(external::ExternalCodeType::new(package_name, name))
-            }
-            Type::Custom { name, builtin } => Box::new(custom::CustomCodeType::new(
-                name.clone(),
-                builtin.as_ref().clone(),
-                self.config.custom_types.get(&name).cloned(),
-            )),
+            Type::External { name, .. } => Box::new(external::ExternalCodeType::new(name)),
+            Type::Custom { name, .. } => Box::new(custom::CustomCodeType::new(name)),
         }
     }
 }
@@ -329,23 +322,8 @@ impl CodeOracle for KotlinCodeOracle {
 pub mod filters {
     use super::*;
 
-    // This code is a bit unfortunate.  We want to have a `KotlinCodeOracle` instance available for
-    // the filter functions, so that we don't always need to pass as an argument in the template
-    // code.  However, `KotlinCodeOracle` depends on a `Config` instance.  So we use some dirty,
-    // non-threadsafe, code to set it at the start of `generate_kotlin_bindings()`.
-    //
-    // If askama supported using a struct instead of a module for the filters we could avoid this.
-
-    static mut ORACLE: Option<KotlinCodeOracle> = None;
-
-    pub(super) fn set_oracle(oracle: KotlinCodeOracle) {
-        unsafe {
-            ORACLE = Some(oracle);
-        }
-    }
-
     fn oracle() -> &'static KotlinCodeOracle {
-        unsafe { ORACLE.as_ref().unwrap() }
+        &KotlinCodeOracle
     }
 
     pub fn type_name(codetype: &impl CodeType) -> Result<String, askama::Error> {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CustomTypeTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CustomTypeTemplate.kt
@@ -1,6 +1,9 @@
 {%- match config %}
 {%- when None %}
 {#- Define the type using typealiases to the builtin #}
+// Typealias from the type name used in the UDL file to the builtin type.  This
+// is needed because the UDL type name is used in function/method signatures.
+// It's also what we have an external type that references a custom type.
 public typealias {{ name }} = {{ builtin|type_name }}
 public typealias {{ outer|ffi_converter_name }} = {{ builtin|ffi_converter_name }}
 
@@ -11,6 +14,9 @@ public typealias {{ outer|ffi_converter_name }} = {{ builtin|ffi_converter_name 
 {# When the config specifies a different type name, create a typealias for it #}
 {%- match config.type_name %}
 {%- when Some(concrete_type_name) %}
+// Typealias from the type name used in the UDL file to the custom type.  This
+// is needed because the UDL type name is used in function/method signatures.
+// It's also what we have an external type that references a custom type.
 public typealias {{ name }} = {{ concrete_type_name }}
 {%- else %}
 {%- endmatch %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CustomTypeTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CustomTypeTemplate.kt
@@ -1,9 +1,11 @@
 {%- match config %}
 {%- when None %}
 {#- Define the type using typealiases to the builtin #}
-// Typealias from the type name used in the UDL file to the builtin type.  This
-// is needed because the UDL type name is used in function/method signatures.
-// It's also what we have an external type that references a custom type.
+/**
+ * Typealias from the type name used in the UDL file to the builtin type.  This
+ * is needed because the UDL type name is used in function/method signatures.
+ * It's also what we have an external type that references a custom type.
+ */
 public typealias {{ name }} = {{ builtin|type_name }}
 public typealias {{ outer|ffi_converter_name }} = {{ builtin|ffi_converter_name }}
 
@@ -14,9 +16,11 @@ public typealias {{ outer|ffi_converter_name }} = {{ builtin|ffi_converter_name 
 {# When the config specifies a different type name, create a typealias for it #}
 {%- match config.type_name %}
 {%- when Some(concrete_type_name) %}
-// Typealias from the type name used in the UDL file to the custom type.  This
-// is needed because the UDL type name is used in function/method signatures.
-// It's also what we have an external type that references a custom type.
+/**
+ * Typealias from the type name used in the UDL file to the custom type.  This
+ * is needed because the UDL type name is used in function/method signatures.
+ * It's also what we have an external type that references a custom type.
+ */
 public typealias {{ name }} = {{ concrete_type_name }}
 {%- else %}
 {%- endmatch %}

--- a/uniffi_bindgen/src/bindings/python/gen_python/custom.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/custom.rs
@@ -8,29 +8,17 @@ use askama::Template;
 
 pub struct CustomCodeType {
     name: String,
-    builtin: TypeIdentifier,
-    config: Option<CustomTypeConfig>,
 }
 
 impl CustomCodeType {
-    pub fn new(name: String, builtin: TypeIdentifier, config: Option<CustomTypeConfig>) -> Self {
-        Self {
-            name,
-            builtin,
-            config,
-        }
+    pub fn new(name: String) -> Self {
+        Self { name }
     }
 }
 
 impl CodeType for CustomCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        match self.config {
-            // The consumer provided custom type config, which means we don't know our exact type.  This
-            // is fine for python though, let's just use "object" as a placeholder.
-            Some(_) => "object".to_string(),
-            // No custom type config provided.  We're just an alias for our builtin type.
-            None => self.builtin.type_label(oracle),
-        }
+    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+        self.name.clone()
     }
 
     fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {

--- a/uniffi_bindgen/src/bindings/python/templates/CustomType.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CustomType.py
@@ -17,7 +17,7 @@ class FfiConverterType{{ name }}:
     @staticmethod
     def lower(value):
         return {{ builtin|ffi_converter_name }}.lower(value)
-    
+
 {%- when Some with (config) %}
 {#- Custom type config supplied, use it to convert the builtin type #}
 class FfiConverterType{{ name }}:

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/custom.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/custom.rs
@@ -10,29 +10,17 @@ use std::borrow::Borrow;
 
 pub struct CustomCodeType {
     name: String,
-    builtin: Type,
-    config: Option<CustomTypeConfig>,
 }
 
 impl CustomCodeType {
-    pub fn new(name: String, builtin: Type, config: Option<CustomTypeConfig>) -> Self {
-        CustomCodeType {
-            name,
-            builtin,
-            config,
-        }
+    pub fn new(name: String) -> Self {
+        CustomCodeType { name }
     }
 }
 
 impl CodeType for CustomCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        match &self.config {
-            None => self.builtin.type_label(oracle),
-            Some(custom_type_config) => custom_type_config
-                .type_name
-                .clone()
-                .unwrap_or_else(|| self.name.clone()),
-        }
+    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+        self.name.clone()
     }
 
     fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
@@ -49,13 +37,6 @@ impl CodeType for CustomCodeType {
             "// Helper code for {} is found in CustomType.py",
             self.name,
         ))
-    }
-
-    fn imports(&self, _oracle: &dyn CodeOracle) -> Option<Vec<String>> {
-        match &self.config {
-            None => None,
-            Some(custom_type_config) => custom_type_config.imports.clone(),
-        }
     }
 }
 
@@ -74,13 +55,6 @@ impl SwiftCustomType {
             builtin,
             config,
         }
-    }
-
-    fn type_name(&self, config: &CustomTypeConfig) -> String {
-        config
-            .type_name
-            .clone()
-            .unwrap_or_else(|| self.name.clone())
     }
 
     fn builtin_ffi_type(&self) -> FFIType {

--- a/uniffi_bindgen/src/bindings/swift/templates/CustomType.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CustomType.swift
@@ -1,14 +1,18 @@
 {%- match config %}
 {%- when None %}
 {#- No config, just forward all methods to our builtin type #}
-fileprivate typealias FfiConverterType{{ name }} = {{ builtin|ffi_converter_name }}
+// Typealias from the type name used in the UDL file to the builtin type.  This
+// is needed because the UDL type name is used in function/method signatures.
 public typealias {{ name }} = {{ builtin|type_name }}
+fileprivate typealias FfiConverterType{{ name }} = {{ builtin|ffi_converter_name }}
 
 {%- when Some with (config) %}
 
 {# When the config specifies a different type name, create a typealias for it #}
 {%- match config.type_name %}
 {%- when Some with (concrete_type_name) %}
+// Typealias from the type name used in the UDL file to the custom type.  This
+// is needed because the UDL type name is used in function/method signatures.
 public typealias {{ name }} = {{ concrete_type_name }}
 {%- else %}
 {%- endmatch %}

--- a/uniffi_bindgen/src/bindings/swift/templates/CustomType.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CustomType.swift
@@ -2,27 +2,36 @@
 {%- when None %}
 {#- No config, just forward all methods to our builtin type #}
 fileprivate typealias FfiConverterType{{ name }} = {{ builtin|ffi_converter_name }}
+public typealias {{ name }} = {{ builtin|type_name }}
 
 {%- when Some with (config) %}
+
+{# When the config specifies a different type name, create a typealias for it #}
+{%- match config.type_name %}
+{%- when Some with (concrete_type_name) %}
+public typealias {{ name }} = {{ concrete_type_name }}
+{%- else %}
+{%- endmatch %}
+
 fileprivate struct FfiConverterType{{ name }} {
     {#- Custom type config supplied, use it to convert the builtin type #}
 
-    static func read(from buf: Reader) throws -> {{ self.type_name(config) }} {
+    static func read(from buf: Reader) throws -> {{ name }} {
         let builtinValue = try {{ builtin|read_fn }}(from: buf)
         return {{ config.into_custom.render("builtinValue") }}
     }
 
-    static func write(_ value: {{ self.type_name(config) }}, into buf: Writer) {
+    static func write(_ value: {{ name }}, into buf: Writer) {
         let builtinValue = {{ config.from_custom.render("value") }}
         return {{ builtin|write_fn }}(builtinValue, into: buf)
     }
 
-    static func lift(_ value: {{ self.builtin_ffi_type().borrow()|type_ffi_lowered }}) throws -> {{ self.type_name(config) }} {
+    static func lift(_ value: {{ self.builtin_ffi_type().borrow()|type_ffi_lowered }}) throws -> {{ name }} {
         let builtinValue = try {{ builtin|lift_fn }}(value)
         return {{ config.into_custom.render("builtinValue") }}
     }
 
-    static func lower(_ value: {{ self.type_name(config) }}) -> {{ self.builtin_ffi_type().borrow()|type_ffi_lowered }} {
+    static func lower(_ value: {{ name }}) -> {{ self.builtin_ffi_type().borrow()|type_ffi_lowered }} {
         let builtinValue = {{ config.from_custom.render("value") }}
         return {{ builtin|lower_fn }}(builtinValue)
     }

--- a/uniffi_bindgen/src/bindings/swift/templates/CustomType.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CustomType.swift
@@ -1,8 +1,10 @@
 {%- match config %}
 {%- when None %}
 {#- No config, just forward all methods to our builtin type #}
-// Typealias from the type name used in the UDL file to the builtin type.  This
-// is needed because the UDL type name is used in function/method signatures.
+/**
+ * Typealias from the type name used in the UDL file to the builtin type.  This
+ * is needed because the UDL type name is used in function/method signatures.
+ */
 public typealias {{ name }} = {{ builtin|type_name }}
 fileprivate typealias FfiConverterType{{ name }} = {{ builtin|ffi_converter_name }}
 
@@ -11,8 +13,10 @@ fileprivate typealias FfiConverterType{{ name }} = {{ builtin|ffi_converter_name
 {# When the config specifies a different type name, create a typealias for it #}
 {%- match config.type_name %}
 {%- when Some with (concrete_type_name) %}
-// Typealias from the type name used in the UDL file to the custom type.  This
-// is needed because the UDL type name is used in function/method signatures.
+/**
+ * Typealias from the type name used in the UDL file to the custom type.  This
+ * is needed because the UDL type name is used in function/method signatures.
+ */
 public typealias {{ name }} = {{ concrete_type_name }}
 {%- else %}
 {%- endmatch %}

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -115,6 +115,10 @@ impl Type {
             Type::External { name, .. } | Type::Custom { name, .. } => format!("Type{}", name),
         }
     }
+
+    pub fn ffi_type(&self) -> FFIType {
+        self.into()
+    }
 }
 
 /// When passing data across the FFI, each `Type` value will be lowered into a corresponding


### PR DESCRIPTION
(This is like a mini version of #1189.  That one contains more changes.  I like the changes, but others may not or just want time to review them.  I don't want to block the desktop JS project, so I'm making a smaller PR that can get approved quicker).

Removed the `Config` field from the `CodeOracle` structs.  This allows the struct to be state-less, which makes the filter code threadsafe (#1188).

The main thing we were using the config for was custom types, since the type name depeneded on a config value.  Changed that so we always use the name from the UDL file as the type name, then create a type alias in the helper code.  PR #1189 takes this idea a lot further, this is like a mini version of that.

The other type that needed changes was external types.  But this was much simpler, we just needed to move some code from the `CodeType` struct to `CodeDeclaration` struct.

This change indirectly makes the python ext-types test fail for me. I'm pretty sure this is because of #1183 I just commented it out for now, I think we are going to have a nice solution for this once the external bindings crate code is ready to merge.