### PR TITLE
Have the manual link back to the repo

### DIFF
--- a/docs/manual/src/Overview.md
+++ b/docs/manual/src/Overview.md
@@ -1,6 +1,7 @@
 # UniFFI
 
-UniFFI is a tool that automatically generates foreign-language bindings targeting Rust libraries.  
+UniFFI is a tool that automatically generates foreign-language bindings targeting Rust libraries.
+The repository can be found on [github](https://github.com/mozilla/uniffi-rs/).
 It fits in the practice of consolidating business logic in a single Rust library while targeting multiple platforms, making it simpler to develop and maintain a cross-platform codebase.  
 Note that this tool will not help you ship a Rust library to these platforms, but simply not have to write bindings code by hand [[0]](https://i.kym-cdn.com/photos/images/newsfeed/000/572/078/d6d.jpg).
 


### PR DESCRIPTION
I was looking at some docs from Ben, which had a link to https://mozilla.github.io/uniffi-rs/, and I noticed that page didn't actually link to uniffi itself - this PR fixes that.