### PR TITLE
Adding support for external fixture/example tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "uniffi_bindgen",
   "uniffi_build",
   "uniffi_macros",
+  "uniffi_testing",
   "uniffi",
   "examples/arithmetic",
   "examples/callbacks",

--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["staticlib", "cdylib", "lib"]
+crate-type = ["lib", "cdylib"]
 name = "arithmetical"
 
 [dependencies]

--- a/examples/callbacks/Cargo.toml
+++ b/examples/callbacks/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib", "cdylib"]
 name = "callbacks"
 
 [dependencies]

--- a/examples/custom-types/Cargo.toml
+++ b/examples/custom-types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "custom-types"
+name = "uniffi-example-custom-types"
 edition = "2018"
 version = "0.17.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]

--- a/examples/geometry/Cargo.toml
+++ b/examples/geometry/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["lib", "cdylib"]
 name = "uniffi_geometry"
 
 [dependencies]

--- a/examples/rondpoint/Cargo.toml
+++ b/examples/rondpoint/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib", "cdylib"]
 name = "uniffi_rondpoint"
 
 [dependencies]

--- a/examples/sprites/Cargo.toml
+++ b/examples/sprites/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["lib", "cdylib"]
 name = "uniffi_sprites"
 
 [dependencies]

--- a/examples/todolist/Cargo.toml
+++ b/examples/todolist/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["staticlib", "cdylib"]
+crate-type = ["lib", "cdylib"]
 name = "uniffi_todolist"
 
 [dependencies]

--- a/fixtures/callbacks/Cargo.toml
+++ b/fixtures/callbacks/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "callbacks"
+name = "uniffi-fixture-callbacks"
 version = "0.17.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"

--- a/fixtures/coverall/Cargo.toml
+++ b/fixtures/coverall/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "coverall"
+name = "uniffi-fixture-coverall"
 version = "0.17.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"

--- a/fixtures/ext-types/guid/Cargo.toml
+++ b/fixtures/ext-types/guid/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ext-types-guid"
+name = "uniffi-fixture-ext-types-guid"
 edition = "2018"
 version = "0.17.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]

--- a/fixtures/ext-types/lib/Cargo.toml
+++ b/fixtures/ext-types/lib/Cargo.toml
@@ -1,13 +1,20 @@
 [package]
-name = "ext-types-lib"
+name = "uniffi-fixture-ext-types"
 edition = "2018"
 version = "0.17.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 
+[package.metadata.uniffi.testing]
+external-crates = [
+    "uniffi-fixture-ext-types-guid",
+    "uniffi-fixture-ext-types-lib-one",
+    "uniffi-example-custom-types",
+]
+
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["lib", "cdylib"]
 name = "uniffi_ext_types_lib"
 
 [dependencies]
@@ -16,13 +23,15 @@ bytes = "1.0"
 uniffi_macros = {path = "../../../uniffi_macros"}
 uniffi = {path = "../../../uniffi", features=["builtin-bindgen"]}
 
-uniffi-one = {path = "../uniffi-one"}
-ext-types-guid = {path = "../guid"}
+uniffi-fixture-ext-types-lib-one = {path = "../uniffi-one"}
+uniffi-fixture-ext-types-guid = {path = "../guid"}
 
 # Reuse one of our examples.
-custom-types = {path = "../../../examples/custom-types"}
+uniffi-example-custom-types = {path = "../../../examples/custom-types"}
 
 url = "2.2"
 
 [build-dependencies]
 uniffi_build = {path = "../../../uniffi_build", features=["builtin-bindgen"]}
+
+

--- a/fixtures/ext-types/uniffi-one/Cargo.toml
+++ b/fixtures/ext-types/uniffi-one/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
-# TODO: modify the crate name to test non-default names.
-name = "uniffi-one"
+name = "uniffi-fixture-ext-types-lib-one"
 edition = "2018"
 version = "0.17.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
@@ -8,7 +7,8 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib", "cdylib"]
+name = "uniffi_one"
 
 [dependencies]
 anyhow = "1"

--- a/fixtures/external-types/lib/Cargo.toml
+++ b/fixtures/external-types/lib/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "external_types_lib"
+name = "uniffi-fixture-external-types"
 edition = "2018"
 version = "0.17.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["staticlib", "cdylib", "lib"]
+crate-type = ["lib", "cdylib"]
 name = "uniffi_external_types_lib"
 
 [dependencies]

--- a/fixtures/reexport-scaffolding-macro/Cargo.toml
+++ b/fixtures/reexport-scaffolding-macro/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 
 [lib]
 name = "reexport_scaffolding_macro"
-crate-type = ["cdylib"]
+crate-type = ["lib", "cdylib"]
 
 [dependencies]
-callbacks = { path = "../callbacks" }
-coverall = { path = "../coverall" }
+uniffi-fixture-callbacks = { path = "../callbacks" }
+uniffi-fixture-coverall = { path = "../coverall" }
 uniffi = { path = "../../uniffi", features=["builtin-bindgen"] }
 
 [dev-dependencies]

--- a/fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency/Cargo.toml
+++ b/fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "cdylib-dependency"
+name = "uniffi-fixture-regression-cdylib-dependency"
 version = "0.17.0"
 authors = ["king6cong <king6cong@gmail.com>"]
 edition = "2018"
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["lib", "cdylib"]

--- a/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
+++ b/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ffi-crate"
+name = "uniffi-fixture-regression-cdylib-dependency-ffi-crate"
 edition = "2018"
 version = "0.17.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
@@ -7,13 +7,13 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["lib", "cdylib"]
 name = "uniffi_empty"
 
 [dependencies]
 uniffi_macros = {path = "../../../../uniffi_macros"}
 uniffi = {path = "../../../../uniffi", features=["builtin-bindgen"]}
-cdylib-dependency = {path = "../cdylib-dependency"}
+uniffi-fixture-regression-cdylib-dependency = {path = "../cdylib-dependency"}
 
 [build-dependencies]
 uniffi_build = {path = "../../../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
+++ b/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "i356-enum-without-int-helpers"
+name = "uniffi-fixture-regression-i356-enum-without-int-helpers"
 edition = "2018"
 version = "0.17.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["lib", "cdylib"]
 name = "uniffi_regression_test_i356"
 
 [dependencies]

--- a/fixtures/regressions/fully-qualified-types/Cargo.toml
+++ b/fixtures/regressions/fully-qualified-types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "i1015-fully-qualified-types"
+name = "uniffi-fixture-regression-i1015-fully-qualified-types"
 edition = "2018"
 version = "0.17.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["lib", "cdylib"]
 name = "uniffi_regression_test_i1015"
 
 [dependencies]

--- a/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
+++ b/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "kotlin-experimental-unsigned-types"
+name = "uniffi-fixture-regression-kotlin-experimental-unsigned-types"
 edition = "2018"
 version = "0.17.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["lib", "cdylib"]
 name = "uniffi_regression_test_kt_unsigned_types"
 
 [dependencies]

--- a/fixtures/swift-omit-labels/Cargo.toml
+++ b/fixtures/swift-omit-labels/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "omit_argument_labels"
+name = "uniffi-fixture-swift-omit-argument-labels"
 version = "0.17.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 publish = false
 
 [lib]
-crate-type = ["staticlib", "cdylib"]
+crate-type = ["lib", "cdylib"]
 name = "uniffi_omit_argument_labels"
 
 [dependencies]

--- a/fixtures/uniffi-fixture-time/Cargo.toml
+++ b/fixtures/uniffi-fixture-time/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["staticlib", "cdylib"]
+crate-type = ["lib", "cdylib"]
 name = "uniffi_chronological"
 
 [dependencies]

--- a/uniffi_testing/Cargo.toml
+++ b/uniffi_testing/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "uniffi_testing"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+cargo_metadata = "0.13"
+lazy_static = "1.4"
+serde = "1"
+serde_json = "1"

--- a/uniffi_testing/README.md
+++ b/uniffi_testing/README.md
@@ -1,0 +1,18 @@
+This crate contains helper code for testing bindings.  Our general system is to
+generate bindings for the libraries from the examples and fixtures
+directories, then execute a script that tests the bindings.
+
+Each bindings crate can do this in a different way, but the typical system is:
+
+  - Construct a `UniFFITestHelper` struct to assist the process
+  - Call `UniFFITestHelper.create_out_dir()` to create a temp directory to
+    store testing files
+  - Call `UniFFITestHelper.copy_cdylibs_to_out_dir()` to copy the dylib
+    artifacts for the example/fixture library to the `out_dir`.  This is needed
+    because the bindings code dynamically links to or loads from this library.
+  - Call `UniFFITestHelper.get_compile_sources()` to iterate over (`udl_path`,
+    `uniffi_config_path`) pairs and generate the bindings from them. This step
+    is specific to the bindings language, it may mean creating a .jar file,
+    compiling a binary, or just copying script files over.
+  - Execute the test script and check if it succeeds.  This step is also
+    specific to the bindings language.

--- a/uniffi_testing/src/lib.rs
+++ b/uniffi_testing/src/lib.rs
@@ -1,0 +1,246 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use anyhow::{bail, Result};
+use cargo_metadata::{Artifact, Message, Metadata, MetadataCommand, Package, Target};
+use serde::Deserialize;
+use std::{
+    collections::hash_map::DefaultHasher,
+    env,
+    env::consts::DLL_EXTENSION,
+    fs::{copy, read_dir},
+    hash::{Hash, Hasher},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+#[derive(Deserialize)]
+struct UniFFITestingMetadata {
+    #[serde(rename = "external-crates")]
+    external_crates: Option<Vec<String>>,
+}
+
+// A source to compile for a test
+#[derive(Debug)]
+pub struct CompileSource {
+    pub udl_path: PathBuf,
+    pub config_path: Option<PathBuf>,
+}
+
+// Store Cargo output to in a lazy_static to avoid calling it more than once.
+lazy_static::lazy_static! {
+    static ref CARGO_METADATA: Metadata = get_cargo_metadata();
+    static ref CARGO_BUILD_MESSAGES: Vec<Message> = get_cargo_build_messages();
+}
+
+/// Struct for running fixture and example tests for bindings generators
+///
+/// Expectations:
+///   - Used from a integration test (a `.rs` file in the tests/ directory)
+///   - The working directory is the project root for the bindings crate. This is the normal case
+///     for test code, just make sure you don't cd somewhere else.
+///   - The bindings crate has a dev-dependency on the fixture crate
+///   - The fixture crate produces a cdylib library
+///   - The fixture crate, and any external-crates, has 1 UDL file in it's src/ directory
+pub struct UniFFITestHelper {
+    name: String,
+    package: Package,
+    metadata: Option<UniFFITestingMetadata>,
+}
+
+impl UniFFITestHelper {
+    pub fn new(name: &str) -> Result<Self> {
+        let package = Self::find_package(name)?;
+        let metadata: Option<UniFFITestingMetadata> = package
+            .metadata
+            .pointer("/uniffi/testing")
+            .cloned()
+            .map(serde_json::from_value)
+            .transpose()?;
+        Ok(Self {
+            name: name.to_string(),
+            package,
+            metadata,
+        })
+    }
+
+    fn find_package(name: &str) -> Result<Package> {
+        let matching: Vec<&Package> = CARGO_METADATA
+            .packages
+            .iter()
+            .filter(|p| p.name == name)
+            .collect();
+        match matching.len() {
+            1 => Ok(matching[0].clone()),
+            n => bail!("cargo metadata return {} packages named {}", n, name),
+        }
+    }
+
+    fn find_packages_for_external_crates(&self) -> Result<Vec<Package>> {
+        // Add any external crates listed in `Cargo.toml`
+        match &self.metadata {
+            None => Ok(vec![]),
+            Some(metadata) => metadata
+                .external_crates
+                .iter()
+                .flatten()
+                .map(|name| Self::find_package(name))
+                .collect(),
+        }
+    }
+
+    fn find_cdylib_path(package: &Package) -> Result<PathBuf> {
+        let cdylib_targets: Vec<&Target> = package
+            .targets
+            .iter()
+            .filter(|t| t.crate_types.iter().any(|t| t == "cdylib"))
+            .collect();
+        let target = match cdylib_targets.len() {
+            1 => cdylib_targets[0],
+            n => bail!("Found {} cdylib targets for {}", n, package.name),
+        };
+
+        let artifacts = CARGO_BUILD_MESSAGES
+            .iter()
+            .filter_map(|message| match message {
+                Message::CompilerArtifact(artifact) => {
+                    if artifact.target == *target {
+                        Some(artifact.clone())
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            })
+            .collect::<Vec<Artifact>>();
+        let artifact = match artifacts.len() {
+            1 => &artifacts[0],
+            n => bail!("Found {} artifacts for target {}", n, target.name),
+        };
+        let cdylib_files: Vec<_> = artifact
+            .filenames
+            .iter()
+            .filter(|nm| matches!(nm.extension(), Some(DLL_EXTENSION)))
+            .collect();
+
+        match cdylib_files.len() {
+            1 => Ok(cdylib_files[0].as_std_path().to_path_buf()),
+            n => bail!("Found {} cdylib files for {}", n, artifact.target.name),
+        }
+    }
+
+    /// Create at `out_dir` for testing
+    ///
+    /// This directory can be used for:
+    ///   - Generated bindings files (usually via the `--out-dir` param)
+    ///   - cdylib libraries that the bindings depend on
+    ///   - Anything else that's useful for testing
+    ///
+    /// This directory typically created as a subdirectory of `CARGO_TARGET_TMPDIR` when running an
+    /// integration test.
+    ///
+    /// We use the script path to create a hash included in the outpuit directory.  This avoids
+    /// path collutions when 2 scripts run against the same fixture.
+    pub fn create_out_dir(
+        &self,
+        temp_dir: impl AsRef<Path>,
+        script_path: impl AsRef<Path>,
+    ) -> Result<PathBuf> {
+        let dirname = format!("{}-{}", self.name, hash_path(script_path.as_ref()));
+        let out_dir = Path::new(temp_dir.as_ref()).join(dirname);
+        if out_dir.exists() {
+            // Clean out any files from previous runs
+            std::fs::remove_dir_all(&out_dir)?;
+        }
+        std::fs::create_dir(&out_dir)?;
+        Ok(out_dir)
+    }
+
+    /// Copy the `cdylib` for a fixture into the out_dir
+    ///
+    /// This is typically needed for the bindings to open it when running the tests
+    ///
+    /// Returns the path to the copied library
+    pub fn copy_cdylibs_to_out_dir(&self, out_dir: impl AsRef<Path>) -> Result<()> {
+        let cdylib_paths = std::iter::once(self.package.clone())
+            .chain(self.find_packages_for_external_crates()?)
+            .map(|p| Self::find_cdylib_path(&p))
+            .collect::<Result<Vec<_>>>()?;
+
+        for path in cdylib_paths.into_iter() {
+            let dest = out_dir.as_ref().join(path.file_name().unwrap());
+            copy(&path, &dest)?;
+        }
+        Ok(())
+    }
+
+    /// Get paths to the UDL and config files for a fixture
+    pub fn get_compile_sources(&self) -> Result<Vec<CompileSource>> {
+        std::iter::once(self.package.clone())
+            .chain(self.find_packages_for_external_crates()?)
+            .map(|p| self.find_compile_source(&p))
+            .collect()
+    }
+
+    fn find_compile_source(&self, package: &Package) -> Result<CompileSource> {
+        let crate_root = package.manifest_path.parent().unwrap().as_std_path();
+        let src_dir = crate_root.join("src");
+        let mut udl_paths = find_files(
+            &src_dir,
+            |path| matches!(path.extension(), Some(ext) if ext.to_ascii_lowercase() == "udl"),
+        )?;
+        let udl_path = match udl_paths.len() {
+            1 => udl_paths.remove(0),
+            n => bail!("Found {} UDL files in {:?}", n, src_dir),
+        };
+        let mut config_paths = find_files(
+            crate_root,
+            |path| matches!(path.file_name(), Some(name) if name == "uniffi.toml"),
+        )?;
+        let config_path = match config_paths.len() {
+            0 => None,
+            1 => Some(config_paths.remove(0)),
+            n => bail!("Found {} UDL files in {:?}", n, crate_root),
+        };
+
+        Ok(CompileSource {
+            udl_path,
+            config_path,
+        })
+    }
+}
+
+fn find_files<F: Fn(&Path) -> bool>(dir: &Path, predicate: F) -> Result<Vec<PathBuf>> {
+    Ok(read_dir(&dir)?
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|p| predicate(p))
+        .collect())
+}
+
+fn get_cargo_metadata() -> Metadata {
+    MetadataCommand::new()
+        .exec()
+        .expect("error running cargo metadata")
+}
+
+fn get_cargo_build_messages() -> Vec<Message> {
+    let mut child = Command::new(env!("CARGO"))
+        .arg("build")
+        .arg("--message-format=json")
+        .arg("--tests")
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Error running cargo build");
+    let output = std::io::BufReader::new(child.stdout.take().unwrap());
+    Message::parse_stream(output)
+        .map(|m| m.expect("Error parsing cargo build messages"))
+        .collect()
+}
+
+fn hash_path(path: &Path) -> String {
+    let mut hasher = DefaultHasher::new();
+    path.hash(&mut hasher);
+    format!("{:x}", hasher.finish())
+}


### PR DESCRIPTION
Added code to allow external bindings crates to find the UDL files and cdylibs for examples/fixtures.  Made a new crate for this, since I didn't want to pull in `serde` as a dependency for `uniffi`. Eventually, this can replace `uniffi/testing.rs` and we can remove some other dependencies from `uniffi` like `cargo_metadata`.

This commit adds a testing framework that works with external bindings, but we're not actually using it yet.  The plan is to use is for the desktop JS bindings, whose code will live in moz-central.

For an example of how this code would be use, take a look at #1205.  It moves the existing bindings to separate crates and switches them to using this testing framework.