### PR TITLE
Include the askama config file into the build

### DIFF
--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -658,6 +658,17 @@ pub fn run_main() -> Result<()> {
     Ok(())
 }
 
+// FIXME(HACK):
+// Include the askama config file into the build.
+// That way cargo tracks the file and other tools relying on file tracking see it as well.
+// See https://bugzilla.mozilla.org/show_bug.cgi?id=1774585
+// In the future askama should handle that itself by using the `track_path::path` API,
+// see https://github.com/rust-lang/rust/pull/84029
+#[allow(dead_code)]
+mod __unused {
+    const _: &[u8] = include_bytes!("../askama.toml");
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
Badboy's fix for sccache builds (https://bugzilla.mozilla.org/show_bug.cgi?id=1774585).

I'm hoping to get r+ on this, but let's wait to merge it until we get approval in that thread that the fix is going to work for moz-central.