### PR TITLE
WIP moving to clap version 3 using the builder API.

### DIFF
--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -20,7 +20,7 @@ weedle = "0.12"
 anyhow = "1"
 askama = { version = "0.11", default-features = false, features = ["config"] }
 heck = "0.3"
-clap = { version = "2", default-features = false }
+clap = { version = "3", features = ["cargo"] }
 paste = "1.0"
 serde = "1"
 toml = "0.5"


### PR DESCRIPTION
This is not complete - it will have different semantics and panics in
various cases.

I initially thought that sticking with the builder interface would be
easier to review, but I'm not that happy with how it is working out,
particularly the "magic" `arg!` macro, and I didn't find good docs
on exactly how to specify things.

Then I realized that clap's "derive" mode actually *is* structopt
(see clap's FAQ) and I've been relatively happy with structopt in
app-services - so thought that before I polish this I'd have a go
at using derive mode (see #1211) there and see how that looks, then we can
decide which one to move forward with.