### PR TITLE
Clearly separate different parts of the exports macro

### DIFF
--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -2,13 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use proc_macro2::TokenStream;
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+use uniffi_meta::{checksum, FnMetadata, Metadata};
 
 mod metadata;
 mod scaffolding;
 
-use self::metadata::gen_metadata;
-use self::scaffolding::gen_scaffolding;
+use self::{metadata::gen_metadata, scaffolding::gen_fn_scaffolding};
 
 // TODO(jplatte): Ensure no generics, no async, …
 // TODO(jplatte): Aggregate errors instead of short-circuiting, whereever possible
@@ -16,12 +17,32 @@ use self::scaffolding::gen_scaffolding;
 enum ExportItem {
     Function {
         item: syn::ItemFn,
-        checksum: u16,
-        meta_static_var: TokenStream,
+        metadata: FnMetadata,
     },
 }
 
 pub fn expand_export(item: syn::Item, mod_path: &[String]) -> syn::Result<TokenStream> {
-    let item = gen_metadata(item, mod_path)?;
-    gen_scaffolding(item, mod_path)
+    match gen_metadata(item, mod_path)? {
+        ExportItem::Function { item, metadata } => {
+            let checksum = checksum(&metadata);
+            let meta_static_var = create_metadata_static_var(&item.sig.ident, metadata.into());
+            let scaffolding = gen_fn_scaffolding(&item, mod_path, checksum)?;
+
+            Ok(quote! {
+                #scaffolding
+                #meta_static_var
+            })
+        }
+    }
+}
+
+fn create_metadata_static_var(name: &Ident, val: Metadata) -> TokenStream {
+    let data: Vec<u8> = bincode::serialize(&val).expect("Error serializing metadata item");
+    let count = data.len();
+    let var_name = format_ident!("UNIFFI_META_{}", name);
+
+    quote! {
+        #[no_mangle]
+        pub static #var_name: [u8; #count] = [#(#data),*];
+    }
 }

--- a/uniffi_macros/src/export/metadata.rs
+++ b/uniffi_macros/src/export/metadata.rs
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use proc_macro2::{Ident, Span, TokenStream};
-use quote::{format_ident, quote, IdentFragment, ToTokens};
-use uniffi_meta::{Metadata, Type};
+use proc_macro2::{Ident, Span};
+use quote::ToTokens;
+use uniffi_meta::Type;
 
 use super::ExportItem;
 
@@ -152,15 +152,4 @@ fn type_not_supported(ty: &impl ToTokens) -> syn::Error {
         &ty,
         "this type is not currently supported by uniffi::export in this position",
     )
-}
-
-fn create_metadata_static_var(name: impl IdentFragment, val: Metadata) -> TokenStream {
-    let data: Vec<u8> = bincode::serialize(&val).expect("Error serializing metadata item");
-    let count = data.len();
-    let var_name = format_ident!("UNIFFI_META_{}", name);
-
-    quote! {
-        #[no_mangle]
-        pub static #var_name: [u8; #count] = [#(#data),*];
-    }
 }

--- a/uniffi_macros/src/export/metadata/function.rs
+++ b/uniffi_macros/src/export/metadata/function.rs
@@ -2,19 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use uniffi_meta::{checksum, FnMetadata, FnParamMetadata};
+use uniffi_meta::{FnMetadata, FnParamMetadata};
 
-use super::{convert_type, create_metadata_static_var};
+use super::convert_type;
 use crate::export::ExportItem;
 
 pub(super) fn gen_fn_metadata(item: syn::ItemFn, mod_path: &[String]) -> syn::Result<ExportItem> {
-    let meta = fn_metadata(&item, mod_path)?;
+    let metadata = fn_metadata(&item, mod_path)?;
 
-    Ok(ExportItem::Function {
-        checksum: checksum(&meta),
-        meta_static_var: create_metadata_static_var(&item.sig.ident, meta.into()),
-        item,
-    })
+    Ok(ExportItem::Function { item, metadata })
 }
 
 fn fn_metadata(f: &syn::ItemFn, mod_path: &[String]) -> syn::Result<FnMetadata> {

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -6,25 +6,7 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 use syn::{FnArg, ItemFn, Pat, ReturnType};
 
-use super::ExportItem;
-
-pub(super) fn gen_scaffolding(item: ExportItem, mod_path: &[String]) -> syn::Result<TokenStream> {
-    match item {
-        ExportItem::Function {
-            item,
-            checksum,
-            meta_static_var,
-        } => {
-            let scaffolding = gen_fn_scaffolding(&item, mod_path, checksum)?;
-            Ok(quote! {
-                #scaffolding
-                #meta_static_var
-            })
-        }
-    }
-}
-
-fn gen_fn_scaffolding(
+pub(super) fn gen_fn_scaffolding(
     item: &ItemFn,
     mod_path: &[String],
     checksum: u16,


### PR DESCRIPTION
With this PR, serializing and emitting the generated metadata is no longer part of collecting the metadata and generating the scaffolding code, respectively.