### PR TITLE
Allow Rust traits to be exposed as an interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
   `Contstructor` to `throws_str()`.  Added a new `throws()` method that returns
   a boolean.
 
+- removed the long deprecated `ThreadSafe` attribute.
+
+### What's changed
+- traits [todo: fill me out! Also needs docs...]
+
 ## v0.20.0 - (_2022-09-13_)
 
 [All changes in v0.20.0](https://github.com/mozilla/uniffi-rs/compare/v0.19.6...v0.20.0).

--- a/examples/callbacks/src/callbacks.udl
+++ b/examples/callbacks/src/callbacks.udl
@@ -1,10 +1,21 @@
-namespace callbacks {};
-
-interface Telephone {
-  constructor();
-  void call(boolean domestic, OnCallAnswered call_responder);
+namespace callbacks {
+  // I'm a phone with builtin sim cards!
+  sequence<SimCard> get_sim_cards();
 };
 
+// This is a trait implemented on the Rust side.
+[Trait]
+interface SimCard {
+  string name(); // The name of the carrier/provider.
+};
+
+// Make calls on one of the sim cards, call back to foreign code with the call status.
+interface Telephone {
+  constructor();
+  void call([ByRef]SimCard sim, boolean domestic, OnCallAnswered call_responder);
+};
+
+// This is a trait implemented on the foreign side.
 callback interface OnCallAnswered {
   string hello();
   void busy();

--- a/examples/callbacks/src/lib.rs
+++ b/examples/callbacks/src/lib.rs
@@ -2,6 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
+// SIM cards.
+trait SimCard: Send + Sync {
+    fn name(&self) -> String;
+}
+
+struct RustySim {}
+impl SimCard for RustySim {
+    fn name(&self) -> String {
+        "rusty!".to_string()
+    }
+}
+
+// namespace functions.
+fn get_sim_cards() -> Vec<Arc<dyn SimCard>> {
+    vec![Arc::new(RustySim {})]
+}
+
+// A trait for the foreign callback.
+// TODO: pass the SimCard.
 pub trait OnCallAnswered {
     fn hello(&self) -> String;
     fn busy(&self);
@@ -14,7 +35,7 @@ impl Telephone {
     fn new() -> Self {
         Telephone
     }
-    fn call(&self, domestic: bool, call_responder: Box<dyn OnCallAnswered>) {
+    fn call(&self, _sim: &dyn SimCard, domestic: bool, call_responder: Box<dyn OnCallAnswered>) {
         if domestic {
             let _ = call_responder.hello();
         } else {

--- a/examples/callbacks/tests/bindings/test_callbacks.kts
+++ b/examples/callbacks/tests/bindings/test_callbacks.kts
@@ -26,23 +26,24 @@ class OnCallAnsweredImpl : OnCallAnswered {
     }
 }
 
+val sim = getSimCards()[0]
 val cbObject = OnCallAnsweredImpl()
 val telephone = Telephone()
 
-telephone.call(true, cbObject)
+telephone.call(sim, true, cbObject)
 assert(cbObject.busyCount == 0) { "yesCount=${cbObject.busyCount} (should be 0)" }
 assert(cbObject.yesCount == 1) { "yesCount=${cbObject.yesCount} (should be 1)" }
 
-telephone.call(true, cbObject)
+telephone.call(sim, true, cbObject)
 assert(cbObject.busyCount == 0) { "yesCount=${cbObject.busyCount} (should be 0)" }
 assert(cbObject.yesCount == 2) { "yesCount=${cbObject.yesCount} (should be 2)" }
 
-telephone.call(false, cbObject)
+telephone.call(sim, false, cbObject)
 assert(cbObject.busyCount == 1) { "yesCount=${cbObject.busyCount} (should be 1)" }
 assert(cbObject.yesCount == 2) { "yesCount=${cbObject.yesCount} (should be 2)" }
 
 val cbObjet2 = OnCallAnsweredImpl()
-telephone.call(true, cbObjet2)
+telephone.call(sim, true, cbObjet2)
 assert(cbObjet2.busyCount == 0) { "yesCount=${cbObjet2.busyCount} (should be 0)" }
 assert(cbObjet2.yesCount == 1) { "yesCount=${cbObjet2.yesCount} (should be 1)" }
 

--- a/examples/callbacks/tests/bindings/test_callbacks.py
+++ b/examples/callbacks/tests/bindings/test_callbacks.py
@@ -19,23 +19,24 @@ class OnCallAnsweredImpl(OnCallAnswered):
     def text_received(self, text):
         self.string_received = text
 
+sim = get_sim_cards()[0]
 cb_object = OnCallAnsweredImpl()
 telephone = Telephone()
 
-telephone.call(domestic=True, call_responder=cb_object)
+telephone.call(sim, domestic=True, call_responder=cb_object)
 assert cb_object.busy_count == 0, f"yes_count={cb_object.busy_count} (should be 0)"
 assert cb_object.yes_count == 1, f"yes_count={cb_object.yes_count} (should be 1)"
 
-telephone.call(domestic=True, call_responder=cb_object)
+telephone.call(sim, domestic=True, call_responder=cb_object)
 assert cb_object.busy_count == 0, f"yes_count={cb_object.busy_count} (should be 0)"
 assert cb_object.yes_count == 2, f"yes_count={cb_object.yes_count} (should be 2)"
 
-telephone.call(domestic=False, call_responder=cb_object)
+telephone.call(sim, domestic=False, call_responder=cb_object)
 assert cb_object.busy_count == 1, f"yes_count={cb_object.busy_count} (should be 1)"
 assert cb_object.yes_count == 2, f"yes_count={cb_object.yes_count} (should be 2)"
 assert cb_object.string_received != "", f"string_received='{cb_object.string_received}' (should be a message)"
 
 cb_object2 = OnCallAnsweredImpl()
-telephone.call(domestic=True, call_responder=cb_object2)
+telephone.call(sim, domestic=True, call_responder=cb_object2)
 assert cb_object2.busy_count == 0, f"yes_count={cb_object2.busy_count} (should be 0)"
 assert cb_object2.yes_count == 1, f"yes_count={cb_object2.yes_count} (should be 1)"

--- a/examples/callbacks/tests/bindings/test_callbacks.swift
+++ b/examples/callbacks/tests/bindings/test_callbacks.swift
@@ -28,23 +28,24 @@ class OnCallAnsweredImpl : OnCallAnswered {
     }
 }
 
+let sim = getSimCards()[0]
 let cbObject = OnCallAnsweredImpl()
 let telephone = Telephone()
 
-telephone.call(domestic: true, callResponder: cbObject)
+telephone.call(sim: sim, domestic: true, callResponder: cbObject)
 assert(cbObject.busyCount == 0, "yesCount=\(cbObject.busyCount) (should be 0)")
 assert(cbObject.yesCount == 1, "yesCount=\(cbObject.yesCount) (should be 1)")
 
-telephone.call(domestic: true, callResponder: cbObject)
+telephone.call(sim: sim, domestic: true, callResponder: cbObject)
 assert(cbObject.busyCount == 0, "yesCount=\(cbObject.busyCount) (should be 0)")
 assert(cbObject.yesCount == 2, "yesCount=\(cbObject.yesCount) (should be 2)")
 
-telephone.call(domestic: false, callResponder: cbObject)
+telephone.call(sim: sim, domestic: false, callResponder: cbObject)
 assert(cbObject.busyCount == 1, "yesCount=\(cbObject.busyCount) (should be 1)")
 assert(cbObject.yesCount == 2, "yesCount=\(cbObject.yesCount) (should be 2)")
 
 let cbObject2 = OnCallAnsweredImpl()
-telephone.call(domestic: true, callResponder: cbObject2)
+telephone.call(sim: sim, domestic: true, callResponder: cbObject2)
 assert(cbObject2.busyCount == 0, "yesCount=\(cbObject2.busyCount) (should be 0)")
 assert(cbObject2.yesCount == 1, "yesCount=\(cbObject2.yesCount) (should be 1)")
 

--- a/uniffi/src/ffi/ffidefault.rs
+++ b/uniffi/src/ffi/ffidefault.rs
@@ -45,6 +45,12 @@ impl FfiDefault for *const std::ffi::c_void {
     }
 }
 
+impl<T: ?Sized> FfiDefault for *mut std::sync::Arc<T> {
+    fn ffi_default() -> Self {
+        std::ptr::null_mut()
+    }
+}
+
 impl FfiDefault for crate::RustBuffer {
     fn ffi_default() -> Self {
         unsafe { Self::from_raw_parts(std::ptr::null_mut(), 0, 0) }

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -632,8 +632,9 @@ unsafe impl<T: Sync + Send> FfiConverter for std::sync::Arc<T> {
 /// Support for passing reference-counted trait objects via the FFI.
 ///
 /// This is different than the last one, since trait objects are stored as 2 pointers (AKA a "fat
-/// pointer): one for the `Arc<T>` and another for the vtable.  Since the foreign side is expecting
-/// a single pointer, everything gets wrapped in a Box
+/// pointer): one for `T` and another for the vtable.  Since the foreign side is expecting
+/// a single pointer, something needs to get wrapped in a Box. And all our `T`s are `Arc<>`s.
+/// So, of `Box<Arc<T>` or `Arc<Box<T>`, an inner `Arc<T>` is more consistent with other impls.
 unsafe impl<T: Sync + Send + ?Sized> FfiConverter for Box<std::sync::Arc<T>> {
     type RustType = std::sync::Arc<T>;
     // Don't use a pointer to <T> as that requires a `pub <T>`

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -213,7 +213,9 @@ impl KotlinCodeOracle {
             Type::Duration => Box::new(miscellany::DurationCodeType),
 
             Type::Enum(id) => Box::new(enum_::EnumCodeType::new(id)),
-            Type::Object(id) => Box::new(object::ObjectCodeType::new(id)),
+            Type::Object(ObjectImpl::Struct(nm)) | Type::Object(ObjectImpl::Trait(nm)) => {
+                Box::new(object::ObjectCodeType::new(nm))
+            }
             Type::Record(id) => Box::new(record::RecordCodeType::new(id)),
             Type::Error(id) => Box::new(error::ErrorCodeType::new(id)),
             Type::CallbackInterface(id) => {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
@@ -59,7 +59,8 @@
 {%- when Type::Error(name) %}
 {% include "ErrorTemplate.kt" %}
 
-{%- when Type::Object(name) %}
+{%- when Type::Object(imp) %}
+{%- let name = imp.id() %}
 {% include "ObjectTemplate.kt" %}
 
 {%- when Type::Record(name) %}

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -234,7 +234,9 @@ impl PythonCodeOracle {
             Type::Duration => Box::new(miscellany::DurationCodeType),
 
             Type::Enum(id) => Box::new(enum_::EnumCodeType::new(id)),
-            Type::Object(id) => Box::new(object::ObjectCodeType::new(id)),
+            Type::Object(ObjectImpl::Struct(nm)) | Type::Object(ObjectImpl::Trait(nm)) => {
+                Box::new(object::ObjectCodeType::new(nm))
+            }
             Type::Record(id) => Box::new(record::RecordCodeType::new(id)),
             Type::Error(id) => Box::new(error::ErrorCodeType::new(id)),
             Type::CallbackInterface(id) => {

--- a/uniffi_bindgen/src/bindings/python/templates/Types.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Types.py
@@ -61,7 +61,8 @@
 {%- when Type::Record(name) %}
 {%- include "RecordTemplate.py" %}
 
-{%- when Type::Object(name) %}
+{%- when Type::Object(imp) %}
+{%- let name = imp.id() %}
 {%- include "ObjectTemplate.py" %}
 
 {%- when Type::Timestamp %}

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -208,7 +208,7 @@ mod filters {
             | Type::Float64 => nm.to_string(),
             Type::Boolean => format!("({} ? 1 : 0)", nm),
             Type::String => format!("RustBuffer.allocFromString({})", nm),
-            Type::Object(name) => format!("({}._uniffi_lower {})", class_name_rb(name)?, nm),
+            Type::Object(imp) => format!("({}._uniffi_lower {})", class_name_rb(imp.id())?, nm),
             Type::CallbackInterface(_) => panic!("No support for lowering callback interfaces yet"),
             Type::Error(_) => panic!("No support for lowering errors, yet"),
             Type::Enum(_)
@@ -240,7 +240,7 @@ mod filters {
             Type::Float32 | Type::Float64 => format!("{}.to_f", nm),
             Type::Boolean => format!("1 == {}", nm),
             Type::String => format!("{}.consumeIntoString", nm),
-            Type::Object(name) => format!("{}._uniffi_allocate({})", class_name_rb(name)?, nm),
+            Type::Object(imp) => format!("{}._uniffi_allocate({})", class_name_rb(imp.id())?, nm),
             Type::CallbackInterface(_) => panic!("No support for lifting callback interfaces, yet"),
             Type::Error(_) => panic!("No support for lowering errors, yet"),
             Type::Enum(_)

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -134,7 +134,8 @@ class RustBufferBuilder
     pack_into 4, 'L>', nanoseconds
   end
 
-  {% when Type::Object with (object_name) -%}
+  {% when Type::Object with (object_imp) -%}
+  {%- let object_name = object_imp.id() %}
   # The Object type {{ object_name }}.
 
   def write_{{ canonical_type_name }}(obj)

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
@@ -131,7 +131,9 @@ class RustBufferStream
     Time.at(seconds, nanoseconds, :nanosecond, in: '+00:00').utc
   end
 
-  {% when Type::Object with (object_name) -%}
+  {% when Type::Object with (object_imp) -%}
+  {%- let object_name = object_imp.id() %}
+
   # The Object type {{ object_name }}.
 
   def read{{ canonical_type_name }}

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -313,7 +313,9 @@ impl SwiftCodeOracle {
             Type::Duration => Box::new(miscellany::DurationCodeType),
 
             Type::Enum(id) => Box::new(enum_::EnumCodeType::new(id)),
-            Type::Object(id) => Box::new(object::ObjectCodeType::new(id)),
+            Type::Object(ObjectImpl::Struct(nm)) | Type::Object(ObjectImpl::Trait(nm)) => {
+                Box::new(object::ObjectCodeType::new(nm))
+            }
             Type::Record(id) => Box::new(record::RecordCodeType::new(id)),
             Type::Error(id) => Box::new(error::ErrorCodeType::new(id)),
             Type::CallbackInterface(id) => {

--- a/uniffi_bindgen/src/bindings/swift/templates/Types.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Types.swift
@@ -70,7 +70,8 @@
 {%- when Type::Error(name) %}
 {%- include "ErrorTemplate.swift" %}
 
-{%- when Type::Object(name) %}
+{%- when Type::Object(imp) %}
+{%- let name = imp.id() %}
 {%- include "ObjectTemplate.swift" %}
 
 {%- when Type::Record(name) %}

--- a/uniffi_bindgen/src/interface/callbacks.rs
+++ b/uniffi_bindgen/src/interface/callbacks.rs
@@ -39,7 +39,7 @@ use anyhow::{bail, Result};
 
 use super::ffi::{FFIArgument, FFIFunction, FFIType};
 use super::object::Method;
-use super::types::{Type, TypeIterator};
+use super::types::{ObjectImpl, Type, TypeIterator};
 use super::{APIConverter, ComponentInterface};
 
 #[derive(Debug, Clone)]
@@ -114,7 +114,10 @@ impl APIConverter<CallbackInterface> for weedle::CallbackInterfaceDefinition<'_>
             match member {
                 weedle::interface::InterfaceMember::Operation(t) => {
                     let mut method: Method = t.convert(ci)?;
-                    method.object_name = object.name.clone();
+                    // This is a little suspect and probably just reflects the fact that
+                    // CallbackInterface and ObjectImpl::Trait are actually the same thing?
+                    method.object_type =
+                        Some(Type::Object(ObjectImpl::Struct(object.name.clone())));
                     object.methods.push(method);
                 }
                 _ => bail!(

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -38,7 +38,7 @@ use anyhow::{bail, Result};
 
 use super::ffi::{FFIArgument, FFIFunction};
 use super::literal::{convert_default_value, Literal};
-use super::types::{Type, TypeIterator};
+use super::types::{ObjectImpl, Type, TypeIterator};
 use super::{
     attributes::{ArgumentAttributes, FunctionAttributes},
     convert_type,
@@ -205,6 +205,10 @@ impl Argument {
 
     pub fn by_ref(&self) -> bool {
         self.by_ref
+    }
+
+    pub fn is_trait_ref(&self) -> bool {
+        matches!(self.type_, Type::Object(ObjectImpl::Trait(_)))
     }
 
     pub fn default_value(&self) -> Option<Literal> {

--- a/uniffi_bindgen/src/interface/types/finder.rs
+++ b/uniffi_bindgen/src/interface/types/finder.rs
@@ -22,7 +22,7 @@ use std::convert::TryFrom;
 use anyhow::{bail, Result};
 
 use super::super::attributes::{EnumAttributes, InterfaceAttributes, TypedefAttributes};
-use super::{Type, TypeUniverse};
+use super::{ObjectImpl, Type, TypeUniverse};
 
 /// Trait to help with an early "type discovery" phase when processing the UDL.
 ///
@@ -63,8 +63,10 @@ impl TypeFinder for weedle::InterfaceDefinition<'_> {
             types.add_type_definition(self.identifier.0, Type::Enum(name))
         } else if InterfaceAttributes::try_from(self.attributes.as_ref())?.contains_error_attr() {
             types.add_type_definition(self.identifier.0, Type::Error(name))
+        } else if InterfaceAttributes::try_from(self.attributes.as_ref())?.is_trait() {
+            types.add_type_definition(self.identifier.0, Type::Object(ObjectImpl::Trait(name)))
         } else {
-            types.add_type_definition(self.identifier.0, Type::Object(name))
+            types.add_type_definition(self.identifier.0, Type::Object(ObjectImpl::Struct(name)))
         }
     }
 }
@@ -200,7 +202,7 @@ mod test {
         "#,
             |types| {
                 assert!(
-                    matches!(types.get_type_definition("TestObject").unwrap(), Type::Object(nm) if nm == "TestObject")
+                    matches!(types.get_type_definition("TestObject").unwrap(), Type::Object(ObjectImpl::Struct(nm)) if nm == "TestObject")
                 );
             },
         );

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -45,7 +45,7 @@ mod filters {
             Type::Enum(name) | Type::Record(name) | Type::Error(name) => format!("r#{}", name),
             Type::Object(imp) => match imp {
                 ObjectImpl::Struct(name) => format!("std::sync::Arc<r#{}>", name),
-                ObjectImpl::Trait(name) => format!("std::sync::Arc<Box<dyn r#{}>>", name),
+                ObjectImpl::Trait(name) => format!("Box<std::sync::Arc<dyn r#{}>>", name),
             },
             Type::CallbackInterface(name) => format!("Box<dyn r#{}>", name),
             Type::Optional(t) => format!("std::option::Option<{}>", type_rs(t)?),
@@ -91,7 +91,7 @@ mod filters {
             Type::Duration => "std::time::Duration".into(),
             // Object is handled by Arc<T>
             Type::Object(ObjectImpl::Struct(name)) => format!("std::sync::Arc<r#{}>", name),
-            Type::Object(ObjectImpl::Trait(name)) => format!("std::sync::Arc<Box<dyn r#{}>>", name),
+            Type::Object(ObjectImpl::Trait(name)) => format!("Box<std::sync::Arc<dyn r#{}>>", name),
             // Other user-defined types are handled by a unit-struct that we generate.  The
             // FfiConverter implementation for this can be found in one of the scaffolding template code.
             //

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -45,7 +45,7 @@ mod filters {
             Type::Enum(name) | Type::Record(name) | Type::Error(name) => format!("r#{}", name),
             Type::Object(imp) => match imp {
                 ObjectImpl::Struct(name) => format!("std::sync::Arc<r#{}>", name),
-                ObjectImpl::Trait(name) => format!("Box<std::sync::Arc<dyn r#{}>>", name),
+                ObjectImpl::Trait(name) => format!("std::sync::Arc<dyn r#{}>", name),
             },
             Type::CallbackInterface(name) => format!("Box<dyn r#{}>", name),
             Type::Optional(t) => format!("std::option::Option<{}>", type_rs(t)?),

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -43,7 +43,10 @@ mod filters {
             Type::Timestamp => "std::time::SystemTime".into(),
             Type::Duration => "std::time::Duration".into(),
             Type::Enum(name) | Type::Record(name) | Type::Error(name) => format!("r#{}", name),
-            Type::Object(name) => format!("std::sync::Arc<r#{}>", name),
+            Type::Object(imp) => match imp {
+                ObjectImpl::Struct(name) => format!("std::sync::Arc<r#{}>", name),
+                ObjectImpl::Trait(name) => format!("std::sync::Arc<Box<dyn r#{}>>", name),
+            },
             Type::CallbackInterface(name) => format!("Box<dyn r#{}>", name),
             Type::Optional(t) => format!("std::option::Option<{}>", type_rs(t)?),
             Type::Sequence(t) => format!("std::vec::Vec<{}>", type_rs(t)?),
@@ -87,7 +90,8 @@ mod filters {
             Type::Timestamp => "std::time::SystemTime".into(),
             Type::Duration => "std::time::Duration".into(),
             // Object is handled by Arc<T>
-            Type::Object(name) => format!("std::sync::Arc<r#{}>", name),
+            Type::Object(ObjectImpl::Struct(name)) => format!("std::sync::Arc<r#{}>", name),
+            Type::Object(ObjectImpl::Trait(name)) => format!("std::sync::Arc<Box<dyn r#{}>>", name),
             // Other user-defined types are handled by a unit-struct that we generate.  The
             // FfiConverter implementation for this can be found in one of the scaffolding template code.
             //

--- a/uniffi_bindgen/src/scaffolding/templates/macros.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/macros.rs
@@ -9,7 +9,9 @@ r#{{ func.name() }}({% call _arg_list_rs_call(func) -%})
 {%- macro _arg_list_rs_call(func) %}
     {%- for arg in func.full_arguments() %}
         match {{- arg.type_().borrow()|ffi_converter }}::try_lift(r#{{ arg.name() }}) {
-        {%- if arg.by_ref() %}
+        {%- if arg.is_trait_ref() %}
+            Ok(ref val) => &***val /* wow! */,
+        {%- else if arg.by_ref() %}
             Ok(ref val) => val,
         {% else %}
             Ok(val) => val,

--- a/uniffi_bindgen/src/scaffolding/templates/macros.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/macros.rs
@@ -10,7 +10,7 @@ r#{{ func.name() }}({% call _arg_list_rs_call(func) -%})
     {%- for arg in func.full_arguments() %}
         match {{- arg.type_().borrow()|ffi_converter }}::try_lift(r#{{ arg.name() }}) {
         {%- if arg.is_trait_ref() %}
-            Ok(ref val) => &***val /* wow! */,
+            Ok(ref val) => &**val,
         {%- else if arg.by_ref() %}
             Ok(ref val) => val,
         {% else %}


### PR DESCRIPTION
We've a use-case where we'd like to have a .udl describe an interface that's actually implemented on the Rust side of the world as a trait rather than a struct. Hopefully the motivation will be clear when looking at the new fixture.

This actually turned out reasonably well, but there is still quite a bit of cleanup to do, and also other edge-cases to explore. I'd also welcome alternative strategies, and something tells me that there's some synergy now between traits and callback interfaces, but I'm yet to explore that. In the meantime, I thought I'd get this up for early feedback.