### PR TITLE
Do not provide library link search path

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -178,7 +178,7 @@ pub fn run_script(out_dir: &Path, script_file: &Path) -> Result<()> {
     // Swift to load only the module(s) for the component under test, but the way we're calling
     // this test function doesn't allow us to pass that name in to the call.
 
-    cmd.arg("-I").arg(out_dir).arg("-L").arg(out_dir);
+    cmd.arg("-I").arg(out_dir);
     for entry in PathBuf::from(out_dir)
         .read_dir()
         .context("Failed to list target directory when running script")?

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
@@ -90,7 +90,6 @@ fileprivate struct {{ ffi_converter }} {
     // Initialize our callback method with the scaffolding code
     private static var callbackInitialized = false
     private static func initCallback() {
-        print("init callback:  {{ type_name  }}")
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
                 {{ cbi.ffi_init_callback().name() }}({{ foreign_callback }}, err)
         }


### PR DESCRIPTION
Somehow this now breaks for me on swiftlang-5.6.0.323.62 clang-1316.0.20.8 for the callback example tests.