### PR TITLE
Implement Timestamp and Duration types in Ruby backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 [All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.19.1...HEAD).
 
+- Implement Timestamp and Duration types in Ruby backend.
+
 ## v0.19.1 - (_2022-06-16_)
 
 [All changes in v0.19.1](https://github.com/mozilla/uniffi-rs/compare/v0.19.0...v0.19.1).

--- a/fixtures/uniffi-fixture-time/tests/bindings/test_chronological.rb
+++ b/fixtures/uniffi-fixture-time/tests/bindings/test_chronological.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require 'test/unit'
+require 'time'
+require 'chronological'
+
+class TestChronological < Test::Unit::TestCase
+  UTC = '+00:00' # ruby 2.6 doesn't support 'UTC' literal yet.
+
+  def test_passing_and_returning_timestamp
+    time  = Time.at 100, 1, :microsecond, in: UTC
+    delta = duration 1, 1, :microsecond
+
+    assert_equal Chronological.add(time, delta), Time.at(101, 2, :microsecond, in: UTC)
+  end
+
+  def test_passing_and_returning_timestamp_with_nanoseconds
+    time  = Time.at 100, 1, :microsecond, in: UTC
+    delta = duration 1, 1001, :nanosecond
+
+    assert_equal Chronological.add(time, delta), Time.at(101, 2001, :nanosecond, in: UTC)
+  end
+
+  def test_passing_timestamp_while_returning_duration
+    from  = Time.at 100, 1, :microsecond, in: UTC
+    to    = Time.at 101, 2, :microsecond, in: UTC
+    delta = duration 1, 1, :microsecond
+
+    assert_equal Chronological.diff(to, from), delta
+  end
+
+  def test_add_with_pre_epoch
+    time  = Time.parse '1955-11-05T00:06:00.283001 UTC'
+    delta = duration 1, 1, :microsecond
+
+    assert_equal Time.parse('1955-11-05T00:06:01.283002 UTC'), Chronological.add(time, delta)
+  end
+
+  def test_exceptions_are_propagated
+    assert_raises Chronological::ChronologicalError::TimeDiffError do
+      Chronological.diff Time.at(100), Time.at(101)
+    end
+  end
+
+  def test_rust_timestamps_behave_like_ruby_timestamps
+    ruby_before = Time.now
+    rust_now    = Chronological.now
+    ruby_after  = Time.now
+
+    assert ruby_before <= rust_now
+    assert ruby_after >= rust_now
+  end
+
+  def test_that_uniffi_returns_UTC_times
+    assert_equal 'UTC', Chronological.now.zone
+
+    assert (Time.now.utc - Chronological.now).abs <= 1.0
+  end
+
+  private
+
+  def duration(*args)
+    Time.at(*args, in: UTC)
+  end
+end

--- a/fixtures/uniffi-fixture-time/tests/test_generated_bindings.rs
+++ b/fixtures/uniffi-fixture-time/tests/test_generated_bindings.rs
@@ -4,5 +4,6 @@ uniffi_macros::build_foreign_language_testcases!(
         "tests/bindings/test_chronological.py",
         "tests/bindings/test_chronological.kts",
         "tests/bindings/test_chronological.swift",
+        "tests/bindings/test_chronological.rb",
     ]
 );

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -165,8 +165,7 @@ mod filters {
             Type::Boolean => format!("{} ? true : false", nm),
             Type::Object(_) | Type::Enum(_) | Type::Error(_) | Type::Record(_) => nm.to_string(),
             Type::String => format!("{}.to_s", nm),
-            Type::Timestamp => panic!("No support for timestamps in Ruby, yet"),
-            Type::Duration => panic!("No support for durations in Ruby, yet"),
+            Type::Timestamp | Type::Duration => nm.to_string(),
             Type::CallbackInterface(_) => panic!("No support for coercing callback interfaces yet"),
             Type::Optional(t) => format!("({} ? {} : nil)", nm, coerce_rb(nm, t)?),
             Type::Sequence(t) => {
@@ -209,8 +208,6 @@ mod filters {
             | Type::Float64 => nm.to_string(),
             Type::Boolean => format!("({} ? 1 : 0)", nm),
             Type::String => format!("RustBuffer.allocFromString({})", nm),
-            Type::Timestamp => panic!("No support for timestamps in Ruby, yet"),
-            Type::Duration => panic!("No support for durations in Ruby, yet"),
             Type::Object(name) => format!("({}._uniffi_lower {})", class_name_rb(name)?, nm),
             Type::CallbackInterface(_) => panic!("No support for lowering callback interfaces yet"),
             Type::Error(_) => panic!("No support for lowering errors, yet"),
@@ -218,6 +215,8 @@ mod filters {
             | Type::Record(_)
             | Type::Optional(_)
             | Type::Sequence(_)
+            | Type::Timestamp
+            | Type::Duration
             | Type::Map(_, _) => format!(
                 "RustBuffer.alloc_from_{}({})",
                 class_name_rb(&type_.canonical_name())?,
@@ -241,8 +240,6 @@ mod filters {
             Type::Float32 | Type::Float64 => format!("{}.to_f", nm),
             Type::Boolean => format!("1 == {}", nm),
             Type::String => format!("{}.consumeIntoString", nm),
-            Type::Timestamp => panic!("No support for timestamps in Ruby, yet"),
-            Type::Duration => panic!("No support for durations in Ruby, yet"),
             Type::Object(name) => format!("{}._uniffi_allocate({})", class_name_rb(name)?, nm),
             Type::CallbackInterface(_) => panic!("No support for lifting callback interfaces, yet"),
             Type::Error(_) => panic!("No support for lowering errors, yet"),
@@ -250,6 +247,8 @@ mod filters {
             | Type::Record(_)
             | Type::Optional(_)
             | Type::Sequence(_)
+            | Type::Timestamp
+            | Type::Duration
             | Type::Map(_, _) => format!(
                 "{}.consumeInto{}",
                 nm,

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -105,6 +105,35 @@ class RustBufferBuilder
     write v
   end
 
+  {% when Type::Timestamp -%}
+  # The Timestamp type.
+  ONE_SECOND_IN_NANOSECONDS = 10**9
+
+  def write_{{ canonical_type_name }}(v)
+    seconds = v.tv_sec
+    nanoseconds = v.tv_nsec
+
+    if seconds < 0
+      nanoseconds = ONE_SECOND_IN_NANOSECONDS - nanoseconds
+    end
+
+    pack_into 8, 'q>', seconds
+    pack_into 4, 'L>', nanoseconds
+  end
+
+  {% when Type::Duration -%}
+  # The Duration type.
+
+  def write_{{ canonical_type_name }}(v)
+    seconds = v.tv_sec
+    nanoseconds = v.tv_nsec
+
+    raise ArgumentError, 'Invalid duration, must be non-negative' if seconds < 0
+
+    pack_into 8, 'Q>', seconds
+    pack_into 4, 'L>', nanoseconds
+  end
+
   {% when Type::Object with (object_name) -%}
   # The Object type {{ object_name }}.
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
@@ -106,6 +106,31 @@ class RustBufferStream
     read(size).force_encoding(Encoding::UTF_8)
   end
 
+  {% when Type::Timestamp -%}
+  # The Timestamp type.
+  ONE_SECOND_IN_NANOSECONDS = 10**9
+
+  def read{{ canonical_type_name }}
+    seconds = unpack_from 8, 'q>'
+    nanoseconds = unpack_from 4, 'L>'
+
+    if seconds < 0
+      nanoseconds = ONE_SECOND_IN_NANOSECONDS - nanoseconds
+    end
+
+    Time.at(seconds, nanoseconds, :nanosecond, in: '+00:00').utc
+  end
+
+  {% when Type::Duration -%}
+  # The Duration type.
+
+  def read{{ canonical_type_name }}
+    seconds = unpack_from 8, 'q>'
+    nanoseconds = unpack_from 4, 'L>'
+
+    Time.at(seconds, nanoseconds, :nanosecond, in: '+00:00').utc
+  end
+
   {% when Type::Object with (object_name) -%}
   # The Object type {{ object_name }}.
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
@@ -80,6 +80,34 @@ class RustBuffer < FFI::Struct
     end
   end
 
+  {% when Type::Timestamp -%}
+  def self.alloc_from_{{ canonical_type_name }}(v)
+    RustBuffer.allocWithBuilder do |builder|
+      builder.write_{{ canonical_type_name }}(v)
+      return builder.finalize
+    end
+  end
+
+  def consumeInto{{ canonical_type_name }}
+    consumeWithStream do |stream|
+      return stream.read{{ canonical_type_name }}
+    end
+  end
+
+  {% when Type::Duration -%}
+  def self.alloc_from_{{ canonical_type_name }}(v)
+    RustBuffer.allocWithBuilder do |builder|
+      builder.write_{{ canonical_type_name }}(v)
+      return builder.finalize
+    end
+  end
+
+  def consumeInto{{ canonical_type_name }}
+    consumeWithStream do |stream|
+      return stream.read{{ canonical_type_name }}
+    end
+  end
+
   {% when Type::Record with (record_name) -%}
   {%- let rec = ci.get_record_definition(record_name).unwrap() -%}
   # The Record type {{ record_name }}.


### PR DESCRIPTION
This PR fixes #469. Both `Timestamp` and `Duration` are implemented through ruby `Time` class for the lack of better way to represent `Duration`. Please have a look at your convenience and let me know if you need more details.