### PR TITLE
Remove a library namespace collition

### DIFF
--- a/fixtures/callbacks/Cargo.toml
+++ b/fixtures/callbacks/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [lib]
 crate-type = ["lib", "cdylib"]
-name = "uniffi_callbacks"
+name = "uniffi_fixture_callbacks"
 
 [dependencies]
 uniffi_macros = {path = "../../uniffi_macros"}

--- a/fixtures/callbacks/src/callbacks.udl
+++ b/fixtures/callbacks/src/callbacks.udl
@@ -1,4 +1,4 @@
-namespace callbacks {};
+namespace fixture_callbacks {};
 
 /// These objects are implemented by the foreign language and passed
 /// to Rust. Rust then calls methods on it when it needs to.

--- a/fixtures/callbacks/tests/bindings/test_callbacks.kts
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.kts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import uniffi.callbacks.*
+import uniffi.fixture_callbacks.*
 
 // A bit more systematic in testing, but this time in English.
 //

--- a/fixtures/callbacks/tests/bindings/test_callbacks.py
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from callbacks import *
+from fixture_callbacks import *
 
 # A bit more systematic in testing, but this time in English.
 #

--- a/fixtures/callbacks/tests/bindings/test_callbacks.swift
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.swift
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#if canImport(callbacks)
-    import callbacks
+#if canImport(fixture_callbacks)
+    import fixture_callbacks
 #endif
 
 // A bit more systematic in testing, but this time in English.

--- a/fixtures/reexport-scaffolding-macro/src/lib.rs
+++ b/fixtures/reexport-scaffolding-macro/src/lib.rs
@@ -1,4 +1,4 @@
-uniffi_callbacks::uniffi_reexport_scaffolding!();
+uniffi_fixture_callbacks::uniffi_reexport_scaffolding!();
 uniffi_coverall::uniffi_reexport_scaffolding!();
 
 #[cfg(test)]


### PR DESCRIPTION
This changes the fixtures/callbacks library name so that it doesn't collide with examples/callbacks.  It prevents `output filename collision` warnings when running `cargo build`