### PR TITLE
Allow external crates to write their own binding generators

### DIFF
--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -639,16 +639,6 @@ where
     }
 }
 
-// This function is not intended to be called, but can be used as for the to workaround
-// https://github.com/rust-lang/rust/issues/50007
-//
-// Basically, if another library adds uniffi as an external crate, then builds into a dylib, that
-// library normally won't have the symbols from uniffi.  However, if that library calls a uniffi
-// function, then it *will* have the symbols.  So as a workaround to 50007, we create a dummy
-// function here, and call it from a dummy function in the library,.
-#[no_mangle]
-pub extern "C" fn extern_symbol_hack() {}
-
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
These are the first bits needed to implement an external binding generator that lives in an outside crate.

Most of the changes are in the `uniffi_bindgen/src/lib.rs` to define a trait `BindingGenerator` that an external crate can use to take advantage of the logic in `uniffi` to parse the `udl` into a `ComponentInterface`.


This is not a breaking change, and only exposes the functionality (it doesn't change the existing crates)

cc @bendk @mhammond 