### PR TITLE
Allow Rust, Python and Kotlin keywords to be used as names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 ###  ⚠️ Breaking Changes ⚠️
 - breaking for external binding generators, the `FFIType::RustArcPtr` now includes an inner `String`. The string represents the name of the object the `RustArcPtr` was derived from.
 
+### What's changed
+- The UDL can contain identifiers which are also keywords in Rust, Python or Kotlin.
+
 ## v0.18.0 - (_2022-05-05_)
 
 [All changes in v0.18.0](https://github.com/mozilla/uniffi-rs/compare/v0.17.0...v0.18.0).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ members = [
   "fixtures/external-types/crate-two",
   "fixtures/external-types/lib",
 
+  "fixtures/keywords/kotlin",
+  "fixtures/keywords/rust",
   "fixtures/reexport-scaffolding-macro",
   "fixtures/regressions/enum-without-i32-helpers",
   "fixtures/regressions/fully-qualified-types",

--- a/fixtures/keywords/README.md
+++ b/fixtures/keywords/README.md
@@ -1,0 +1,17 @@
+These fixtures are designed to test that keywords from supported languages
+are able to be used.
+
+Each directory is a specialized fixture for each language (although the
+`rust` directory does double-duty for Python)
+
+The reason we don't try and combine these into a single fixture is that we'd
+like a highe degree is assurance that each language has a keyword used
+in every possible context. By trying to combine them, we would end up needing
+multiple, say, `enum`, `interface`, function arguments, variant discriminators,
+etc. So there's a reasonable change we'd accidently not have an `enum` with a
+(say) kotlin keyword.
+
+Separate fixtures means someone familiar with Kotlin and look at 1 fixture and
+fairly easily verify all cases are covered.
+
+Feel free to have a poke at uniffi(hah)-ing them though!

--- a/fixtures/keywords/kotlin/Cargo.toml
+++ b/fixtures/keywords/kotlin/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "uniffi-fixture-keywords-kotlin"
+version = "0.18.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+name = "uniffi_keywords_kotlin"
+
+[dependencies]
+thiserror = "1.0"
+uniffi_macros = {path = "../../../uniffi_macros"}
+uniffi = {path = "../../../uniffi", features=["builtin-bindgen"]}
+
+[build-dependencies]
+uniffi_build = {path = "../../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/keywords/kotlin/build.rs
+++ b/fixtures/keywords/kotlin/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/keywords.udl").unwrap();
+}

--- a/fixtures/keywords/kotlin/src/keywords.udl
+++ b/fixtures/keywords/kotlin/src/keywords.udl
@@ -1,0 +1,43 @@
+namespace keywords_kotlin {
+    void if(u8 break);
+};
+
+interface break {
+    void class(u8 object);
+    void object(u8? class);
+};
+
+callback interface continue {
+    return return(return v);
+    continue? continue(sequence<continue> continue);
+    record<u8, break> break(break? v);
+    while while(sequence<while> while);
+    record<u8, sequence<class>>? class(record<u8, sequence<class>> v);
+};
+
+dictionary return {
+    u8 class;
+    u8? object;
+};
+
+dictionary while {
+    return class;
+    return? fun;
+    sequence<return> object;
+    record<u8, return> break;
+};
+
+[Enum]
+interface false {
+    true(u8 object);
+};
+
+[Error]
+enum class {
+    "object",
+};
+
+[Error]
+interface fun {
+   class(u8 object);
+};

--- a/fixtures/keywords/kotlin/src/lib.rs
+++ b/fixtures/keywords/kotlin/src/lib.rs
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::{collections::HashMap, sync::Arc};
+
+pub fn r#if(_object: u8) {}
+
+#[allow(non_camel_case_types)]
+pub struct r#break {}
+
+impl r#break {
+    pub fn class(&self, _object: u8) {}
+    pub fn object(&self, _class: Option<u8>) {}
+}
+
+#[allow(non_camel_case_types)]
+trait r#continue {
+    fn r#return(&self, v: r#return) -> r#return;
+    fn r#continue(&self, v: Vec<Box<dyn r#continue>>) -> Option<Box<dyn r#continue>>;
+    fn r#break(&self, _v: Option<Arc<r#break>>) -> HashMap<u8, Arc<r#break>>;
+    fn r#while(&self, _v: Vec<r#while>) -> r#while;
+    fn class(&self, _v: HashMap<u8, Vec<class>>) -> Option<HashMap<u8, Vec<class>>>;
+}
+
+#[allow(non_camel_case_types)]
+pub struct r#return {
+    class: u8,
+    object: Option<u8>,
+}
+
+#[allow(non_camel_case_types)]
+pub struct r#while {
+    class: r#return,
+    fun: Option<r#return>,
+    object: Vec<r#return>,
+    r#break: HashMap<u8, r#return>,
+}
+
+#[allow(non_camel_case_types)]
+pub enum r#false {
+    #[allow(non_camel_case_types)]
+    r#true { object: u8 },
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, thiserror::Error)]
+pub enum class {
+    #[error("object error")]
+    object,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, thiserror::Error)]
+pub enum fun {
+    #[error("class?")]
+    class { object: u8 },
+}
+
+include!(concat!(env!("OUT_DIR"), "/keywords.uniffi.rs"));

--- a/fixtures/keywords/kotlin/tests/bindings/test_keywords.kts
+++ b/fixtures/keywords/kotlin/tests/bindings/test_keywords.kts
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import java.util.concurrent.*
+
+import uniffi.keywords_kotlin.*
+// able to import is the real test, but might as well call something.
+`if`(1.toUByte())

--- a/fixtures/keywords/kotlin/tests/test_generated_bindings.rs
+++ b/fixtures/keywords/kotlin/tests/test_generated_bindings.rs
@@ -1,0 +1,4 @@
+uniffi_macros::build_foreign_language_testcases!(
+    ["src/keywords.udl",],
+    ["tests/bindings/test_keywords.kts",]
+);

--- a/fixtures/keywords/rust/Cargo.toml
+++ b/fixtures/keywords/rust/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "uniffi-fixture-keywords-rust"
+version = "0.18.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+name = "uniffi_keywords_rust"
+
+[dependencies]
+thiserror = "1.0"
+uniffi_macros = {path = "../../../uniffi_macros"}
+uniffi = {path = "../../../uniffi", features=["builtin-bindgen"]}
+
+[build-dependencies]
+uniffi_build = {path = "../../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/keywords/rust/build.rs
+++ b/fixtures/keywords/rust/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/keywords.udl").unwrap();
+}

--- a/fixtures/keywords/rust/src/keywords.udl
+++ b/fixtures/keywords/rust/src/keywords.udl
@@ -1,0 +1,51 @@
+// Nominally checking Rust keywords, but we try and use as many from
+// Python as well to kill two birds with one stone.
+
+namespace keywords_rust {
+    void if(u8 async);
+};
+
+interface break {
+    return return(return v);
+    sequence<continue>? continue(sequence<continue> continue);
+    record<u8, break>? break(record<u8, break> v);
+    void yield(u8 async);
+    void async(u8? yield);
+};
+
+callback interface continue {
+    return return(return v);
+    continue? continue(sequence<continue> continue);
+    record<u8, break> break(break? v);
+    while while(sequence<while> while);
+    record<u8, sequence<yield>>? yield(record<u8, sequence<yield>> v);
+};
+
+dictionary return {
+    u8 yield;
+    u8? async;
+};
+
+dictionary while {
+    return return;
+    sequence<continue> continue;
+    record<u8, break> break;
+    break? for;
+    sequence<return> async;
+};
+
+[Enum]
+interface async {
+    as(u8 async);
+};
+
+[Error]
+enum yield {
+    "async",
+};
+
+[Error]
+interface for {
+   return(return return);
+   yield(u8 async);
+};

--- a/fixtures/keywords/rust/src/lib.rs
+++ b/fixtures/keywords/rust/src/lib.rs
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::{collections::HashMap, sync::Arc};
+
+pub fn r#if(_async: u8) {}
+
+#[allow(non_camel_case_types)]
+pub struct r#break {}
+
+impl r#break {
+    pub fn r#return(&self, v: r#return) -> r#return {
+        v
+    }
+    pub fn r#break(&self, v: HashMap<u8, Arc<r#break>>) -> Option<HashMap<u8, Arc<r#break>>> {
+        Some(v)
+    }
+    fn r#continue(&self, v: Vec<Box<dyn r#continue>>) -> Option<Vec<Box<dyn r#continue>>> {
+        Some(v)
+    }
+    pub fn r#yield(&self, _async: u8) {}
+    pub fn r#async(&self, _yield: Option<u8>) {}
+}
+
+#[allow(non_camel_case_types)]
+trait r#continue {
+    fn r#return(&self, v: r#return) -> r#return;
+    fn r#continue(&self, v: Vec<Box<dyn r#continue>>) -> Option<Box<dyn r#continue>>;
+    fn r#break(&self, _v: Option<Arc<r#break>>) -> HashMap<u8, Arc<r#break>>;
+    fn r#while(&self, _v: Vec<r#while>) -> r#while;
+    fn r#yield(&self, _v: HashMap<u8, Vec<r#yield>>) -> Option<HashMap<u8, Vec<r#yield>>>;
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Debug)]
+pub struct r#return {
+    r#yield: u8,
+    r#async: Option<u8>,
+}
+
+#[allow(non_camel_case_types)]
+pub struct r#while {
+    r#return: r#return,
+    r#continue: Vec<Box<dyn r#continue>>,
+    r#break: HashMap<u8, Arc<r#break>>,
+    r#for: Option<Arc<r#break>>,
+    r#async: Vec<r#return>,
+}
+
+#[allow(non_camel_case_types)]
+pub enum r#async {
+    #[allow(non_camel_case_types)]
+    r#as { r#async: u8 },
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, thiserror::Error)]
+pub enum r#yield {
+    #[error("async error")]
+    r#async,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, thiserror::Error)]
+pub enum r#for {
+    #[error("return")]
+    r#return { r#return: r#return },
+
+    #[error("yield?")]
+    r#yield { r#async: u8 },
+}
+
+include!(concat!(env!("OUT_DIR"), "/keywords.uniffi.rs"));

--- a/fixtures/keywords/rust/tests/bindings/test_keywords.py
+++ b/fixtures/keywords/rust/tests/bindings/test_keywords.py
@@ -1,0 +1,11 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import unittest
+from datetime import datetime, timezone
+
+# A successful import all this test really needs...
+import keywords_rust
+# but might as well call something.
+keywords_rust._if(0)

--- a/fixtures/keywords/rust/tests/test_generated_bindings.rs
+++ b/fixtures/keywords/rust/tests/test_generated_bindings.rs
@@ -1,0 +1,4 @@
+uniffi_macros::build_foreign_language_testcases!(
+    ["src/keywords.udl",],
+    ["tests/bindings/test_keywords.py",]
+);

--- a/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
+++ b/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `Cell<u32>` cannot be shared between threads safely
   --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
    |
-   | uniffi::deps::static_assertions::assert_impl_all!(Counter: Sync, Send);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
+   | uniffi::deps::static_assertions::assert_impl_all!(r#Counter: Sync, Send);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
    |
    = help: within `Counter`, the trait `Sync` is not implemented for `Cell<u32>`
 note: required because it appears within the type `Counter`
@@ -13,15 +13,15 @@ note: required because it appears within the type `Counter`
 note: required by a bound in `assert_impl_all`
   --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
    |
-   | uniffi::deps::static_assertions::assert_impl_all!(Counter: Sync, Send);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   | uniffi::deps::static_assertions::assert_impl_all!(r#Counter: Sync, Send);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the macro `uniffi::deps::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
   --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
    |
-   |         <std::sync::Arc<Counter> as uniffi::FfiConverter>::lower(_arc)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FfiConverter` is not implemented for `Arc<Counter>`
+   |         <std::sync::Arc<r#Counter> as uniffi::FfiConverter>::lower(_arc)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FfiConverter` is not implemented for `Arc<Counter>`
    |
    = help: the following implementations were found:
              <Arc<T> as FfiConverter>
@@ -29,8 +29,8 @@ error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
 error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
   --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
    |
-   |         <std::sync::Arc<Counter> as uniffi::FfiConverter>::lower(_arc)
-   |                                                                  ^^^^ the trait `FfiConverter` is not implemented for `Arc<Counter>`
+   |         <std::sync::Arc<r#Counter> as uniffi::FfiConverter>::lower(_arc)
+   |                                                                    ^^^^ the trait `FfiConverter` is not implemented for `Arc<Counter>`
    |
    = help: the following implementations were found:
              <Arc<T> as FfiConverter>
@@ -38,8 +38,8 @@ error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
 error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
    --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
     |
-    |         match<std::sync::Arc<Counter> as uniffi::FfiConverter>::try_lift(ptr) {
-    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FfiConverter` is not implemented for `Arc<Counter>`
+    |         match<std::sync::Arc<r#Counter> as uniffi::FfiConverter>::try_lift(r#ptr) {
+    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FfiConverter` is not implemented for `Arc<Counter>`
     |
     = help: the following implementations were found:
               <Arc<T> as FfiConverter>
@@ -47,8 +47,8 @@ error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
 error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
    --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
     |
-    |         match<std::sync::Arc<Counter> as uniffi::FfiConverter>::try_lift(ptr) {
-    |                                                                          ^^^ the trait `FfiConverter` is not implemented for `Arc<Counter>`
+    |         match<std::sync::Arc<r#Counter> as uniffi::FfiConverter>::try_lift(r#ptr) {
+    |                                                                            ^^^^^ the trait `FfiConverter` is not implemented for `Arc<Counter>`
     |
     = help: the following implementations were found:
               <Arc<T> as FfiConverter>

--- a/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
+++ b/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
@@ -1,8 +1,8 @@
 error[E0425]: cannot find function `get_dict` in this scope
   --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
    |
-   |     <std::collections::HashMap<f32, u64> as uniffi::FfiConverter>::lower(get_dict())
-   |                                                                          ^^^^^^^^ not found in this scope
+   |     <std::collections::HashMap<r#f32, r#u64> as uniffi::FfiConverter>::lower(r#get_dict())
+   |                                                                              ^^^^^^^^^^ not found in this scope
 
 error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
   --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
@@ -45,8 +45,8 @@ note: required by a bound in `assert_impl_all`
 error[E0277]: the trait bound `f32: Hash` is not satisfied
   --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
    |
-   |     <std::collections::HashMap<f32, u64> as uniffi::FfiConverter>::lower(get_dict())
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Hash` is not implemented for `f32`
+   |     <std::collections::HashMap<r#f32, r#u64> as uniffi::FfiConverter>::lower(r#get_dict())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Hash` is not implemented for `f32`
    |
    = help: the following implementations were found:
              <i128 as Hash>
@@ -59,8 +59,8 @@ error[E0277]: the trait bound `f32: Hash` is not satisfied
 error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
   --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
    |
-   |     <std::collections::HashMap<f32, u64> as uniffi::FfiConverter>::lower(get_dict())
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `f32`
+   |     <std::collections::HashMap<r#f32, r#u64> as uniffi::FfiConverter>::lower(r#get_dict())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `f32`
    |
    = help: the following implementations were found:
              <i128 as std::cmp::Eq>

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -22,6 +22,7 @@ camino = "1.0.8"
 clap = { version = "~3.1", features = ["cargo", "std", "derive"] }
 fs-err = "2.7.0"
 heck = "0.4"
+lazy_static = "1.4"
 paste = "1.0"
 serde = "1"
 serde_json = "1.0.80"

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -240,12 +240,12 @@ impl CodeOracle for KotlinCodeOracle {
 
     /// Get the idiomatic Kotlin rendering of a function name.
     fn fn_name(&self, nm: &str) -> String {
-        nm.to_string().to_lower_camel_case()
+        format!("`{}`", nm.to_string().to_lower_camel_case())
     }
 
     /// Get the idiomatic Kotlin rendering of a variable name.
     fn var_name(&self, nm: &str) -> String {
-        nm.to_string().to_lower_camel_case()
+        format!("`{}`", nm.to_string().to_lower_camel_case())
     }
 
     /// Get the idiomatic Kotlin rendering of an individual enum variant.
@@ -259,7 +259,8 @@ impl CodeOracle for KotlinCodeOracle {
     /// "Error" for any type of error but in the Java world, "Error" means a non-recoverable error
     /// and is distinguished from an "Exception".
     fn error_name(&self, nm: &str) -> String {
-        let name = nm.to_string();
+        // errors are a class in kotlin.
+        let name = self.class_name(nm);
         match name.strip_suffix("Error") {
             None => name,
             Some(stripped) => format!("{}Exception", stripped),
@@ -359,11 +360,8 @@ pub mod filters {
         Ok(oracle().enum_variant_name(nm))
     }
 
-    /// Get the idiomatic Kotlin rendering of an exception name
-    ///
-    /// This replaces "Error" at the end of the name with "Exception".  Rust code typically uses
-    /// "Error" for any type of error but in the Java world, "Error" means a non-recoverable error
-    /// and is distinguished from an "Exception".
+    /// Get the idiomatic Kotlin rendering of an exception name, replacing
+    /// `Error` with `Exception`.
     pub fn exception_name(nm: &str) -> Result<String, askama::Error> {
         Ok(oracle().error_name(nm))
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -62,7 +62,7 @@
 -#}
 {%- macro arg_list_ffi_decl(func) %}
     {%- for arg in func.arguments() %}
-        {{- arg.name() }}: {{ arg.type_().borrow()|ffi_type_name -}},
+        {{- arg.name()|var_name }}: {{ arg.type_().borrow()|ffi_type_name -}},
     {%- endfor %}
     _uniffi_out_err: RustCallStatus
 {%- endmacro -%}
@@ -76,7 +76,7 @@
 {%- endmacro -%}
 
 {%- macro ffi_function_definition(func) %}
-fun {{ func.name() }}(
+fun {{ func.name()|fn_name }}(
     {%- call arg_list_ffi_decl(func) %}
 ){%- match func.return_type() -%}{%- when Some with (type_) %}: {{ type_|ffi_type_name }}{% when None %}: Unit{% endmatch %}
 {% endmacro %}

--- a/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
@@ -30,7 +30,7 @@ class {{ type_name }}:
             {% endif %}
 
         def __str__(self):
-            return "{{ type_name }}.{{ variant.name()|enum_variant_py }}({% for field in variant.fields() %}{{ field.name() }}={}{% if loop.last %}{% else %}, {% endif %}{% endfor %})".format({% for field in variant.fields() %}self.{{ field.name() }}{% if loop.last %}{% else %}, {% endif %}{% endfor %})
+            return "{{ type_name }}.{{ variant.name()|enum_variant_py }}({% for field in variant.fields() %}{{ field.name()|var_name }}={}{% if loop.last %}{% else %}, {% endif %}{% endfor %})".format({% for field in variant.fields() %}self.{{ field.name()|var_name }}{% if loop.last %}{% else %}, {% endif %}{% endfor %})
 
         def __eq__(self, other):
             if not other.is_{{ variant.name()|var_name }}():

--- a/uniffi_bindgen/src/bindings/python/templates/ErrorTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ErrorTemplate.py
@@ -27,7 +27,7 @@ class {{ type_name }}(Exception):
             {%- if variant.has_fields() %}
             field_parts = [
                 {%- for field in variant.fields() %}
-                '{{ field.name() }}={!r}'.format(self.{{ field.name() }}),
+                '{{ field.name()|var_name }}={!r}'.format(self.{{ field.name()|var_name }}),
                 {%- endfor %}
             ]
             return "{{ type_name }}.{{ variant.name()|class_name }}({})".format(', '.join(field_parts))

--- a/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
@@ -20,7 +20,7 @@ class {{ type_name }}:
         {%- endfor %}
 
     def __str__(self):
-        return "{{ type_name }}({% for field in rec.fields() %}{{ field.name() }}={}{% if loop.last %}{% else %}, {% endif %}{% endfor %})".format({% for field in rec.fields() %}self.{{ field.name() }}{% if loop.last %}{% else %}, {% endif %}{% endfor %})
+        return "{{ type_name }}({% for field in rec.fields() %}{{ field.name()|var_name }}={}{% if loop.last %}{% else %}, {% endif %}{% endfor %})".format({% for field in rec.fields() %}self.{{ field.name()|var_name }}{% if loop.last %}{% else %}, {% endif %}{% endfor %})
 
     def __eq__(self, other):
         {%- for field in rec.fields() %}
@@ -41,5 +41,5 @@ class {{ ffi_converter_name }}(FfiConverterRustBuffer):
     @staticmethod
     def write(value, buf):
         {%- for field in rec.fields() %}
-        {{ field|write_fn }}(value.{{ field.name() }}, buf)
+        {{ field|write_fn }}(value.{{ field.name()|var_name }}, buf)
         {%- endfor %}

--- a/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
@@ -5,7 +5,7 @@ def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}):
     {%- call py::setup_args(func) %}
     return {{ return_type|lift_fn }}({% call py::to_ffi_call(func) %})
 
-{% when None -%}
+{% when None %}
 
 def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}):
     {%- call py::setup_args(func) %}

--- a/uniffi_bindgen/src/bindings/python/templates/macros.py
+++ b/uniffi_bindgen/src/bindings/python/templates/macros.py
@@ -32,7 +32,7 @@ rust_call(
 
 {%- macro _arg_list_ffi_call(func) %}
     {%- for arg in func.arguments() %}
-        {{ arg|lower_fn }}({{ arg.name() }})
+        {{ arg|lower_fn }}({{ arg.name()|var_name }})
         {%- if !loop.last %},{% endif %}
     {%- endfor %}
 {%- endmacro -%}
@@ -72,12 +72,12 @@ rust_call(
     {%- for arg in func.arguments() %}
     {%- match arg.default_value() %}
     {%- when None %}
-    {{ arg.name() }} = {{ arg.name()|coerce_py(arg.type_().borrow()) -}}
+    {{ arg.name()|var_name }} = {{ arg.name()|var_name|coerce_py(arg.type_().borrow()) -}}
     {%- when Some with(literal) %}
-    if {{ arg.name() }} is DEFAULT:
-        {{ arg.name() }} = {{ literal|literal_py(arg.type_().borrow()) }}
+    if {{ arg.name()|var_name }} is DEFAULT:
+        {{ arg.name()|var_name }} = {{ literal|literal_py(arg.type_().borrow()) }}
     else:
-        {{ arg.name() }} = {{ arg.name()|coerce_py(arg.type_().borrow()) -}}
+        {{ arg.name()|var_name }} = {{ arg.name()|var_name|coerce_py(arg.type_().borrow()) -}}
     {%- endmatch %}
     {% endfor -%}
 {%- endmacro -%}
@@ -90,12 +90,12 @@ rust_call(
         {%- for arg in func.arguments() %}
         {%- match arg.default_value() %}
         {%- when None %}
-        {{ arg.name() }} = {{ arg.name()|coerce_py(arg.type_().borrow()) -}}
+        {{ arg.name()|var_name }} = {{ arg.name()|var_name|coerce_py(arg.type_().borrow()) -}}
         {%- when Some with(literal) %}
-        if {{ arg.name() }} is DEFAULT:
-            {{ arg.name() }} = {{ literal|literal_py(arg.type_().borrow()) }}
+        if {{ arg.name()|var_name }} is DEFAULT:
+            {{ arg.name()|var_name }} = {{ literal|literal_py(arg.type_().borrow()) }}
         else:
-            {{ arg.name() }} = {{ arg.name()|coerce_py(arg.type_().borrow()) -}}
+            {{ arg.name()|var_name }} = {{ arg.name()|var_name|coerce_py(arg.type_().borrow()) -}}
         {%- endmatch %}
         {% endfor -%}
 {%- endmacro -%}

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -42,17 +42,17 @@ mod filters {
             Type::String => "String".into(),
             Type::Timestamp => "std::time::SystemTime".into(),
             Type::Duration => "std::time::Duration".into(),
-            Type::Enum(name) | Type::Record(name) | Type::Error(name) => name.clone(),
-            Type::Object(name) => format!("std::sync::Arc<{}>", name),
-            Type::CallbackInterface(name) => format!("Box<dyn {}>", name),
+            Type::Enum(name) | Type::Record(name) | Type::Error(name) => format!("r#{}", name),
+            Type::Object(name) => format!("std::sync::Arc<r#{}>", name),
+            Type::CallbackInterface(name) => format!("Box<dyn r#{}>", name),
             Type::Optional(t) => format!("std::option::Option<{}>", type_rs(t)?),
             Type::Sequence(t) => format!("std::vec::Vec<{}>", type_rs(t)?),
             Type::Map(k, v) => format!(
-                "std::collections::HashMap<{}, {}>",
+                "std::collections::HashMap<r#{}, r#{}>",
                 type_rs(k)?,
                 type_rs(v)?
             ),
-            Type::Custom { name, .. } => name.clone(),
+            Type::Custom { name, .. } => format!("r#{}", name),
             Type::External { .. } => panic!("External types coming to a uniffi near you soon!"),
         })
     }
@@ -87,7 +87,7 @@ mod filters {
             Type::Timestamp => "std::time::SystemTime".into(),
             Type::Duration => "std::time::Duration".into(),
             // Object is handled by Arc<T>
-            Type::Object(name) => format!("std::sync::Arc<{}>", name),
+            Type::Object(name) => format!("std::sync::Arc<r#{}>", name),
             // Other user-defined types are handled by a unit-struct that we generate.  The
             // FfiConverter implementation for this can be found in one of the scaffolding template code.
             //
@@ -100,10 +100,12 @@ mod filters {
             }
             // Wrapper types are implemented by generics that wrap the FfiConverter implementation of the
             // inner type.
-            Type::Optional(inner) => format!("std::option::Option<{}>", ffi_converter_name(inner)?),
-            Type::Sequence(inner) => format!("std::vec::Vec<{}>", ffi_converter_name(inner)?),
+            Type::Optional(inner) => {
+                format!("std::option::Option<r#{}>", ffi_converter_name(inner)?)
+            }
+            Type::Sequence(inner) => format!("std::vec::Vec<r#{}>", ffi_converter_name(inner)?),
             Type::Map(k, v) => format!(
-                "std::collections::HashMap<{}, {}>",
+                "std::collections::HashMap<r#{}, r#{}>",
                 ffi_converter_name(k)?,
                 ffi_converter_name(v)?
             ),

--- a/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
@@ -41,11 +41,11 @@ impl Drop for {{ trait_impl }} {
 
 uniffi::deps::static_assertions::assert_impl_all!({{ trait_impl }}: Send);
 
-impl {{ trait_name }} for {{ trait_impl }} {
+impl r#{{ trait_name }} for {{ trait_impl }} {
     {%- for meth in cbi.methods() %}
 
     {#- Method declaration #}
-    fn {{ meth.name() -}}
+    fn r#{{ meth.name() -}}
     ({% call rs::arg_list_decl_with_prefix("&self", meth) %})
     {%- match meth.return_type() %}
     {%- when Some with (return_type) %} -> {{ return_type.borrow()|type_rs }}
@@ -61,7 +61,7 @@ impl {{ trait_name }} for {{ trait_impl }} {
         let mut args_buf = Vec::new();
         {% endif -%}
         {%- for arg in meth.arguments() %}
-        {{ arg.type_().borrow()|ffi_converter }}::write({{ arg.name() }}, &mut args_buf);
+        {{ arg.type_().borrow()|ffi_converter }}::write(r#{{ arg.name() }}, &mut args_buf);
         {%- endfor -%}
         let args_rbuf = uniffi::RustBuffer::from_vec(args_buf);
 
@@ -99,7 +99,7 @@ impl {{ trait_name }} for {{ trait_impl }} {
 
 unsafe impl uniffi::FfiConverter for {{ trait_impl }} {
     // This RustType allows for rust code that inputs this type as a Box<dyn CallbackInterfaceTrait> param
-    type RustType = Box<dyn {{ trait_name }}>;
+    type RustType = Box<dyn r#{{ trait_name }}>;
     type FfiType = u64;
 
     // Lower and write are tricky to implement because we have a dyn trait as our type.  There's

--- a/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
@@ -12,30 +12,30 @@ pub struct {{ e.type_().borrow()|ffi_converter_name }};
 
 #[doc(hidden)]
 impl uniffi::RustBufferFfiConverter for {{ e.type_().borrow()|ffi_converter_name }} {
-    type RustType = {{ e.name() }};
+    type RustType = r#{{ e.name() }};
 
     fn write(obj: Self::RustType, buf: &mut std::vec::Vec<u8>) {
         use uniffi::deps::bytes::BufMut;
         match obj {
             {%- for variant in e.variants() %}
-            {{ e.name() }}::{{ variant.name() }} { {% for field in variant.fields() %}{{ field.name() }}, {%- endfor %} } => {
+            r#{{ e.name() }}::r#{{ variant.name() }} { {% for field in variant.fields() %}r#{{ field.name() }}, {%- endfor %} } => {
                 buf.put_i32({{ loop.index }});
                 {% for field in variant.fields() -%}
-                {{ field.type_().borrow()|ffi_converter }}::write({{ field.name() }}, buf);
+                {{ field.type_().borrow()|ffi_converter }}::write(r#{{ field.name() }}, buf);
                 {%- endfor %}
             },
             {%- endfor %}
         };
     }
 
-    fn try_read(buf: &mut &[u8]) -> uniffi::deps::anyhow::Result<{{ e.name() }}> {
+    fn try_read(buf: &mut &[u8]) -> uniffi::deps::anyhow::Result<r#{{ e.name() }}> {
         use uniffi::deps::bytes::Buf;
         uniffi::check_remaining(buf, 4)?;
         Ok(match buf.get_i32() {
             {%- for variant in e.variants() %}
-            {{ loop.index }} => {{ e.name() }}::{{ variant.name() }}{% if variant.has_fields() %} {
+            {{ loop.index }} => r#{{ e.name() }}::r#{{ variant.name() }}{% if variant.has_fields() %} {
                 {% for field in variant.fields() %}
-                {{ field.name() }}: {{ field.type_().borrow()|ffi_converter }}::try_read(buf)?,
+                r#{{ field.name() }}: {{ field.type_().borrow()|ffi_converter }}::try_read(buf)?,
                 {%- endfor %}
             }{% endif %},
             {%- endfor %}

--- a/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
@@ -12,7 +12,7 @@ pub struct {{ e.type_().borrow()|ffi_converter_name }};
 
 #[doc(hidden)]
 impl uniffi::RustBufferFfiConverter for {{ e.type_().borrow()|ffi_converter_name }} {
-    type RustType = {{ e.name() }};
+    type RustType = r#{{ e.name() }};
 
     {% if e.is_flat() %}
 
@@ -20,12 +20,12 @@ impl uniffi::RustBufferFfiConverter for {{ e.type_().borrow()|ffi_converter_name
     // as the error message in the foreign language.
 
 
-    fn write(obj: {{ e.name() }}, buf: &mut std::vec::Vec<u8>) {
+    fn write(obj: r#{{ e.name() }}, buf: &mut std::vec::Vec<u8>) {
         use uniffi::deps::bytes::BufMut;
         let msg = obj.to_string();
         match obj {
             {%- for variant in e.variants() %}
-            {{ e.name() }}::{{ variant.name() }}{..} => {
+            r#{{ e.name() }}::r#{{ variant.name() }}{..} => {
                 buf.put_i32({{ loop.index }});
                 <String as uniffi::FfiConverter>::write(msg, buf);
             },
@@ -33,7 +33,7 @@ impl uniffi::RustBufferFfiConverter for {{ e.type_().borrow()|ffi_converter_name
         };
     }
 
-    fn try_read(_buf: &mut &[u8]) -> uniffi::deps::anyhow::Result<{{ e.name() }}> {
+    fn try_read(_buf: &mut &[u8]) -> uniffi::deps::anyhow::Result<r#{{ e.name() }}> {
         // It's not currently possible to send errors from the foreign language *into* Rust.
         panic!("try_read not supported for flat errors");
     }
@@ -47,30 +47,30 @@ impl uniffi::RustBufferFfiConverter for {{ e.type_().borrow()|ffi_converter_name
     // the Rust enum has fields and they're just not listed. In that case we use the `Variant{..}`
     // syntax to match the variant while ignoring its fields.
 
-    fn write(obj: {{ e.name() }}, buf: &mut std::vec::Vec<u8>) {
+    fn write(obj: r#{{ e.name() }}, buf: &mut std::vec::Vec<u8>) {
         use uniffi::deps::bytes::BufMut;
         match obj {
             {%- for variant in e.variants() %}
-            {{ e.name() }}::{{ variant.name() }}{% if variant.has_fields() %} { {% for field in variant.fields() %}{{ field.name() }}, {%- endfor %} }{% else %}{..}{% endif %} => {
+            r#{{ e.name() }}::r#{{ variant.name() }}{% if variant.has_fields() %} { {% for field in variant.fields() %}r#{{ field.name() }}, {%- endfor %} }{% else %}{..}{% endif %} => {
                 buf.put_i32({{ loop.index }});
                 {% for field in variant.fields() -%}
-                {{ field.type_().borrow()|ffi_converter }}::write({{ field.name() }}, buf);
+                {{ field.type_().borrow()|ffi_converter }}::write(r#{{ field.name() }}, buf);
                 {%- endfor %}
             },
             {%- endfor %}
         };
     }
 
-    fn try_read(buf: &mut &[u8]) -> uniffi::deps::anyhow::Result<{{ e.name() }}> {
+    fn try_read(buf: &mut &[u8]) -> uniffi::deps::anyhow::Result<r#{{ e.name() }}> {
         // It's not currently supported to send errors from the foreign language *into* Rust,
         // but this is what the supporting code might look like...
         use uniffi::deps::bytes::Buf;
         uniffi::check_remaining(buf, 4)?;
         Ok(match buf.get_i32() {
             {%- for variant in e.variants() %}
-            {{ loop.index }} => {{ e.name() }}::{{ variant.name() }}{% if variant.has_fields() %} {
+            {{ loop.index }} => r#{{ e.name() }}::r#{{ variant.name() }}{% if variant.has_fields() %} {
                 {% for field in variant.fields() %}
-                {{ field.name() }}: {{ field.type_().borrow()|ffi_converter }}::try_read(buf)?,
+                r#{{ field.name() }}: {{ field.type_().borrow()|ffi_converter }}::try_read(buf)?,
                 {%- endfor %}
             }{% endif %},
             {%- endfor %}

--- a/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
@@ -26,7 +26,7 @@ trait UniffiCustomTypeConverter {
 pub struct FfiConverterType{{ name }};
 
 unsafe impl uniffi::FfiConverter for FfiConverterType{{ name }} {
-    type RustType = {{ name }};
+    type RustType = r#{{ name }};
     type FfiType = {{ FFIType::from(builtin).borrow()|type_ffi }};
 
     fn lower(obj: {{ name }} ) -> Self::FfiType {
@@ -34,14 +34,14 @@ unsafe impl uniffi::FfiConverter for FfiConverterType{{ name }} {
     }
 
     fn try_lift(v: Self::FfiType) -> uniffi::Result<{{ name }}> {
-        <{{ name }} as UniffiCustomTypeConverter>::into_custom(<{{ builtin|type_rs }} as uniffi::FfiConverter>::try_lift(v)?)
+        <r#{{ name }} as UniffiCustomTypeConverter>::into_custom(<{{ builtin|type_rs }} as uniffi::FfiConverter>::try_lift(v)?)
     }
 
     fn write(obj: {{ name }}, buf: &mut Vec<u8>) {
         <{{ builtin|type_rs }} as uniffi::FfiConverter>::write(<{{ name }} as UniffiCustomTypeConverter>::from_custom(obj), buf);
     }
 
-    fn try_read(buf: &mut &[u8]) -> uniffi::Result<{{ name }}> {
+    fn try_read(buf: &mut &[u8]) -> uniffi::Result<r#{{ name }}> {
         <{{ name }} as UniffiCustomTypeConverter>::into_custom(<{{ builtin|type_rs }} as uniffi::FfiConverter>::try_read(buf)?)
     }
 }

--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -29,7 +29,7 @@ fn uniffi_note_threadsafe_deprecation_{{ obj.name() }}() {}
 // if they are not, but unfortunately it fails with an unactionably obscure error message.
 // By asserting the requirement explicitly, we help Rust produce a more scrutable error message
 // and thus help the user debug why the requirement isn't being met.
-uniffi::deps::static_assertions::assert_impl_all!({{ obj.name() }}: Sync, Send);
+uniffi::deps::static_assertions::assert_impl_all!(r#{{ obj.name() }}: Sync, Send);
 
 {% let ffi_free = obj.ffi_object_free() -%}
 #[doc(hidden)]
@@ -38,14 +38,14 @@ pub extern "C" fn {{ ffi_free.name() }}(ptr: *const std::os::raw::c_void, call_s
     uniffi::call_with_output(call_status, || {
         assert!(!ptr.is_null());
         {#- turn it into an Arc and explicitly drop it. #}
-        drop(unsafe { std::sync::Arc::from_raw(ptr as *const {{ obj.name() }}) })
+        drop(unsafe { std::sync::Arc::from_raw(ptr as *const r#{{ obj.name() }}) })
     })
 }
 
 {%- for cons in obj.constructors() %}
     #[doc(hidden)]
     #[no_mangle]
-    pub extern "C" fn {{ cons.ffi_func().name() }}(
+    pub extern "C" fn r#{{ cons.ffi_func().name() }}(
         {%- call rs::arg_list_ffi_decl(cons.ffi_func()) %}) -> *const std::os::raw::c_void /* *const {{ obj.name() }} */ {
         uniffi::deps::log::debug!("{{ cons.ffi_func().name() }}");
         {% if obj.uses_deprecated_threadsafe_attribute() %}
@@ -61,7 +61,7 @@ pub extern "C" fn {{ ffi_free.name() }}(ptr: *const std::os::raw::c_void, call_s
 {%- for meth in obj.methods() %}
     #[doc(hidden)]
     #[no_mangle]
-    pub extern "C" fn {{ meth.ffi_func().name() }}(
+    pub extern "C" fn r#{{ meth.ffi_func().name() }}(
         {%- call rs::arg_list_ffi_decl(meth.ffi_func()) %}
     ) {% call rs::return_signature(meth) %} {
         uniffi::deps::log::debug!("{{ meth.ffi_func().name() }}");

--- a/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
@@ -13,20 +13,20 @@ pub struct {{ rec.type_().borrow()|ffi_converter_name }};
 
 #[doc(hidden)]
 impl uniffi::RustBufferFfiConverter for {{ rec.type_().borrow()|ffi_converter_name }} {
-    type RustType = {{ rec.name() }};
+    type RustType = r#{{ rec.name() }};
 
-    fn write(obj: {{ rec.name() }}, buf: &mut std::vec::Vec<u8>) {
+    fn write(obj: r#{{ rec.name() }}, buf: &mut std::vec::Vec<u8>) {
         // If the provided struct doesn't match the fields declared in the UDL, then
         // the generated code here will fail to compile with somewhat helpful error.
         {%- for field in rec.fields() %}
-        {{ field.type_().borrow()|ffi_converter }}::write(obj.{{ field.name() }}, buf);
+        {{ field.type_().borrow()|ffi_converter }}::write(obj.r#{{ field.name() }}, buf);
         {%- endfor %}
     }
 
-    fn try_read(buf: &mut &[u8]) -> uniffi::deps::anyhow::Result<{{ rec.name() }}> {
-        Ok({{ rec.name() }} {
+    fn try_read(buf: &mut &[u8]) -> uniffi::deps::anyhow::Result<r#{{ rec.name() }}> {
+        Ok(r#{{ rec.name() }} {
             {%- for field in rec.fields() %}
-                {{ field.name() }}: {{ field.type_().borrow()|ffi_converter }}::try_read(buf)?,
+                r#{{ field.name() }}: {{ field.type_().borrow()|ffi_converter }}::try_read(buf)?,
             {%- endfor %}
         })
     }

--- a/uniffi_bindgen/src/scaffolding/templates/TopLevelFunctionTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/TopLevelFunctionTemplate.rs
@@ -6,7 +6,7 @@
 #}
 #[doc(hidden)]
 #[no_mangle]
-pub extern "C" fn {{ func.ffi_func().name() }}(
+pub extern "C" fn r#{{ func.ffi_func().name() }}(
     {% call rs::arg_list_ffi_decl(func.ffi_func()) %}
 ) {% call rs::return_signature(func) %} {
     // If the provided function does not match the signature specified in the UDL

--- a/uniffi_bindgen/src/scaffolding/templates/macros.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/macros.rs
@@ -3,12 +3,12 @@
 #}
 
 {%- macro to_rs_call(func) -%}
-{{ func.name() }}({% call _arg_list_rs_call(func) -%})
+r#{{ func.name() }}({% call _arg_list_rs_call(func) -%})
 {%- endmacro -%}
 
 {%- macro _arg_list_rs_call(func) %}
     {%- for arg in func.full_arguments() %}
-        match {{- arg.type_().borrow()|ffi_converter }}::try_lift({{ arg.name() }}) {
+        match {{- arg.type_().borrow()|ffi_converter }}::try_lift(r#{{ arg.name() }}) {
         {%- if arg.by_ref() %}
             Ok(ref val) => val,
         {% else %}
@@ -36,7 +36,7 @@
 -#}
 {%- macro arg_list_ffi_decl(func) %}
     {%- for arg in func.arguments() %}
-        {{- arg.name() }}: {{ arg.type_().borrow()|type_ffi -}},
+        r#{{- arg.name() }}: {{ arg.type_().borrow()|type_ffi -}},
     {%- endfor %}
     call_status: &mut uniffi::RustCallStatus
 {%- endmacro -%}
@@ -45,7 +45,7 @@
     {{- prefix -}}
     {%- if meth.arguments().len() > 0 %}, {# whitespace #}
         {%- for arg in meth.arguments() %}
-            {{- arg.name() }}: {{ arg.type_().borrow()|type_rs -}}{% if loop.last %}{% else %},{% endif %}
+            r#{{- arg.name() }}: {{ arg.type_().borrow()|type_rs -}}{% if loop.last %}{% else %},{% endif %}
         {%- endfor %}
     {%- endif %}
 {%- endmacro -%}
@@ -57,7 +57,7 @@
 {% macro ret(func) %}{% match func.return_type() %}{% when Some with (return_type) %}{{ return_type|ffi_converter }}::lower(_retval){% else %}_retval{% endmatch %}{% endmacro %}
 
 {% macro construct(obj, cons) %}
-    {{- obj.name() }}::{% call to_rs_call(cons) -%}
+    r#{{- obj.name() }}::{% call to_rs_call(cons) -%}
 {% endmacro %}
 
 {% macro to_rs_constructor_call(obj, cons) %}
@@ -81,17 +81,17 @@
 {% match meth.throws_type() -%}
 {% when Some with (e) -%}
 uniffi::call_with_result(call_status, || {
-    let _retval =  {{ obj.name() }}::{% call to_rs_call(meth) %}.map_err(Into::into).map_err({{ e|ffi_converter }}::lower)?;
+    let _retval =  r#{{ obj.name() }}::{% call to_rs_call(meth) %}.map_err(Into::into).map_err({{ e|ffi_converter }}::lower)?;
     Ok({% call ret(meth) %})
 })
 {% else %}
 uniffi::call_with_output(call_status, || {
     {% match meth.return_type() -%}
     {% when Some with (return_type) -%}
-    let retval = {{ obj.name() }}::{% call to_rs_call(meth) %};
+    let retval = r#{{ obj.name() }}::{% call to_rs_call(meth) %};
     {{ return_type|ffi_converter }}::lower(retval)
     {% else -%}
-    {{ obj.name() }}::{% call to_rs_call(meth) %}
+    r#{{ obj.name() }}::{% call to_rs_call(meth) %}
     {% endmatch -%}
 })
 {% endmatch -%}


### PR DESCRIPTION
So I started trying to resurrect #1059, but discovered the
failure there was that I used `when` in the UDL, which unknown
to me was a keyword in Kotlin. Which got me looking back at #1170,
which is for swift.

So one yak after another, I thought I'd see how a new fixture
which used keywords from all languages would pan out, and here
we are.

In the same way #1170 unconditionally quotes all names, this
patch uses `r#` syntax for all names in the scaffolding. Python
adds an explicit list of keywords.

This adds support for Kotlin - swift should be almost identical to Kotlin, but thought I'd leave that for a followup.

WDYT?
