### PR TITLE
Replace uses of String::push_str

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -263,11 +263,7 @@ impl CodeOracle for KotlinCodeOracle {
         let name = nm.to_string();
         match name.strip_suffix("Error") {
             None => name,
-            Some(stripped) => {
-                let mut kt_exc_name = stripped.to_owned();
-                kt_exc_name.push_str("Exception");
-                kt_exc_name
-            }
+            Some(stripped) => format!("{}Exception", stripped),
         }
     }
 

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -232,11 +232,7 @@ impl CodeOracle for PythonCodeOracle {
         let name = nm.to_string();
         match name.strip_suffix("Error") {
             None => name,
-            Some(stripped) => {
-                let mut py_exc_name = stripped.to_owned();
-                py_exc_name.push_str("Exception");
-                py_exc_name
-            }
+            Some(stripped) => format!("{}Exception", stripped),
         }
     }
 

--- a/uniffi_bindgen/src/interface/callbacks.rs
+++ b/uniffi_bindgen/src/interface/callbacks.rs
@@ -120,7 +120,7 @@ impl APIConverter<CallbackInterface> for weedle::CallbackInterfaceDefinition<'_>
             match member {
                 weedle::interface::InterfaceMember::Operation(t) => {
                     let mut method: Method = t.convert(ci)?;
-                    method.object_name.push_str(object.name.as_str());
+                    method.object_name = object.name.clone();
                     object.methods.push(method);
                 }
                 _ => bail!(

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -89,9 +89,7 @@ impl Function {
     }
 
     pub fn derive_ffi_func(&mut self, ci_prefix: &str) -> Result<()> {
-        self.ffi_func.name.push_str(ci_prefix);
-        self.ffi_func.name.push('_');
-        self.ffi_func.name.push_str(&self.name);
+        self.ffi_func.name = format!("{}_{}", ci_prefix, self.name);
         self.ffi_func.arguments = self.arguments.iter().map(|arg| arg.into()).collect();
         self.ffi_func.return_type = self.return_type.as_ref().map(|rt| rt.into());
         Ok(())

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -483,7 +483,7 @@ impl ComponentInterface {
         if !self.namespace.is_empty() {
             bail!("duplicate namespace definition");
         }
-        self.namespace.push_str(&defn.name);
+        self.namespace = defn.name;
         Ok(())
     }
 

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -226,7 +226,7 @@ impl APIConverter<Object> for weedle::InterfaceDefinition<'_> {
                     if !member_names.insert(method.name.clone()) {
                         bail!("Duplicate interface member name: \"{}\"", method.name())
                     }
-                    method.object_name.push_str(object.name.as_str());
+                    method.object_name = object.name.clone();
                     object.methods.push(method);
                 }
                 _ => bail!("no support for interface member type {:?} yet", member),
@@ -280,11 +280,7 @@ impl Constructor {
     }
 
     fn derive_ffi_func(&mut self, ci_prefix: &str, obj_prefix: &str) {
-        self.ffi_func.name.push_str(ci_prefix);
-        self.ffi_func.name.push('_');
-        self.ffi_func.name.push_str(obj_prefix);
-        self.ffi_func.name.push('_');
-        self.ffi_func.name.push_str(&self.name);
+        self.ffi_func.name = format!("{}_{}_{}", ci_prefix, obj_prefix, self.name);
         self.ffi_func.arguments = self.arguments.iter().map(Into::into).collect();
         self.ffi_func.return_type = Some(FFIType::RustArcPtr);
     }
@@ -399,11 +395,7 @@ impl Method {
     }
 
     pub fn derive_ffi_func(&mut self, ci_prefix: &str, obj_prefix: &str) -> Result<()> {
-        self.ffi_func.name.push_str(ci_prefix);
-        self.ffi_func.name.push('_');
-        self.ffi_func.name.push_str(obj_prefix);
-        self.ffi_func.name.push('_');
-        self.ffi_func.name.push_str(&self.name);
+        self.ffi_func.name = format!("{}_{}_{}", ci_prefix, obj_prefix, self.name);
         self.ffi_func.arguments = self.full_arguments().iter().map(Into::into).collect();
         self.ffi_func.return_type = self.return_type.as_ref().map(Into::into);
         Ok(())


### PR DESCRIPTION
All push(_str) chains started off with an empty string and were really just assignments spread out over multiple lines.