### PR TITLE
Do not bundle the WebIDL tests

### DIFF
--- a/weedle2/Cargo.toml
+++ b/weedle2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weedle2"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Sharad Chand <sharad.d.chand@gmail.com>", "Jan-Erik Rediger <jrediger@mozilla.com>"]
 description = "A WebIDL Parser"
 license = "MIT"

--- a/weedle2/Cargo.toml
+++ b/weedle2/Cargo.toml
@@ -9,6 +9,8 @@ homepage = "https://github.com/mozilla/uniffi-rs/tree/main/weedle2"
 repository = "https://github.com/mozilla/uniffi-rs"
 readme = "./README.md"
 edition = "2018"
+# No need to include the large tests in the published package
+exclude = ["tests"]
 
 [lib]
 name = "weedle"


### PR DESCRIPTION
They are large and not needed in consumers, such as mozilla-central,
which bundles all dependencies.