### PR TITLE
Add Swift bindings generation support for reserved words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 [All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.19.6...HEAD).
 
+### What's changed
+- The UDL can contain identifiers which are also keywords in Swift, except in namespace functions.
+
 ## v0.19.6 - (_2022-08-31_)
 
 [All changes in v0.19.6](https://github.com/mozilla/uniffi-rs/compare/v0.19.5...v0.19.6).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
 
   "fixtures/keywords/kotlin",
   "fixtures/keywords/rust",
+  "fixtures/keywords/swift",
   "fixtures/reexport-scaffolding-macro",
   "fixtures/regressions/enum-without-i32-helpers",
   "fixtures/regressions/fully-qualified-types",

--- a/fixtures/keywords/README.md
+++ b/fixtures/keywords/README.md
@@ -5,10 +5,10 @@ Each directory is a specialized fixture for each language (although the
 `rust` directory does double-duty for Python)
 
 The reason we don't try and combine these into a single fixture is that we'd
-like a highe degree is assurance that each language has a keyword used
+like a high degree of assurance that each language has a keyword used
 in every possible context. By trying to combine them, we would end up needing
 multiple, say, `enum`, `interface`, function arguments, variant discriminators,
-etc. So there's a reasonable change we'd accidently not have an `enum` with a
+etc. So there's a reasonable change we'd accidentally not have an `enum` with a
 (say) kotlin keyword.
 
 Separate fixtures means someone familiar with Kotlin and look at 1 fixture and

--- a/fixtures/keywords/swift/Cargo.toml
+++ b/fixtures/keywords/swift/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "uniffi-fixture-keywords-swift"
+version = "0.19.6"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+name = "uniffi_keywords_swift"
+
+[dependencies]
+thiserror = "1.0"
+uniffi_macros = {path = "../../../uniffi_macros"}
+uniffi = {path = "../../../uniffi", features=["builtin-bindgen"]}
+
+[build-dependencies]
+uniffi_build = {path = "../../../uniffi_build", features=["builtin-bindgen"]}

--- a/fixtures/keywords/swift/build.rs
+++ b/fixtures/keywords/swift/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/keywords.udl").unwrap();
+}

--- a/fixtures/keywords/swift/src/keywords.udl
+++ b/fixtures/keywords/swift/src/keywords.udl
@@ -1,0 +1,32 @@
+namespace keywords_swift {
+
+};
+
+enum case {
+    "internal",
+};
+
+[Enum]
+interface for {
+    internal(u8 break);
+};
+
+dictionary return {
+    u8 class;
+    u8? switch;
+};
+
+interface break {
+    void class(u8 internal);
+    void internal(u8? class);
+};
+
+[Error]
+enum class {
+    "internal",
+};
+
+[Error]
+interface func {
+   class(u8 object);
+};

--- a/fixtures/keywords/swift/src/lib.rs
+++ b/fixtures/keywords/swift/src/lib.rs
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// pub fn r#if(_break: u8) {}
+
+#[allow(non_camel_case_types)]
+pub enum r#case {
+    r#internal,
+}
+
+#[allow(non_camel_case_types)]
+pub enum r#for {
+    #[allow(non_camel_case_types)]
+    r#internal { r#break: u8 },
+}
+
+#[allow(non_camel_case_types)]
+pub struct r#return {
+    class: u8,
+    switch: Option<u8>,
+}
+
+#[allow(non_camel_case_types)]
+pub struct r#break {}
+
+impl r#break {
+    pub fn class(&self, _internal: u8) {}
+    pub fn internal(&self, _class: Option<u8>) {}
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, thiserror::Error)]
+pub enum class {
+    #[error("internal error")]
+    internal,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, thiserror::Error)]
+pub enum func {
+    #[error("class?")]
+    class { object: u8 },
+}
+
+include!(concat!(env!("OUT_DIR"), "/keywords.uniffi.rs"));

--- a/fixtures/keywords/swift/tests/bindings/test_keywords.swift
+++ b/fixtures/keywords/swift/tests/bindings/test_keywords.swift
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import keywords_swift
+
+// able to import is the real test, but might as well call something.
+let case_internal = Case.internal;

--- a/fixtures/keywords/swift/tests/test_generated_bindings.rs
+++ b/fixtures/keywords/swift/tests/test_generated_bindings.rs
@@ -1,0 +1,4 @@
+uniffi_macros::build_foreign_language_testcases!(
+    ["src/keywords.udl",],
+    ["tests/bindings/test_keywords.swift",]
+);

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -341,22 +341,22 @@ impl CodeOracle for SwiftCodeOracle {
 
     /// Get the idiomatic Swift rendering of a function name.
     fn fn_name(&self, nm: &str) -> String {
-        nm.to_string().to_lower_camel_case()
+        format!("`{}`", nm.to_string().to_lower_camel_case())
     }
 
     /// Get the idiomatic Swift rendering of a variable name.
     fn var_name(&self, nm: &str) -> String {
-        nm.to_string().to_lower_camel_case()
+        format!("`{}`", nm.to_string().to_lower_camel_case())
     }
 
     /// Get the idiomatic Swift rendering of an individual enum variant.
     fn enum_variant_name(&self, nm: &str) -> String {
-        nm.to_string().to_lower_camel_case()
+        format!("`{}`", nm.to_string().to_lower_camel_case())
     }
 
     /// Get the idiomatic Swift rendering of an exception name.
     fn error_name(&self, nm: &str) -> String {
-        self.class_name(nm)
+        format!("`{}`", self.class_name(nm))
     }
 
     fn ffi_type_label(&self, ffi_type: &FFIType) -> String {


### PR DESCRIPTION
This change is based on #1237 but isn't quite as complete. I wasn't able to get reserved words working as a pub fn in the namespace. I need this fix to to expose an API in a project I'm working on that is using a Swift reserved word (`internal`) as an enum variant name. 

If I can get this PR ready to merge I'm also happy to do a corresponding change for the master branch. If you'd rather I do the master branch change first I can do it that way, I started with 0.19 because that the version of uniffi my project is currently using.