### PR TITLE
Add full team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# This CODEOWNERS file defines individuals or teams that are responsible
+# for code in this repository.
+# See https://help.github.com/articles/about-codeowners/ for details.
+
+* @mozilla/uniffi-devs

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -132,8 +132,15 @@ When submitting a PR:
 - Please do not include merge commits in pull requests; include only commits with the new relevant code.
 - We encourage you to [GPG sign your commits](https://help.github.com/articles/managing-commit-signature-verification).
 
-## Code Review ##
+### Code Review
 
 This project is production Mozilla code and subject to our [code-review requirements](https://firefox-source-docs.mozilla.org/contributing/Code_Review_FAQ.html).
 Every change must be reviewed and approved by a member with write access to the main `mozilla/uniffi-rs` repository.
 
+### Merging code
+
+Pull requests can be merged if all tests are passing and it got at least one approving review from a member of the `@mozilla/uniffi-devs` team.
+We make use of GitHub's functionality to [automatically merge a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request).
+Enabling that is the task of the Pull Request author.
+
+For Pull Requests from outside contributors the reviewer should merge the Pull Request upon a successful review or should enable the automatic merge if tests have not yet finished.


### PR DESCRIPTION
Making use of GitHub's ability to auto-assign people from a team in a
round-robin fashion:
https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#routing-algorithms

I took out Travis, Lougenia and Elise from the review cycle, as they haven't been working on UniFFI really (can be done at https://github.com/orgs/mozilla/teams/uniffi-devs/edit/review_assignment)

---

~~Re mergify: it will need to be activated. I think I can do that, if not I can ask github admins.
I opted for a simple config, similar to what's used on a-s already:
a label for merging.
I plan to add some docs to make this more clear.~~