### PR TITLE
Removing a couple of RustBuffer tests

### DIFF
--- a/uniffi/src/ffi/rustbuffer.rs
+++ b/uniffi/src/ffi/rustbuffer.rs
@@ -351,21 +351,4 @@ mod test {
         let rbuf = unsafe { RustBuffer::from_raw_parts(v.as_mut_ptr(), 3, 2) };
         rbuf.destroy_into_vec();
     }
-
-    #[test]
-    #[should_panic]
-    fn test_rustbuffer_vec_capacity_must_fit_in_i32() {
-        RustBuffer::from_vec(Vec::with_capacity((i32::MAX as usize) + 1));
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_rustbuffer_vec_len_must_fit_in_i32() {
-        let mut v = Vec::new();
-        // We don't want to actually materialize a huge vec, so unsafety it is!
-        // This won't cause problems because the contained items are Plain Old Data.
-        // (And also we expect to panic without accessing them).
-        unsafe { v.set_len((i32::MAX as usize) + 1) }
-        RustBuffer::from_vec(v);
-    }
 }


### PR DESCRIPTION
I think we're better off without these tests for a few reasons:
  - I don't have confidence that these tests are testing what they say
    they are.  It also seems likely that the panics are caused by a)
    trying to allocate a 2GB Vec and b) trying to use a Vec with
    `len > capacity`.
  - The code they're testing is hard to get wrong.  If we're trying to
    coerce a `u32` into an `i32` and the value overflows, it seems like you
    would have to go out of your way not to panic.
  - jplatte pointed out that having even `u8` data that's uninitialized
    causes undefined behavior (https://github.com/mozilla/uniffi-rs/pull/1215/files/bc655fc8fc2b67b3d2090659ba9bb254e5ea6866#r850255739)

I'm definitely open to a conversation about this though.  I know there are lots of philosophies on unit testing.