### PR TITLE
Update to clap v3 using derive macros

### DIFF
--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -20,7 +20,7 @@ weedle = "0.12"
 anyhow = "1"
 askama = { version = "0.11", default-features = false, features = ["config"] }
 heck = "0.3"
-clap = { version = "2", default-features = false }
+clap = { version = "3", features = ["cargo", "std", "derive"] }
 paste = "1.0"
 serde = "1"
 toml = "0.5"


### PR DESCRIPTION
This upgrades `clap` to version 3.0 via "derive" macros. It seems a bit cleaner to me, and it also seems less error prone, as it highlighted the fact that a `--manifest-path` option was specified for the `generate` command but it was unused.

It enabled more features of `clap` and no longer specifies `default-features = false` - so we get color options etc. I can't see a good reason to avoid that for this use-case, but I might be missing the reason it was done this way in the first place.

I *think* it's complete, but have a local test failure I can't explain, so we'll see what CI says. There's also another PR which sticks with the `builder` interface which I'll put up for comparison, but I'm leaning towards this being the better option.