### PR TITLE
Drop the dependency on `enum_variant_macros` used for a single `From` implementation

### DIFF
--- a/fixtures/callbacks/Cargo.toml
+++ b/fixtures/callbacks/Cargo.toml
@@ -13,7 +13,6 @@ name = "uniffi_callbacks"
 [dependencies]
 uniffi_macros = {path = "../../uniffi_macros"}
 uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
-thiserror = "1.0"
 
 [build-dependencies]
 uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/external-types/crate-one/Cargo.toml
+++ b/fixtures/external-types/crate-one/Cargo.toml
@@ -7,10 +7,3 @@ license = "MPL-2.0"
 publish = false
 
 [dependencies]
-anyhow = "1"
-bytes = "1.0"
-uniffi_macros = {path = "../../../uniffi_macros"}
-uniffi = {path = "../../../uniffi", features=["builtin-bindgen"]}
-
-[build-dependencies]
-uniffi_build = {path = "../../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/external-types/crate-two/Cargo.toml
+++ b/fixtures/external-types/crate-two/Cargo.toml
@@ -7,11 +7,4 @@ license = "MPL-2.0"
 publish = false
 
 [dependencies]
-anyhow = "1"
-bytes = "1.0"
-uniffi_macros = {path = "../../../uniffi_macros"}
-uniffi = {path = "../../../uniffi", features=["builtin-bindgen"]}
 crate_one = {path = "../crate-one"}
-
-[build-dependencies]
-uniffi_build = {path = "../../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/simple-fns/Cargo.toml
+++ b/fixtures/simple-fns/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 uniffi = { path = "../../uniffi", features = ["builtin-bindgen"] }
-thiserror = "1.0"
 
 [build-dependencies]
 uniffi_build = { path = "../../uniffi_build", features = ["builtin-bindgen"] }

--- a/fixtures/uitests/Cargo.toml
+++ b/fixtures/uitests/Cargo.toml
@@ -13,8 +13,5 @@ name = "uniffi_uitests"
 uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
 uniffi_macros = {path = "../../uniffi_macros", features=["builtin-bindgen"]}
 
-[build-dependencies]
-uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}
-
 [dev-dependencies]
 trybuild = "1.0.53"

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/main.rs"
 anyhow = "1"
 askama = { version = "0.11", default-features = false, features = ["config"] }
 bincode = "1.3"
-cargo_metadata = "0.14"
 camino = "1.0.8"
 clap = { version = "3.1", features = ["cargo", "std", "derive"] }
 fs-err = "2.7.0"

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -16,15 +16,12 @@ proc-macro = true
 [dependencies]
 bincode = "1.3"
 camino = "1.0.8"
-extension-trait = "1.0.1"
 fs-err = "2.7.0"
-glob = "0.3"
 once_cell = "1.10.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 serde = "1.0.136"
-syn = { version = "1.0", features = ["extra-traits"] }
-tempfile = "3.3.0"
+syn = { version = "1.0", features = ["full"] }
 toml = "0.5.9"
 uniffi_build = { path = "../uniffi_build", version = "=0.19.5"}
 uniffi_meta = { path = "../uniffi_meta", version = "=0.19.5"}

--- a/uniffi_meta/Cargo.toml
+++ b/uniffi_meta/Cargo.toml
@@ -10,5 +10,4 @@ keywords = ["ffi", "bindgen"]
 
 [dependencies]
 bincode = "1.3"
-enum_variant_macros = "0.2"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/uniffi_meta/Cargo.toml
+++ b/uniffi_meta/Cargo.toml
@@ -9,5 +9,4 @@ license = "MPL-2.0"
 keywords = ["ffi", "bindgen"]
 
 [dependencies]
-bincode = "1.3"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -72,7 +72,13 @@ pub fn fn_ffi_symbol_name(mod_path: &[String], name: &str, checksum: u16) -> Str
 }
 
 /// Enum covering all the possible metadata types
-#[derive(Clone, Debug, enum_variant_macros::FromVariants, Hash, Deserialize, Serialize)]
+#[derive(Clone, Debug, Hash, Deserialize, Serialize)]
 pub enum Metadata {
     Func(FnMetadata),
+}
+
+impl From<FnMetadata> for Metadata {
+    fn from(value: FnMetadata) -> Metadata {
+        Metadata::Func(value)
+    }
 }


### PR DESCRIPTION
I feel like this dependency doesn't really carry its weight.