### PR TITLE
Exposes Enum variants from the enum module

### DIFF
--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -61,7 +61,7 @@ mod attributes;
 mod callbacks;
 pub use callbacks::CallbackInterface;
 mod enum_;
-pub use enum_::Enum;
+pub use enum_::{Enum, Variant};
 mod error;
 pub use error::Error;
 mod function;


### PR DESCRIPTION
When trying to work with enums and variants in an external crate, realized that the variants aren't exposed

Exposing them here so consumers can work with them - over in https://github.com/bendk/gecko-dev/blob/3bb95300c964533827b1e4629a7f8a3320eac376/toolkit/components/uniffi-bindgen-gecko-js/src/render/js.rs we rely on the types themselves being accessible by an external crate