### PR TITLE
Adding a note on a 0.19.0 breaking change that we didn't notice.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 
 ###  ⚠️ Breaking Changes ⚠️
 - breaking for external binding generators, the `FFIType::RustArcPtr` now includes an inner `String`. The string represents the name of the object the `RustArcPtr` was derived from.
+- Kotlin exception names are now formatted as strict UpperCamelCase.  Most names shouldn't change, but names that use one word with all caps will be affected (for example `URL` -> `Url`, `JSONException` -> `JsonException`)
 
 ### What's changed
 - The UDL can contain identifiers which are also keywords in Rust, Python or Kotlin.


### PR DESCRIPTION
The change was introduced here: https://github.com/mozilla/uniffi-rs/commit/16ac8d6937550a74e79c824896e1cbb0279130e3#diff-522f0ef157bc0a32453bafd790a9058a35cbb8a721df58a9b51b1ec6b74db5caR263

We're noticing it in here: https://github.com/mozilla-mobile/android-components/pull/12781