### PR TITLE
Release v0.19.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ## [[UnreleasedVersion]] - (_[[ReleaseDate]]_)
 
-[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.18.0...HEAD).
+[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.19.0...HEAD).
+
+## v0.19.0 - (_2022-06-16_)
+
+[All changes in v0.19.0](https://github.com/mozilla/uniffi-rs/compare/v0.18.0...v0.19.0).
 
 ###  ⚠️ Breaking Changes ⚠️
 - breaking for external binding generators, the `FFIType::RustArcPtr` now includes an inner `String`. The string represents the name of the object the `RustArcPtr` was derived from.

--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-arithmetic"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/callbacks/Cargo.toml
+++ b/examples/callbacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-callbacks"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/custom-types/Cargo.toml
+++ b/examples/custom-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-custom-types"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/geometry/Cargo.toml
+++ b/examples/geometry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-geometry"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/rondpoint/Cargo.toml
+++ b/examples/rondpoint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-rondpoint"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/sprites/Cargo.toml
+++ b/examples/sprites/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-sprites"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/todolist/Cargo.toml
+++ b/examples/todolist/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-todolist"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/callbacks/Cargo.toml
+++ b/fixtures/callbacks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-callbacks"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/coverall/Cargo.toml
+++ b/fixtures/coverall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-coverall"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/ext-types/guid/Cargo.toml
+++ b/fixtures/ext-types/guid/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-ext-types-guid"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/ext-types/lib/Cargo.toml
+++ b/fixtures/ext-types/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-ext-types"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/ext-types/uniffi-one/Cargo.toml
+++ b/fixtures/ext-types/uniffi-one/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-ext-types-lib-one"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/external-types/crate-one/Cargo.toml
+++ b/fixtures/external-types/crate-one/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crate_one"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/external-types/crate-two/Cargo.toml
+++ b/fixtures/external-types/crate-two/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crate_two"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/external-types/lib/Cargo.toml
+++ b/fixtures/external-types/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-external-types"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/reexport-scaffolding-macro/Cargo.toml
+++ b/fixtures/reexport-scaffolding-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-reexport-scaffolding-macro"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency/Cargo.toml
+++ b/fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-regression-cdylib-dependency"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["king6cong <king6cong@gmail.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
+++ b/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-regression-cdylib-dependency-ffi-crate"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
+++ b/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-regression-i356-enum-without-int-helpers"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/fully-qualified-types/Cargo.toml
+++ b/fixtures/regressions/fully-qualified-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-regression-i1015-fully-qualified-types"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
+++ b/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-regression-kotlin-experimental-unsigned-types"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/swift-omit-labels/Cargo.toml
+++ b/fixtures/swift-omit-labels/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-swift-omit-argument-labels"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/uitests/Cargo.toml
+++ b/fixtures/uitests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_uitests"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/uniffi-fixture-time/Cargo.toml
+++ b/fixtures/uniffi-fixture-time/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-time"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -4,7 +4,7 @@ description = "a multi-language bindings generator for rust (runtime support cod
 documentation = "https://mozilla.github.io/uniffi-rs"
 homepage = "https://mozilla.github.io/uniffi-rs"
 repository = "https://github.com/mozilla/uniffi-rs"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 edition = "2021"
@@ -20,7 +20,7 @@ log = "0.4"
 # Regular dependencies
 cargo_metadata = "0.14"
 paste = "1.0"
-uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "=0.18.0" }
+uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "=0.19.0"}
 static_assertions = "1.1.0"
 
 [features]

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_bindgen"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (codegen and cli tooling)"
 documentation = "https://mozilla.github.io/uniffi-rs"

--- a/uniffi_build/Cargo.toml
+++ b/uniffi_build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_build"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (build script helpers)"
 documentation = "https://mozilla.github.io/uniffi-rs"

--- a/uniffi_build/Cargo.toml
+++ b/uniffi_build/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["ffi", "bindgen"]
 [dependencies]
 anyhow = "1"
 camino = "1.0.8"
-uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "=0.18.0" }
+uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "=0.19.0"}
 
 [features]
 default = []

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -19,7 +19,7 @@ glob = "0.3"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["extra-traits"] }
-uniffi_build = { path = "../uniffi_build", version = "=0.18.0" }
+uniffi_build = { path = "../uniffi_build", version = "=0.19.0"}
 
 [features]
 default = []

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_macros"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (convenience macros)"
 documentation = "https://mozilla.github.io/uniffi-rs"

--- a/uniffi_testing/Cargo.toml
+++ b/uniffi_testing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi_testing"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 license = "MPL-2.0"
 publish = false


### PR DESCRIPTION
Merging back the 0.19.0 release changes.

I had some issues using `cargo release` for this one.  The `uniffi_macros` changes depended on a change in `uniffi_build`, which lead to an error when I tried the dry run.  I ended up creating 2 commits for the release and also needing to manually run `cargo publish` a couple times.  AFAICT this all worked out and everything is correct, there's just 2 commits instead of one.