### PR TITLE
Re-generate expected output for non_hashable_record_key test

### DIFF
--- a/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
+++ b/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
@@ -10,6 +10,12 @@ error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
    | uniffi::deps::static_assertions::assert_impl_all!(f32: ::std::cmp::Eq, ::std::hash::Hash); // record<f32, u64>
    |                                                   ^^^ the trait `std::cmp::Eq` is not implemented for `f32`
    |
+   = help: the following implementations were found:
+             <i128 as std::cmp::Eq>
+             <i16 as std::cmp::Eq>
+             <i32 as std::cmp::Eq>
+             <i64 as std::cmp::Eq>
+           and 8 others
 note: required by a bound in `assert_impl_all`
   --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
    |
@@ -23,6 +29,12 @@ error[E0277]: the trait bound `f32: Hash` is not satisfied
    | uniffi::deps::static_assertions::assert_impl_all!(f32: ::std::cmp::Eq, ::std::hash::Hash); // record<f32, u64>
    |                                                   ^^^ the trait `Hash` is not implemented for `f32`
    |
+   = help: the following implementations were found:
+             <i128 as Hash>
+             <i16 as Hash>
+             <i32 as Hash>
+             <i64 as Hash>
+           and 8 others
 note: required by a bound in `assert_impl_all`
   --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
    |
@@ -36,6 +48,12 @@ error[E0277]: the trait bound `f32: Hash` is not satisfied
    |     <std::collections::HashMap<f32, u64> as uniffi::FfiConverter>::lower(get_dict())
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Hash` is not implemented for `f32`
    |
+   = help: the following implementations were found:
+             <i128 as Hash>
+             <i16 as Hash>
+             <i32 as Hash>
+             <i64 as Hash>
+           and 8 others
    = note: required because of the requirements on the impl of `RustBufferFfiConverter` for `HashMap<f32, u64>`
 
 error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
@@ -44,4 +62,10 @@ error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
    |     <std::collections::HashMap<f32, u64> as uniffi::FfiConverter>::lower(get_dict())
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `f32`
    |
+   = help: the following implementations were found:
+             <i128 as std::cmp::Eq>
+             <i16 as std::cmp::Eq>
+             <i32 as std::cmp::Eq>
+             <i64 as std::cmp::Eq>
+           and 8 others
    = note: required because of the requirements on the impl of `RustBufferFfiConverter` for `HashMap<f32, u64>`


### PR DESCRIPTION
Seems like the output changed in some version between Rust 1.57 and 1.60