### PR TITLE
Callback exceptions

### DIFF
--- a/docs/manual/src/udl/callback_interfaces.md
+++ b/docs/manual/src/udl/callback_interfaces.md
@@ -18,10 +18,12 @@ by the host operating system (e.g. the key chain).
 
 ```rust,no_run
 pub trait Keychain: Send + Sync + Debug {
-  fn get(&self, key: String) -> Option<String>;
-  fn put(&self, key: String, value: String);
+  fn get(&self, key: String) -> Result<Option<String>, KeyChainError>
+  fn put(&self, key: String, value: String) -> Result<(), KeyChainError>
 }
 ```
+
+### Why + Send + Sync?
 
 The concrete types that UniFFI generates for callback interfaces implement `Send`, `Sync`, and `Debug`, so it's safe to
 include these as supertraits of your callback interface trait.  This isn't strictly necessary, but it's often useful.  In
@@ -30,16 +32,44 @@ particular, `Sync + Send` is useful when:
     interface type)
   - Storing `Box<dyn CallbackInterfaceTrait>` inside a global `Mutex` or `RwLock`
 
-## 2. Define a callback interface in the UDL.
+
+## 2. Setup error handling
+
+All methods of the Rust trait should return a Result.  The error half of that result must
+be an [error type defined in the UDL](./errors.md).
+
+It's currently allowed for callback interface methods to return a regular value
+rather than a `Result<>`.  However, this is means that any exception from the
+foreign bindings will lead to a panic.
+
+### Extra requirements for errors used in callback interfaces
+
+In order to support errors in callback interfaces, UniFFI must be able to
+properly [lift the error](../internals/lifting_and_lowering.md).  This means
+that the if the error is described by an `enum` rather than an `interface` in
+the UDL (see (./errors.md)) then all variants of the Rust enum must be unit variants.
+
+In addition to expected errors, a callback interface call can result in all kinds of
+unexpected errors.  Some examples are the foreign code throws an exception that's not part
+of the exception type or there was a problem marshalling the data for the call.  UniFFI
+uses `uniffi::UnexpectedUniFFICallbackError` for these cases.  Your code must include a
+`From<uniffi::UnexpectedUniFFICallbackError>` impl for your error type to handle those or
+the UniFFI scaffolding code will fail to compile.  See the `example/callbacks` for an
+exapmle of how to do this.
+
+## 3. Define a callback interface in the UDL.
 
 ```webidl
 callback interface Keychain {
+    [Throws=KeyChainError]
     string? get(string key);
+
+    [Throws=KeyChainError]
     void put(string key, string data);
 };
 ```
 
-## 3. And allow it to be passed into Rust.
+## 4. And allow it to be passed into Rust.
 
 Here, we define a constructor to pass the keychain to rust, and then another method
 which may use it.

--- a/examples/callbacks/Cargo.toml
+++ b/examples/callbacks/Cargo.toml
@@ -13,6 +13,7 @@ name = "uniffi_callbacks"
 [dependencies]
 uniffi_macros = {path = "../../uniffi_macros"}
 uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
+thiserror = "1.0"
 
 [build-dependencies]
 uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/examples/callbacks/src/callbacks.udl
+++ b/examples/callbacks/src/callbacks.udl
@@ -1,12 +1,18 @@
 namespace callbacks {};
 
-interface Telephone {
-  constructor();
-  void call(boolean domestic, OnCallAnswered call_responder);
+[Error]
+enum TelephoneError {
+  "Busy",
+  "InternalTelephoneError",
 };
 
-callback interface OnCallAnswered {
-  string hello();
-  void busy();
-  void text_received(string text);
+interface Telephone {
+  constructor();
+  [Throws=TelephoneError]
+  string call(CallAnswerer answerer);
+};
+
+callback interface CallAnswerer {
+  [Throws=TelephoneError]
+  string answer();
 };

--- a/examples/callbacks/src/lib.rs
+++ b/examples/callbacks/src/lib.rs
@@ -2,25 +2,35 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-pub trait OnCallAnswered {
-    fn hello(&self) -> String;
-    fn busy(&self);
-    fn text_received(&self, text: String);
+#[derive(Debug, thiserror::Error)]
+pub enum TelephoneError {
+    #[error("Busy")]
+    Busy,
+    #[error("InternalTelephoneError")]
+    InternalTelephoneError,
 }
 
-#[derive(Debug, Clone)]
-struct Telephone;
-impl Telephone {
-    fn new() -> Self {
-        Telephone
+// Need to implement this From<> impl in order to handle unexpected callback errors.  See the
+// Callback Interfaces section of the handbook for more info.
+impl From<uniffi::UnexpectedUniFFICallbackError> for TelephoneError {
+    fn from(_: uniffi::UnexpectedUniFFICallbackError) -> Self {
+        Self::InternalTelephoneError
     }
-    fn call(&self, domestic: bool, call_responder: Box<dyn OnCallAnswered>) {
-        if domestic {
-            let _ = call_responder.hello();
-        } else {
-            call_responder.busy();
-            call_responder.text_received("Not now, I'm on another call!".into());
-        }
+}
+
+pub trait CallAnswerer {
+    fn answer(&self) -> Result<String, TelephoneError>;
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Telephone;
+impl Telephone {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn call(&self, answerer: Box<dyn CallAnswerer>) -> Result<String, TelephoneError> {
+        answerer.answer()
     }
 }
 

--- a/examples/callbacks/tests/bindings/test_callbacks.kts
+++ b/examples/callbacks/tests/bindings/test_callbacks.kts
@@ -4,46 +4,39 @@
 
 import uniffi.callbacks.*
 
+class SomeOtherError: Exception()
+
 // Simple example just to see it work.
 // Pass in a string, get a string back.
 // Pass in nothing, get unit back.
-class OnCallAnsweredImpl : OnCallAnswered {
-    var yesCount: Int = 0
-    var busyCount: Int = 0
-    var stringReceived = ""
-
-    override fun hello(): String {
-        yesCount ++
-        return "Hi hi $yesCount"
-    }
-
-    override fun busy() {
-        busyCount ++
-    }
-
-    override fun textReceived(text: String) {
-        stringReceived = text
+class CallAnswererImpl(val mode: String) : CallAnswerer {
+    override fun answer(): String {
+        if (mode == "normal") {
+            return "Bonjour"
+        } else if (mode == "busy") {
+            throw TelephoneException.Busy("I'm busy")
+        } else {
+            throw SomeOtherError();
+        }
     }
 }
 
-val cbObject = OnCallAnsweredImpl()
 val telephone = Telephone()
 
-telephone.call(true, cbObject)
-assert(cbObject.busyCount == 0) { "yesCount=${cbObject.busyCount} (should be 0)" }
-assert(cbObject.yesCount == 1) { "yesCount=${cbObject.yesCount} (should be 1)" }
+assert(telephone.call(CallAnswererImpl("normal")) == "Bonjour")
 
-telephone.call(true, cbObject)
-assert(cbObject.busyCount == 0) { "yesCount=${cbObject.busyCount} (should be 0)" }
-assert(cbObject.yesCount == 2) { "yesCount=${cbObject.yesCount} (should be 2)" }
+try {
+    telephone.call(CallAnswererImpl("busy"))
+    throw RuntimeException("Should have thrown a Busy exception!")
+} catch(e: TelephoneException.Busy) {
+    // It's okay
+}
 
-telephone.call(false, cbObject)
-assert(cbObject.busyCount == 1) { "yesCount=${cbObject.busyCount} (should be 1)" }
-assert(cbObject.yesCount == 2) { "yesCount=${cbObject.yesCount} (should be 2)" }
-
-val cbObjet2 = OnCallAnsweredImpl()
-telephone.call(true, cbObjet2)
-assert(cbObjet2.busyCount == 0) { "yesCount=${cbObjet2.busyCount} (should be 0)" }
-assert(cbObjet2.yesCount == 1) { "yesCount=${cbObjet2.yesCount} (should be 1)" }
+try {
+    telephone.call(CallAnswererImpl("something-else"))
+    throw RuntimeException("Should have thrown a Busy exception!")
+} catch(e: TelephoneException.InternalTelephoneException) {
+    // It's okay
+}
 
 telephone.destroy()

--- a/examples/callbacks/tests/bindings/test_callbacks.py
+++ b/examples/callbacks/tests/bindings/test_callbacks.py
@@ -1,41 +1,34 @@
+import unittest
 from callbacks import *
 
-# Simple example just to see it work.
-# Pass in a string, get a string back.
-# Pass in nothing, get unit back.
-class OnCallAnsweredImpl(OnCallAnswered):
-    def __init__(self):
-        self.yes_count = 0
-        self.busy_count = 0
-        self.string_received = ""
+class CallAnswererImpl(CallAnswerer):
+    def __init__(self, mode):
+        self.mode = mode
 
-    def hello(self):
-        self.yes_count += 1
-        return f"Hi hi {self.yes_count}"
+    def answer(self):
+        if self.mode == "ready":
+            return "Bonjour"
+        elif self.mode == "busy":
+            raise TelephoneError.Busy()
+        else:
+            raise ValueError("Testing an unexpected error")
 
-    def busy(self):
-        self.busy_count += 1
+class CallbacksTest(unittest.TestCase):
+    def test_answer(self):
+        cb_object = CallAnswererImpl("ready")
+        telephone = Telephone()
+        self.assertEqual("Bonjour", telephone.call(cb_object))
 
-    def text_received(self, text):
-        self.string_received = text
+    def test_busy(self):
+        cb_object = CallAnswererImpl("busy")
+        telephone = Telephone()
+        with self.assertRaises(TelephoneError.Busy):
+            telephone.call(cb_object)
 
-cb_object = OnCallAnsweredImpl()
-telephone = Telephone()
+    def test_unexpected_error(self):
+        cb_object = CallAnswererImpl("something-else")
+        telephone = Telephone()
+        with self.assertRaises(TelephoneError.InternalTelephoneError):
+            telephone.call(cb_object)
 
-telephone.call(domestic=True, call_responder=cb_object)
-assert cb_object.busy_count == 0, f"yes_count={cb_object.busy_count} (should be 0)"
-assert cb_object.yes_count == 1, f"yes_count={cb_object.yes_count} (should be 1)"
-
-telephone.call(domestic=True, call_responder=cb_object)
-assert cb_object.busy_count == 0, f"yes_count={cb_object.busy_count} (should be 0)"
-assert cb_object.yes_count == 2, f"yes_count={cb_object.yes_count} (should be 2)"
-
-telephone.call(domestic=False, call_responder=cb_object)
-assert cb_object.busy_count == 1, f"yes_count={cb_object.busy_count} (should be 1)"
-assert cb_object.yes_count == 2, f"yes_count={cb_object.yes_count} (should be 2)"
-assert cb_object.string_received != "", f"string_received='{cb_object.string_received}' (should be a message)"
-
-cb_object2 = OnCallAnsweredImpl()
-telephone.call(domestic=True, call_responder=cb_object2)
-assert cb_object2.busy_count == 0, f"yes_count={cb_object2.busy_count} (should be 0)"
-assert cb_object2.yes_count == 1, f"yes_count={cb_object2.yes_count} (should be 1)"
+unittest.main()

--- a/fixtures/callbacks/Cargo.toml
+++ b/fixtures/callbacks/Cargo.toml
@@ -13,6 +13,7 @@ name = "uniffi_fixture_callbacks"
 [dependencies]
 uniffi_macros = {path = "../../uniffi_macros"}
 uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
+thiserror = "1.0"
 
 [build-dependencies]
 uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/callbacks/src/callbacks.udl
+++ b/fixtures/callbacks/src/callbacks.udl
@@ -1,11 +1,30 @@
 namespace fixture_callbacks {};
 
+[Error]
+enum SimpleError {
+  "BadArgument",
+  "UnexpectedError",
+};
+
+[Error]
+interface ComplexError {
+   ReallyBadArgument(i32 code);
+   UnexpectedErrorWithReason(string reason);
+};
+
+
 /// These objects are implemented by the foreign language and passed
 /// to Rust. Rust then calls methods on it when it needs to.
+///
+/// Some methods throw SimpleError and some throw ComplexError so that we can test both field-less and fielded errors
 callback interface ForeignGetters {
+  [Throws=SimpleError]
   boolean get_bool(boolean v, boolean argument_two);
+  [Throws=SimpleError]
   string get_string(string v, boolean arg2);
+  [Throws=ComplexError]
   string? get_option(string? v, boolean arg2);
+  [Throws=SimpleError]
   sequence<i32> get_list(sequence<i32> v, boolean arg2);
 };
 
@@ -13,10 +32,15 @@ callback interface ForeignGetters {
 /// to get the value.
 interface RustGetters {
   constructor();
+  [Throws=SimpleError]
   boolean get_bool(ForeignGetters callback, boolean v, boolean argument_two);
+  [Throws=SimpleError]
   string get_string(ForeignGetters callback, string v, boolean arg2);
+  [Throws=ComplexError]
   string? get_option(ForeignGetters callback, string? v, boolean arg2);
+  [Throws=SimpleError]
   sequence<i32> get_list(ForeignGetters callback, sequence<i32> v, boolean arg2);
+  [Throws=SimpleError]
   string? get_string_optional_callback(ForeignGetters? callback, string v, boolean arg2);
 };
 
@@ -25,6 +49,9 @@ interface RustGetters {
 /// Rust developers need to declare these traits extending `Send` so
 /// they can be stored in Rust— i.e. not passed in as an argument to
 /// be used immediately.
+///
+/// These methods don't throw any error so that we can test older callback
+//interfaces that don't support them.
 callback interface StoredForeignStringifier {
   string from_simple_type(i32 value);
   // Test if types are collected from callback interfaces.

--- a/fixtures/callbacks/tests/bindings/test_callbacks.py
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from fixture_callbacks import *
+import unittest
 
 # A bit more systematic in testing, but this time in English.
 #
@@ -16,12 +17,20 @@ class PythonGetters(ForeignGetters):
         return v ^ argumentTwo
 
     def get_string(self, v, arg2):
+        if v == "bad-argument":
+            raise SimpleError.BadArgument()
+        elif v == "unexpected-error":
+            raise ValueError("unexpected value")
         if arg2:
             return "1234567890123"
         else:
             return v
 
     def get_option(self, v, arg2):
+        if v == "bad-argument":
+            raise ComplexError.ReallyBadArgument(20)
+        elif v == "unexpected-error":
+            raise ValueError("unexpected value")
         if arg2:
             if v:
                 return v.upper()
@@ -36,34 +45,42 @@ class PythonGetters(ForeignGetters):
         else:
             return []
 
-callback = PythonGetters()
-for v in [True, False]:
-    flag = True
-    expected = callback.get_bool(v, flag)
-    observed = rust_getters.get_bool(callback, v, flag)
-    assert expected == observed, f"roundtripping through callback: {expected} != {observed}"
+class ForeignGettersTest(unittest.TestCase):
+    def test_get_bool(self):
+        callback = PythonGetters()
+        for v in [True, False]:
+            flag = True
+            expected = callback.get_bool(v, flag)
+            observed = rust_getters.get_bool(callback, v, flag)
+            self.assertEqual(expected, observed, f"roundtripping through callback: {expected} != {observed}")
 
-for v in [[1, 2], [0, 1]]:
-    flag = True
-    expected = callback.get_list(v, flag)
-    observed = rust_getters.get_list(callback, v, flag)
-    assert expected == observed, f"roundtripping through callback: {expected} != {observed}"
+    def test_get_list(self):
+        callback = PythonGetters()
+        for v in [[1, 2], [0, 1]]:
+            flag = True
+            expected = callback.get_list(v, flag)
+            observed = rust_getters.get_list(callback, v, flag)
+            self.assertEqual(expected, observed, f"roundtripping through callback: {expected} != {observed}")
 
-for v in ["Hello", "world"]:
-    flag = True
-    expected = callback.get_string(v, flag)
-    observed = rust_getters.get_string(callback, v, flag)
-    assert expected == observed, f"roundtripping through callback: {expected} != {observed}"
+    def test_get_string(self):
+        callback = PythonGetters()
+        for v in ["Hello", "world"]:
+            flag = True
+            expected = callback.get_string(v, flag)
+            observed = rust_getters.get_string(callback, v, flag)
+            self.assertEqual(expected, observed, f"roundtripping through callback: {expected} != {observed}")
 
-for v in ["Some", None]:
-    flag = False
-    expected = callback.get_option(v, flag)
-    observed = rust_getters.get_option(callback, v, flag)
-    assert expected == observed, f"roundtripping through callback: {expected} != {observed}"
+    def test_get_optional(self):
+        callback = PythonGetters()
+        for v in ["Some", None]:
+            flag = False
+            expected = callback.get_option(v, flag)
+            observed = rust_getters.get_option(callback, v, flag)
+            self.assertEqual(expected, observed, f"roundtripping through callback: {expected} != {observed}")
 
-
-assert rust_getters.get_string_optional_callback(callback, "TestString", False) == "TestString"
-assert rust_getters.get_string_optional_callback(None, "TestString", False) == None
+    def test_get_string_optional_callback(self):
+        self.assertEqual(rust_getters.get_string_optional_callback(PythonGetters(), "TestString", False), "TestString")
+        self.assertEqual(rust_getters.get_string_optional_callback(None, "TestString", False), None)
 
 # 2. Pass the callback in as a constructor argument, to be stored on the Object struct.
 # This is crucial if we want to configure a system at startup,
@@ -73,15 +90,30 @@ class StoredPythonStringifier(StoredForeignStringifier):
     def from_simple_type(self, value):
         return f"python: {value}"
 
-    # We don't test this, but we're checking that the arg type is included in the minimal list of types used
-    # in the UDL.
-    # If this doesn't compile, then look at TypeResolver.
-    def from_complex_type(values):
-        return f"python: {values}"
+class StoredStringifierTest(unittest.TestCase):
+    def test_stored_stringifier(self):
+        python_stringifier = StoredPythonStringifier()
+        rust_stringifier = RustStringifier(python_stringifier)
+        for v in [1, 2]:
+            expected = python_stringifier.from_simple_type(v)
+            observed = rust_stringifier.from_simple_type(v)
+            self.assertEqual(expected, observed, f"callback is sent on construction: {expected} != {observed}")
 
-python_stringifier = StoredPythonStringifier()
-rust_stringifier = RustStringifier(python_stringifier)
-for v in [1, 2]:
-    expected = python_stringifier.from_simple_type(v)
-    observed = rust_stringifier.from_simple_type(v)
-    assert expected == observed, f"callback is sent on construction: {expected} != {observed}"
+class TestCallbackErrors(unittest.TestCase):
+    def test_simple_errors(self):
+        callback = PythonGetters()
+        with self.assertRaises(SimpleError.BadArgument):
+            rust_getters.get_string(callback, "bad-argument", True)
+        with self.assertRaises(SimpleError.UnexpectedError):
+            rust_getters.get_string(callback, "unexpected-error", True)
+
+    def test_complex_errors(self):
+        callback = PythonGetters()
+        with self.assertRaises(ComplexError.ReallyBadArgument) as cm:
+            rust_getters.get_option(callback, "bad-argument", True)
+        self.assertEqual(cm.exception.code, 20)
+        with self.assertRaises(ComplexError.UnexpectedErrorWithReason) as cm:
+            rust_getters.get_option(callback, "unexpected-error", True)
+        self.assertEqual(cm.exception.reason, repr(ValueError("unexpected value")))
+
+unittest.main()

--- a/fixtures/callbacks/tests/bindings/test_callbacks.swift
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.swift
@@ -6,6 +6,8 @@
     import fixture_callbacks
 #endif
 
+struct SomeOtherError: Error { }
+
 // A bit more systematic in testing, but this time in English.
 //
 // 1. Pass in the callback as arguments.
@@ -13,44 +15,60 @@
 // with a variety of return types.
 let rustGetters = RustGetters()
 class SwiftGetters: ForeignGetters {
-    func getBool(v: Bool, argumentTwo: Bool) -> Bool { v != argumentTwo }
-    func getString(v: String, arg2: Bool) -> String { arg2 ? "1234567890123" : v }
-    func getOption(v: String?, arg2: Bool) -> String? { arg2 ? v?.uppercased() : v }
-    func getList(v: [Int32], arg2: Bool) -> [Int32] { arg2 ? v : [] }
+    func getBool(v: Bool, argumentTwo: Bool) throws -> Bool { v != argumentTwo }
+    func getString(v: String, arg2: Bool) throws -> String { 
+        if v == "bad-argument" {
+            throw SimpleError.BadArgument(message: "Bad argument")
+        }
+        if v == "unexpected-error" {
+            throw SomeOtherError()
+        }
+        return arg2 ? "1234567890123" : v
+    }
+    func getOption(v: String?, arg2: Bool) throws -> String? {
+        if v == "bad-argument" {
+            throw ComplexError.ReallyBadArgument(code: 20)
+        }
+        if v == "unexpected-error" {
+            throw SomeOtherError()
+        }
+        return arg2 ? v?.uppercased() : v
+    }
+    func getList(v: [Int32], arg2: Bool) throws -> [Int32] { arg2 ? v : [] }
 }
 
-func test() {
+do {
     let callback = SwiftGetters()
     [true, false].forEach { v in
         let flag = true
-        let expected = callback.getBool(v: v, argumentTwo: flag)
-        let observed = rustGetters.getBool(callback: callback, v: v, argumentTwo: flag)
+        let expected = try! callback.getBool(v: v, argumentTwo: flag)
+        let observed = try! rustGetters.getBool(callback: callback, v: v, argumentTwo: flag)
         assert(expected == observed, "roundtripping through callback: \(String(describing: expected)) != \(String(describing: observed))")
     }
 
     [[Int32(1), Int32(2)], [Int32(0), Int32(1)]].forEach { v in
         let flag = true
-        let expected = callback.getList(v: v, arg2: flag)
-        let observed = rustGetters.getList(callback: callback, v: v, arg2: flag)
+        let expected = try! callback.getList(v: v, arg2: flag)
+        let observed = try! rustGetters.getList(callback: callback, v: v, arg2: flag)
         assert(expected == observed, "roundtripping through callback: \(String(describing: expected)) != \(String(describing: observed))")
     }
 
     ["Hello", "world"].forEach { v in
         let flag = true
-        let expected = callback.getString(v: v, arg2: flag)
-        let observed = rustGetters.getString(callback: callback, v: v, arg2: flag)
+        let expected = try! callback.getString(v: v, arg2: flag)
+        let observed = try! rustGetters.getString(callback: callback, v: v, arg2: flag)
         assert(expected == observed, "roundtripping through callback: \(String(describing: expected)) != \(String(describing: observed))")
     }
 
     ["Some", nil].forEach { v in
         let flag = false
-        let expected = callback.getOption(v: v, arg2: flag)
-        let observed = rustGetters.getOption(callback: callback, v: v, arg2: flag)
+        let expected = try! callback.getOption(v: v, arg2: flag)
+        let observed = try! rustGetters.getOption(callback: callback, v: v, arg2: flag)
         assert(expected == observed, "roundtripping through callback: \(String(describing: expected)) != \(String(describing: observed))")
     }
 
-    assert(rustGetters.getStringOptionalCallback(callback: callback, v: "TestString", arg2: false) == "TestString")
-    assert(rustGetters.getStringOptionalCallback(callback: nil, v: "TestString", arg2: false) == nil)
+    assert(try! rustGetters.getStringOptionalCallback(callback: callback, v: "TestString", arg2: false) == "TestString")
+    assert(try! rustGetters.getStringOptionalCallback(callback: nil, v: "TestString", arg2: false) == nil)
 
     // rustGetters.destroy()
 
@@ -74,4 +92,35 @@ func test() {
         assert(expected == observed, "callback is sent on construction: \(expected) != \(observed)")
     }
 
+
+    // 3. Error handling
+    do {
+        _ = try rustGetters.getString(callback: callback, v: "bad-argument", arg2: true)
+        assertionFailure("getString() should have thrown an exception")
+    } catch SimpleError.BadArgument {
+        // Expected exception
+    }
+
+    do {
+        _ = try rustGetters.getString(callback: callback, v: "unexpected-error", arg2: true)
+        assertionFailure("getString() should have thrown an exception")
+    } catch SimpleError.UnexpectedError {
+        // Expected exception
+    }
+
+    do {
+        _ = try rustGetters.getOption(callback: callback, v: "bad-argument", arg2: true)
+        assertionFailure("getString() should have thrown an exception")
+    } catch ComplexError.ReallyBadArgument(let code) {
+        // Expected exception
+        assert(code == 20)
+    }
+
+    do {
+        _ = try rustGetters.getOption(callback: callback, v: "unexpected-error", arg2: true)
+        assertionFailure("getString() should have thrown an exception")
+    } catch ComplexError.UnexpectedErrorWithReason(let reason) {
+        // Expected exception
+        assert(reason == String(describing: SomeOtherError()))
+    }
 }

--- a/fixtures/uitests/src/errors.udl
+++ b/fixtures/uitests/src/errors.udl
@@ -1,0 +1,14 @@
+[Error]
+enum ArithmeticError {
+  "IntegerOverflow",
+  "DivisionByZero",
+  "UnexpectedError",
+};
+
+callback interface Calculator {
+  [Throws=ArithmeticError]
+  u64 add(u64 a, u64 b);
+};
+
+namespace errors {
+};

--- a/fixtures/uitests/tests/ui/fieldless_errors_used_in_callbacks_cant_have_fields.rs
+++ b/fixtures/uitests/tests/ui/fieldless_errors_used_in_callbacks_cant_have_fields.rs
@@ -1,0 +1,30 @@
+// Unfortunately, path is relative to a temporary build directory :-/
+uniffi_macros::generate_and_include_scaffolding!("../../../fixtures/uitests/src/errors.udl");
+
+fn main() { /* empty main required by `trybuild` */}
+
+#[derive(Debug)]
+enum ArithmeticError {
+  IntegerOverflow,
+  // Since this is listed in the UDL as not having fields and is used in a callback interface, it
+  // really needs to have no fields.
+  DivisionByZero { numerator: u64 },
+  // Tuple-style fields are also invalid
+  UnexpectedError(String),
+}
+
+impl std::fmt::Display for ArithmeticError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        <Self as std::fmt::Debug>::fmt(self, f)
+    }
+}
+
+impl From<uniffi::UnexpectedUniFFICallbackError> for ArithmeticError {
+    fn from(e: uniffi::UnexpectedUniFFICallbackError) -> ArithmeticError {
+        ArithmeticError::UnexpectedError(e.to_string())
+    }
+}
+
+pub trait Calculator {
+    fn add(&self, a: u64, b: u64) -> Result<u64, ArithmeticError>;
+}

--- a/fixtures/uitests/tests/ui/fieldless_errors_used_in_callbacks_cant_have_fields.stderr
+++ b/fixtures/uitests/tests/ui/fieldless_errors_used_in_callbacks_cant_have_fields.stderr
@@ -1,0 +1,11 @@
+error[E0063]: missing field `numerator` in initializer of `ArithmeticError`
+  --> $OUT_DIR[uniffi_uitests]/errors.uniffi.rs
+   |
+   |             2 => r#ArithmeticError::r#DivisionByZero{ },
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `numerator`
+
+error[E0063]: missing field `0` in initializer of `ArithmeticError`
+  --> $OUT_DIR[uniffi_uitests]/errors.uniffi.rs
+   |
+   |             3 => r#ArithmeticError::r#UnexpectedError{ },
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `0`

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
@@ -53,10 +53,17 @@ fileprivate let {{ foreign_callback }} : ForeignCallback =
                 // TODO catch errors and report them back to Rust.
                 // https://github.com/mozilla/uniffi-rs/issues/351
 
-    }
-    {% endfor %}
+        }
+        {% endfor %}
 
-        let cb = try! {{ ffi_converter_name }}.lift(handle)
+        let cb: {{ cbi|type_name }}
+        do {
+            cb = try {{ ffi_converter_name }}.lift(handle)
+        } catch {
+            out_buf.pointee = {{ Type::String.borrow()|lower_fn }}("{{ cbi.name() }}: Invalid handle")
+            return -1
+        }
+
         switch method {
             case IDX_CALLBACK_FREE:
                 {{ ffi_converter_name }}.drop(handle: handle)
@@ -66,11 +73,22 @@ fileprivate let {{ foreign_callback }} : ForeignCallback =
             {% for meth in cbi.methods() -%}
             {% let method_name = format!("invoke_{}", meth.name())|fn_name -%}
             case {{ loop.index }}:
-                let buffer = try! {{ method_name }}(cb, args)
-                out_buf.pointee = buffer
-                // Value written to out buffer.
-                // See docs of ForeignCallback in `uniffi/src/ffi/foreigncallbacks.rs`
-                return 1
+                do {
+                    out_buf.pointee = try {{ method_name }}(cb, args)
+                    // Value written to out buffer.
+                    // See docs of ForeignCallback in `uniffi/src/ffi/foreigncallbacks.rs`
+                    return 1
+                {%- match meth.throws_type() %}
+                {%- when Some(error_type) %}
+                } catch let error as {{ error_type|type_name }} {
+                    out_buf.pointee = {{ error_type|lower_fn }}(error)
+                    return -2
+                {%- else %}
+                {%- endmatch %}
+                } catch let error {
+                    out_buf.pointee = {{ Type::String.borrow()|lower_fn }}(String(describing: error))
+                    return -1
+                }
             {% endfor %}
             // This should never happen, because an out of bounds method index won't
             // ever be used. Once we can catch errors, we should return an InternalError.


### PR DESCRIPTION
This is a work-in-progress for handling exceptions in callback interfaces.  It changes a few things:

- The `Throws` attribute is now offecially supported on CallbackInterface methods, allowing callback interfaces to specify which errors they will throw.  If we catch one of those exceptions, we serialize it to the `RustBuffer` that's normally used for the return value and send it back to Rust.
- On the Rust side, this means the callback interface trait methods need to change to return `Result<T>` instead of `T`.
- For now, `Throws` is optional and we fall back on the old behavior if it's not present.  But this is deprecated.
- We also handle unexpected exceptions in callback interface.  If we see one of those, we stringify it and serialize it to the `RustBuffer`.  This gets converted into a `uniffi::UnexpectedCallbackError` in Rust.  Users need to write a `From<>` impl for that struct to their error enum (unless they're on the old/deprecated behavior).
- I updated `callback_interfaces.md` to describe the new system, updated the callbacks example, and implemented it on Python/Kotlin.
- I made a slight change to the FFI return values for callback interface call.  See my [comment below](https://github.com/mozilla/uniffi-rs/pull/1344#discussion_r972681969) for details.