### PR TITLE
Further improve fs / path code

### DIFF
--- a/fixtures/reexport-scaffolding-macro/Cargo.toml
+++ b/fixtures/reexport-scaffolding-macro/Cargo.toml
@@ -18,7 +18,7 @@ uniffi-fixture-coverall = { path = "../coverall" }
 uniffi = { path = "../../uniffi", features=["builtin-bindgen"] }
 
 [dev-dependencies]
-cargo_metadata = "0.13"
+cargo_metadata = "0.14"
 lazy_static = "1.4"
 libloading = "0.7"
 uniffi_bindgen = { path = "../../uniffi_bindgen" }

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -18,7 +18,7 @@ camino = "1.0.8"
 lazy_static = "1.4"
 log = "0.4"
 # Regular dependencies
-cargo_metadata = "0.13"
+cargo_metadata = "0.14"
 paste = "1.0"
 uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "=0.18.0" }
 static_assertions = "1.1.0"

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -20,6 +20,7 @@ askama = { version = "0.11", default-features = false, features = ["config"] }
 cargo_metadata = "0.14"
 camino = "1.0.8"
 clap = { version = "3.1", features = ["cargo", "std", "derive"] }
+fs-err = "2.7.0"
 heck = "0.4"
 paste = "1.0"
 serde = "1"

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -15,12 +15,12 @@ name = "uniffi-bindgen"
 path = "src/main.rs"
 
 [dependencies]
-cargo_metadata = "0.13"
-weedle2 = { version = "2.0.0", path = "../weedle2" }
 anyhow = "1"
 askama = { version = "0.11", default-features = false, features = ["config"] }
-heck = "0.4"
+cargo_metadata = "0.13"
 clap = { version = "3.1", features = ["cargo", "std", "derive"] }
+heck = "0.4"
 paste = "1.0"
 serde = "1"
 toml = "0.5"
+weedle2 = { version = "2.0.0", path = "../weedle2" }

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 askama = { version = "0.11", default-features = false, features = ["config"] }
-cargo_metadata = "0.13"
+cargo_metadata = "0.14"
 clap = { version = "3.1", features = ["cargo", "std", "derive"] }
 heck = "0.4"
 paste = "1.0"

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 anyhow = "1"
 askama = { version = "0.11", default-features = false, features = ["config"] }
 cargo_metadata = "0.14"
+camino = "1.0.8"
 clap = { version = "3.1", features = ["cargo", "std", "derive"] }
 heck = "0.4"
 paste = "1.0"

--- a/uniffi_bindgen/src/bindings/kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/mod.rs
@@ -4,7 +4,8 @@
 
 use anyhow::{bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
-use std::{env, ffi::OsString, fs::File, io::Write, process::Command};
+use fs_err::{self as fs, File};
+use std::{env, ffi::OsString, io::Write, process::Command};
 
 pub mod gen_kotlin;
 pub use gen_kotlin::{generate_bindings, Config};
@@ -18,9 +19,9 @@ pub fn write_bindings(
     try_format_code: bool,
 ) -> Result<()> {
     let mut kt_file = full_bindings_path(config, out_dir)?;
-    std::fs::create_dir_all(&kt_file)?;
+    fs::create_dir_all(&kt_file)?;
     kt_file.push(format!("{}.kt", ci.namespace()));
-    let mut f = File::create(&kt_file).context("Failed to create .kt file for bindings")?;
+    let mut f = File::create(&kt_file)?;
     write!(f, "{}", generate_bindings(config, ci)?)?;
     if try_format_code {
         if let Err(e) = Command::new("ktlint").arg("-F").arg(&kt_file).output() {

--- a/uniffi_bindgen/src/bindings/mod.rs
+++ b/uniffi_bindgen/src/bindings/mod.rs
@@ -8,9 +8,9 @@
 //! along with some helpers for executing foreign language scripts or tests.
 
 use anyhow::{bail, Result};
+use camino::Utf8Path;
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
-use std::path::Path;
 
 use crate::interface::ComponentInterface;
 use crate::MergeWith;
@@ -102,7 +102,7 @@ impl MergeWith for Config {
 pub fn write_bindings(
     config: &Config,
     ci: &ComponentInterface,
-    out_dir: &Path,
+    out_dir: &Utf8Path,
     language: TargetLanguage,
     try_format_code: bool,
 ) -> Result<()> {
@@ -128,7 +128,7 @@ pub fn write_bindings(
 pub fn compile_bindings(
     config: &Config,
     ci: &ComponentInterface,
-    out_dir: &Path,
+    out_dir: &Utf8Path,
     language: TargetLanguage,
 ) -> Result<()> {
     match language {
@@ -144,7 +144,11 @@ pub fn compile_bindings(
 ///
 /// Note: This function is only used for compiling the unit tests. See #1169 for plans to refactor
 /// it.
-pub fn run_script(out_dir: &Path, script_file: &Path, language: TargetLanguage) -> Result<()> {
+pub fn run_script(
+    out_dir: &Utf8Path,
+    script_file: &Utf8Path,
+    language: TargetLanguage,
+) -> Result<()> {
     match language {
         TargetLanguage::Kotlin => kotlin::run_script(out_dir, script_file)?,
         TargetLanguage::Swift => swift::run_script(out_dir, script_file)?,

--- a/uniffi_bindgen/src/bindings/python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/mod.rs
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::{env, fs::File, io::Write, process::Command};
+use std::{env, io::Write, process::Command};
 
 use anyhow::{bail, Context, Result};
+use fs_err::File;
 
 pub mod gen_python;
 use camino::Utf8Path;
@@ -20,7 +21,7 @@ pub fn write_bindings(
     try_format_code: bool,
 ) -> Result<()> {
     let py_file = out_dir.join(format!("{}.py", ci.namespace()));
-    let mut f = File::create(&py_file).context("Failed to create .py file for bindings")?;
+    let mut f = File::create(&py_file)?;
     write!(f, "{}", generate_python_bindings(config, ci)?)?;
 
     if try_format_code {

--- a/uniffi_bindgen/src/bindings/ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/mod.rs
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::{env, fs::File, io::Write, process::Command};
+use std::{env, io::Write, process::Command};
 
 use anyhow::{bail, Context, Result};
+use fs_err::File;
 
 pub mod gen_ruby;
 use camino::Utf8Path;
@@ -21,7 +22,7 @@ pub fn write_bindings(
     try_format_code: bool,
 ) -> Result<()> {
     let rb_file = out_dir.join(format!("{}.rb", ci.namespace()));
-    let mut f = File::create(&rb_file).context("Failed to create .rb file for bindings")?;
+    let mut f = File::create(&rb_file)?;
     write!(f, "{}", generate_ruby_bindings(config, ci)?)?;
 
     if try_format_code {

--- a/uniffi_bindgen/src/bindings/ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/mod.rs
@@ -2,11 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::{env, fs::File, io::Write, path::Path, process::Command};
+use std::{env, fs::File, io::Write, process::Command};
 
 use anyhow::{bail, Context, Result};
 
 pub mod gen_ruby;
+use camino::Utf8Path;
 pub use gen_ruby::{Config, RubyWrapper};
 
 use super::super::interface::ComponentInterface;
@@ -16,7 +17,7 @@ use super::super::interface::ComponentInterface;
 pub fn write_bindings(
     config: &Config,
     ci: &ComponentInterface,
-    out_dir: &Path,
+    out_dir: &Utf8Path,
     try_format_code: bool,
 ) -> Result<()> {
     let rb_file = out_dir.join(format!("{}.rb", ci.namespace()));
@@ -24,14 +25,10 @@ pub fn write_bindings(
     write!(f, "{}", generate_ruby_bindings(config, ci)?)?;
 
     if try_format_code {
-        if let Err(e) = Command::new("rubocop")
-            .arg("-A")
-            .arg(rb_file.to_str().unwrap())
-            .output()
-        {
+        if let Err(e) = Command::new("rubocop").arg("-A").arg(&rb_file).output() {
             println!(
                 "Warning: Unable to auto-format {} using rubocop: {:?}",
-                rb_file.file_name().unwrap().to_str().unwrap(),
+                rb_file.file_name().unwrap(),
                 e
             )
         }
@@ -51,11 +48,12 @@ pub fn generate_ruby_bindings(config: &Config, ci: &ComponentInterface) -> Resul
 
 /// Execute the specifed ruby script, with environment based on the generated
 /// artifacts in the given output directory.
-pub fn run_script(out_dir: &Path, script_file: &Path) -> Result<()> {
+pub fn run_script(out_dir: &Utf8Path, script_file: &Utf8Path) -> Result<()> {
     let mut cmd = Command::new("ruby");
     // This helps ruby find the generated .rb wrapper for rust component.
     let rubypath = env::var_os("RUBYLIB").unwrap_or_default();
-    let rubypath = env::join_paths(env::split_paths(&rubypath).chain(vec![out_dir.to_path_buf()]))?;
+    let rubypath =
+        env::join_paths(env::split_paths(&rubypath).chain(vec![out_dir.as_std_path().to_owned()]))?;
 
     cmd.env("RUBYLIB", rubypath);
     // We should now be able to execute the tests successfully.

--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -29,9 +29,11 @@
 //!  * How to read from and write into a byte buffer.
 //!
 
+use std::{ffi::OsString, io::Write, process::Command};
+
 use anyhow::{bail, Context, Result};
 use camino::Utf8Path;
-use std::{ffi::OsString, fs::File, io::Write, process::Command};
+use fs_err::File;
 
 pub mod gen_swift;
 pub use gen_swift::{generate_bindings, Config};
@@ -67,17 +69,14 @@ pub fn write_bindings(
     } = generate_bindings(config, ci)?;
 
     let source_file = out_dir.join(format!("{}.swift", config.module_name()));
-    let mut l = File::create(&source_file).context("Failed to create .swift file for bindings")?;
+    let mut l = File::create(&source_file)?;
     write!(l, "{}", library)?;
 
-    let header_file = out_dir.join(config.header_filename());
-    let mut h = File::create(&header_file).context("Failed to create .h file for bindings")?;
+    let mut h = File::create(out_dir.join(config.header_filename()))?;
     write!(h, "{}", header)?;
 
     if let Some(modulemap) = modulemap {
-        let modulemap_file = out_dir.join(config.modulemap_filename());
-        let mut m = File::create(&modulemap_file)
-            .context("Failed to create .modulemap file for bindings")?;
+        let mut m = File::create(out_dir.join(config.modulemap_filename()))?;
         write!(m, "{}", modulemap)?;
     }
 

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -100,7 +100,7 @@ pub struct ComponentInterface {
     errors: Vec<Error>,
 }
 
-impl<'ci> ComponentInterface {
+impl ComponentInterface {
     /// Parse a `ComponentInterface` from a string containing a WebIDL definition.
     pub fn from_webidl(idl: &str) -> Result<Self> {
         let mut ci = Self {

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -94,19 +94,13 @@
 
 const BINDGEN_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
 use clap::{Parser, Subcommand};
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::io::prelude::*;
-use std::{
-    collections::HashMap,
-    env,
-    fs::File,
-    path::{Path, PathBuf},
-    process::Command,
-    str::FromStr,
-};
+use std::{collections::HashMap, env, fs::File, process::Command, str::FromStr};
 
 pub mod backend;
 pub mod bindings;
@@ -134,8 +128,8 @@ pub trait BindingGeneratorConfig: for<'de> Deserialize<'de> {
 
 fn load_bindings_config<BC: BindingGeneratorConfig>(
     ci: &ComponentInterface,
-    udl_file: &Path,
-    config_file_override: Option<&Path>,
+    udl_file: &Utf8Path,
+    config_file_override: Option<&Utf8Path>,
 ) -> Result<BC> {
     // Load the config from the TOML value, falling back to an empty map if it doesn't exist
     let mut config_map: toml::value::Table =
@@ -191,8 +185,8 @@ impl<'de> Deserialize<'de> for EmptyBindingGeneratorConfig {
 // If there is an error parsing the file then Err will be returned. If the file is missing or the
 // entry for the bindings is missing, then Ok(None) will be returned.
 fn load_bindings_config_toml<BC: BindingGeneratorConfig>(
-    udl_file: &Path,
-    config_file_override: Option<&Path>,
+    udl_file: &Utf8Path,
+    config_file_override: Option<&Utf8Path>,
 ) -> Result<Option<toml::Value>> {
     let config_path = match config_file_override {
         Some(cfg) => cfg.to_owned(),
@@ -204,9 +198,9 @@ fn load_bindings_config_toml<BC: BindingGeneratorConfig>(
     }
 
     let contents = slurp_file(&config_path)
-        .with_context(|| format!("Failed to read config file from {:?}", config_path))?;
+        .with_context(|| format!("Failed to read config file from {}", config_path))?;
     let full_config = toml::Value::from_str(&contents)
-        .with_context(|| format!("Failed to parse config file {:?}", config_path))?;
+        .with_context(|| format!("Failed to parse config file {}", config_path))?;
 
     Ok(full_config
         .get("bindings")
@@ -232,7 +226,7 @@ pub trait BindingGenerator: Sized {
         &self,
         ci: ComponentInterface,
         config: Self::Config,
-        out_dir: &Path,
+        out_dir: &Utf8Path,
     ) -> anyhow::Result<()>;
 }
 
@@ -252,9 +246,9 @@ pub trait BindingGenerator: Sized {
 /// - `out_dir_override`: The path to write the bindings to. If [`None`], it will be the path to the parent directory of the `udl_file`
 pub fn generate_external_bindings(
     binding_generator: impl BindingGenerator,
-    udl_file: impl AsRef<Path>,
-    config_file_override: Option<impl AsRef<Path>>,
-    out_dir_override: Option<impl AsRef<Path>>,
+    udl_file: impl AsRef<Utf8Path>,
+    config_file_override: Option<impl AsRef<Utf8Path>>,
+    out_dir_override: Option<impl AsRef<Utf8Path>>,
 ) -> Result<()> {
     let out_dir_override = out_dir_override.as_ref().map(|p| p.as_ref());
     let config_file_override = config_file_override.as_ref().map(|p| p.as_ref());
@@ -262,15 +256,15 @@ pub fn generate_external_bindings(
     let component = parse_udl(udl_file.as_ref()).context("Error parsing UDL")?;
     let bindings_config =
         load_bindings_config(&component, udl_file.as_ref(), config_file_override)?;
-    binding_generator.write_bindings(component, bindings_config, out_dir.as_path())
+    binding_generator.write_bindings(component, bindings_config, &out_dir)
 }
 
 // Generate the infrastructural Rust code for implementing the UDL interface,
 // such as the `extern "C"` function definitions and record data types.
 pub fn generate_component_scaffolding(
-    udl_file: &Path,
-    config_file_override: Option<&Path>,
-    out_dir_override: Option<&Path>,
+    udl_file: &Utf8Path,
+    config_file_override: Option<&Utf8Path>,
+    out_dir_override: Option<&Utf8Path>,
     format_code: bool,
 ) -> Result<()> {
     let component = parse_udl(udl_file)?;
@@ -279,13 +273,9 @@ pub fn generate_component_scaffolding(
         guess_crate_root(udl_file)?,
         config_file_override,
     );
-    let mut filename = Path::new(&udl_file)
-        .file_stem()
-        .context("not a file")?
-        .to_os_string();
-    filename.push(".uniffi.rs");
-    let mut out_dir = get_out_dir(udl_file, out_dir_override)?;
-    out_dir.push(filename);
+    let file_stem = udl_file.file_stem().context("not a file")?;
+    let filename = format!("{}.uniffi.rs", file_stem);
+    let out_dir = get_out_dir(udl_file, out_dir_override)?.join(filename);
     let mut f = File::create(&out_dir).context("Failed to create output file")?;
     write!(f, "{}", RustScaffolding::new(&component)).context("Failed to write output file")?;
     if format_code {
@@ -297,10 +287,10 @@ pub fn generate_component_scaffolding(
 // Generate the bindings in the target languages that call the scaffolding
 // Rust code.
 pub fn generate_bindings(
-    udl_file: &Path,
-    config_file_override: Option<&Path>,
+    udl_file: &Utf8Path,
+    config_file_override: Option<&Utf8Path>,
     target_languages: Vec<&str>,
-    out_dir_override: Option<&Path>,
+    out_dir_override: Option<&Utf8Path>,
     try_format_code: bool,
 ) -> Result<()> {
     let component = parse_udl(udl_file)?;
@@ -325,10 +315,10 @@ pub fn generate_bindings(
 // Run tests against the foreign language bindings (generated and compiled at the same time).
 // Note that the cdylib we're testing against must be built already.
 pub fn run_tests(
-    cdylib_dir: impl AsRef<Path>,
-    udl_files: &[impl AsRef<Path>],
-    test_scripts: &[impl AsRef<Path>],
-    config_file_override: Option<&Path>,
+    cdylib_dir: impl AsRef<Utf8Path>,
+    udl_files: &[impl AsRef<Utf8Path>],
+    test_scripts: &[impl AsRef<Utf8Path>],
+    config_file_override: Option<&Utf8Path>,
 ) -> Result<()> {
     // XXX - this is just for tests, so one config_file_override for all .udl files doesn't really
     // make sense, so we don't let tests do this.
@@ -374,7 +364,7 @@ pub fn run_tests(
 /// For now, we assume that the UDL file is in `./src/something.udl` relative
 /// to the crate root. We might consider something more sophisticated in
 /// future.
-fn guess_crate_root(udl_file: &Path) -> Result<&Path> {
+fn guess_crate_root(udl_file: &Utf8Path) -> Result<&Utf8Path> {
     let path_guess = udl_file
         .parent()
         .context("UDL file has no parent folder!")?
@@ -388,34 +378,34 @@ fn guess_crate_root(udl_file: &Path) -> Result<&Path> {
 
 fn get_config(
     component: &ComponentInterface,
-    crate_root: &Path,
-    config_file_override: Option<&Path>,
+    crate_root: &Utf8Path,
+    config_file_override: Option<&Utf8Path>,
 ) -> Result<Config> {
     let default_config: Config = component.into();
 
     let config_file = match config_file_override {
         Some(cfg) => Some(cfg.to_owned()),
-        None => crate_root.join("uniffi.toml").canonicalize().ok(),
+        None => crate_root.join("uniffi.toml").canonicalize_utf8().ok(),
     };
 
     match config_file {
         Some(path) => {
             let contents = slurp_file(&path)
-                .with_context(|| format!("Failed to read config file from {:?}", &path))?;
+                .with_context(|| format!("Failed to read config file from {}", &path))?;
             let loaded_config: Config = toml::de::from_str(&contents)
-                .with_context(|| format!("Failed to generate config from file {:?}", &path))?;
+                .with_context(|| format!("Failed to generate config from file {}", &path))?;
             Ok(loaded_config.merge_with(&default_config))
         }
         None => Ok(default_config),
     }
 }
 
-fn get_out_dir(udl_file: &Path, out_dir_override: Option<&Path>) -> Result<PathBuf> {
+fn get_out_dir(udl_file: &Utf8Path, out_dir_override: Option<&Utf8Path>) -> Result<Utf8PathBuf> {
     Ok(match out_dir_override {
         Some(s) => {
             // Create the directory if it doesn't exist yet.
             std::fs::create_dir_all(&s)?;
-            s.canonicalize().context("Unable to find out-dir")?
+            s.canonicalize_utf8().context("Unable to find out-dir")?
         }
         None => udl_file
             .parent()
@@ -424,14 +414,14 @@ fn get_out_dir(udl_file: &Path, out_dir_override: Option<&Path>) -> Result<PathB
     })
 }
 
-fn parse_udl(udl_file: &Path) -> Result<ComponentInterface> {
+fn parse_udl(udl_file: &Utf8Path) -> Result<ComponentInterface> {
     let udl =
-        slurp_file(udl_file).map_err(|_| anyhow!("Failed to read UDL from {:?}", &udl_file))?;
+        slurp_file(udl_file).with_context(|| format!("Failed to read UDL from {}", &udl_file))?;
     udl.parse::<interface::ComponentInterface>()
         .context("Failed to parse UDL")
 }
 
-fn slurp_file(file_name: &Path) -> Result<String> {
+fn slurp_file(file_name: &Utf8Path) -> Result<String> {
     let mut contents = String::new();
     let mut f = File::open(file_name)?;
     f.read_to_string(&mut contents)?;
@@ -509,7 +499,7 @@ enum Commands {
             short,
             help = "Directory in which to write generated files. Default is same folder as .udl file."
         )]
-        out_dir: Option<PathBuf>,
+        out_dir: Option<Utf8PathBuf>,
 
         #[clap(long, short, help = "Do not try to format the generated bindings.")]
         no_format: bool,
@@ -519,10 +509,10 @@ enum Commands {
             short,
             help = "Path to the optional uniffi config file. If not provided, uniffi-bindgen will try to guess it from the UDL's file location."
         )]
-        config: Option<PathBuf>,
+        config: Option<Utf8PathBuf>,
 
         #[clap(help = "Path to the UDL file.")]
-        udl_file: PathBuf,
+        udl_file: Utf8PathBuf,
     },
 
     #[clap(name = "scaffolding", about = "Generate Rust scaffolding code")]
@@ -532,20 +522,20 @@ enum Commands {
             short,
             help = "Directory in which to write generated files. Default is same folder as .udl file."
         )]
-        out_dir: Option<PathBuf>,
+        out_dir: Option<Utf8PathBuf>,
 
         #[clap(
             long,
             short,
             help = "Path to the optional uniffi config file. If not provided, uniffi-bindgen will try to guess it from the UDL's file location."
         )]
-        config: Option<PathBuf>,
+        config: Option<Utf8PathBuf>,
 
         #[clap(long, short, help = "Do not try to format the generated bindings.")]
         no_format: bool,
 
         #[clap(help = "Path to the UDL file.")]
-        udl_file: PathBuf,
+        udl_file: Utf8PathBuf,
     },
 
     #[clap(
@@ -556,20 +546,20 @@ enum Commands {
         #[clap(
             help = "Path to the directory containing the cdylib the scripts will be testing against."
         )]
-        cdylib_dir: PathBuf,
+        cdylib_dir: Utf8PathBuf,
 
         #[clap(help = "Path to the UDL file.")]
-        udl_file: PathBuf,
+        udl_file: Utf8PathBuf,
 
         #[clap(help = "Foreign language(s) test scripts to run.")]
-        test_scripts: Vec<PathBuf>,
+        test_scripts: Vec<Utf8PathBuf>,
 
         #[clap(
             long,
             short,
             help = "Path to the optional uniffi config file. If not provided, uniffi-bindgen will try to guess it from the UDL's file location."
         )]
-        config: Option<PathBuf>,
+        config: Option<Utf8PathBuf>,
     },
 }
 
@@ -617,7 +607,7 @@ mod test {
     #[test]
     fn test_guessing_of_crate_root_directory_from_udl_file() {
         // When running this test, this will be the ./uniffi_bindgen directory.
-        let this_crate_root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+        let this_crate_root = Utf8PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
 
         let example_crate_root = this_crate_root
             .parent()

--- a/uniffi_build/Cargo.toml
+++ b/uniffi_build/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["ffi", "bindgen"]
 
 [dependencies]
 anyhow = "1"
+camino = "1.0.8"
 uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "=0.18.0" }
 
 [features]

--- a/uniffi_build/src/lib.rs
+++ b/uniffi_build/src/lib.rs
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use anyhow::{Context, Result};
-use std::{env, path::Path};
+use camino::Utf8Path;
+use std::env;
 
 /// Generate the rust "scaffolding" required to build a uniffi component.
 ///
@@ -20,22 +21,22 @@ use std::{env, path::Path};
 /// the `uniffi_bindgen` crate and call its methods directly, rather than using the
 /// command-line tool. This is mostly useful for developers who are working on uniffi
 /// itself and need to test out their changes to the bindings generator.
-pub fn generate_scaffolding(udl_file: impl AsRef<Path>) -> Result<()> {
+pub fn generate_scaffolding(udl_file: impl AsRef<Utf8Path>) -> Result<()> {
     let udl_file = udl_file.as_ref();
 
-    println!("cargo:rerun-if-changed={}", udl_file.display());
+    println!("cargo:rerun-if-changed={}", udl_file);
     // The UNIFFI_TESTS_DISABLE_EXTENSIONS variable disables some bindings, but it is evaluated
     // at *build* time, so we need to rebuild when it changes.
     println!("cargo:rerun-if-env-changed=UNIFFI_TESTS_DISABLE_EXTENSIONS");
     // Why don't we just depend on uniffi-bindgen and call the public functions?
     // Calling the command line helps making sure that the generated swift/Kotlin/whatever
     // bindings were generated with the same version of uniffi as the Rust scaffolding code.
-    let out_dir = env::var_os("OUT_DIR").context("$OUT_DIR missing?!")?;
+    let out_dir = env::var("OUT_DIR").context("$OUT_DIR missing?!")?;
     run_uniffi_bindgen_scaffolding(out_dir.as_ref(), udl_file)
 }
 
 #[cfg(not(feature = "builtin-bindgen"))]
-fn run_uniffi_bindgen_scaffolding(out_dir: &Path, udl_file: &Path) -> Result<()> {
+fn run_uniffi_bindgen_scaffolding(out_dir: &Utf8Path, udl_file: &Utf8Path) -> Result<()> {
     use anyhow::bail;
     use std::process::Command;
 
@@ -56,6 +57,6 @@ fn run_uniffi_bindgen_scaffolding(out_dir: &Path, udl_file: &Path) -> Result<()>
 }
 
 #[cfg(feature = "builtin-bindgen")]
-fn run_uniffi_bindgen_scaffolding(out_dir: &Path, udl_file: &Path) -> Result<()> {
+fn run_uniffi_bindgen_scaffolding(out_dir: &Utf8Path, udl_file: &Utf8Path) -> Result<()> {
     uniffi_bindgen::generate_component_scaffolding(udl_file, None, Some(out_dir), false)
 }

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -14,10 +14,10 @@ keywords = ["ffi", "bindgen"]
 proc-macro = true
 
 [dependencies]
+glob = "0.3"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["extra-traits"] }
-glob = "0.3"
 uniffi_build = { path = "../uniffi_build", version = "=0.18.0" }
 
 [features]

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["ffi", "bindgen"]
 proc-macro = true
 
 [dependencies]
+camino = "1.0.8"
 glob = "0.3"
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -7,9 +7,9 @@
 //! Currently this is just for easily generating integration tests, but maybe
 //! we'll put some other code-annotation helper macros in here at some point.
 
+use camino::{Utf8Path, Utf8PathBuf};
 use quote::{format_ident, quote};
 use std::env;
-use std::path::{Path, PathBuf};
 use syn::{bracketed, punctuated::Punctuated, LitStr, Token};
 
 /// A macro to build testcases for a component's generated bindings.
@@ -38,8 +38,8 @@ pub fn build_foreign_language_testcases(paths: proc_macro::TokenStream) -> proc_
         .udl_files
         .iter()
         .map(|file_path| {
-            let pathbuf: PathBuf = [&pkg_dir, file_path].iter().collect();
-            let path = pathbuf.to_string_lossy();
+            let pathbuf: Utf8PathBuf = [&pkg_dir, file_path].iter().collect();
+            let path = pathbuf.to_string();
             quote! { #path }
         })
         .collect::<Vec<proc_macro2::TokenStream>>();
@@ -48,12 +48,11 @@ pub fn build_foreign_language_testcases(paths: proc_macro::TokenStream) -> proc_
     let test_functions = paths.test_scripts
         .iter()
         .map(|file_path| {
-            let test_file_pathbuf: PathBuf = [&pkg_dir, file_path].iter().collect();
-            let test_file_path = test_file_pathbuf.to_string_lossy();
+            let test_file_pathbuf: Utf8PathBuf = [&pkg_dir, file_path].iter().collect();
+            let test_file_path = test_file_pathbuf.to_string();
             let test_file_name = test_file_pathbuf
                 .file_name()
-                .expect("Test file has no name, cannot build tests for generated bindings")
-                .to_string_lossy();
+                .expect("Test file has no name, cannot build tests for generated bindings");
             let test_name = format_ident!(
                 "uniffi_foreign_language_testcase_{}",
                 test_file_name.replace(|c: char| !c.is_alphanumeric(), "_")
@@ -79,7 +78,7 @@ pub fn build_foreign_language_testcases(paths: proc_macro::TokenStream) -> proc_
 }
 
 // UNIFFI_TESTS_DISABLE_EXTENSIONS contains a comma-sep'd list of extensions (without leading `.`)
-fn should_skip_path(path: &Path) -> bool {
+fn should_skip_path(path: &Utf8Path) -> bool {
     let ext = path.extension().expect("File has no extension!");
     env::var("UNIFFI_TESTS_DISABLE_EXTENSIONS")
         .map(|v| v.split(',').any(|look| look == ext))
@@ -163,7 +162,7 @@ pub fn generate_and_include_scaffolding(
 ) -> proc_macro::TokenStream {
     let udl_file = syn::parse_macro_input!(udl_file as syn::LitStr);
     let udl_file_string = udl_file.value();
-    let udl_file_path = Path::new(&udl_file_string);
+    let udl_file_path = Utf8Path::new(&udl_file_string);
     if std::env::var("OUT_DIR").is_err() {
         quote! {
             compile_error!("This macro assumes the crate has a build.rs script, but $OUT_DIR is not present");
@@ -175,8 +174,7 @@ pub fn generate_and_include_scaffolding(
     } else {
         // We know the filename is good because `generate_scaffolding` succeeded,
         // so this `unwrap` will never fail.
-        let name = udl_file_path.file_stem().unwrap().to_os_string();
-        let name = LitStr::new(&name.to_string_lossy(), udl_file.span());
+        let name = LitStr::new(udl_file_path.file_stem().unwrap(), udl_file.span());
         quote! {
             uniffi_macros::include_scaffolding!(#name);
         }

--- a/uniffi_testing/Cargo.toml
+++ b/uniffi_testing/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1"
-cargo_metadata = "0.13"
+cargo_metadata = "0.14"
 lazy_static = "1.4"
 serde = "1"
 serde_json = "1"

--- a/uniffi_testing/Cargo.toml
+++ b/uniffi_testing/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1"
+camino = "1.0.8"
 cargo_metadata = "0.14"
 lazy_static = "1.4"
 serde = "1"

--- a/uniffi_testing/Cargo.toml
+++ b/uniffi_testing/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 anyhow = "1"
 camino = "1.0.8"
 cargo_metadata = "0.14"
+fs-err = "2.7.0"
 lazy_static = "1.4"
 serde = "1"
 serde_json = "1"

--- a/uniffi_testing/src/lib.rs
+++ b/uniffi_testing/src/lib.rs
@@ -5,12 +5,12 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 use anyhow::{bail, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use cargo_metadata::{Artifact, Message, Metadata, MetadataCommand, Package, Target};
+use fs_err as fs;
 use serde::Deserialize;
 use std::{
     collections::hash_map::DefaultHasher,
     env,
     env::consts::DLL_EXTENSION,
-    fs::{copy, read_dir},
     hash::{Hash, Hasher},
     process::{Command, Stdio},
 };
@@ -151,9 +151,9 @@ impl UniFFITestHelper {
         let out_dir = temp_dir.as_ref().join(dirname);
         if out_dir.exists() {
             // Clean out any files from previous runs
-            std::fs::remove_dir_all(&out_dir)?;
+            fs::remove_dir_all(&out_dir)?;
         }
-        std::fs::create_dir(&out_dir)?;
+        fs::create_dir(&out_dir)?;
         Ok(out_dir)
     }
 
@@ -170,7 +170,7 @@ impl UniFFITestHelper {
 
         for path in cdylib_paths.into_iter() {
             let dest = out_dir.as_ref().join(path.file_name().unwrap());
-            copy(&path, &dest)?;
+            fs::copy(&path, &dest)?;
         }
         Ok(())
     }
@@ -212,7 +212,7 @@ impl UniFFITestHelper {
 }
 
 fn find_files<F: Fn(&Utf8Path) -> bool>(dir: &Utf8Path, predicate: F) -> Result<Vec<Utf8PathBuf>> {
-    read_dir(&dir)?
+    fs::read_dir(&dir)?
         .flatten()
         .map(|entry| entry.path().try_into())
         .try_fold(Vec::new(), |mut vec, path| {

--- a/weedle2/Cargo.toml
+++ b/weedle2/Cargo.toml
@@ -14,4 +14,5 @@ edition = "2018"
 name = "weedle"
 
 [dependencies]
+fs-err = "2.7.0"
 nom = { version = "5.0.0", default-features = false, features = ["std"] }

--- a/weedle2/tests/webidl.rs
+++ b/weedle2/tests/webidl.rs
@@ -1,12 +1,12 @@
 extern crate weedle;
 
-use std::fs;
 use std::io::Read;
 
+use fs_err::File;
 use weedle::*;
 
 fn read_file(path: &str) -> String {
-    let mut file = fs::File::open(path).unwrap();
+    let mut file = File::open(path).unwrap();
     let mut file_content = String::new();
     file.read_to_string(&mut file_content).unwrap();
     file_content


### PR DESCRIPTION
Basically a follow-up to #1235.

The main commits are the final two: the first one introduces `camino`s `Utf8Path(Buf)` types in more places and the second one replaces `std::fs` by the `fs_err` crate, which improves error messages by attaching the file or directory path upon which an operation was attempted.

The first three commits are just drive-by improvements that should be obvious 🙂 