### PR TITLE
Changing uniffi_meta version to 0.19.0

### DIFF
--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -28,4 +28,4 @@ serde = "1"
 serde_json = "1.0.80"
 toml = "0.5"
 weedle2 = { version = "3.0.0", path = "../weedle2" }
-uniffi_meta = { path = "../uniffi_meta", version = "=0.18.0" }
+uniffi_meta = { path = "../uniffi_meta", version = "=0.19.0" }

--- a/uniffi_meta/Cargo.toml
+++ b/uniffi_meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_meta"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
This isn't published yet, but the version needs to match the other
crate's Cargo.toml files.