### PR TITLE
Adding Todolist `uniffi.toml` with geckojs section

### DIFF
--- a/examples/todolist/src/todolist.udl
+++ b/examples/todolist/src/todolist.udl
@@ -1,6 +1,6 @@
 namespace todolist {
     TodoList? get_default_list();
-    undefined set_default_list(TodoList list);
+    void set_default_list(TodoList list);
 
     [Throws=TodoError]
     TodoEntry create_entry_with(string todo);

--- a/examples/todolist/uniffi.toml
+++ b/examples/todolist/uniffi.toml
@@ -1,0 +1,7 @@
+[bindings.geckojs.receiver_thread]
+default = "worker"
+main = [
+  "set_default_list",
+  "TodoList",
+  "TodoList.make_default",
+]


### PR DESCRIPTION
This PR adds a `uniffi.toml` section for configuring threading that I hope to use for the Desktop JS project.

The backstory is that desktop privileged JS has a unique threading model: You should never block the main thread and there's no way support for thread pools or other ways to start a new thread (web workers are currently not used and we didn't want to introduce them just for UniFFI support).  However, the C++ code that runs underneath the JS engine has a simple ways to run code in a worker thread.  We decided to make it so each function runs on a worker thread and returns a promise to the JS code.  This seems like the best choice for most functions, but some functions run quick enough that we can just make a blocking call.  It would be nice to allow those functions to run directly.  This becomes a bit more important once we introduce async functions -- either hand-written or with UniFFI support.  It's silly to run an async function in a worker thread and get a Promise of a Promise.

Those details are unique to Desktop JS, but the overall threading model is similar to other languages.  On Swift/Kotlin, we typically create thread pools to wrap blocking functions with an async API.  Because of this, I tried to come up with something fairly general that we could maybe eventually use for these languages.

This PR doesn't change any behavior.  I'm mainly looking to see if others agree with my design decisions:

- Putting the configuration in `uniffi.toml` rather than some config file in the moz-central
- The general system is to map function/method names to tags that indicate the threading model for that call.  I'm hoping that this could maybe specify a thread pool on Swift/Kotlin, but this is just a hope.  I can't completely picture how this would work.
- I used `direct` and `worker` to specify the threading model for JS calls.  I wanted to distinguish this from `sync` / `async`, which seems like a different distinction to me.  `worker` calls are always async, but if we ever added async support in general to UniFFI I could easily see an async `direct` call (i.e. one that returns a Future).
- I used `-default` to specify the default model.  I think it's important to have a safe default in case a dev adds a function call, but forgets to add configuration for it.  The leading dash is there so that it doesn't conflict with an actual function name
- Method calls get put in their own nested table, with `-constructor` specifying the constructor threading.

What do you think about the overall design and also the TOML syntax?  I'm definitely open to bikeshedding suggestions for how this should be specified.