### PR TITLE
Refactored the throws code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 [All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.20.0...HEAD).
 
+###  ⚠️ Breaking Changes ⚠️
+
+- `uniffi_bindgen`: Renamed the `throws()` method of `Function`, `Method`, and
+  `Contstructor` to `throws_str()`.  Added a new `throws()` method that returns
+  a boolean.
+
 ## v0.20.0 - (_2022-09-13_)
 
 [All changes in v0.20.0](https://github.com/mozilla/uniffi-rs/compare/v0.19.6...v0.20.0).

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -5,9 +5,9 @@
 
 public interface {{ type_name }}Interface {
     {% for meth in obj.methods() -%}
-    {%- match meth.throws() -%}
+    {%- match meth.throws_type() -%}
     {%- when Some with (throwable) %}
-    @Throws({{ throwable|exception_name }}::class)
+    @Throws({{ throwable|type_name }}::class)
     {%- else -%}
     {%- endmatch %}
     fun {{ meth.name()|fn_name }}({% call kt::arg_list_decl(meth) %})
@@ -44,9 +44,9 @@ class {{ type_name }}(
     }
 
     {% for meth in obj.methods() -%}
-    {%- match meth.throws() -%}
+    {%- match meth.throws_type() -%}
     {%- when Some with (throwable) %}
-    @Throws({{ throwable|exception_name }}::class)
+    @Throws({{ throwable|type_name }}::class)
     {%- else -%}
     {%- endmatch %}
     {%- match meth.return_type() -%}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
@@ -1,6 +1,6 @@
-{%- match func.throws() -%}
+{%- match func.throws_type() -%}
 {%- when Some with (throwable) %}
-@Throws({{ throwable|exception_name }}::class)
+@Throws({{ throwable|type_name }}::class)
 {%- else -%}
 {%- endmatch %}
 {%- match func.return_type() -%}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -5,9 +5,9 @@
 #}
 
 {%- macro to_ffi_call(func) -%}
-    {%- match func.throws() %}
+    {%- match func.throws_type() %}
     {%- when Some with (e) %}
-    rustCallWithError({{ e|exception_name}})
+    rustCallWithError({{ e|type_name}})
     {%- else %}
     rustCall()
     {%- endmatch %} { _status ->
@@ -16,9 +16,9 @@
 {%- endmacro -%}
 
 {%- macro to_ffi_call_with_prefix(prefix, func) %}
-    {%- match func.throws() %}
+    {%- match func.throws_type() %}
     {%- when Some with (e) %}
-    rustCallWithError({{ e|exception_name}})
+    rustCallWithError({{ e|type_name}})
     {%- else %}
     rustCall()
     {%- endmatch %} { _status ->

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -376,11 +376,6 @@ pub mod filters {
         Ok(oracle().enum_variant_name(nm))
     }
 
-    /// Get the idiomatic Python rendering of an exception name
-    pub fn exception_name(nm: &str) -> Result<String, askama::Error> {
-        Ok(oracle().error_name(nm))
-    }
-
     pub fn coerce_py(nm: &str, type_: &Type) -> Result<String, askama::Error> {
         let oracle = oracle();
         Ok(oracle.find(type_).coerce(oracle, nm))

--- a/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
@@ -5,7 +5,7 @@
 #}
 
 {%- macro to_ffi_call(func) -%}
-    {%- match func.throws() -%}
+    {%- match func.throws_name() -%}
     {%- when Some with (e) -%}
       {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ e|class_name_rb }},
     {%- else -%}
@@ -17,7 +17,7 @@
 {%- endmacro -%}
 
 {%- macro to_ffi_call_with_prefix(prefix, func) -%}
-    {%- match func.throws() -%}
+    {%- match func.throws_name() -%}
     {%- when Some with (e) -%}
       {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ e|class_name_rb }},
     {%- else -%}

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -469,13 +469,4 @@ pub mod filters {
     pub fn enum_variant_swift(nm: &str) -> Result<String, askama::Error> {
         Ok(oracle().enum_variant_name(nm))
     }
-
-    /// Get the idiomatic Swift rendering of an exception name
-    ///
-    /// This replaces "Error" at the end of the name with "Exception".  Rust code typically uses
-    /// "Error" for any type of error but in the Java world, "Error" means a non-recoverable error
-    /// and is distinguished from an "Exception".
-    pub fn exception_name(nm: &str) -> Result<String, askama::Error> {
-        Ok(oracle().error_name(nm))
-    }
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
@@ -28,7 +28,7 @@ fileprivate let {{ foreign_callback }} : ForeignCallback =
 
             let reader = Reader(data: Data(rustBuffer: args))
             {% if meth.return_type().is_some() %}let result = {% endif -%}
-            {% if meth.throws().is_some() %}try {% endif -%}
+            {% if meth.throws() %}try {% endif -%}
             swiftCallbackInterface.{{ meth.name()|fn_name }}(
                     {% for arg in meth.arguments() -%}
                     {% if !config.omit_argument_labels() %}{{ arg.name()|var_name }}: {% endif %} try {{ arg|read_fn }}(from: reader)
@@ -37,7 +37,7 @@ fileprivate let {{ foreign_callback }} : ForeignCallback =
                 )
             {% else %}
             {% if meth.return_type().is_some() %}let result = {% endif -%}
-            {% if meth.throws().is_some() %}try {% endif -%}
+            {% if meth.throws() %}try {% endif -%}
             swiftCallbackInterface.{{ meth.name()|fn_name }}()
             {% endif -%}
 

--- a/uniffi_bindgen/src/bindings/swift/templates/macros.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/macros.swift
@@ -89,9 +89,9 @@
 {%- endmacro -%}
 
 {%- macro throws(func) %}
-{%- match func.throws() %}{% when Some with (e) %}throws{% else %}{% endmatch %}
+{%- if func.throws() %}throws{% endif %}
 {%- endmacro -%}
 
 {%- macro try(func) %}
-{%- match func.throws() %}{% when Some with (e) %}try{% else %}try!{% endmatch %}
+{%- if func.throws() %}try{% else %}try!{% endif %}
 {%- endmacro -%}

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -81,7 +81,11 @@ impl Function {
         &self.ffi_func
     }
 
-    pub fn throws(&self) -> Option<&str> {
+    pub fn throws(&self) -> bool {
+        self.attributes.get_throws_err().is_some()
+    }
+
+    pub fn throws_name(&self) -> Option<&str> {
         self.attributes.get_throws_err()
     }
 
@@ -272,7 +276,7 @@ mod test {
         let func1 = ci.get_function_definition("minimal").unwrap();
         assert_eq!(func1.name(), "minimal");
         assert!(func1.return_type().is_none());
-        assert!(func1.throws().is_none());
+        assert!(func1.throws_type().is_none());
         assert_eq!(func1.arguments().len(), 0);
 
         let func2 = ci.get_function_definition("rich").unwrap();
@@ -281,7 +285,7 @@ mod test {
             func2.return_type().unwrap().canonical_name(),
             "SequenceOptionalstring"
         );
-        assert!(matches!(func2.throws(), Some("TestError")));
+        assert!(matches!(func2.throws_type(), Some(Type::Error(s)) if s == "TestError"));
         assert_eq!(func2.arguments().len(), 2);
         assert_eq!(func2.arguments()[0].name(), "arg1");
         assert_eq!(func2.arguments()[0].type_().canonical_name(), "u32");

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -264,7 +264,11 @@ impl Constructor {
         &self.ffi_func
     }
 
-    pub fn throws(&self) -> Option<&str> {
+    pub fn throws(&self) -> bool {
+        self.attributes.get_throws_err().is_some()
+    }
+
+    pub fn throws_name(&self) -> Option<&str> {
         self.attributes.get_throws_err()
     }
 
@@ -377,7 +381,11 @@ impl Method {
         &self.ffi_func
     }
 
-    pub fn throws(&self) -> Option<&str> {
+    pub fn throws(&self) -> bool {
+        self.attributes.get_throws_err().is_some()
+    }
+
+    pub fn throws_name(&self) -> Option<&str> {
         self.attributes.get_throws_err()
     }
 


### PR DESCRIPTION
Added a bool function that returns if a function throws or not. Named this one "throws" and renamed the old method to "throws_name". We could almost get rid of that one, but it's still used by the Ruby code

This is just a bit of prep work for getting callback interface errors working.
