### PR TITLE
Format scaffolding with library `prettyplease`

### DIFF
--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -26,8 +26,10 @@ goblin = "0.5"
 heck = "0.4"
 once_cell = "1.12"
 paste = "1.0"
+prettyplease = "0.1"
 serde = "1"
 serde_json = "1.0.80"
+syn = { version = "1", default-features = false, features = ["full", "parsing"] }
 toml = "0.5"
 weedle2 = { version = "4.0.0", path = "../weedle2" }
 uniffi_meta = { path = "../uniffi_meta", version = "=0.19.5"}


### PR DESCRIPTION
Previously uniffi-bindgen used rustfmt from the command line, which
has more failure modes than using a library (see #1318). In addition,
prettyplease is explicitly geared towards formatting generated code.

Also fixes #1320, as the prettyplease formatter doesn't fail.

---

Note that `syn::parse_file` may error, but AFAICT, that would mean the generated scaffolding is syntactically incorrect. Maybe this should be a panic instead?