### PR TITLE
Upgrade weedle2 to nom 6

### DIFF
--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -25,4 +25,4 @@ heck = "0.4"
 paste = "1.0"
 serde = "1"
 toml = "0.5"
-weedle2 = { version = "2.0.0", path = "../weedle2" }
+weedle2 = { version = "3.0.0", path = "../weedle2" }

--- a/weedle2/Cargo.toml
+++ b/weedle2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weedle2"
-version = "2.0.1"
+version = "3.0.0"
 authors = ["Sharad Chand <sharad.d.chand@gmail.com>", "Jan-Erik Rediger <jrediger@mozilla.com>"]
 description = "A WebIDL Parser"
 license = "MIT"
@@ -17,4 +17,4 @@ name = "weedle"
 
 [dependencies]
 fs-err = "2.7.0"
-nom = { version = "5.0.0", default-features = false, features = ["std"] }
+nom = { version = "6.0.0", default-features = false, features = ["std"] }

--- a/weedle2/src/common.rs
+++ b/weedle2/src/common.rs
@@ -60,14 +60,14 @@ ast_types! {
 
     /// Parses `(item1, item2, item3,...)?`
     struct Punctuated<T, S> where [T: Parse<'a>, S: Parse<'a> + ::std::default::Default] {
-        list: Vec<T> = separated_list!(weedle!(S), weedle!(T)),
+        list: Vec<T> = separated_list0!(weedle!(S), weedle!(T)),
         separator: S = marker,
     }
 
     /// Parses `item1, item2, item3, ...`
     struct PunctuatedNonEmpty<T, S> where [T: Parse<'a>, S: Parse<'a> + ::std::default::Default] {
         list: Vec<T> = terminated!(
-            separated_nonempty_list!(weedle!(S), weedle!(T)),
+            separated_list1!(weedle!(S), weedle!(T)),
             opt!(weedle!(S))
         ),
         separator: S = marker,

--- a/weedle2/src/lib.rs
+++ b/weedle2/src/lib.rs
@@ -32,8 +32,8 @@
     many0,
     opt,
     recognize,
-    separated_list,
-    separated_nonempty_list,
+    separated_list0,
+    separated_list1,
     terminated
 )]
 extern crate nom;
@@ -47,7 +47,7 @@ use self::literal::StringLit;
 use self::mixin::MixinMembers;
 use self::namespace::NamespaceMembers;
 use self::types::{AttributedType, ReturnType};
-pub use nom::{error::ErrorKind, Err, IResult};
+pub use nom::{error::Error, error::ErrorKind, Err, IResult};
 
 #[macro_use]
 mod macros;
@@ -80,7 +80,7 @@ pub mod types;
 ///
 /// println!("{:?}", parsed);
 /// ```
-pub fn parse(raw: &str) -> Result<Definitions<'_>, Err<(&str, ErrorKind)>> {
+pub fn parse(raw: &str) -> Result<Definitions<'_>, Err<Error<&str>>> {
     let (remaining, parsed) = Definitions::parse(raw)?;
     assert!(
         remaining.is_empty(),

--- a/weedle2/src/term.rs
+++ b/weedle2/src/term.rs
@@ -21,11 +21,11 @@ macro_rules! ident_tag (
             match tag!($i, $tok) {
                 Err(e) => Err(e),
                 Ok((i, o)) => {
-                    use nom::{character::is_alphanumeric, Err as NomErr, error::ErrorKind};
+                    use nom::{character::is_alphanumeric, Err as NomErr, error::Error, error::ErrorKind};
                     let mut res = Ok((i, o));
                     if let Some(&c) = i.as_bytes().first() {
                         if is_alphanumeric(c) || c == b'_' || c == b'-' {
-                            res = Err(NomErr::Error(($i, ErrorKind::Tag)));
+                            res = Err(NomErr::Error(Error::new($i, ErrorKind::Tag)));
                         }
                     }
                     res


### PR DESCRIPTION
The big bummer here is that because weedle2 re-exports `nom` types and exposes them in return types, each nom version bump requires a version bump of the weedle2 crate itself.