### PR TITLE
Apply `omit_argument_labels` option when calling into a callback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
   "fixtures/regressions/cdylib-crate-type-dependency/ffi-crate",
   "fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency",
   "fixtures/regressions/missing-newline",
+  "fixtures/regressions/swift-callbacks-omit-labels",
   "fixtures/uitests",
   "fixtures/uniffi-fixture-time",
   "fixtures/simple-fns",

--- a/fixtures/regressions/swift-callbacks-omit-labels/Cargo.toml
+++ b/fixtures/regressions/swift-callbacks-omit-labels/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "uniffi-fixture-regression-callbacks-omit-labels"
+edition = "2021"
+version = "0.19.3"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+name = "uniffi_regression_test_callbacks_omit_labels"
+
+[dependencies]
+uniffi_macros = {path = "../../../uniffi_macros"}
+uniffi = {path = "../../../uniffi", features=["builtin-bindgen"]}
+
+[build-dependencies]
+uniffi_build = {path = "../../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/regressions/swift-callbacks-omit-labels/README.md
+++ b/fixtures/regressions/swift-callbacks-omit-labels/README.md
@@ -1,0 +1,6 @@
+# Regression test for [issue 1312](https://github.com/mozilla/uniffi-rs/issues/1312)
+
+We didn't apply the same `omit_argument_labels` configuration to callbacks,
+leading to a compilation error.
+
+We replicate the reported buggy code and turn that into a full blown test now.

--- a/fixtures/regressions/swift-callbacks-omit-labels/build.rs
+++ b/fixtures/regressions/swift-callbacks-omit-labels/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/test.udl").unwrap();
+}

--- a/fixtures/regressions/swift-callbacks-omit-labels/src/lib.rs
+++ b/fixtures/regressions/swift-callbacks-omit-labels/src/lib.rs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pub struct UserModel {
+    name: String,
+}
+
+pub trait ClientDelegate: Sync + Send {
+    fn did_receive_friend_request(&self, user: UserModel);
+}
+
+#[derive(Debug, Clone)]
+struct Client;
+
+impl Client {
+    fn new() -> Self {
+        Self
+    }
+
+    fn friend_request(&self, delegate: Box<dyn ClientDelegate>) {
+        let user = UserModel {
+            name: "Alice".to_string(),
+        };
+        delegate.did_receive_friend_request(user);
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/test.uniffi.rs"));

--- a/fixtures/regressions/swift-callbacks-omit-labels/src/test.udl
+++ b/fixtures/regressions/swift-callbacks-omit-labels/src/test.udl
@@ -1,0 +1,17 @@
+// Regression test for https://github.com/mozilla/uniffi-rs/issues/1312
+
+namespace regression_test_callbacks_omit_labels { };
+
+dictionary UserModel {
+    string name;
+};
+
+interface Client {
+    constructor();
+
+    void friend_request(ClientDelegate delegate);
+};
+
+callback interface ClientDelegate {
+    void did_receive_friend_request(UserModel user);
+};

--- a/fixtures/regressions/swift-callbacks-omit-labels/tests/bindings/test.swift
+++ b/fixtures/regressions/swift-callbacks-omit-labels/tests/bindings/test.swift
@@ -1,0 +1,26 @@
+// Regression test for https://github.com/mozilla/uniffi-rs/issues/1312
+//
+// Really this can be detected at compile time:
+// We didn't apply the same `omit_argument_labels` configuration to callbacks,
+// leading to a compilation error.
+// To make sure everything gets called right though we write a full test here.
+
+import regression_test_callbacks_omit_labels
+
+class ClientDelegateImpl: ClientDelegate {
+    var recvCount: Int = 0
+    var lastFriend = ""
+
+    func didReceiveFriendRequest(_ user: UserModel) {
+        recvCount += 1
+        lastFriend = user.name
+    }
+}
+
+let cd = ClientDelegateImpl()
+let client = Client()
+
+client.friendRequest(cd)
+
+assert(cd.recvCount == 1, "delegate should be called once")
+assert(cd.lastFriend == "Alice", "delegate should have received Alice's friend request")

--- a/fixtures/regressions/swift-callbacks-omit-labels/tests/test_generated_bindings.rs
+++ b/fixtures/regressions/swift-callbacks-omit-labels/tests/test_generated_bindings.rs
@@ -1,0 +1,1 @@
+uniffi_macros::build_foreign_language_testcases!(["src/test.udl"], ["tests/bindings/test.swift",]);

--- a/fixtures/regressions/swift-callbacks-omit-labels/uniffi.toml
+++ b/fixtures/regressions/swift-callbacks-omit-labels/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.swift]
+omit_argument_labels = true

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
@@ -31,7 +31,7 @@ fileprivate let {{ foreign_callback }} : ForeignCallback =
             {% if meth.throws().is_some() %}try {% endif -%}
             swiftCallbackInterface.{{ meth.name()|fn_name }}(
                     {% for arg in meth.arguments() -%}
-                    {{ arg.name()|var_name }}: try {{ arg|read_fn }}(from: reader)
+                    {% if !config.omit_argument_labels() %}{{ arg.name()|var_name }}: {% endif %} try {{ arg|read_fn }}(from: reader)
                     {%- if !loop.last %}, {% endif %}
                     {% endfor -%}
                 )


### PR DESCRIPTION
This also adds a test to make sure we're not breaking it again.

Fixes #1312