### PR TITLE
Assert that record keys satisfy HashMap requirements (Eq & Hash)

### DIFF
--- a/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
+++ b/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
@@ -1,7 +1,47 @@
-error: Failed to generate scaffolding from UDL file at ../../../fixtures/uitests/src/records.udl
- --> tests/ui/non_hashable_record_key.rs:2:1
-  |
-2 | uniffi_macros::generate_and_include_scaffolding!("../../../fixtures/uitests/src/records.udl");
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the macro `uniffi_macros::generate_and_include_scaffolding` (in Nightly builds, run with -Z macro-backtrace for more info)
+error[E0425]: cannot find function `get_dict` in this scope
+  --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
+   |
+   |     <std::collections::HashMap<f32, u64> as uniffi::FfiConverter>::lower(get_dict())
+   |                                                                          ^^^^^^^^ not found in this scope
+
+error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
+  --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
+   |
+   | uniffi::deps::static_assertions::assert_impl_all!(f32: ::std::cmp::Eq, ::std::hash::Hash); // record<f32, u64>
+   |                                                   ^^^ the trait `std::cmp::Eq` is not implemented for `f32`
+   |
+note: required by a bound in `assert_impl_all`
+  --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
+   |
+   | uniffi::deps::static_assertions::assert_impl_all!(f32: ::std::cmp::Eq, ::std::hash::Hash); // record<f32, u64>
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   = note: this error originates in the macro `uniffi::deps::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `f32: Hash` is not satisfied
+  --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
+   |
+   | uniffi::deps::static_assertions::assert_impl_all!(f32: ::std::cmp::Eq, ::std::hash::Hash); // record<f32, u64>
+   |                                                   ^^^ the trait `Hash` is not implemented for `f32`
+   |
+note: required by a bound in `assert_impl_all`
+  --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
+   |
+   | uniffi::deps::static_assertions::assert_impl_all!(f32: ::std::cmp::Eq, ::std::hash::Hash); // record<f32, u64>
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   = note: this error originates in the macro `uniffi::deps::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `f32: Hash` is not satisfied
+  --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
+   |
+   |     <std::collections::HashMap<f32, u64> as uniffi::FfiConverter>::lower(get_dict())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Hash` is not implemented for `f32`
+   |
+   = note: required because of the requirements on the impl of `RustBufferFfiConverter` for `HashMap<f32, u64>`
+
+error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
+  --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
+   |
+   |     <std::collections::HashMap<f32, u64> as uniffi::FfiConverter>::lower(get_dict())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `f32`
+   |
+   = note: required because of the requirements on the impl of `RustBufferFfiConverter` for `HashMap<f32, u64>`

--- a/uniffi_bindgen/src/interface/types/resolver.rs
+++ b/uniffi_bindgen/src/interface/types/resolver.rs
@@ -119,37 +119,13 @@ impl TypeResolver for weedle::types::SequenceType<'_> {
     }
 }
 
-/// Validate that the type can be used for record keys.
-///
-/// Every record key type needs to be hashable and comparable.
-/// We therefore only allow integers, string and booleans as keys in a record.
-/// These are guaranteed to be hashable.
-fn validate_record_key_type(typ: Type) -> Result<Type> {
-    match typ {
-        Type::UInt8
-        | Type::Int8
-        | Type::UInt16
-        | Type::Int16
-        | Type::UInt32
-        | Type::Int32
-        | Type::UInt64
-        | Type::Int64
-        | Type::Boolean
-        | Type::String => Ok(typ),
-        _ => bail!(
-            "Hashable & comparable key type required, got {}",
-            typ.canonical_name()
-        ),
-    }
-}
-
 impl TypeResolver for weedle::types::RecordKeyType<'_> {
     fn resolve_type_expression(&self, types: &mut TypeUniverse) -> Result<Type> {
         use weedle::types::RecordKeyType::*;
         match self {
             Byte(_) | USV(_) => bail!("WebIDL Byte or USV string type not implemented ({:?}); consider using DOMString or string", self),
             DOM(_) => types.add_known_type(Type::String),
-            NonAny(t) => validate_record_key_type(t.resolve_type_expression(types)?)
+            NonAny(t) => t.resolve_type_expression(types)
         }
     }
 }

--- a/uniffi_bindgen/src/scaffolding/templates/scaffolding_template.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/scaffolding_template.rs
@@ -8,6 +8,15 @@
 // seems to show that single line as context for the user.
 uniffi::assert_compatible_version!("{{ uniffi_version }}"); // Please check that you depend on version {{ uniffi_version }} of the `uniffi` crate.
 
+{% for ty in ci.iter_types() %}
+{%- match ty %}
+{%- when Type::Map with (k, v) -%}
+{# Next comment MUST be after the line to be in the compiler output #}
+uniffi::deps::static_assertions::assert_impl_all!({{ k|type_rs }}: ::std::cmp::Eq, ::std::hash::Hash); // record<{{ k|type_rs }}, {{ v|type_rs }}>
+{%- else %}
+{%- endmatch %}
+{% endfor %}
+
 {% include "RustBuffer.rs" %}
 
 // Error definitions, corresponding to `error` in the UDL.


### PR DESCRIPTION
This removes the explicit type check in code,
moving the assertion to the generated scaffolding code,
in order to improve the error message.

Fixes #1221

---

I'm not perfectly happy with this solution, but it's the best I could do for now.