### PR TITLE
Fixes argument names for callback interfaces in swift to be camelcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 [All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.19.3...HEAD).
 
 - Implement Timestamp and Duration types in Ruby backend.
+- Fixed in a bug where callback interfaces with arguments that include underscores do not get converted to camelCase on Swift.
 
 ## v0.19.3 - (_2022-07-08_)
 

--- a/fixtures/callbacks/src/callbacks.udl
+++ b/fixtures/callbacks/src/callbacks.udl
@@ -3,7 +3,7 @@ namespace callbacks {};
 /// These objects are implemented by the foreign language and passed
 /// to Rust. Rust then calls methods on it when it needs to.
 callback interface ForeignGetters {
-  boolean get_bool(boolean v, boolean arg2);
+  boolean get_bool(boolean v, boolean argument_two);
   string get_string(string v, boolean arg2);
   string? get_option(string? v, boolean arg2);
   sequence<i32> get_list(sequence<i32> v, boolean arg2);
@@ -13,7 +13,7 @@ callback interface ForeignGetters {
 /// to get the value.
 interface RustGetters {
   constructor();
-  boolean get_bool(ForeignGetters callback, boolean v, boolean arg2);
+  boolean get_bool(ForeignGetters callback, boolean v, boolean argument_two);
   string get_string(ForeignGetters callback, string v, boolean arg2);
   string? get_option(ForeignGetters callback, string? v, boolean arg2);
   sequence<i32> get_list(ForeignGetters callback, sequence<i32> v, boolean arg2);

--- a/fixtures/callbacks/src/lib.rs
+++ b/fixtures/callbacks/src/lib.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 trait ForeignGetters {
-    fn get_bool(&self, v: bool, arg2: bool) -> bool;
+    fn get_bool(&self, v: bool, argument_two: bool) -> bool;
     fn get_string(&self, v: String, arg2: bool) -> String;
     fn get_option(&self, v: Option<String>, arg2: bool) -> Option<String>;
     fn get_list(&self, v: Vec<i32>, arg2: bool) -> Vec<i32>;
@@ -16,8 +16,8 @@ impl RustGetters {
     pub fn new() -> Self {
         RustGetters
     }
-    fn get_bool(&self, callback: Box<dyn ForeignGetters>, v: bool, arg2: bool) -> bool {
-        callback.get_bool(v, arg2)
+    fn get_bool(&self, callback: Box<dyn ForeignGetters>, v: bool, argument_two: bool) -> bool {
+        callback.get_bool(v, argument_two)
     }
     fn get_string(&self, callback: Box<dyn ForeignGetters>, v: String, arg2: bool) -> String {
         callback.get_string(v, arg2)

--- a/fixtures/callbacks/tests/bindings/test_callbacks.kts
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.kts
@@ -11,7 +11,7 @@ import uniffi.callbacks.*
 // with a variety of return types.
 val rustGetters = RustGetters()
 class KotlinGetters(): ForeignGetters {
-    override fun getBool(v: Boolean, arg2: Boolean): Boolean = v xor arg2
+    override fun getBool(v: Boolean, argumentTwo: Boolean): Boolean = v xor argumentTwo
     override fun getString(v: String, arg2: Boolean): String = if (arg2) "1234567890123" else v
     override fun getOption(v: String?, arg2: Boolean): String? = if (arg2) v?.uppercase() else v
     override fun getList(v: List<Int>, arg2: Boolean): List<Int> = if (arg2) v else listOf()

--- a/fixtures/callbacks/tests/bindings/test_callbacks.py
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.py
@@ -12,8 +12,8 @@ from callbacks import *
 rust_getters = RustGetters()
 
 class PythonGetters(ForeignGetters):
-    def get_bool(self, v, arg2):
-        return v ^ arg2
+    def get_bool(self, v, argumentTwo):
+        return v ^ argumentTwo
 
     def get_string(self, v, arg2):
         if arg2:

--- a/fixtures/callbacks/tests/bindings/test_callbacks.swift
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.swift
@@ -13,7 +13,7 @@
 // with a variety of return types.
 let rustGetters = RustGetters()
 class SwiftGetters: ForeignGetters {
-    func getBool(v: Bool, arg2: Bool) -> Bool { v != arg2 }
+    func getBool(v: Bool, argumentTwo: Bool) -> Bool { v != argumentTwo }
     func getString(v: String, arg2: Bool) -> String { arg2 ? "1234567890123" : v }
     func getOption(v: String?, arg2: Bool) -> String? { arg2 ? v?.uppercased() : v }
     func getList(v: [Int32], arg2: Bool) -> [Int32] { arg2 ? v : [] }
@@ -23,8 +23,8 @@ func test() {
     let callback = SwiftGetters()
     [true, false].forEach { v in
         let flag = true
-        let expected = callback.getBool(v: v, arg2: flag)
-        let observed = rustGetters.getBool(callback: callback, v: v, arg2: flag)
+        let expected = callback.getBool(v: v, argumentTwo: flag)
+        let observed = rustGetters.getBool(callback: callback, v: v, argumentTwo: flag)
         assert(expected == observed, "roundtripping through callback: \(String(describing: expected)) != \(String(describing: observed))")
     }
 

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
@@ -31,7 +31,7 @@ fileprivate let {{ foreign_callback }} : ForeignCallback =
             {% if meth.throws().is_some() %}try {% endif -%}
             swiftCallbackInterface.{{ meth.name()|fn_name }}(
                     {% for arg in meth.arguments() -%}
-                    {{ arg.name() }}: try {{ arg|read_fn }}(from: reader)
+                    {{ arg.name()|var_name }}: try {{ arg|read_fn }}(from: reader)
                     {%- if !loop.last %}, {% endif %}
                     {% endfor -%}
                 )


### PR DESCRIPTION
There was a mismatch in swift in the arguments of the callback interface, when calling the callback interface, the swift code generates snake_case arguments instead of camelcase.

I could define a unique test for this, but I changed the existing test instead, happy to go back and make a regression test for it though!