### PR TITLE
[Discuss] Prototype of how async could work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "uniffi",
   "weedle2",
   "examples/arithmetic",
+  "examples/async-calc",
   "examples/callbacks",
   "examples/geometry",
   "examples/rondpoint",

--- a/examples/async-calc/Cargo.toml
+++ b/examples/async-calc/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "async-calc"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "uniffi_asynccalc"
+
+[dependencies]
+futures = "0.3.21"
+pinky-swear = "6.1.0"
+uniffi_macros = {path = "../../uniffi_macros"}
+uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
+
+[build-dependencies]
+uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/examples/async-calc/build.rs
+++ b/examples/async-calc/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/asynccalc.udl").unwrap();
+}

--- a/examples/async-calc/src/asynccalc.udl
+++ b/examples/async-calc/src/asynccalc.udl
@@ -1,0 +1,21 @@
+namespace asynccalc {
+    // Async rust function that awaits on the bindings calcullations
+    void double_then_square(PromiseInt promise, AsyncCalculator calculator, i32 value);
+};
+
+// Promise-like interface for Rust to return an int
+callback interface PromiseInt {
+  void resolve(i32 value);
+};
+
+// Promise-like interface for a callback interface to return an int
+interface BindingsPromiseInt {
+  void resolve(i32 value);
+};
+
+// Interface for doing async calculations on the bindings side.
+callback interface AsyncCalculator {
+  void double(BindingsPromiseInt promise, i32 value);
+  void square(BindingsPromiseInt promise, i32 value);
+};
+

--- a/examples/async-calc/src/lib.rs
+++ b/examples/async-calc/src/lib.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+use pinky_swear::{Pinky, PinkySwear};
+
+mod tasks;
+
+pub trait PromiseInt: Send + Sync {
+    fn resolve(&self, value: i32);
+}
+
+pub struct BindingsPromiseInt {
+    pinky: Pinky<i32>,
+}
+
+impl BindingsPromiseInt {
+    fn new() -> (PinkySwear<i32>, Self) {
+        let (future, pinky) = PinkySwear::new();
+        return (future, Self { pinky })
+    }
+
+    pub fn resolve(&self, value: i32) {
+        self.pinky.swear(value);
+        tasks::poll_tasks();
+    }
+}
+pub trait AsyncCalculator: Send + Sync {
+    fn double(&self, promise: Arc<BindingsPromiseInt>, value: i32);
+    fn square(&self, promise: Arc<BindingsPromiseInt>, value: i32);
+}
+
+// Wrap the AsyncCalculator trait in a struct that's easier to use from rust
+pub struct WrappedAsyncCalculator {
+    inner: Box<dyn AsyncCalculator>,
+}
+
+impl WrappedAsyncCalculator {
+    async fn double(&self, value: i32) -> i32 {
+        let (future, promise) = BindingsPromiseInt::new();
+        self.inner.double(Arc::new(promise), value);
+        future.await
+    }
+
+    async fn square(&self, value: i32) -> i32 {
+        let (future, promise) = BindingsPromiseInt::new();
+        self.inner.square(Arc::new(promise), value);
+        future.await
+    }
+}
+
+pub fn double_then_square(promise: Box<dyn PromiseInt>, calculator: Box<dyn AsyncCalculator>, value: i32)
+{
+    tasks::Task::start(async move {
+        let result = double_then_square_impl(
+            WrappedAsyncCalculator { inner: calculator },
+            value,
+        ).await;
+        promise.resolve(result);
+    });
+}
+
+// Inner code that does the actual work
+async fn double_then_square_impl(calculator: WrappedAsyncCalculator, value: i32) -> i32 {
+    calculator.square(
+        calculator.double(value).await
+    ).await
+}
+
+uniffi_macros::include_scaffolding!("asynccalc");

--- a/examples/async-calc/src/tasks.rs
+++ b/examples/async-calc/src/tasks.rs
@@ -1,0 +1,50 @@
+use futures::task::{waker_ref, ArcWake};
+use futures::future::{BoxFuture, FutureExt};
+use std::cell::RefCell;
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use std::task::Context;
+
+// Extremely simple async task executer system
+//
+// - Use Task::start() to start a new async task.  It should be passed an Unit-returning async function.
+// - Tasks should only await pinky-swear promises
+// - After you resolve a pinky swear promise, call `poll_tasks()` to run any tasks that were
+//   awaiting on that promise.
+
+// Top-level task object.
+pub struct Task(Mutex<BoxFuture<'static, ()>>);
+
+// Tasks that are ready to be polled.
+//
+// I think thread local is good for some corner cases, but maybe we don't need it.
+thread_local! {
+  static TASKS_TO_POLL: RefCell<Vec<Arc<Task>>> = RefCell::new(Vec::new());
+}
+
+impl Task {
+    pub fn start(future: impl Future<Output=()> + 'static + Send) {
+        Self::poll(Arc::new(Self(Mutex::new(future.boxed()))))
+    }
+
+    #[allow(unused_must_use)]
+    pub fn poll(arc_self: Arc<Self>) {
+        let waker = waker_ref(&arc_self);
+        let context = &mut Context::from_waker(&waker);
+        arc_self.0.lock().unwrap().as_mut().poll(context);
+    }
+}
+
+impl ArcWake for Task {
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        TASKS_TO_POLL.with(|tasks_to_poll| tasks_to_poll.borrow_mut().push(arc_self.clone()));
+    }
+}
+
+pub fn poll_tasks() {
+  TASKS_TO_POLL.with(|tasks_to_poll| {
+      for task in tasks_to_poll.borrow_mut().drain(..) {
+          Task::poll(task);
+      }
+  });
+}

--- a/examples/async-calc/tests/bindings/test_async_calc.py
+++ b/examples/async-calc/tests/bindings/test_async_calc.py
@@ -1,0 +1,39 @@
+import asyncio
+from asynccalc import *
+
+class AsyncCalculatorImpl(AsyncCalculator):
+    def __init__(self):
+        self.py_calculator = PyAsyncCalculator()
+
+    def double(self, promise, value):
+        asyncio.create_task(self.py_calculator.double(value)).add_done_callback(lambda fut: promise.resolve(fut.result()))
+
+    def square(self, promise, value):
+        asyncio.create_task(self.py_calculator.square(value)).add_done_callback(lambda fut: promise.resolve(fut.result()))
+
+class PromiseIntImpl(PromiseInt):
+    def __init__(self):
+        self.future = asyncio.Future()
+
+    def resolve(self, value):
+        self.future.set_result(value)
+        print("Promise resolved: ", value)
+
+async def double_then_square_wrapper(value):
+    promise = PromiseIntImpl()
+    double_then_square(promise, AsyncCalculatorImpl(), 4)
+    return await promise.future
+
+class PyAsyncCalculator:
+    async def double(self, value):
+        # Imagine awaiting some slow network request here
+        return value + value
+
+    async def square(self, value):
+        # Imagine awaiting some CPU-bound process running in a different thread here
+        return value * value
+
+async def main():
+    assert await double_then_square_wrapper(4) == 64
+
+asyncio.run(main())

--- a/examples/async-calc/tests/test_generated_bindings.rs
+++ b/examples/async-calc/tests/test_generated_bindings.rs
@@ -1,0 +1,6 @@
+uniffi_macros::build_foreign_language_testcases!(
+    ["src/asynccalc.udl",],
+    [
+        "tests/bindings/test_async_calc.py",
+    ]
+);

--- a/uniffi_bindgen/src/bindings/python/templates/wrapper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/wrapper.py
@@ -42,7 +42,7 @@ DEFAULT = object()
 # Public interface members begin here.
 {{ type_helper_code }}
 
-{%- for func in ci.iter_function_definitions() %}
+{% for func in ci.iter_function_definitions() %}
 {%- include "TopLevelFunctionTemplate.py" %}
 {%- endfor %}
 


### PR DESCRIPTION
Here's some code I put together showing how I think async could work for the Nimbus use case: Rust async code that awaits on async callback interfaces methods.  There's a bunch of extra code in this PR, but the idea is we have an example with:

- [A Python callback interface with async methods](https://github.com/bendk/uniffi-rs/blob/96e60ac52bd93a99abed4743e2220efff2fe0dac/examples/async-calc/tests/bindings/test_async_calc.py#L27-L34)
- [A Rust function that awaits those methods](https://github.com/bendk/uniffi-rs/blob/96e60ac52bd93a99abed4743e2220efff2fe0dac/examples/async-calc/src/lib.rs#L61-L65)
- [A Python function that awaits the Rust function](https://github.com/bendk/uniffi-rs/blob/96e60ac52bd93a99abed4743e2220efff2fe0dac/examples/async-calc/tests/bindings/test_async_calc.py#L36-L37)

To make this work, we convert these async functions to a sync function that inputs a Promise as it's first argument then add a bunch of glue/wrapper code.

There's also a [simple async executor](https://github.com/bendk/uniffi-rs/blob/96e60ac52bd93a99abed4743e2220efff2fe0dac/examples/async-calc/src/tasks.rs) that handles this code.  When we a promise is resolved, we call `poll_tasks()` which advances any futures that were awaiting on that promise.  This gives us the nice feature that futures always run in the same thread where the promise was resolved.  This will fail if you try to await on a network request or something, but that's a different use case.

My takeways:
  - This provides motivation for implementing async:
     - It shows it's possible
     - If we made this a UniFFI feature, then the glue code could be auto-generated and it could be a nice developer experience
  - It also provides motivation for not implementing it yet:
     - It shows it's possible to do async with the current UniFFI
     - The amount of glue code scales with the number of async functions and also the number of async return types.  AFAICT, the Nimbus use case is very simple, maybe only a single async function.  It might be reasonable to implement that by hand like I did for this example crate.
   - This requires language support to convert between promise/callback style code and async functions.  Python's Future class works well and I was able to cobble something together on Rust, but I'm not sure all languages have something like this.
   - Async will require some extra dependencies.  I needed to pull in `futures` and `pinky_swear`.  Maybe we could do without the `pinky_swear` dependency, but it would be really hard to do this without `futures`.  If we do async, I think it should be behind a feature gate.