### PR TITLE
Updating the callback interface docs

### DIFF
--- a/docs/manual/src/SUMMARY.md
+++ b/docs/manual/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Tutorial](./Getting_started.md)
   - [Prerequisites](./tutorial/Prerequisites.md)
   - [Describing the interface](./tutorial/udl_file.md)
+  - [Callback Interfaces](./tutorial/callback_interfaces.md)
   - [Generating the Rust scaffolding code](./tutorial/Rust_scaffolding.md)
   - [Generating the foreign-language bindings](./tutorial/foreign_language_bindings.md)
 - [The UDL file](./udl_file_spec.md)

--- a/docs/manual/src/tutorial/callback_interfaces.md
+++ b/docs/manual/src/tutorial/callback_interfaces.md
@@ -17,11 +17,18 @@ This toy example defines a way of Rust accessing a key-value store exposed
 by the host operating system (e.g. the key chain).
 
 ```rust,no_run
-trait Keychain: Send {
+trait Keychain: Send + Sync + Debug {
   pub fn get(key: String) -> Option<String>
   pub fn put(key: String, value: String)
 }
 ```
+
+The concrete types that UniFFI generates for callback interfaces implement `Send`, `Sync`, and `Debug`, so it's safe to
+include these as supertraits of your callback interface trait.  This isn't strictly necessary, but it's often useful.  In
+particular, `Sync + Send` is useful when:
+  - Storing `Box<dyn CallbackInterfaceTrait>` types inside a type that needs to be `Send + Send` (for example a UniFFI
+    interface type)
+  - Storing `Box<dyn CallbackInterfaceTrait>` inside a global `Mutex` or `RwLock`
 
 ## 2. Define a callback interface in the UDL.
 


### PR DESCRIPTION
- List them in the table of contents.  I think this page has been
  completely unavailable for a while.
- Added notes on making callback types Send+Send.  I'm planning on using
  this in app-services and didn't realize how to do it.