### PR TITLE
Merge back changes from the 0.19.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,18 @@
 
 ## [[UnreleasedVersion]] - (_[[ReleaseDate]]_)
 
-[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.19.2...HEAD).
+[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.19.3...HEAD).
+
+- Implement Timestamp and Duration types in Ruby backend.
+
+## v0.19.3 - (_2022-07-08_)
+
+[All changes in v0.19.3](https://github.com/mozilla/uniffi-rs/compare/v0.19.2...v0.19.3).
 
 ## v0.19.2 - (_2022-06-28_)
 
 [All changes in v0.19.2](https://github.com/mozilla/uniffi-rs/compare/v0.19.1...v0.19.2).
 
-- Fixed sccache issue with the `askama.toml` config file.
-
-- Implement Timestamp and Duration types in Ruby backend.
 - Fixed sccache issue with the `askama.toml` config file.
 
 ## v0.19.1 - (_2022-06-16_)

--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-arithmetic"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/callbacks/Cargo.toml
+++ b/examples/callbacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-callbacks"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/custom-types/Cargo.toml
+++ b/examples/custom-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-custom-types"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/geometry/Cargo.toml
+++ b/examples/geometry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-geometry"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/rondpoint/Cargo.toml
+++ b/examples/rondpoint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-rondpoint"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/sprites/Cargo.toml
+++ b/examples/sprites/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-sprites"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/todolist/Cargo.toml
+++ b/examples/todolist/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-todolist"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/callbacks/Cargo.toml
+++ b/fixtures/callbacks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-callbacks"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/coverall/Cargo.toml
+++ b/fixtures/coverall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-coverall"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/ext-types/guid/Cargo.toml
+++ b/fixtures/ext-types/guid/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-ext-types-guid"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/ext-types/lib/Cargo.toml
+++ b/fixtures/ext-types/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-ext-types"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/ext-types/uniffi-one/Cargo.toml
+++ b/fixtures/ext-types/uniffi-one/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-ext-types-lib-one"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/external-types/crate-one/Cargo.toml
+++ b/fixtures/external-types/crate-one/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crate_one"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/external-types/crate-two/Cargo.toml
+++ b/fixtures/external-types/crate-two/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crate_two"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/external-types/lib/Cargo.toml
+++ b/fixtures/external-types/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-external-types"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/keywords/kotlin/Cargo.toml
+++ b/fixtures/keywords/kotlin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-keywords-kotlin"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 publish = false

--- a/fixtures/keywords/rust/Cargo.toml
+++ b/fixtures/keywords/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-keywords-rust"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 publish = false

--- a/fixtures/reexport-scaffolding-macro/Cargo.toml
+++ b/fixtures/reexport-scaffolding-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-reexport-scaffolding-macro"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency/Cargo.toml
+++ b/fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-regression-cdylib-dependency"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["king6cong <king6cong@gmail.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
+++ b/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-regression-cdylib-dependency-ffi-crate"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
+++ b/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-regression-i356-enum-without-int-helpers"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/fully-qualified-types/Cargo.toml
+++ b/fixtures/regressions/fully-qualified-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-regression-i1015-fully-qualified-types"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
+++ b/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-regression-kotlin-experimental-unsigned-types"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/missing-newline/Cargo.toml
+++ b/fixtures/regressions/missing-newline/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-regression-missing-newline"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 license = "MPL-2.0"
 publish = false
 

--- a/fixtures/swift-omit-labels/Cargo.toml
+++ b/fixtures/swift-omit-labels/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-swift-omit-argument-labels"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/uitests/Cargo.toml
+++ b/fixtures/uitests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_uitests"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/uniffi-fixture-time/Cargo.toml
+++ b/fixtures/uniffi-fixture-time/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-time"
 edition = "2021"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -4,7 +4,7 @@ description = "a multi-language bindings generator for rust (runtime support cod
 documentation = "https://mozilla.github.io/uniffi-rs"
 homepage = "https://mozilla.github.io/uniffi-rs"
 repository = "https://github.com/mozilla/uniffi-rs"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 edition = "2021"
@@ -20,8 +20,8 @@ once_cell = "1.12"
 # Regular dependencies
 cargo_metadata = "0.14"
 paste = "1.0"
-uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "=0.19.2"}
-uniffi_macros = { path = "../uniffi_macros", version = "=0.19.2" }
+uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "=0.19.3"}
+uniffi_macros = { path = "../uniffi_macros", version = "=0.19.3" }
 static_assertions = "1.1.0"
 
 [features]

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_bindgen"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (codegen and cli tooling)"
 documentation = "https://mozilla.github.io/uniffi-rs"
@@ -28,4 +28,4 @@ serde = "1"
 serde_json = "1.0.80"
 toml = "0.5"
 weedle2 = { version = "3.0.0", path = "../weedle2" }
-uniffi_meta = { path = "../uniffi_meta", version = "=0.19.2" }
+uniffi_meta = { path = "../uniffi_meta", version = "=0.19.3" }

--- a/uniffi_build/Cargo.toml
+++ b/uniffi_build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_build"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (build script helpers)"
 documentation = "https://mozilla.github.io/uniffi-rs"
@@ -13,7 +13,7 @@ keywords = ["ffi", "bindgen"]
 [dependencies]
 anyhow = "1"
 camino = "1.0.8"
-uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "=0.19.2"}
+uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "=0.19.3"}
 
 [features]
 default = []

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_macros"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (convenience macros)"
 documentation = "https://mozilla.github.io/uniffi-rs"
@@ -26,8 +26,8 @@ serde_json = "1.0.79"
 syn = { version = "1.0", features = ["extra-traits"] }
 tempfile = "3.3.0"
 toml = "0.5.9"
-uniffi_build = { path = "../uniffi_build", version = "=0.19.2" }
-uniffi_meta = { path = "../uniffi_meta", version = "=0.19.2" }
+uniffi_build = { path = "../uniffi_build", version = "=0.19.3" }
+uniffi_meta = { path = "../uniffi_meta", version = "=0.19.3" }
 
 [features]
 default = []

--- a/uniffi_meta/Cargo.toml
+++ b/uniffi_meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_meta"
-version = "0.19.2"
+version = "0.19.3"
 edition = "2021"
 
 [dependencies]

--- a/uniffi_testing/Cargo.toml
+++ b/uniffi_testing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi_testing"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
-version = "0.19.2"
+version = "0.19.3"
 edition = "2021"
 license = "MPL-2.0"
 publish = false


### PR DESCRIPTION
This lists a lot of commits that don't actually reflect the changes here.  I feel like there's a better way to do this, but I'm not sure how.  The actual changes should just be to `CHANGELOG` and bumping the versions of all crates to `0.19.3'