### PR TITLE
Adds missing licenses and authors

### DIFF
--- a/fixtures/callbacks/Cargo.toml
+++ b/fixtures/callbacks/Cargo.toml
@@ -3,6 +3,7 @@ name = "uniffi-fixture-callbacks"
 version = "0.17.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/fixtures/coverall/Cargo.toml
+++ b/fixtures/coverall/Cargo.toml
@@ -3,6 +3,7 @@ name = "uniffi-fixture-coverall"
 version = "0.17.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/fixtures/reexport-scaffolding-macro/Cargo.toml
+++ b/fixtures/reexport-scaffolding-macro/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "uniffi-fixture-reexport-scaffolding-macro"
-version = "0.1.0"
+version = "0.17.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
+license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency/Cargo.toml
+++ b/fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency/Cargo.toml
@@ -3,6 +3,7 @@ name = "uniffi-fixture-regression-cdylib-dependency"
 version = "0.17.0"
 authors = ["king6cong <king6cong@gmail.com>"]
 edition = "2018"
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/fixtures/swift-omit-labels/Cargo.toml
+++ b/fixtures/swift-omit-labels/Cargo.toml
@@ -3,6 +3,7 @@ name = "uniffi-fixture-swift-omit-argument-labels"
 version = "0.17.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/fixtures/uitests/Cargo.toml
+++ b/fixtures/uitests/Cargo.toml
@@ -3,6 +3,7 @@ name = "uniffi_uitests"
 version = "0.17.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/uniffi_testing/Cargo.toml
+++ b/uniffi_testing/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "uniffi_testing"
-version = "0.1.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+version = "0.17.0"
 edition = "2021"
+license = "MPL-2.0"
 
 [dependencies]
 anyhow = "1"


### PR DESCRIPTION
cc @bendk 

Firefox desktop won't let us vendor crates without licenses (I think crates.io will also complain), so I added them wherever I saw them missing