### PR TITLE
Clarify our Rust version policy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
   # Our minimum supported rust version is specified here.
   prepare-rust-min-version:
     steps:
-      - run: rustup override set 1.57.0
+      - run: rustup override set 1.59.0
       - run: rustup update
   build-api-docs:
     steps:

--- a/docs/policies/rust-versions.md
+++ b/docs/policies/rust-versions.md
@@ -7,19 +7,23 @@ which aren't always able to be on that latest version.
 
 Given UniFFI is currently developed and maintained by Mozilla staff, it should
 be no surprise that an important consideration is mozilla-central (aka, the
-main Firefox repository). While at time of writing UniFFI is not used by
-mozilla-central, this policy is unashamedly focused on ensuring it will be
-able to.
+main Firefox repository). This policy exists to ensure UniFFI can always be
+used by mozilla-central.
 
 ## Mozilla-central Rust policies.
 
-It should also come as no surprise that the Rust policy for mozilla-central
-is somewhat flexible. There is an official [Rust Update Policy Document
-](https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html])
-but everything in the future is documented as "estimated".
+The Rust policy for mozilla-central has an official
+[Rust Update Policy Document
+](https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html),
+the tl;dr of which is:
 
-Ultimately though, that page defines 2 Rust versions - "Uses" and "Requires",
-and our policy revolves around these.
+* There's a "Uses" version which all of Mozilla's CI uses for releasing Firefox.
+  Discover it in the most recent updates to [this meta bug on Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1504858)
+
+* There's a "Requires" version, which Mozilla is committed to supporting,
+  primarily for downstream builders such as Linux distributions.
+  [Discover it here](https://searchfox.org/mozilla-central/search?q=MINIMUM_RUST_VERSION&path=python/mozboot/mozboot/util.py). This version is tested in mozilla-central's CI,
+  but nothing is shipped by mozilla with it.
 
 # UniFFI Rust version policy
 


### PR DESCRIPTION
As noted in #1242, our Rust policy wasn't as clear as it could be, so I attempted to fix it. I also changed the language about uniffi not currently being in mozilla-central - while that's true today, it look like landing very soon, so I tried to future-proof that. @jplatte, I can't add you as a reviewer, but would like your feedback anyway. 
