### PR TITLE
Require at least clap v3.1

### DIFF
--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -20,7 +20,7 @@ weedle2 = { version = "2.0.0", path = "../weedle2" }
 anyhow = "1"
 askama = { version = "0.11", default-features = false, features = ["config"] }
 heck = "0.4"
-clap = { version = "3", features = ["cargo", "std", "derive"] }
+clap = { version = "3.1", features = ["cargo", "std", "derive"] }
 paste = "1.0"
 serde = "1"
 toml = "0.5"


### PR DESCRIPTION
3.0 to <=3.0.14 do not work
It will fail with something like this:

    error[E0405]: cannot find trait `CommandFactory` in crate `clap`
       --> uniffi_bindgen/src/lib.rs:499:10
        |
    499 | #[derive(Parser)]
        |          ^^^^^^ not found in `clap`
        |
        = note: this error originates in the derive macro `Parser` (in Nightly builds, run with -Z macro-backtrace for more info)

This seems to have been fixed in 3.1
Changelog is here: https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#310---2022-02-16