### PR TITLE
Update Rust to 1.63, MSR to 1.61.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
   # Our minimum supported rust version is specified here.
   prepare-rust-min-version:
     steps:
-      - run: rustup override set 1.59.0
+      - run: rustup override set 1.61.0
       - run: rustup update
   build-api-docs:
     steps:
@@ -98,15 +98,19 @@ jobs:
       - run:
           name: "Print the Rust version, to help with debugging"
           command: rustc --version
+      # Note "-j 1" here and below - we saw OOM errors which this tries to workaround and is
+      # hopefully a cheaper workaround than an "resource_class: xlarge".
+      # Probably https://github.com/rust-lang/rust/issues/97549 which is a 1.61 issue.
+      # We should revert this once we move past 1.61
       - run:
           name: Build all code
           command: |
             # Ensures that all examples are built and avaiable
-            cargo build
+            cargo build -j 1
       # some tests fail on earlier rust versions and we want to ignore them:
-      # * trybuild_ui_tests - error message had a comma inserted! Can probably
-      #   be re-enabled after the next rust version bump.
-      - run: cargo test -- --skip trybuild_ui_tests
+      # * trybuild_ui_tests - 1.61 vs 1.62 hits https://github.com/dtolnay/trybuild/issues/186
+      #   (which was WONTFIXd, so this is the best we can do)
+      - run: cargo test -j 1 -- --skip trybuild_ui_tests
   Deploy website:
     docker:
       - image: rfkelly/uniffi-ci:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
       - run:
           name: "Print the Rust version, to help with debugging"
           command: rustc --version
-      # Note "-j 1" here and below - we saw OOM errors which this tries to workaround and is
+      # Note "-j" here and below - we saw OOM errors which this tries to workaround and is
       # hopefully a cheaper workaround than an "resource_class: xlarge".
       # Probably https://github.com/rust-lang/rust/issues/97549 which is a 1.61 issue.
       # We should revert this once we move past 1.61
@@ -106,11 +106,11 @@ jobs:
           name: Build all code
           command: |
             # Ensures that all examples are built and avaiable
-            cargo build -j 1
+            cargo build -j 2
       # some tests fail on earlier rust versions and we want to ignore them:
       # * trybuild_ui_tests - 1.61 vs 1.62 hits https://github.com/dtolnay/trybuild/issues/186
       #   (which was WONTFIXd, so this is the best we can do)
-      - run: cargo test -j 1 -- --skip trybuild_ui_tests
+      - run: cargo test -j 2 -- --skip trybuild_ui_tests
   Deploy website:
     docker:
       - image: rfkelly/uniffi-ci:latest

--- a/examples/sprites/src/lib.rs
+++ b/examples/sprites/src/lib.rs
@@ -58,7 +58,7 @@ impl Sprite {
 
     fn move_by(&self, direction: Vector) {
         let mut current_position = self.current_position.write().unwrap();
-        *current_position = translate(&*current_position, direction)
+        *current_position = translate(&current_position, direction)
     }
 }
 

--- a/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
+++ b/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
@@ -23,8 +23,7 @@ error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
    |         <std::sync::Arc<r#Counter> as uniffi::FfiConverter>::lower(_arc)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FfiConverter` is not implemented for `Arc<Counter>`
    |
-   = help: the following implementations were found:
-             <Arc<T> as FfiConverter>
+   = help: the trait `FfiConverter` is implemented for `Arc<T>`
 
 error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
   --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
@@ -32,8 +31,7 @@ error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
    |         <std::sync::Arc<r#Counter> as uniffi::FfiConverter>::lower(_arc)
    |                                                                    ^^^^ the trait `FfiConverter` is not implemented for `Arc<Counter>`
    |
-   = help: the following implementations were found:
-             <Arc<T> as FfiConverter>
+   = help: the trait `FfiConverter` is implemented for `Arc<T>`
 
 error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
    --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
@@ -41,8 +39,7 @@ error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
     |         match<std::sync::Arc<r#Counter> as uniffi::FfiConverter>::try_lift(r#ptr) {
     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FfiConverter` is not implemented for `Arc<Counter>`
     |
-    = help: the following implementations were found:
-              <Arc<T> as FfiConverter>
+    = help: the trait `FfiConverter` is implemented for `Arc<T>`
 
 error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
    --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
@@ -50,5 +47,4 @@ error[E0277]: the trait bound `Arc<Counter>: FfiConverter` is not satisfied
     |         match<std::sync::Arc<r#Counter> as uniffi::FfiConverter>::try_lift(r#ptr) {
     |                                                                            ^^^^^ the trait `FfiConverter` is not implemented for `Arc<Counter>`
     |
-    = help: the following implementations were found:
-              <Arc<T> as FfiConverter>
+    = help: the trait `FfiConverter` is implemented for `Arc<T>`

--- a/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
+++ b/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
@@ -10,12 +10,16 @@ error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
    | uniffi::deps::static_assertions::assert_impl_all!(f32: ::std::cmp::Eq, ::std::hash::Hash); // record<f32, u64>
    |                                                   ^^^ the trait `std::cmp::Eq` is not implemented for `f32`
    |
-   = help: the following implementations were found:
-             <i128 as std::cmp::Eq>
-             <i16 as std::cmp::Eq>
-             <i32 as std::cmp::Eq>
-             <i64 as std::cmp::Eq>
-           and 8 others
+   = help: the following other types implement trait `std::cmp::Eq`:
+             i128
+             i16
+             i32
+             i64
+             i8
+             isize
+             u128
+             u16
+           and 4 others
 note: required by a bound in `assert_impl_all`
   --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
    |
@@ -29,12 +33,16 @@ error[E0277]: the trait bound `f32: Hash` is not satisfied
    | uniffi::deps::static_assertions::assert_impl_all!(f32: ::std::cmp::Eq, ::std::hash::Hash); // record<f32, u64>
    |                                                   ^^^ the trait `Hash` is not implemented for `f32`
    |
-   = help: the following implementations were found:
-             <i128 as Hash>
-             <i16 as Hash>
-             <i32 as Hash>
-             <i64 as Hash>
-           and 8 others
+   = help: the following other types implement trait `Hash`:
+             i128
+             i16
+             i32
+             i64
+             i8
+             isize
+             u128
+             u16
+           and 4 others
 note: required by a bound in `assert_impl_all`
   --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
    |
@@ -48,12 +56,16 @@ error[E0277]: the trait bound `f32: Hash` is not satisfied
    |     <std::collections::HashMap<f32, u64> as uniffi::FfiConverter>::lower(r#get_dict())
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Hash` is not implemented for `f32`
    |
-   = help: the following implementations were found:
-             <i128 as Hash>
-             <i16 as Hash>
-             <i32 as Hash>
-             <i64 as Hash>
-           and 8 others
+   = help: the following other types implement trait `Hash`:
+             i128
+             i16
+             i32
+             i64
+             i8
+             isize
+             u128
+             u16
+           and 4 others
    = note: required because of the requirements on the impl of `RustBufferFfiConverter` for `HashMap<f32, u64>`
 
 error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
@@ -62,10 +74,14 @@ error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
    |     <std::collections::HashMap<f32, u64> as uniffi::FfiConverter>::lower(r#get_dict())
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `f32`
    |
-   = help: the following implementations were found:
-             <i128 as std::cmp::Eq>
-             <i16 as std::cmp::Eq>
-             <i32 as std::cmp::Eq>
-             <i64 as std::cmp::Eq>
-           and 8 others
+   = help: the following other types implement trait `std::cmp::Eq`:
+             i128
+             i16
+             i32
+             i64
+             i8
+             isize
+             u128
+             u16
+           and 4 others
    = note: required because of the requirements on the impl of `RustBufferFfiConverter` for `HashMap<f32, u64>`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # * ./.circleci/config.yml which also specifies the rust versions used in CI.
 
 [toolchain]
-channel = "1.60.0"
+channel = "1.63.0"
 targets = [
     "aarch64-linux-android",
     "armv7-linux-androideabi",

--- a/uniffi_bindgen/src/interface/types/resolver.rs
+++ b/uniffi_bindgen/src/interface/types/resolver.rs
@@ -71,7 +71,7 @@ impl TypeResolver for &weedle::types::AttributedNonAnyType<'_> {
         if self.attributes.is_some() {
             bail!("type attributes are not supported yet");
         }
-        (&self.type_).resolve_type_expression(types)
+        self.type_.resolve_type_expression(types)
     }
 }
 
@@ -80,7 +80,7 @@ impl TypeResolver for &weedle::types::AttributedType<'_> {
         if self.attributes.is_some() {
             bail!("type attributes are not supported yet");
         }
-        (&self.type_).resolve_type_expression(types)
+        self.type_.resolve_type_expression(types)
     }
 }
 
@@ -132,8 +132,8 @@ impl TypeResolver for weedle::types::RecordKeyType<'_> {
 
 impl TypeResolver for weedle::types::RecordType<'_> {
     fn resolve_type_expression(&self, types: &mut TypeUniverse) -> Result<Type> {
-        let key_type = (&self.generics.body.0).resolve_type_expression(types)?;
-        let value_type = (&self.generics.body.2).resolve_type_expression(types)?;
+        let key_type = self.generics.body.0.resolve_type_expression(types)?;
+        let value_type = self.generics.body.2.resolve_type_expression(types)?;
         types.add_known_type(Type::Map(Box::new(key_type), Box::new(value_type)))
     }
 }

--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -61,6 +61,7 @@ pub extern "C" fn {{ ffi_free.name() }}(ptr: *const std::os::raw::c_void, call_s
 {%- for meth in obj.methods() %}
     #[doc(hidden)]
     #[no_mangle]
+    #[allow(clippy::let_unit_value)] // Sometimes we generate code that binds `_retval` to `()`.
     pub extern "C" fn r#{{ meth.ffi_func().name() }}(
         {%- call rs::arg_list_ffi_decl(meth.ffi_func()) %}
     ) {% call rs::return_signature(meth) %} {


### PR DESCRIPTION
As per our [Rust version policy](https://github.com/mozilla/uniffi-rs/blob/main/docs/policies/rust-versions.md)

Requires some clippy fixes. Also fixed some clippy complaints in nightly.