### PR TITLE
Adding `uniffi_` prefix to the callback example

### DIFF
--- a/examples/callbacks/Cargo.toml
+++ b/examples/callbacks/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [lib]
 crate-type = ["lib", "cdylib"]
-name = "callbacks"
+name = "uniffi_callbacks"
 
 [dependencies]
 uniffi_macros = {path = "../../uniffi_macros"}

--- a/examples/callbacks/uniffi.toml
+++ b/examples/callbacks/uniffi.toml
@@ -1,9 +1,9 @@
 [bindings.kotlin]
 package_name = "uniffi.callbacks"
-cdylib_name = "callbacks"
+cdylib_name = "uniffi_callbacks"
 
 [bindings.swift]
-cdylib_name = "callbacks"
+cdylib_name = "uniffi_callbacks"
 
 [bindings.python]
-cdylib_name = "callbacks"
+cdylib_name = "uniffi_callbacks"


### PR DESCRIPTION
I want to use this to test callbacks on desktop JS. This makes it
consistent with other examples.