### PR TITLE
New regression test: We missed a newline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
   "fixtures/regressions/kotlin-experimental-unsigned-types",
   "fixtures/regressions/cdylib-crate-type-dependency/ffi-crate",
   "fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency",
+  "fixtures/regressions/missing-newline",
   "fixtures/uitests",
   "fixtures/uniffi-fixture-time",
   "fixtures/simple-fns",

--- a/fixtures/regressions/missing-newline/Cargo.toml
+++ b/fixtures/regressions/missing-newline/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "uniffi-fixture-regression-missing-newline"
+edition = "2021"
+version = "0.19.1"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+name = "uniffi_regression_test_missing_newline"
+
+[dependencies]
+uniffi_macros = {path = "../../../uniffi_macros"}
+uniffi = {path = "../../../uniffi", features=["builtin-bindgen"]}
+
+[build-dependencies]
+uniffi_build = {path = "../../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/regressions/missing-newline/README.md
+++ b/fixtures/regressions/missing-newline/README.md
@@ -1,0 +1,8 @@
+# Regression test for missing newline error in v0.19.1
+
+In between v0.18.0 and v0.19.1 the Python code generation was changed,
+causing invalid code to be generated in some very specific instances:
+
+A void top-level function as well as the use of a hashmap somewhere.
+It missed adding a newline in the right place, thus merging subsequent lines,
+causing the code to be invalid.

--- a/fixtures/regressions/missing-newline/build.rs
+++ b/fixtures/regressions/missing-newline/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/test.udl").unwrap();
+}

--- a/fixtures/regressions/missing-newline/src/lib.rs
+++ b/fixtures/regressions/missing-newline/src/lib.rs
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::collections::HashMap;
+
+pub fn empty_func() {
+    // Intentionally left empty
+}
+
+pub fn get_dict() -> HashMap<String, String> {
+    HashMap::default()
+}
+
+include!(concat!(env!("OUT_DIR"), "/test.uniffi.rs"));

--- a/fixtures/regressions/missing-newline/src/test.udl
+++ b/fixtures/regressions/missing-newline/src/test.udl
@@ -1,0 +1,10 @@
+// We define a top-level function returning nothing (`void`),
+// and use a record (a map) someplace else.
+// This should compile and run fine, but in v0.19.1 it generated invalid Python code
+// due to a missed newline.
+
+namespace regression_test_missing_newline {
+  void empty_func();
+
+  record<string, string> get_dict();
+};

--- a/fixtures/regressions/missing-newline/tests/bindings/test.py
+++ b/fixtures/regressions/missing-newline/tests/bindings/test.py
@@ -1,0 +1,10 @@
+# This is just a basic "it loaded and ran" test.
+# What we're really guarding against is failure to
+# load the bindings as a result of buggy codegen.
+
+from regression_test_missing_newline import *
+
+# does not throw
+empty_func()
+
+assert get_dict() == {}

--- a/fixtures/regressions/missing-newline/tests/test_generated_bindings.rs
+++ b/fixtures/regressions/missing-newline/tests/test_generated_bindings.rs
@@ -1,0 +1,1 @@
+uniffi_macros::build_foreign_language_testcases!(["src/test.udl"], ["tests/bindings/test.py",]);


### PR DESCRIPTION
This is already fixed in `main`, but was an issue in 0.19.1