### PR TITLE
[Discuss] IR for bindings generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [workspace]
 members = [
+  "bindings-ir",
+  "bindings-ir-kotlin",
+  "bindings-ir-tests",
+  "render-macro",
   "uniffi_bindgen",
   "uniffi_build",
   "uniffi_macros",

--- a/bindings-ir-kotlin/Cargo.toml
+++ b/bindings-ir-kotlin/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bindings-ir-kotlin"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bytes = "1.0"
+camino = "1.0.8"
+heck = "0.4"
+paste = "1.0"
+bindings-ir = { path = "../bindings-ir" }
+render-macro = { path = "../render-macro" }
+tera = { version = "1", default-features = false }
+
+[dev-dependencies]
+bindings-ir-tests = { path = "../bindings-ir-tests" }
+cargo_metadata = "0.14"
+lazy_static = "1.4"

--- a/bindings-ir-kotlin/src/buffer.rs
+++ b/bindings-ir-kotlin/src/buffer.rs
@@ -1,0 +1,85 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use bindings_ir::Renderer;
+use tera::Result;
+
+pub fn setup_renderer(renderer: &mut Renderer) -> Result<()> {
+    renderer.add_ast_templates([
+        (
+            "BufferStreamDef",
+            include_str!("templates/BufferStreamDef.kt"),
+        ),
+        ("BufStreamCreate", "{{ name }}({{ pointer }}, {{ size}})"),
+        ("BufStreamIntoPointer", "{{ buf }}.ptr"),
+        ("BufStreamPos", "{{ buf }}.byteBuf.position()"),
+        ("BufStreamSetPos", "{{ buf }}.byteBuf.position({{ pos }})"),
+        ("BufStreamSize", "{{ buf }}.size"),
+        ("BufStreamReadInt8", "{{ buf }}.byteBuf.get()"),
+        ("BufStreamReadUInt8", "{{ buf }}.byteBuf.get().toUByte()"),
+        ("BufStreamReadInt16", "{{ buf }}.byteBuf.getShort()"),
+        (
+            "BufStreamReadUInt16",
+            "{{ buf }}.byteBuf.getShort().toUShort()",
+        ),
+        ("BufStreamReadInt32", "{{ buf }}.byteBuf.getInt()"),
+        ("BufStreamReadUInt32", "{{ buf }}.byteBuf.getInt().toUInt()"),
+        ("BufStreamReadInt64", "{{ buf }}.byteBuf.getLong()"),
+        (
+            "BufStreamReadUInt64",
+            "{{ buf }}.byteBuf.getLong().toULong()",
+        ),
+        ("BufStreamReadFloat32", "{{ buf }}.byteBuf.getFloat()"),
+        ("BufStreamReadFloat64", "{{ buf }}.byteBuf.getDouble()"),
+        (
+            "BufStreamReadPointer",
+            "com.sun.jna.Pointer({{ buf }}.byteBuf.getLong())",
+        ),
+        ("BufStreamReadString", "{{ buf }}.readString({{ size }})"),
+        ("BufStreamWriteInt8", "{{ buf }}.byteBuf.put({{ value }})"),
+        (
+            "BufStreamWriteUInt8",
+            "{{ buf }}.byteBuf.put({{ value }}.toByte())",
+        ),
+        (
+            "BufStreamWriteInt16",
+            "{{ buf }}.byteBuf.putShort({{ value }})",
+        ),
+        (
+            "BufStreamWriteUInt16",
+            "{{ buf }}.byteBuf.putShort({{ value }}.toShort())",
+        ),
+        (
+            "BufStreamWriteInt32",
+            "{{ buf }}.byteBuf.putInt({{ value }})",
+        ),
+        (
+            "BufStreamWriteUInt32",
+            "{{ buf }}.byteBuf.putInt({{ value }}.toInt())",
+        ),
+        (
+            "BufStreamWriteInt64",
+            "{{ buf }}.byteBuf.putLong({{ value }})",
+        ),
+        (
+            "BufStreamWriteUInt64",
+            "{{ buf }}.byteBuf.putLong({{ value }}.toLong())",
+        ),
+        (
+            "BufStreamWriteFloat32",
+            "{{ buf }}.byteBuf.putFloat({{ value }})",
+        ),
+        (
+            "BufStreamWriteFloat64",
+            "{{ buf }}.byteBuf.putDouble({{ value }})",
+        ),
+        (
+            "BufStreamWritePointer",
+            "{{ buf }}.byteBuf.putLong(com.sun.jna.Pointer.nativeValue({{ value }}))",
+        ),
+        ("BufStreamWriteString", "{{ buf }}.writeString({{ value }})"),
+    ])
+}

--- a/bindings-ir-kotlin/src/class.rs
+++ b/bindings-ir-kotlin/src/class.rs
@@ -1,0 +1,34 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use bindings_ir::Renderer;
+use tera::Result;
+
+pub fn setup_renderer(renderer: &mut Renderer) -> Result<()> {
+    renderer.add_ast_templates([
+        ("ClassDef", include_str!("templates/ClassDef.kt")),
+        ("DataClassDef", include_str!("templates/DataClassDef.kt")),
+        ("EnumDef", include_str!("templates/EnumDef.kt")),
+        (
+            "ExceptionBaseDef",
+            include_str!("templates/ExceptionBaseDef.kt"),
+        ),
+        ("ExceptionDef", include_str!("templates/ExceptionDef.kt")),
+        ("ClassCreate", include_str!("templates/ClassCreate.kt")),
+        ("DataClassCreate", "{{ name }}({{ values|comma_join }})"),
+        ("EnumCreate", include_str!("templates/EnumCreate.kt")),
+        ("ExceptionCreate", "{{ name }}({{ values|comma_join }})"),
+        (
+            "MethodCall",
+            "{{ obj }}.{{ name }}({{ values|comma_join }})",
+        ),
+        (
+            "StaticMethodCall",
+            "{{ class }}.{{ name }}({{ values|comma_join }})",
+        ),
+        ("IntoRust", "{{ obj }}.intoRust()"),
+    ])
+}

--- a/bindings-ir-kotlin/src/collections.rs
+++ b/bindings-ir-kotlin/src/collections.rs
@@ -1,0 +1,22 @@
+use bindings_ir::Renderer;
+use tera::Result;
+
+pub fn setup_renderer(renderer: &mut Renderer) -> Result<()> {
+    renderer.add_ast_templates([
+        ("ListCreate", "mutableListOf<{{ inner }}>()"),
+        ("ListLen", "{{ list }}.size"),
+        ("ListGet", "{{ list }}[{{ index }}]"),
+        ("ListSet", "{{ list }}[{{ index }}] = {{ value }}"),
+        ("ListPush", "{{ list }}.add({{ value }})"),
+        ("ListPop", "{{ list }}.removeLast()"),
+        ("ListEmpty", "{{ list }}.clear()"),
+        ("ListIterate", include_str!("templates/ListIterate.kt")),
+        ("MapCreate", "mutableMapOf<{{ key }}, {{ value }}>()"),
+        ("MapLen", "{{ map }}.size"),
+        ("MapGet", "{{ map }}.get({{ key }})"),
+        ("MapSet", "{{ map }}.put({{ key }}, {{ value }})"),
+        ("MapRemove", "{{ map }}.remove({{ key }})"),
+        ("MapEmpty", "{{ map }}.clear()"),
+        ("MapIterate", include_str!("templates/MapIterate.kt")),
+    ])
+}

--- a/bindings-ir-kotlin/src/ffi.rs
+++ b/bindings-ir-kotlin/src/ffi.rs
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use bindings_ir::{ir::Type, Renderer};
+use heck::ToUpperCamelCase;
+use tera::{to_value, try_get_value, Result, Value};
+
+pub fn setup_renderer(renderer: &mut Renderer) -> Result<()> {
+    // These are needed to deal with Kotlin's half-support of unsigned integers, which it inherited
+    // from Java.  Kotlin supports unsigned ints at the language level, but many APIs don't
+    // including JNA and ByteBuffer.
+    //
+    // To work around this, we use signed integers for those APIs then convert to unsigned integers
+    // when we actually want to use the values and vice-versa when sending values to those APIs.
+    // Note that this conversion just changes the type, no bits are altered.
+    renderer
+        .tera_mut()
+        .register_filter("to_ffi_converter", |value: &'_ Value, _: &_| {
+            let type_ = try_get_value!("to_ffi_converter", "value", Type, value);
+            Ok(match type_ {
+                Type::UInt8 => Value::String("toByte".into()),
+                Type::UInt16 => Value::String("toShort".into()),
+                Type::UInt32 => Value::String("toInt".into()),
+                Type::UInt64 => Value::String("toLong".into()),
+                _ => Value::Null,
+            })
+        });
+    renderer
+        .tera_mut()
+        .register_filter("from_ffi_converter", |value: &'_ Value, _: &_| {
+            let type_ = try_get_value!("from_ffi_converter", "value", Type, value);
+            Ok(match type_ {
+                Type::UInt8 => Value::String("toUByte".into()),
+                Type::UInt16 => Value::String("toUShort".into()),
+                Type::UInt32 => Value::String("toUInt".into()),
+                Type::UInt64 => Value::String("toULong".into()),
+                _ => Value::Null,
+            })
+        });
+    renderer
+        .tera_mut()
+        .register_filter("ffi_type", |value: &'_ Value, _: &_| {
+            let type_ = try_get_value!("ffi_type", "value", Type, value);
+            Ok(match type_ {
+                Type::UInt8 => Value::String("Byte".into()),
+                Type::UInt16 => Value::String("Short".into()),
+                Type::UInt32 => Value::String("Int".into()),
+                Type::UInt64 => Value::String("Long".into()),
+                Type::Reference { inner, .. } => match *inner {
+                    Type::CStruct { .. } => Value::String("com.sun.jna.Pointer".into()),
+                    Type::Pointer { .. } => Value::String("com.sun.jna.Pointer".into()),
+                    _ => panic!("References to {inner:?} are not supported"),
+                },
+                // Other values can be rendered as normal using the Type template by returning the
+                // value.
+                _ => value.clone(),
+            })
+        });
+    renderer
+        .tera_mut()
+        .register_tester("struct_reference", |value: Option<&'_ Value>, _: &_| {
+            let value = match value {
+                Some(v) => v,
+                None => return Ok(false)
+            };
+            let type_ = try_get_value!("ffi_type", "value", Type, value);
+            Ok(matches!(type_, Type::Reference { inner, .. } if matches!(*inner, Type::CStruct { .. })))
+        });
+    // Default value to use for FFI Types in CStructs.  These must have a default because JNA
+    // requires a no-arg constructor.
+    renderer
+        .tera_mut()
+        .register_filter("ffi_default", |value: &'_ Value, _: &_| {
+            let type_ = try_get_value!("ffi_type", "value", Type, value);
+            Ok(match type_ {
+                Type::Int8 | Type::Int16 | Type::Int32 | Type::Int64 => to_value("0"),
+                Type::UInt8 => to_value("0.toUByte()"),
+                Type::UInt16 => to_value("0.toUShort()"),
+                Type::UInt32 => to_value("0.toUInt()"),
+                Type::UInt64 => to_value("0.toULong()"),
+                Type::Float32 => to_value("0.0.toFloat()"),
+                Type::Float64 => to_value("0.0"),
+                Type::Pointer { .. } => to_value("com.sun.jna.Pointer.NULL"),
+                Type::CStruct { name } => to_value(format!("{}()", name.to_upper_camel_case())),
+                Type::Nullable { .. } => to_value("null"),
+                _ => panic!("{type_:?} not supported as a CStruct field"),
+            }?)
+        });
+    renderer.add_ast_templates([
+        ("PointerSize", "com.sun.jna.Native.POINTER_SIZE"),
+        ("CStructDef", include_str!("templates/CStructDef.kt")),
+        ("CStructCreate", "{{ name }}({{ values|comma_join }})"),
+        (
+            "FFICall",
+            "BindgenRendererFFILib.{{ name|to_lower_camel_case }}({{ values|comma_join }})",
+        ),
+        ("Destructure", "val ({{ vars|comma_join }}) = {{ cstruct }}"),
+    ])
+}

--- a/bindings-ir-kotlin/src/lib.rs
+++ b/bindings-ir-kotlin/src/lib.rs
@@ -1,0 +1,152 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::collections::HashSet;
+use tera::Result;
+
+mod buffer;
+mod class;
+mod collections;
+mod ffi;
+#[cfg(test)]
+mod tests;
+mod types;
+
+use bindings_ir::{ir::*, Renderer, TeraArgs};
+use heck::ToUpperCamelCase;
+use tera::{to_value, try_get_value, Value};
+
+pub fn render_module(module: Module) -> Result<String> {
+    render_module_with_mode(module, RenderMode::Normal)
+}
+
+pub fn render_test_script(module: Module) -> Result<String> {
+    render_module_with_mode(module, RenderMode::TestScript)
+}
+
+pub fn render_module_with_mode(module: Module, mode: RenderMode) -> Result<String> {
+    let mut renderer = Renderer::new();
+    renderer.add_ast_templates([
+        ("Module", include_str!("templates/Module.kt")),
+        ("NativeLibrary", include_str!("templates/NativeLibrary.kt")),
+        ("FunctionDef", include_str!("templates/FunctionDef.kt")),
+        ("Block", include_str!("templates/Block.kt")),
+        // Statements
+        ("ExpressionStatement", "{{ expr }}"),
+        ("Return", "return{% if value %} {{ value }}{% endif %}"),
+        ("Val", "val {{ name }}: {{ type }} = {{ initial }}"),
+        ("Var", "var {{ name }}: {{ type }} = {{ initial }}"),
+        ("Assign", "{{ name }} = {{ value }}"),
+        ("Set", "{{ container }}.{{ field }} = {{ value }}"),
+        ("Assert", "assert({{ value }})"),
+        ("AssertRaises", include_str!("templates/AssertRaises.kt")),
+        (
+            "AssertRaisesWithString",
+            include_str!("templates/AssertRaisesWithString.kt"),
+        ),
+        ("Gc", include_str!("templates/Gc.kt")),
+        ("If", include_str!("templates/If.kt")),
+        ("For", include_str!("templates/For.kt")),
+        ("Loop", include_str!("templates/Loop.kt")),
+        ("Break", "break"),
+        ("MatchEnum", include_str!("templates/MatchEnum.kt")),
+        ("MatchInt", include_str!("templates/MatchInt.kt")),
+        ("MatchNullable", include_str!("templates/MatchNullable.kt")),
+        // Expressions
+        ("Ident", "{{ name }}"),
+        ("Get", "{{ container }}.{{ field }}"),
+        ("This", "this"),
+        ("Call", "{{ name }}({{ values|comma_join }})"),
+        ("IsInstance", "({{ value }} is {{ class }})"),
+        ("Eq", "({{ first }} == {{ second }})"),
+        ("Gt", "({{ first }} > {{ second }})"),
+        ("Ge", "({{ first }} >= {{ second }})"),
+        ("Lt", "({{ first }} < {{ second }})"),
+        ("Le", "({{ first }} <= {{ second }})"),
+        ("Add", "({{ first }} + {{ second }}).{{ type|cast_int_fn }}()"),
+        ("Sub", "({{ first }} - {{ second }}).{{ type|cast_int_fn }}()"),
+        ("Mul", "({{ first }} * {{ second }}).{{ type|cast_int_fn }}()"),
+        ("Div", "({{ first }} / {{ second }}).{{ type|cast_int_fn }}()"),
+        ("And", "({{ first }} && {{ second }})"),
+        ("Or", "({{ first }} || {{ second }})"),
+        ("Not", "(!{{ value }})"),
+        ("StrMinByteLen", "({{ string }}.length * 3)"),
+        ("StrConcat", include_str!("templates/StrConcat.kt")),
+        ("Raise", "throw {{ exception }}"),
+        (
+            "RaiseInternalException",
+            "throw InternalException({{ message }})",
+        ),
+        // Kotlin doesn't differentiate between nullable values vs non-nullable
+        ("Some", "{{ inner }}"),
+        (
+            "Unwrap",
+            "({{ nullable }} ?: throw RuntimeException({{ message }}))",
+        ),
+        // Kotlin always uses references, so nothing is needed for the Ref expression
+        ("Ref", "{{ name }}"),
+        ("Argument", "{{ name }}: {{ type }}"),
+        (
+            "Field",
+            "{% if mutable %}var{% else %}val{% endif %} {{ name }}: {{ type }}",
+        ),
+        // Names
+        ("ClassName", "{{ name|to_class_name }}"),
+        ("CStructName", "{{ name|to_upper_camel_case }}"),
+        ("ArgName", "{{ name|to_lower_camel_case }}"),
+        ("FieldName", "{{ name|to_lower_camel_case }}"),
+        ("FunctionName", "{{ name|to_lower_camel_case }}"),
+        ("VarName", "{{ name|to_lower_camel_case }}"),
+    ])?;
+    match mode {
+        RenderMode::Normal => {
+            renderer.add_ast_templates([("Private", "internal"), ("Public", "public")])?;
+        }
+        RenderMode::TestScript => {
+            // Ignore visibility modifiers when rendering test scripts.  They won't have any effect
+            // and it's invalid to set a visibility modifier for a function in a test script, since
+            // they're technically local functions.
+            renderer.add_ast_templates([("Private", ""), ("Public", "")])?;
+        }
+    }
+    let exception_names: HashSet<String> = module
+        .iter_definitions()
+        .filter_map(|def| match def {
+            Definition::Exception(ExceptionDef { name, .. }) => Some(name.to_string()),
+            Definition::ExceptionBase(ExceptionBaseDef { name, .. }) => Some(name.to_string()),
+            _ => None,
+        })
+        .collect();
+
+    renderer
+        .tera_mut()
+        .register_filter("to_class_name", move |value: &Value, _: &'_ TeraArgs| {
+            let mut name = try_get_value!("to_exception_name", "value", String, value);
+            name = name.to_upper_camel_case();
+            if exception_names.contains(&name) {
+                // Replace "Error" at the end of the name with "Exception".  Rust code typically uses
+                // "Error" for any type of error but in the Java world, "Error" means a non-recoverable error
+                // and is distinguished from an "Exception".
+                name = match name.strip_suffix("Error") {
+                    None => name,
+                    Some(stripped) => format!("{}Exception", stripped),
+                };
+            };
+            Ok(to_value(&name).unwrap())
+        });
+
+    buffer::setup_renderer(&mut renderer)?;
+    class::setup_renderer(&mut renderer)?;
+    collections::setup_renderer(&mut renderer)?;
+    ffi::setup_renderer(&mut renderer)?;
+    types::setup_renderer(&mut renderer)?;
+
+    renderer.render_module(module)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum RenderMode {
+    Normal,
+    TestScript,
+}

--- a/bindings-ir-kotlin/src/templates/AssertRaises.kt
+++ b/bindings-ir-kotlin/src/templates/AssertRaises.kt
@@ -1,0 +1,6 @@
+try {
+    {{ stmt }}
+    throw AssertionError("{{ name }} not thrown")
+} catch (e: {{ name }} ) {
+    // pass
+}

--- a/bindings-ir-kotlin/src/templates/AssertRaisesWithString.kt
+++ b/bindings-ir-kotlin/src/templates/AssertRaisesWithString.kt
@@ -1,0 +1,6 @@
+try {
+    {{ stmt }}
+    throw AssertionError("exception not thrown")
+} catch (e: Throwable) {
+    assert(e.message == {{ string_value }})
+}

--- a/bindings-ir-kotlin/src/templates/Block.kt
+++ b/bindings-ir-kotlin/src/templates/Block.kt
@@ -1,0 +1,3 @@
+{%- for stmt in statements -%}
+{{ stmt }}
+{% endfor -%}

--- a/bindings-ir-kotlin/src/templates/BufferStreamDef.kt
+++ b/bindings-ir-kotlin/src/templates/BufferStreamDef.kt
@@ -1,0 +1,12 @@
+class {{ name }} (internal val ptr: com.sun.jna.Pointer, internal val size: Int) {
+    internal val byteBuf = ptr.getByteBuffer(0, size.toLong()).also { it.order(java.nio.ByteOrder.BIG_ENDIAN) }
+    fun readString(size: Int): String {
+        val byteArr = ByteArray(size)
+        byteBuf.get(byteArr)
+        return byteArr.toString(Charsets.UTF_8)
+    }
+
+    fun writeString(value: String) {
+        byteBuf.put(value.toByteArray(Charsets.UTF_8))
+    }
+}

--- a/bindings-ir-kotlin/src/templates/CStructDef.kt
+++ b/bindings-ir-kotlin/src/templates/CStructDef.kt
@@ -1,0 +1,11 @@
+@com.sun.jna.Structure.FieldOrder({% for field in fields %}"{{ field.name }}"{% if not loop.last %}, {% endif %}{% endfor %})
+open class {{ name }} (
+    {# Note: jna.Structure requires that all fields are `var` #}
+    {%- for field in fields %}
+    @JvmField var {{ field.name }}: {{ field.type }} = {{ field.type|ffi_default }},
+    {%- endfor %}
+) : com.sun.jna.Structure(), com.sun.jna.Structure.ByValue { }
+
+{%- for field in fields %}
+operator fun {{ name }}.component{{ loop.index }}() = this.{{ field.name }}
+{%- endfor %}

--- a/bindings-ir-kotlin/src/templates/ClassCreate.kt
+++ b/bindings-ir-kotlin/src/templates/ClassCreate.kt
@@ -1,0 +1,6 @@
+{%- set class = get_class(name=name) -%}
+{%- if class.destructor -%}
+{{ name }}({{ values|comma_join }}).also { objectCleaner.register(it, {{ name }}.Cleaner({% for f in class.fields %}it.{{ f.name }}, {% endfor %}it.shouldRunDestructor)) }
+{%- else %}
+{{ name }}({{ values|comma_join }})
+{%- endif %}

--- a/bindings-ir-kotlin/src/templates/ClassDef.kt
+++ b/bindings-ir-kotlin/src/templates/ClassDef.kt
@@ -1,0 +1,56 @@
+{{ vis }} class {{ name }} internal constructor({{ fields|comma_join }}) {
+    {%- if constructor %}
+    {{ constructor.vis }} constructor({{ constructor.args|comma_join }}): this({{ constructor.initializers|comma_join }})
+    {%- endif %}
+
+    {%- for method in methods %}
+    {%- if method.method_type.ir_type != "Static" %}
+    {{ method.vis }} fun {{ method.name }}(
+        {%- for arg in method.args %}
+        {{ arg }},
+        {%- endfor %}
+    ){%- if method.return_type %}: {{ method.return_type }}{%- endif %} {
+        {{ method.body }}
+    }
+    {%- endif %}
+    {%- endfor %}
+
+    {%- if destructor %}
+    val shouldRunDestructor = java.util.concurrent.atomic.AtomicBoolean(true)
+    class Cleaner (
+        {%- for field in fields %}
+        {{ field }},
+        {%- endfor %}
+        val shouldRunDestructor: java.util.concurrent.atomic.AtomicBoolean
+    ) : Runnable {
+        override fun run() {
+            if (shouldRunDestructor.get()) {
+                {{ destructor.body }}
+            }
+        }
+    }
+    {%- endif %}
+
+    {%- if into_rust %}
+    fun intoRust(): {{ into_rust.return_type }} {
+        {%- if destructor %}
+        shouldRunDestructor.set(false)
+        {%- endif %}
+        {{ into_rust.body }}
+    }
+    {%- endif %}
+
+    companion object {
+        {%- for method in methods %}
+        {%- if method.method_type.ir_type == "Static" %}
+        {{ method.vis }} fun {{ method.name }}(
+            {%- for arg in method.args %}
+            {{ arg }},
+            {%- endfor %}
+        ){%- if method.return_type %}: {{ method.return_type }}{%- endif %} {
+            {{ method.body }}
+        }
+        {%- endif %}
+        {%- endfor %}
+    }
+}

--- a/bindings-ir-kotlin/src/templates/DataClassDef.kt
+++ b/bindings-ir-kotlin/src/templates/DataClassDef.kt
@@ -1,0 +1,1 @@
+{{ vis }} data class {{ name }} ({{ fields|comma_join }})

--- a/bindings-ir-kotlin/src/templates/EnumCreate.kt
+++ b/bindings-ir-kotlin/src/templates/EnumCreate.kt
@@ -1,0 +1,2 @@
+{%- set enum = get_enum(name=name) -%}
+{{ name }}.{{ variant }}{%- if enum|has_fields%}({{ values|comma_join }}){%- endif %}

--- a/bindings-ir-kotlin/src/templates/EnumDef.kt
+++ b/bindings-ir-kotlin/src/templates/EnumDef.kt
@@ -1,0 +1,14 @@
+{%- if self|has_fields %}
+// Kotlin's version of an enum with fields is set of sealed classses
+{{ vis }} sealed interface {{ name }} {
+    {%- for variant in variants %}
+    data class {{ variant.name }}({{ variant.fields|comma_join }}): {{ name }}
+    {%- endfor %}
+}
+{%- else %}
+{{ vis }} enum class {{ name }} {
+    {%- for variant in variants %}
+    {{ variant.name }},
+    {%- endfor %}
+}
+{%- endif %}

--- a/bindings-ir-kotlin/src/templates/ExceptionBaseDef.kt
+++ b/bindings-ir-kotlin/src/templates/ExceptionBaseDef.kt
@@ -1,0 +1,1 @@
+open class {{ name }}(): {% if parent %}{{ parent }}{% else %}Throwable{% endif %}()

--- a/bindings-ir-kotlin/src/templates/ExceptionDef.kt
+++ b/bindings-ir-kotlin/src/templates/ExceptionDef.kt
@@ -1,0 +1,8 @@
+class {{ name }}({{ fields|comma_join}}): {{ parent }}() {
+    {%- if as_string %}
+    override val message: String
+        get() {
+            {{ as_string.body }}
+        }
+    {%- endif %}
+}

--- a/bindings-ir-kotlin/src/templates/For.kt
+++ b/bindings-ir-kotlin/src/templates/For.kt
@@ -1,0 +1,3 @@
+for ({{ var }} in IntRange({{start}}, {{end}} - 1)) {
+    {{ block }}
+}

--- a/bindings-ir-kotlin/src/templates/FunctionDef.kt
+++ b/bindings-ir-kotlin/src/templates/FunctionDef.kt
@@ -1,0 +1,3 @@
+{{ vis }} fun {{ name }}({{ args|comma_join }}){% if return_type %} : {{ return_type }}{%- endif %} {
+    {{ body }}
+}

--- a/bindings-ir-kotlin/src/templates/Gc.kt
+++ b/bindings-ir-kotlin/src/templates/Gc.kt
@@ -1,0 +1,11 @@
+// It's not possible to force Kotlin to GC, but hopefully this should work in well enough to make our test suites pass
+System.gc()
+System.runFinalization()
+Thread.sleep(1000)
+System.gc()
+System.runFinalization()
+Thread.sleep(1000)
+System.gc()
+System.runFinalization()
+Thread.sleep(1000)
+

--- a/bindings-ir-kotlin/src/templates/If.kt
+++ b/bindings-ir-kotlin/src/templates/If.kt
@@ -1,0 +1,7 @@
+if ({{ expr }}) {
+    {{ then }}
+}
+{%- if else %} else {
+    {{ else }}
+}
+{%- endif %}

--- a/bindings-ir-kotlin/src/templates/ListIterate.kt
+++ b/bindings-ir-kotlin/src/templates/ListIterate.kt
@@ -1,0 +1,3 @@
+for ({{ var }} in {{ list }}) {
+    {{ block }}
+}

--- a/bindings-ir-kotlin/src/templates/Loop.kt
+++ b/bindings-ir-kotlin/src/templates/Loop.kt
@@ -1,0 +1,3 @@
+while (true) {
+    {{ block }}
+}

--- a/bindings-ir-kotlin/src/templates/MapIterate.kt
+++ b/bindings-ir-kotlin/src/templates/MapIterate.kt
@@ -1,0 +1,6 @@
+{%- set tmp_var = temp_var_name() -%}
+for ({{ tmp_var }} in {{ map }}.entries.iterator()) {
+    val {{ key_var }} = {{ tmp_var }}.key;
+    val {{ val_var }} = {{ tmp_var }}.value;
+    {{ block }}
+}

--- a/bindings-ir-kotlin/src/templates/MatchEnum.kt
+++ b/bindings-ir-kotlin/src/templates/MatchEnum.kt
@@ -1,0 +1,25 @@
+{%- set enum = get_enum(name=name) -%}
+when ({{ value }}) {
+    {%- for arm in arms %}
+    {%- if arm.ir_type == "Variant" %}
+    {%- set variant_def = enum|variant(name=arm.variant) -%}
+    {%- if enum|has_fields %}
+    is {{ name }}.{{ arm.variant }} -> {
+        // Bind variables for the match
+        {%- for item in zip(field=variant_def.fields, var=arm.vars) %}
+        val {{ item.var }} = {{ value }}.{{ item.field.name }}
+        {%- endfor %}
+        {{ arm.block }}
+    }
+    {%- else %}
+    {{ name }}.{{ arm.variant }} -> {
+        {{ arm.block }}
+    }
+    {%- endif %}
+    {%- elif arm.ir_type == "Default" %}
+    else -> {
+        {{ arm.block }}
+    }
+    {%- endif %}
+    {%- endfor %}
+}

--- a/bindings-ir-kotlin/src/templates/MatchInt.kt
+++ b/bindings-ir-kotlin/src/templates/MatchInt.kt
@@ -1,0 +1,13 @@
+when ({{ value }}) {
+    {%- for arm in arms %}
+    {%- if arm.ir_type == "Value" %}
+    {{ arm.value }} -> {
+        {{ arm.block }}
+    }
+    {%- elif arm.ir_type == "Default" %}
+    else -> {
+        {{ arm.block }}
+    }
+    {%- endif %}
+    {%- endfor %}
+}

--- a/bindings-ir-kotlin/src/templates/MatchNullable.kt
+++ b/bindings-ir-kotlin/src/templates/MatchNullable.kt
@@ -1,0 +1,8 @@
+{%- set tmp_var = temp_var_name() -%}
+val {{ tmp_var }} = {{ value }}
+if ({{ tmp_var }} == null) {
+    {{ null_arm.block }}
+} else {
+    val {{ some_arm.var }} = {{ tmp_var }}
+    {{ some_arm.block }}
+}

--- a/bindings-ir-kotlin/src/templates/Module.kt
+++ b/bindings-ir-kotlin/src/templates/Module.kt
@@ -1,0 +1,21 @@
+private val objectCleaner = java.lang.ref.Cleaner.create()
+public class InternalException(message: String) : RuntimeException(message)
+{%- if native_library %}
+{{ native_library }}
+{%- endif %}
+
+{%- for name, definition in definitions %}
+{{ definition }}
+{%- endfor %}
+
+{%- if tests %}
+// Define tests
+{%- for test in tests %}
+{{ test }}
+{%- endfor %}
+
+// Run tests
+{%- for test in tests %}
+{{ test.name }}()
+{%- endfor %}
+{%- endif %}

--- a/bindings-ir-kotlin/src/templates/NativeLibrary.kt
+++ b/bindings-ir-kotlin/src/templates/NativeLibrary.kt
@@ -1,0 +1,50 @@
+internal interface BindgenRendererFFILib : com.sun.jna.Library {
+    {%- for name, func in functions %}
+    fun {{ name }}({% for arg in func.args %}{{ arg.name }}: {{ arg.type|ffi_type }}{% if not loop.last %}, {% endif %}{% endfor %}){% if func.return_type %}: {{ func.return_type|ffi_type }}{% endif %}
+    {%- endfor %}
+
+    companion object {
+        internal val ffiLib: BindgenRendererFFILib by lazy {
+            com.sun.jna.Native.load("{{ name }}", BindgenRendererFFILib::class.java)
+        }
+
+        {%- for name, func in functions %}
+        fun {{ name|to_lower_camel_case }}({{ func.args|comma_join }}){% if func.return_type %}: {{ func.return_type }}{% endif %} {
+            {%- set return_var = temp_var_name() %}
+            {%- for arg in func.args %}
+            {%- if arg.type is struct_reference %}
+            {{ arg.name }}.write()
+            {%- endif %}
+            {%- endfor %}
+
+            val {{ return_var }} = this.ffiLib.{{ name }}(
+                {%- for arg in func.args %}
+                {%- set converter = arg.type|to_ffi_converter %}
+                {%- if converter %}
+                {{ arg.name }}.{{ converter }}(),
+                {%- elif arg.type is struct_reference %}
+                {{ arg.name }}.getPointer(),
+                {%- else %}
+                {{ arg.name }},
+                {%- endif %}
+                {%- endfor %}
+            )
+
+            {%- for arg in func.args %}
+            {%- if arg.type is struct_reference and arg.type.mutable %}
+            {{ arg.name }}.read()
+            {%- endif %}
+            {%- endfor %}
+
+            {%- if func.return_type %}
+            {%- set converter = func.return_type|from_ffi_converter %}
+            {%- if converter %}
+            return {{ return_var }}.{{ converter }}()
+            {%- else %}
+            return {{ return_var }}
+            {%- endif %}
+            {%- endif %}
+        }
+        {%- endfor %}
+    }
+}

--- a/bindings-ir-kotlin/src/templates/StrConcat.kt
+++ b/bindings-ir-kotlin/src/templates/StrConcat.kt
@@ -1,0 +1,1 @@
+StringBuilder(){% for v in values %}.append({{ v }}){% endfor %}.toString()

--- a/bindings-ir-kotlin/src/tests.rs
+++ b/bindings-ir-kotlin/src/tests.rs
@@ -1,0 +1,134 @@
+use super::render_test_script;
+use bindings_ir::ir::Module;
+use camino::Utf8Path;
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::process::Command;
+use tera::Result;
+
+pub fn render_test_suite(module: Module, path: &Utf8Path) -> Result<()> {
+    let source = render_test_script(module)?;
+    Ok(write!(File::create(path)?, "{}", source)?)
+}
+
+pub fn run_test_suite(test_dir: &Utf8Path, script_file: &Utf8Path) {
+    let mut cmd = Command::new("kotlinc");
+    // Start with the system classpath, we need that to find JNA
+    // Add the test dir so that JNA can load the library
+    cmd.arg("-classpath").arg(format!(
+        "{}:{test_dir}",
+        env::var_os("CLASSPATH")
+            .unwrap_or_default()
+            .into_string()
+            .expect("Error reading CLASSPATH env")
+    ));
+    // Enable runtime assertions, for easy testing etc.
+    cmd.arg("-J-ea");
+    // Supress warnings from the generated code
+    cmd.arg("-nowarn");
+    cmd.arg("-script").arg(script_file);
+    let status = cmd
+        .spawn()
+        .expect("Failed to spawn `kotlinc` to run Kotlin script")
+        .wait()
+        .expect("Failed to wait for `kotlinc` when running Kotlin script");
+    if !status.success() {
+        panic!("running `kotlinc` failed")
+    }
+}
+
+fn run_test(test_dir: &Utf8Path, suite: Module) {
+    let script_path = test_dir.join("test_script.kts");
+    println!("Running {script_path}");
+    render_test_suite(suite, &script_path).unwrap();
+    run_test_suite(test_dir, &script_path);
+}
+
+#[test]
+fn kotlin_basic() {
+    run_test(
+        &bindings_ir_tests::setup_test_dir("kotlin-basic"),
+        bindings_ir_tests::basic_tests(),
+    );
+}
+
+#[test]
+fn kotlin_math() {
+    run_test(
+        &bindings_ir_tests::setup_test_dir("kotlin-math"),
+        bindings_ir_tests::math_tests(),
+    );
+}
+
+#[test]
+fn kotlin_ffi_calls() {
+    run_test(
+        &bindings_ir_tests::setup_test_dir("kotlin-ffi-calls"),
+        bindings_ir_tests::ffi_tests(),
+    );
+}
+
+#[test]
+fn kotlin_compounds() {
+    run_test(
+        &bindings_ir_tests::setup_test_dir("kotlin-compounds"),
+        bindings_ir_tests::compound_tests(),
+    );
+}
+
+#[test]
+fn kotlin_pointers() {
+    run_test(
+        &bindings_ir_tests::setup_test_dir("kotlin-pointers"),
+        bindings_ir_tests::pointer_tests(),
+    );
+}
+
+#[test]
+fn kotlin_cstructs() {
+    run_test(
+        &bindings_ir_tests::setup_test_dir("kotlin-cstructs"),
+        bindings_ir_tests::cstructs_tests(),
+    );
+}
+
+#[test]
+fn kotlin_strings() {
+    run_test(
+        &bindings_ir_tests::setup_test_dir("kotlin-strings"),
+        bindings_ir_tests::string_tests(),
+    );
+}
+
+#[test]
+fn kotlin_classes() {
+    run_test(
+        &bindings_ir_tests::setup_test_dir("kotlin-classes"),
+        bindings_ir_tests::class_tests(),
+    );
+}
+
+#[test]
+fn kotlin_enums() {
+    run_test(
+        &bindings_ir_tests::setup_test_dir("kotlin-enums"),
+        bindings_ir_tests::enum_tests(),
+    );
+}
+
+#[test]
+fn kotlin_exceptions() {
+    run_test(
+        &bindings_ir_tests::setup_test_dir("kotlin-exceptions"),
+        bindings_ir_tests::exception_tests(),
+    );
+}
+
+#[test]
+fn kotlin_control_flow() {
+    run_test(
+        &bindings_ir_tests::setup_test_dir("kotlin-control-flow"),
+        bindings_ir_tests::control_flow_tests(),
+    );
+}

--- a/bindings-ir-kotlin/src/types.rs
+++ b/bindings-ir-kotlin/src/types.rs
@@ -1,0 +1,71 @@
+use bindings_ir::{Renderer, ir::Type};
+use tera::{try_get_value, Result, Value};
+
+pub fn setup_renderer(renderer: &mut Renderer) -> Result<()> {
+    renderer
+        .tera_mut()
+        .register_filter("quote_string", |value: &'_ Value, _: &_| {
+            let value = try_get_value!("quote_string", "value", String, value);
+            // quote all '$' chars
+            Ok(Value::String(format!("\"{}\"", value.replace('$', "\\$"))))
+        });
+    renderer.tera_mut()
+        .register_filter("cast_int_fn", |value: &'_ Value, _: &_| {
+            let value = try_get_value!("cast_int", "type", Type, value);
+            Ok(match value {
+                Type::Int8 => "toByte",
+                Type::Int16 => "toShort",
+                Type::Int32 => "toInt",
+                Type::Int64 => "toLong",
+                Type::UInt8 => "toUByte",
+                Type::UInt16 => "toUShort",
+                Type::UInt32 => "toUInt",
+                Type::UInt64 => "toULong",
+                _ => unimplemented!(),
+            }.into())
+        });
+    renderer.add_ast_templates([
+        ("String", "String"),
+        ("Boolean", "Boolean"),
+        ("Object", "{{ class }}"),
+        ("Reference", "{{ inner }}"),
+        ("List", "MutableList<{{ inner }}>"),
+        ("Map", "MutableMap<{{ key }}, {{ value }}>"),
+        ("Nullable", "{{ inner }}?"),
+        ("UInt8", "UByte"),
+        ("Int8", "Byte"),
+        ("UInt16", "UShort"),
+        ("Int16", "Short"),
+        ("UInt32", "UInt"),
+        ("Int32", "Int"),
+        ("UInt64", "ULong"),
+        ("Int64", "Long"),
+        ("Float32", "Float"),
+        ("Float64", "Double"),
+        ("Pointer", "com.sun.jna.Pointer"),
+        ("CStruct", "{{ name }}"),
+        ("LiteralBoolean", "{{ value }}"),
+        ("LiteralString", "{{ value|quote_string }}"),
+        ("LiteralNull", "null"),
+        ("LiteralInt", "{{ value }}"),
+        ("LiteralInt8", "({{ value }}).toByte()"),
+        ("LiteralInt16", "({{ value }}).toShort()"),
+        ("LiteralInt32", "{{ value }}"),
+        ("LiteralInt64", "{{ value }}L"),
+        ("LiteralUInt8", "({{ value }}).toUByte()"),
+        ("LiteralUInt16", "({{ value }}).toUShort()"),
+        // Need to use L suffix for U32 literals to ensure enough width
+        ("LiteralUInt32", "({{ value }}L).toUInt()"),
+        ("LiteralUInt64", "({{ value }}L).toULong()"),
+        ("LiteralFloat32", "({{ value }}).toFloat()"),
+        ("LiteralFloat64", "({{ value }}).toDouble()"),
+        ("CastInt8", "({{ value }}).toByte()"),
+        ("CastInt16", "({{ value }}).toShort()"),
+        ("CastInt32", "{{ value }}.toInt()"),
+        ("CastInt64", "{{ value }}.toLong()"),
+        ("CastUInt8", "({{ value }}).toUByte()"),
+        ("CastUInt16", "({{ value }}).toUShort()"),
+        ("CastUInt32", "({{ value }}).toUInt()"),
+        ("CastUInt64", "({{ value }}).toULong()"),
+    ])
+}

--- a/bindings-ir-tests/Cargo.toml
+++ b/bindings-ir-tests/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bindings-ir-tests"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[dependencies]
+bindings-ir = { path="../bindings-ir" }
+bytes = "1"
+camino = "1.0.8"
+cargo_metadata = "0.14"
+lazy_static = "1.4"
+once_cell = "1.12"

--- a/bindings-ir-tests/src/basic.rs
+++ b/bindings-ir-tests/src/basic.rs
@@ -1,0 +1,43 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::test_module;
+use bindings_ir::ir::*;
+
+pub fn basic_tests() -> Module {
+    let mut module = test_module();
+
+    module.add_function(FunctionDef {
+        vis: public(),
+        name: "get_bool".into(),
+        throws: None,
+        args: vec![],
+        return_type: boolean().into(),
+        body: block([
+            val("foo", boolean(), lit::boolean(true)),
+            return_(ident("foo")),
+        ]),
+    });
+
+    module.add_function(FunctionDef {
+        vis: private(),
+        name: "invert".into(),
+        throws: None,
+        args: vec![arg("input", boolean())],
+        return_type: boolean().into(),
+        body: block([return_(not(ident("input")))]),
+    });
+
+    module.add_test(
+        "test_function_calls",
+        [
+            assert(call("get_bool", [])),
+            assert(not(call("invert", [call("get_bool", [])]))),
+        ],
+    );
+
+    module
+}

--- a/bindings-ir-tests/src/classes.rs
+++ b/bindings-ir-tests/src/classes.rs
@@ -1,0 +1,250 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::test_module;
+use bindings_ir::ir::*;
+
+pub fn class_tests() -> Module {
+    let mut module = test_module();
+
+    module.add_class(ClassDef {
+        vis: private(),
+        name: "Adder".into(),
+        fields: vec![field("ptr", pointer("Adder"))],
+        constructor: Constructor {
+            vis: public(),
+            args: vec![arg("amount", int32())],
+            initializers: vec![ffi_call("adder_create", [ident("amount")])],
+        }
+        .into(),
+        methods: vec![
+            Method {
+                vis: public(),
+                method_type: MethodType::Normal,
+                throws: None,
+                name: "add".into(),
+                args: vec![arg("x", int32())],
+                return_type: int32().into(),
+                body: block([return_(ffi_call(
+                    "adder_add",
+                    [get(this(), "ptr"), ident("x")],
+                ))]),
+            },
+            Method {
+                vis: public(),
+                method_type: MethodType::Static,
+                throws: None,
+                name: "static_add".into(),
+                args: vec![arg("x", int32()), arg("y", int32())],
+                return_type: int32().into(),
+                body: block([return_(add(int32(), ident("x"), ident("y")))]),
+            },
+        ],
+        destructor: Destructor {
+            body: block([ffi_call("adder_destroy", [ident("ptr")]).into_statement()]),
+        }
+        .into(),
+        into_rust: IntoRustMethod {
+            return_type: pointer("Adder"),
+            body: block([return_(ident("ptr"))]),
+        }
+        .into(),
+    });
+
+    module.add_test(
+        "test_adder",
+        [
+            val(
+                "adder",
+                object("Adder"),
+                create_class("Adder", [lit::int32(5)]),
+            ),
+            assert_eq(
+                method_call(ident("adder"), "add", [lit::int32(5)]),
+                lit::int32(10),
+            ),
+            assert_eq(
+                method_call(ident("adder"), "add", [lit::int32(10)]),
+                lit::int32(15),
+            ),
+            assert_eq(
+                static_method_call("Adder", "static_add", [lit::int32(2), lit::int32(3)]),
+                lit::int32(5),
+            ),
+        ],
+    );
+
+    // Test using a reference to an object
+    module.add_function(FunctionDef {
+        vis: private(),
+        name: "use_adder".into(),
+        throws: None,
+        args: vec![arg("adder", reference(object("Adder")))],
+        return_type: int32().into(),
+        body: block([return_(method_call(ident("adder"), "add", [lit::int32(1)]))]),
+    });
+    module.add_test(
+        "test_adder_ref",
+        [
+            val(
+                "adder",
+                object("Adder"),
+                create_class("Adder", [lit::int32(1)]),
+            ),
+            assert_eq(call("use_adder", [ref_("adder")]), lit::int32(2)),
+        ],
+    );
+
+    // Create an adder, then drop the reference so that we can test destructors
+    module.add_function(FunctionDef {
+        vis: private(),
+        name: "create_adder_then_quit".into(),
+        throws: None,
+        args: vec![],
+        return_type: None,
+        body: block([create_class("Adder", [lit::int32(5)]).into_statement()]),
+    });
+
+    // Create an adder, then drop the reference so that we can test destructors
+    module.add_function(FunctionDef {
+        vis: private(),
+        name: "create_adder_consume_then_quit".into(),
+        throws: None,
+        args: vec![],
+        return_type: None,
+        body: block([ffi_call(
+            "adder_consume",
+            [into_rust(create_class("Adder", [lit::int32(5)]))],
+        )
+        .into_statement()]),
+    });
+
+    module.add_test(
+        "test_adder_destructor",
+        [
+            gc(),
+            ffi_call("adder_reset_free_count", []).into_statement(),
+            call("create_adder_then_quit", []).into_statement(),
+            gc(),
+            assert_eq(ffi_call("adder_get_free_count", []), lit::uint32(1)),
+        ],
+    );
+
+    module.add_test(
+        "test_adder_consume",
+        [
+            gc(),
+            ffi_call("adder_reset_free_count", []).into_statement(),
+            call("create_adder_consume_then_quit", []).into_statement(),
+            gc(),
+            assert_eq(ffi_call("adder_get_free_count", []), lit::uint32(0)),
+        ],
+    );
+
+    // Data class tests
+    module.add_data_class(DataClassDef {
+        vis: public(),
+        name: "TestDataClass".into(),
+        fields: vec![field("adder", object("Adder")), mut_field("value", int32())],
+    });
+
+    module.add_test(
+        "test_data_class",
+        [
+            val(
+                "test_data_class",
+                object("TestDataClass"),
+                create_data_class(
+                    "TestDataClass",
+                    [create_class("Adder", [lit::int32(5)]), lit::int32(10)],
+                ),
+            ),
+            assert_eq(
+                method_call(
+                    ident("test_data_class.adder"),
+                    "add",
+                    [ident("test_data_class.value")],
+                ),
+                lit::int32(15),
+            ),
+        ],
+    );
+
+    module.add_function(FunctionDef {
+        vis: private(),
+        name: "create_test_data_class_then_quit".into(),
+        throws: None,
+        args: vec![],
+        return_type: None,
+        body: block([create_class("Adder", [lit::int32(5)]).into_statement()]),
+    });
+
+    module.add_test(
+        "test_data_class_member_destructor",
+        [
+            gc(),
+            ffi_call("adder_reset_free_count", []).into_statement(),
+            call("create_test_data_class_then_quit", []).into_statement(),
+            gc(),
+            assert_eq(ffi_call("adder_get_free_count", []), lit::uint32(1)),
+        ],
+    );
+
+    // Data class tests
+    module.add_class(ClassDef {
+        vis: private(),
+        name: "MutableClass".into(),
+        fields: vec![mut_field("value", int32())],
+        constructor: Constructor {
+            vis: public(),
+            args: vec![],
+            initializers: vec![lit::int32(0)],
+        }
+        .into(),
+        methods: vec![Method {
+            vis: private(),
+            method_type: MethodType::Mutable,
+            throws: None,
+            name: "inc_value".into(),
+            args: vec![],
+            return_type: None,
+            body: block([set(this(), "value", add(int32(), lit::int32(1), get(this(), "value")))]),
+        }],
+        ..ClassDef::default()
+    });
+
+    // Test using a reference to an object
+    module.add_function(FunctionDef {
+        vis: private(),
+        name: "inc_value".into(),
+        throws: None,
+        args: vec![arg("mut_obj", reference_mut(object("MutableClass")))],
+        return_type: None,
+        body: block([set(
+            ident("mut_obj"),
+            "value",
+            add(int32(), lit::int32(1), ident("mut_obj.value")),
+        )]),
+    });
+
+    module.add_test(
+        "test_mutate_fields",
+        [
+            mut_val(
+                "mut_obj",
+                object("MutableClass"),
+                create_class("MutableClass", []),
+            ),
+            assert_eq(ident("mut_obj.value"), lit::int32(0)),
+            method_call(ident("mut_obj"), "inc_value", []).into_statement(),
+            assert_eq(ident("mut_obj.value"), lit::int32(1)),
+            call("inc_value", [ref_mut("mut_obj")]).into_statement(),
+            assert_eq(ident("mut_obj.value"), lit::int32(2)),
+        ],
+    );
+
+    module
+}

--- a/bindings-ir-tests/src/compounds.rs
+++ b/bindings-ir-tests/src/compounds.rs
@@ -1,0 +1,157 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::test_module;
+use bindings_ir::ir::*;
+
+pub fn compound_tests() -> Module {
+    let mut module = test_module();
+
+    module.add_test(
+        "test_nulls",
+        [
+            val("maybe_int", nullable(int32()), some(lit::int32(1))),
+            val("maybe_int2", nullable(int32()), lit::null()),
+            match_nullable(
+                ident("maybe_int"),
+                arm::some("x", [assert_eq(ident("x"), lit::int32(1))]),
+                arm::null([assert(lit::boolean(false))]),
+            ),
+            match_nullable(
+                ident("maybe_int2"),
+                arm::some("x", [assert(lit::boolean(false))]),
+                arm::null([]),
+            ),
+            assert_eq(
+                unwrap(ident("maybe_int"), lit::string("unwrap failed")),
+                lit::int32(1),
+            ),
+            assert_raises_with_string(
+                lit::string("unwrap failed"),
+                unwrap(ident("maybe_int2"), lit::string("unwrap failed")).into_statement(),
+            ),
+        ],
+    );
+
+    module.add_test(
+        "test_list_operations",
+        [
+            mut_val("l", list(int32()), list::create(int32())),
+            assert_eq(list::len("l"), lit::int32(0)),
+            list::push("l", lit::int32(1)),
+            list::push("l", lit::int32(2)),
+            list::push("l", lit::int32(3)),
+            assert_eq(list::len("l"), lit::int32(3)),
+            assert_eq(list::get("l", lit::int32(0)), lit::int32(1)),
+            list::set("l", lit::int32(0), lit::int32(4)),
+            assert_eq(list::get("l", lit::int32(0)), lit::int32(4)),
+            assert_eq(list::pop("l"), lit::int32(3)),
+            assert_eq(list::pop("l"), lit::int32(2)),
+            assert_eq(list::pop("l"), lit::int32(4)),
+            assert_eq(list::len("l"), lit::int32(0)),
+        ],
+    );
+
+    module.add_test(
+        "test_list_equality",
+        [
+            mut_val("l1", list(int32()), list::create(int32())),
+            mut_val("l2", list(int32()), list::create(int32())),
+            assert_eq(ident("l1"), ident("l2")),
+            list::push("l1", lit::int32(1)),
+            assert_ne(ident("l1"), ident("l2")),
+            list::push("l2", lit::int32(1)),
+            assert_eq(ident("l1"), ident("l2")),
+            list::empty("l2"),
+            assert_ne(ident("l1"), ident("l2")),
+            list::push("l2", lit::int32(2)),
+            assert_ne(ident("l1"), ident("l2")),
+        ],
+    );
+
+    module.add_test(
+        "test_list_iteration",
+        [
+            mut_val("l", list(int32()), list::create(int32())),
+            var("sum", int32(), lit::int32(0)),
+            list::push("l", lit::int32(1)),
+            list::push("l", lit::int32(2)),
+            list::push("l", lit::int32(3)),
+            list::iterate("l", "i", [add_assign(int32(), "sum", ident("i"))]),
+            assert_eq(ident("sum"), lit::int32(6)),
+        ],
+    );
+
+    module.add_test(
+        "test_map_operations",
+        [
+            mut_val("m", map(int32(), string()), map::create(int32(), string())),
+            assert_eq(map::len("m"), lit::int32(0)),
+            map::set("m", lit::int32(1), lit::string("apple")),
+            map::set("m", lit::int32(2), lit::string("banana")),
+            map::set("m", lit::int32(3), lit::string("pear")),
+            assert_eq(map::len("m"), lit::int32(3)),
+            assert_eq(map::get("m", lit::int32(1)), lit::string("apple")),
+            map::set("m", lit::int32(1), lit::string("strawberry")),
+            assert_eq(map::get("m", lit::int32(1)), lit::string("strawberry")),
+            map::remove("m", lit::int32(1)),
+            assert_eq(map::len("m"), lit::int32(2)),
+            map::empty("m"),
+            assert_eq(map::len("m"), lit::int32(0)),
+        ],
+    );
+
+    module.add_test(
+        "test_map_equality",
+        [
+            mut_val("m1", map(int32(), string()), map::create(int32(), string())),
+            mut_val("m2", map(int32(), string()), map::create(int32(), string())),
+            assert_eq(ident("m1"), ident("m2")),
+            map::set("m1", lit::int32(1), lit::string("apple")),
+            assert_ne(ident("m1"), ident("m2")),
+            map::set("m2", lit::int32(1), lit::string("apple")),
+            assert_eq(ident("m1"), ident("m2")),
+            map::set("m2", lit::int32(1), lit::string("banana")),
+            assert_ne(ident("m1"), ident("m2")),
+            map::empty("m1"),
+            assert_ne(ident("m1"), ident("m2")),
+            map::remove("m2", lit::int32(1)),
+            assert_eq(ident("m1"), ident("m2")),
+        ],
+    );
+
+    module.add_test(
+        "test_map_iteration",
+        [
+            mut_val("m", map(int32(), string()), map::create(int32(), string())),
+            var("count", int32(), lit::int32(0)),
+            map::set("m", lit::int32(1), lit::string("apple")),
+            map::set("m", lit::int32(2), lit::string("banana")),
+            map::set("m", lit::int32(3), lit::string("strawberry")),
+            map::iterate(
+                "m",
+                "k",
+                "v",
+                [
+                    match_int(
+                        int32(),
+                        ident("k"),
+                        [
+                            arm::int(1, [assert_eq(ident("v"), lit::string("apple"))]),
+                            arm::int(2, [assert_eq(ident("v"), lit::string("banana"))]),
+                            arm::int(3, [assert_eq(ident("v"), lit::string("strawberry"))]),
+                            arm::int_default([assert(lit::boolean(false))]),
+                        ],
+                    ),
+                    add_assign(int32(), "count", lit::int32(1)),
+                ],
+            ),
+            assert_eq(ident("count"), lit::int32(3)),
+        ],
+    );
+
+    module
+}

--- a/bindings-ir-tests/src/control_flow.rs
+++ b/bindings-ir-tests/src/control_flow.rs
@@ -1,0 +1,83 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::test_module;
+use bindings_ir::ir::*;
+
+pub fn control_flow_tests() -> Module {
+    let mut module = test_module();
+
+    module.add_function(FunctionDef {
+        vis: private(),
+        name: "if_checker".into(),
+        throws: None,
+        args: vec![arg("x", boolean()), arg("y", boolean())],
+        return_type: string().into(),
+        body: block([
+            if_(ident("x"), [return_(lit::string("x is true"))]),
+            if_else(
+                ident("y"),
+                [return_(lit::string("y is true"))],
+                [return_(lit::string("neither is true"))],
+            ),
+        ]),
+    });
+
+    module.add_test(
+        "test_if",
+        [
+            assert_eq(
+                lit::string("x is true"),
+                call("if_checker", [lit::boolean(true), lit::boolean(false)]),
+            ),
+            assert_eq(
+                lit::string("y is true"),
+                call("if_checker", [lit::boolean(false), lit::boolean(true)]),
+            ),
+            assert_eq(
+                lit::string("neither is true"),
+                call("if_checker", [lit::boolean(false), lit::boolean(false)]),
+            ),
+        ],
+    );
+
+    module.add_test(
+        "test_for",
+        [
+            mut_val("l", list(int32()), list::create(int32())),
+            for_(
+                "x",
+                lit::int32(0),
+                lit::int32(3),
+                [list::push("l", mul(int32(), ident("x"), ident("x")))],
+            ),
+            assert_eq(list::len("l"), lit::int32(3)),
+            assert_eq(list::get("l", lit::int32(0)), lit::int32(0)),
+            assert_eq(list::get("l", lit::int32(1)), lit::int32(1)),
+            assert_eq(list::get("l", lit::int32(2)), lit::int32(4)),
+        ],
+    );
+
+    module.add_test(
+        "test_loop_and_break",
+        [
+            mut_val("l", list(int32()), list::create(int32())),
+            var("i", int32(), lit::int32(0)),
+            loop_([
+                list::push("l", ident("i")),
+                if_(gt(ident("i"), lit::int32(2)), [break_()]),
+                add_assign(int32(), "i", lit::int32(1)),
+            ]),
+            assert_eq(list::len("l"), lit::int32(4)),
+            assert_eq(list::get("l", lit::int32(0)), lit::int32(0)),
+            assert_eq(list::get("l", lit::int32(1)), lit::int32(1)),
+            assert_eq(list::get("l", lit::int32(2)), lit::int32(2)),
+            assert_eq(list::get("l", lit::int32(3)), lit::int32(3)),
+        ],
+    );
+
+    module
+}

--- a/bindings-ir-tests/src/cstructs.rs
+++ b/bindings-ir-tests/src/cstructs.rs
@@ -1,0 +1,100 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::test_module;
+use bindings_ir::ir::*;
+
+pub fn cstructs_tests() -> Module {
+    let mut module = test_module();
+
+    module.add_test(
+        "test_structs",
+        [
+            mut_val(
+                "n",
+                cstruct("Numbers"),
+                ffi_call("make_numbers", [lit::int32(2), lit::int32(3)]),
+            ),
+            assert_eq(ident("n.a"), lit::int32(2)),
+            assert_eq(ident("n.b"), lit::int32(3)),
+            val(
+                "n2",
+                cstruct("Numbers"),
+                create_cstruct("Numbers", [lit::int32(2), lit::int32(3)]),
+            ),
+            assert_eq(ident("n.a"), lit::int32(2)),
+            assert_eq(ident("n.b"), lit::int32(3)),
+            assert_eq(ffi_call("add_numbers", [ident("n")]), lit::int32(5)),
+            assert_eq(ffi_call("add_numbers", [ident("n2")]), lit::int32(5)),
+            set(ident("n"), "a", lit::int32(30)),
+            assert_eq(ffi_call("add_numbers", [ident("n")]), lit::int32(33)),
+            destructure("Numbers", ident("n"), ["a", "b"]),
+            assert_eq(ident("a"), lit::int32(30)),
+            assert_eq(ident("b"), lit::int32(3)),
+        ],
+    );
+
+    module.add_test(
+        "test_cstruct_field_types",
+        [
+            var(
+                "x",
+                cstruct("CStructWithAllTypes"),
+                create_cstruct(
+                    "CStructWithAllTypes",
+                    [
+                        lit::int8(-1),
+                        lit::uint8(1),
+                        lit::int16(-2),
+                        lit::uint16(2),
+                        lit::int32(-3),
+                        lit::uint32(3),
+                        lit::int64(-4),
+                        lit::uint64(4),
+                        lit::float32("1.0"),
+                        lit::float64("-3.0"),
+                        create_cstruct("Numbers", [lit::int(0), lit::int(1)]),
+                        ffi_call("get_read_buffer_ptr", []),
+                    ],
+                ),
+            ),
+            set(ident("x"), "i8", lit::int8(0)),
+            set(ident("x"), "u8", lit::uint8(0)),
+            set(ident("x"), "i16", lit::int16(0)),
+            set(ident("x"), "u16", lit::uint16(0)),
+            set(ident("x"), "i32", lit::int32(0)),
+            set(ident("x"), "u32", lit::uint32(0)),
+            set(ident("x"), "i64", lit::int64(0)),
+            set(ident("x"), "u64", lit::uint64(0)),
+            set(ident("x"), "f32", lit::float32("0.5")),
+            set(ident("x"), "f64", lit::float64("-1.2")),
+            set(
+                ident("x"),
+                "numbers",
+                create_cstruct("Numbers", [lit::int(2), lit::int(3)]),
+            ),
+            set(ident("x"), "pointer", ffi_call("get_write_buffer_ptr", [])),
+            set(ident("x"), "nullable_pointer", lit::null()),
+        ],
+    );
+
+    module.add_test(
+        "test_struct_refs",
+        [
+            mut_val(
+                "n",
+                cstruct("Numbers"),
+                create_cstruct("Numbers", [lit::int32(2), lit::int32(3)]),
+            ),
+            assert_eq(ffi_call("add_numbers_ref", [ref_("n")]), lit::int32(5)),
+            ffi_call("double_each_number", [ref_mut("n")]).into_statement(),
+            assert_eq(ident("n.a"), lit::int32(4)),
+            assert_eq(ident("n.b"), lit::int32(6)),
+        ],
+    );
+
+    module
+}

--- a/bindings-ir-tests/src/enums.rs
+++ b/bindings-ir-tests/src/enums.rs
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::test_module;
+use bindings_ir::ir::*;
+
+pub fn enum_tests() -> Module {
+    let mut module = test_module();
+
+    module.add_enum(EnumDef {
+        vis: private(),
+        name: "EnumWithoutFields".into(),
+        variants: vec![
+            Variant {
+                name: "A".into(),
+                fields: vec![],
+            },
+            Variant {
+                name: "B".into(),
+                fields: vec![],
+            },
+        ],
+    });
+    module.add_enum(EnumDef {
+        vis: public(),
+        name: "EnumWithFields".into(),
+        variants: vec![
+            Variant {
+                name: "A".into(),
+                fields: vec![field("x", int32()), field("y", int32())],
+            },
+            Variant {
+                name: "B".into(),
+                fields: vec![field("str", string())],
+            },
+        ],
+    });
+
+    module.add_test(
+        "test_fieldless",
+        [
+            var("match_arm", string(), lit::string("none")),
+            val(
+                "test_enum",
+                object("EnumWithoutFields"),
+                create_enum("EnumWithoutFields", "A", []),
+            ),
+            match_enum(
+                ident("test_enum"),
+                "EnumWithoutFields",
+                [
+                    arm::variant("A", [], [assign("match_arm", lit::string("a"))]),
+                    arm::variant("B", [], [assign("match_arm", lit::string("b"))]),
+                ],
+            ),
+            assert_eq(ident("match_arm"), lit::string("a")),
+        ],
+    );
+    module.add_test(
+        "test_int_fields",
+        [
+            var("match_arm", string(), lit::string("none")),
+            val(
+                "test_enum",
+                object("EnumWithFields"),
+                create_enum("EnumWithFields", "A", [lit::int(1), lit::int(2)]),
+            ),
+            match_enum(
+                ident("test_enum"),
+                "EnumWithFields",
+                [
+                    arm::variant(
+                        "A",
+                        [String::from("x"), String::from("y")],
+                        [
+                            assign("match_arm", lit::string("a")),
+                            assert_eq(ident("x"), lit::int(1)),
+                            assert_eq(ident("y"), lit::int(2)),
+                        ],
+                    ),
+                    arm::variant(
+                        "B",
+                        [String::from("str")],
+                        [assign("match_arm", lit::string("b"))],
+                    ),
+                ],
+            ),
+            assert_eq(ident("match_arm"), lit::string("a")),
+        ],
+    );
+    module.add_test(
+        "test_string_fields",
+        [
+            var("match_arm", string(), lit::string("none")),
+            val(
+                "test_enum",
+                object("EnumWithFields"),
+                create_enum("EnumWithFields", "B", [lit::string("something")]),
+            ),
+            match_enum(
+                ident("test_enum"),
+                "EnumWithFields",
+                [
+                    arm::variant(
+                        "A",
+                        [String::from("x"), String::from("y")],
+                        [assign("match_arm", lit::string("a"))],
+                    ),
+                    arm::variant(
+                        "B",
+                        [String::from("str")],
+                        [
+                            assign("match_arm", lit::string("b")),
+                            assert_eq(ident("str"), lit::string("something")),
+                        ],
+                    ),
+                ],
+            ),
+            assert_eq(ident("match_arm"), lit::string("b")),
+        ],
+    );
+    module.add_test(
+        "test_default",
+        [
+            var("match_arm", string(), lit::string("none")),
+            val(
+                "test_enum",
+                object("EnumWithFields"),
+                create_enum("EnumWithFields", "A", [lit::int(1), lit::int(2)]),
+            ),
+            match_enum(
+                ident("test_enum"),
+                "EnumWithFields",
+                [
+                    arm::variant("B", [String::from("x"), String::from("y")], []),
+                    arm::variant_default([assign("match_arm", lit::string("default_matched"))]),
+                ],
+            ),
+            assert_eq(ident("match_arm"), lit::string("default_matched")),
+        ],
+    );
+
+    module
+}

--- a/bindings-ir-tests/src/exceptions.rs
+++ b/bindings-ir-tests/src/exceptions.rs
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::test_module;
+use bindings_ir::ir::*;
+
+pub fn exception_tests() -> Module {
+    let mut module = test_module();
+
+    module.add_exception_base(exception_base_def("ExceptionBase"));
+    module.add_exception_base(exception_base_def_child("ExceptionBase", "ExceptionMiddle"));
+    module.add_exception(ExceptionDef {
+        name: "TestException".into(),
+        parent: "ExceptionMiddle".into(),
+        ..ExceptionDef::default()
+    });
+    module.add_exception(ExceptionDef {
+        name: "ExceptionWithFields".into(),
+        parent: "ExceptionMiddle".into(),
+        fields: vec![field("x", int32())],
+        ..ExceptionDef::default()
+    });
+    module.add_exception(ExceptionDef {
+        name: "ExceptionWithAsString".into(),
+        parent: "ExceptionMiddle".into(),
+        fields: vec![field("reason", string())],
+        as_string: AsStringMethod {
+            body: block([return_(string::concat([
+                lit::string("error: "),
+                ident("reason"),
+            ]))]),
+        }
+        .into(),
+    });
+
+    module.add_function(FunctionDef {
+        vis: private(),
+        name: "throw_test_exception".into(),
+        throws: Some("ExceptionBase".into()),
+        args: vec![],
+        return_type: None,
+        body: block([raise(create_exception("TestException", []))]),
+    });
+
+    module.add_test(
+        "test_exceptions",
+        [
+            assert_raises(
+                "TestException",
+                call("throw_test_exception", []).into_statement(),
+            ),
+            assert_raises(
+                "ExceptionMiddle",
+                call("throw_test_exception", []).into_statement(),
+            ),
+            assert_raises(
+                "ExceptionBase",
+                call("throw_test_exception", []).into_statement(),
+            ),
+            assert_raises(
+                "ExceptionWithFields",
+                raise(create_exception("ExceptionWithFields", [lit::int(2)])),
+            ),
+            assert_raises_with_string(
+                lit::string("error: bad value"),
+                raise(create_exception(
+                    "ExceptionWithAsString",
+                    [lit::string("bad value")],
+                )),
+            ),
+        ],
+    );
+
+    module.add_test(
+        "test_runtime_exceptions",
+        [assert_raises_with_string(
+            lit::string("something failed"),
+            raise_internal_exception(string::concat([
+                lit::string("something "),
+                lit::string("failed"),
+            ])),
+        )],
+    );
+
+    module.add_function(FunctionDef {
+        name: "check_is_instance".into(),
+        vis: private(),
+        args: vec![arg("exc", object("ExceptionBase"))],
+        return_type: boolean().into(),
+        throws: None,
+        body: block([return_(is_instance(ident("exc"), "TestException"))]),
+    });
+
+    module.add_test(
+        "test_is_instance",
+        [
+            assert(call(
+                "check_is_instance",
+                [create_exception("TestException", [])],
+            )),
+            assert(not(call(
+                "check_is_instance",
+                [create_exception("ExceptionWithFields", [lit::int(2)])],
+            ))),
+        ],
+    );
+
+    module
+}

--- a/bindings-ir-tests/src/ffi.rs
+++ b/bindings-ir-tests/src/ffi.rs
@@ -1,0 +1,54 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::test_module;
+use bindings_ir::ir::*;
+
+pub fn ffi_tests() -> Module {
+    let mut module = test_module();
+
+    module.add_test(
+        "test_call_roundtrip_functions",
+        [
+            ("roundtrip_u8", lit::uint8(1)),
+            ("roundtrip_i8", lit::int8(-1)),
+            ("roundtrip_u16", lit::uint16(2)),
+            ("roundtrip_i16", lit::int16(-2)),
+            ("roundtrip_u32", lit::uint32(4)),
+            ("roundtrip_i32", lit::int32(-4)),
+            ("roundtrip_u64", lit::uint64(8)),
+            ("roundtrip_i64", lit::int64(-8)),
+            ("roundtrip_f32", lit::float32("0.5")),
+            ("roundtrip_f64", lit::float64("0.5")),
+        ]
+        .into_iter()
+        .map(|(ffi_func, literal)| assert_eq(ffi_call(ffi_func, [literal.clone()]), literal)),
+    );
+
+    module.add_test(
+        "test_cast",
+        [
+            assert_eq(cast::uint8(lit::int(1)), lit::uint8(1)),
+            assert_eq(cast::int8(lit::int(-1)), lit::int8(-1)),
+            assert_eq(cast::uint16(lit::int(2)), lit::uint16(2)),
+            assert_eq(cast::int16(lit::int(-2)), lit::int16(-2)),
+            assert_eq(cast::uint32(lit::int(4)), lit::uint32(4)),
+            assert_eq(cast::int32(lit::int(-4)), lit::int32(-4)),
+            assert_eq(cast::uint64(lit::int(8)), lit::uint64(8)),
+            assert_eq(cast::int64(lit::int(-8)), lit::int64(-8)),
+        ],
+    );
+
+    module.add_test(
+        "test_pointer_size",
+        [assert_eq(
+            pointer_size(),
+            lit::int(std::mem::size_of::<*const u8>() as i32),
+        )],
+    );
+
+    module
+}

--- a/bindings-ir-tests/src/lib.rs
+++ b/bindings-ir-tests/src/lib.rs
@@ -1,0 +1,34 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+mod basic;
+mod classes;
+mod compounds;
+mod control_flow;
+mod cstructs;
+mod enums;
+mod exceptions;
+mod ffi;
+mod math;
+mod pointers;
+mod strings;
+mod testdir;
+mod testlib;
+
+pub use basic::basic_tests;
+pub use classes::class_tests;
+pub use compounds::compound_tests;
+pub use control_flow::control_flow_tests;
+pub use cstructs::cstructs_tests;
+pub use enums::enum_tests;
+pub use exceptions::exception_tests;
+pub use ffi::ffi_tests;
+pub use math::math_tests;
+pub use pointers::pointer_tests;
+pub use strings::string_tests;
+pub use testdir::setup_test_dir;
+
+use testlib::test_module;

--- a/bindings-ir-tests/src/math.rs
+++ b/bindings-ir-tests/src/math.rs
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::test_module;
+use bindings_ir::ir::*;
+
+
+pub fn math_tests() -> Module {
+    let mut module = test_module();
+
+    module.add_test(
+        "test_integer_math",
+        [
+            assert_eq(add(int8(), lit::int8(1), lit::int8(1)), lit::int8(2)),
+            assert_eq(sub(uint64(), lit::uint64(3), lit::uint64(2)), lit::uint64(1)),
+            assert_eq(mul(int32(), lit::int32(2), lit::int32(-2)), lit::int32(-4)),
+            assert_eq(div(uint16(), lit::uint16(4), lit::uint16(2)), lit::uint16(2)),
+            assert_eq(
+                mul(int64(), add(int64(), lit::int64(1), lit::int64(1)), sub(int64(), lit::int64(4), lit::int64(2))),
+                lit::int64(4),
+            ),
+        ],
+    );
+
+    module.add_test(
+        "test_integer_comparisions",
+        [
+            assert(gt(lit::int8(3), lit::int8(2))),
+            assert(ge(lit::uint16(3), lit::uint16(3))),
+            assert(lt(lit::int32(2), lit::int32(3))),
+            assert(le(lit::uint32(2), lit::uint32(2))),
+            assert_eq(lit::int64(1), lit::int64(1)),
+        ],
+    );
+
+    module.add_test(
+        "test_integer_matching",
+        [
+            var("arm", string(), lit::string("")),
+            match_int(
+                int32(),
+                lit::int32(2),
+                [
+                    arm::int(1, [assign("arm", lit::string("one"))]),
+                    arm::int(2, [assign("arm", lit::string("two"))]),
+                    arm::int_default([assign("arm", lit::string("default"))]),
+                ],
+            ),
+            assert_eq(ident("arm"), lit::string("two")),
+            match_int(
+                uint8(),
+                lit::int32(4),
+                [
+                    arm::int(1, [assign("arm", lit::string("one"))]),
+                    arm::int(2, [assign("arm", lit::string("two"))]),
+                    arm::int_default([assign("arm", lit::string("default"))]),
+                ],
+            ),
+            assert_eq(ident("arm"), lit::string("default")),
+        ],
+    );
+
+    module.add_test(
+        "test_boolean_logic",
+        [
+            assert(lit::boolean(true)),
+            assert(not(lit::boolean(false))),
+            assert(and(lit::boolean(true), lit::boolean(true))),
+            assert(not(and(lit::boolean(true), lit::boolean(false)))),
+            assert(or(lit::boolean(true), lit::boolean(false))),
+            assert(not(or(lit::boolean(false), lit::boolean(false)))),
+        ],
+    );
+
+    module
+}

--- a/bindings-ir-tests/src/pointers.rs
+++ b/bindings-ir-tests/src/pointers.rs
@@ -1,0 +1,172 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::test_module;
+use bindings_ir::ir::*;
+
+pub fn pointer_tests() -> Module {
+    let mut module = test_module();
+
+    module.add_test(
+        "test_pointer_args_and_returns",
+        [
+            val(
+                "ptr",
+                pointer("BufPtr"),
+                ffi_call("get_read_buffer_ptr", []),
+            ),
+            assert_eq(
+                ffi_call("is_read_buffer_ptr", [ident("ptr")]),
+                lit::uint8(1),
+            ),
+        ],
+    );
+
+    module.add_test(
+        "test_buffer_read",
+        [
+            val(
+                "read_ptr",
+                pointer("BufPtr"),
+                ffi_call("get_read_buffer_ptr", []),
+            ),
+            mut_val(
+                "read_buf",
+                object("BufStream"),
+                buf::create(
+                    "BufStream",
+                    ident("read_ptr"),
+                    ffi_call("get_read_buffer_size", []),
+                ),
+            ),
+            assert_eq(
+                buf::size(ident("read_buf")),
+                ffi_call("get_read_buffer_size", []),
+            ),
+            assert_eq(buf::read_uint8(ident("read_buf")), lit::uint8(1)),
+            assert_eq(buf::pos(ident("read_buf")), lit::int(1)),
+            assert_eq(buf::read_int8(ident("read_buf")), lit::int8(-1)),
+            assert_eq(buf::pos(ident("read_buf")), lit::int(2)),
+            assert_eq(buf::read_uint16(ident("read_buf")), lit::uint16(2)),
+            assert_eq(buf::pos(ident("read_buf")), lit::int(4)),
+            assert_eq(buf::read_int16(ident("read_buf")), lit::int16(-2)),
+            assert_eq(buf::pos(ident("read_buf")), lit::int(6)),
+            assert_eq(buf::read_uint32(ident("read_buf")), lit::uint32(4)),
+            assert_eq(buf::pos(ident("read_buf")), lit::int(10)),
+            assert_eq(buf::read_int32(ident("read_buf")), lit::int32(-4)),
+            assert_eq(buf::pos(ident("read_buf")), lit::int(14)),
+            assert_eq(buf::read_uint64(ident("read_buf")), lit::uint64(8)),
+            assert_eq(buf::pos(ident("read_buf")), lit::int(22)),
+            assert_eq(buf::read_int64(ident("read_buf")), lit::int64(-8)),
+            assert_eq(buf::pos(ident("read_buf")), lit::int(30)),
+            assert_eq(buf::read_float32(ident("read_buf")), lit::float32("1.5")),
+            assert_eq(buf::pos(ident("read_buf")), lit::int(34)),
+            assert_eq(buf::read_float64(ident("read_buf")), lit::float64("-0.5")),
+            assert_eq(buf::pos(ident("read_buf")), lit::int(42)),
+            assert_eq(
+                buf::read_pointer("BufPtr", ident("read_buf")),
+                ident("read_ptr"),
+            ),
+            assert_eq(buf::pos(ident("read_buf")), lit::int(50)),
+            assert_eq(
+                buf::into_ptr("BufPtr", ident("read_buf")),
+                ffi_call("get_read_buffer_ptr", []),
+            ),
+            buf::set_pos(ident("read_buf"), lit::int(2)),
+            assert_eq(buf::read_uint16(ident("read_buf")), lit::uint16(2)),
+        ],
+    );
+
+    module.add_test(
+        "test_buffer_write",
+        [
+            mut_val(
+                "write_buf",
+                object("BufStream"),
+                buf::create(
+                    "BufStream",
+                    ffi_call("get_write_buffer_ptr", []),
+                    ffi_call("get_write_buffer_size", []),
+                ),
+            ),
+            buf::write_uint8(ident("write_buf"), lit::uint8(1)),
+            assert_eq(buf::pos(ident("write_buf")), lit::int(1)),
+            buf::write_int8(ident("write_buf"), lit::int8(-1)),
+            assert_eq(buf::pos(ident("write_buf")), lit::int(2)),
+            buf::write_uint16(ident("write_buf"), lit::uint16(2)),
+            assert_eq(buf::pos(ident("write_buf")), lit::int(4)),
+            buf::write_int16(ident("write_buf"), lit::int16(-2)),
+            assert_eq(buf::pos(ident("write_buf")), lit::int(6)),
+            buf::write_uint32(ident("write_buf"), lit::uint32(4)),
+            assert_eq(buf::pos(ident("write_buf")), lit::int(10)),
+            buf::write_int32(ident("write_buf"), lit::int32(-4)),
+            assert_eq(buf::pos(ident("write_buf")), lit::int(14)),
+            buf::write_uint64(ident("write_buf"), lit::uint64(8)),
+            assert_eq(buf::pos(ident("write_buf")), lit::int(22)),
+            buf::write_int64(ident("write_buf"), lit::int64(-8)),
+            assert_eq(buf::pos(ident("write_buf")), lit::int(30)),
+            buf::write_float32(ident("write_buf"), lit::float32("1.5")),
+            assert_eq(buf::pos(ident("write_buf")), lit::int(34)),
+            buf::write_float64(ident("write_buf"), lit::float64("-0.5")),
+            assert_eq(buf::pos(ident("write_buf")), lit::int(42)),
+            buf::write_pointer(
+                "BufPtr",
+                ident("write_buf"),
+                ffi_call("get_read_buffer_ptr", []),
+            ),
+            assert_eq(buf::pos(ident("write_buf")), lit::int(50)),
+            assert_eq(
+                ffi_call("write_buffer_matches_read_buffer", []),
+                lit::uint8(1),
+            ),
+        ],
+    );
+
+    module.add_test(
+        "test_buffer_read_string",
+        [
+            val("size", int32(), ffi_call("get_string_buffer_size", [])),
+            mut_val(
+                "string_buf",
+                object("BufStream"),
+                buf::create(
+                    "BufStream",
+                    ffi_call("get_string_buffer_ptr", []),
+                    ident("size"),
+                ),
+            ),
+            assert_eq(
+                buf::read_string(ident("string_buf"), ident("size")),
+                lit::string("🦊test-string🦊"),
+            ),
+            assert_eq(buf::pos(ident("string_buf")), ident("size")),
+        ],
+    );
+
+    module.add_test(
+        "test_buffer_write_string",
+        [
+            mut_val(
+                "write_string_buf",
+                object("BufStream"),
+                buf::create(
+                    "BufStream",
+                    ffi_call("get_write_buffer_ptr", []),
+                    ffi_call("get_write_buffer_size", []),
+                ),
+            ),
+            buf::write_string(ident("write_string_buf"), lit::string("🦊test-string🦊")),
+            assert_eq(
+                ffi_call("write_buffer_matches_string_buffer", []),
+                lit::uint8(1),
+            ),
+            assert_eq(
+                buf::pos(ident("write_string_buf")),
+                ffi_call("get_string_buffer_size", []),
+            ),
+        ],
+    );
+
+    module
+}

--- a/bindings-ir-tests/src/strings.rs
+++ b/bindings-ir-tests/src/strings.rs
@@ -1,0 +1,38 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::test_module;
+use bindings_ir::ir::*;
+
+pub fn string_tests() -> Module {
+    let mut module = test_module();
+
+    module.add_test(
+        "test_strings",
+        [
+            assert_eq(lit::string("aa"), lit::string("aa")),
+            assert_ne(lit::string("aa"), lit::string("ab")),
+            assert_eq(
+                string::concat([
+                    lit::string("My values are: ["),
+                    lit::int(1),
+                    lit::string(", "),
+                    lit::int32(2),
+                    lit::string(", "),
+                    lit::uint8(3),
+                    lit::string("]"),
+                ]),
+                lit::string("My values are: [1, 2, 3]"),
+            ),
+            assert(ge(
+                string::min_byte_len(lit::string("🦊🦊")),
+                lit::int("🦊🦊".len() as i32),
+            )),
+        ],
+    );
+
+    module
+}

--- a/bindings-ir-tests/src/testdir.rs
+++ b/bindings-ir-tests/src/testdir.rs
@@ -1,0 +1,82 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use camino::Utf8PathBuf;
+use std::env::consts::DLL_EXTENSION;
+use std::fs;
+use std::process::{Command, Stdio};
+
+// Cache the path to bindings_ir_tests.so to avoid running `cargo build` multiple times.
+lazy_static::lazy_static! {
+    static ref TARGET_DIRECTORY: Utf8PathBuf = calc_target_dir();
+    static ref TEST_SO_PATH: Utf8PathBuf = calc_test_so_path();
+}
+
+// Create at test directory
+//
+// This sets up a new directory inside the testing tempdir, with `bindings_ir_tests.so`
+// file inside it.  Bindings renderer tests can then create test scripts, modules, jar files, etc.
+// inside this directory, compile everything together, and run the tests.
+//
+// target_tempdir should be a copy of env!("CARGO_TARGET_TMPDIR").
+// name is the name of a subdirectory to create
+pub fn setup_test_dir(name: &str) -> Utf8PathBuf {
+    let dir = TARGET_DIRECTORY.join("bindings-ir-tests").join(name);
+    if dir.exists() {
+        // Clean out any files from previous runs
+        fs::remove_dir_all(&dir).unwrap();
+    }
+    fs::create_dir_all(&dir).unwrap();
+    fs::copy(
+        TEST_SO_PATH.as_path(),
+        dir.join(TEST_SO_PATH.file_name().unwrap()),
+    )
+    .unwrap();
+    dir
+}
+
+fn calc_target_dir() -> Utf8PathBuf {
+    cargo_metadata::MetadataCommand::new()
+        .exec()
+        .expect("Error running cargo metadata")
+        .target_directory
+}
+
+fn calc_test_so_path() -> Utf8PathBuf {
+    let mut command = Command::new(env!("CARGO"))
+        .arg("build")
+        .arg("--tests")
+        .arg("--message-format=json")
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Error running cargo build");
+    let reader = std::io::BufReader::new(command.stdout.take().unwrap());
+    let artifact = cargo_metadata::Message::parse_stream(reader)
+        .map(|m| m.expect("Error parsing cargo build messages"))
+        .find_map(|message| match message {
+            cargo_metadata::Message::CompilerArtifact(artifact) => {
+                if artifact.target.name == "bindings-ir-tests" {
+                    Some(artifact)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        })
+        .expect("Error finding libbindings_ir_tests.so");
+    command.wait().unwrap();
+
+    let cdylib_files: Vec<_> = artifact
+        .filenames
+        .iter()
+        .filter(|nm| matches!(nm.extension(), Some(DLL_EXTENSION)))
+        .collect();
+
+    match cdylib_files.len() {
+        1 => cdylib_files[0].to_owned(),
+        n => panic!("Found {n} cdylib files for bindings-ir-tests"),
+    }
+}

--- a/bindings-ir-tests/src/testlib.rs
+++ b/bindings-ir-tests/src/testlib.rs
@@ -1,0 +1,377 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/// C functions to test against
+use bindings_ir::ir::*;
+use bytes::BufMut;
+use once_cell::sync::OnceCell;
+use std::ffi::c_void;
+
+// Simple functions that input/output numbers
+#[no_mangle]
+pub extern "C" fn roundtrip_i8(value: i8) -> i8 {
+    value
+}
+
+#[no_mangle]
+pub extern "C" fn roundtrip_i16(value: i16) -> i16 {
+    value
+}
+
+#[no_mangle]
+pub extern "C" fn roundtrip_i32(value: i32) -> i32 {
+    value
+}
+
+#[no_mangle]
+pub extern "C" fn roundtrip_i64(value: i64) -> i64 {
+    value
+}
+
+#[no_mangle]
+pub extern "C" fn roundtrip_u8(value: u8) -> u8 {
+    value
+}
+
+#[no_mangle]
+pub extern "C" fn roundtrip_u16(value: u16) -> u16 {
+    value
+}
+
+#[no_mangle]
+pub extern "C" fn roundtrip_u32(value: u32) -> u32 {
+    value
+}
+
+#[no_mangle]
+pub extern "C" fn roundtrip_u64(value: u64) -> u64 {
+    value
+}
+
+#[no_mangle]
+pub extern "C" fn roundtrip_f32(value: f32) -> f32 {
+    value
+}
+
+#[no_mangle]
+pub extern "C" fn roundtrip_f64(value: f64) -> f64 {
+    value
+}
+
+#[no_mangle]
+pub extern "C" fn roundtrip_bool(value: bool) -> bool {
+    value
+}
+
+// Buffer functionality
+static READ_BUFFER_CELL: OnceCell<Vec<u8>> = OnceCell::new();
+static WRITE_BUFFER_CELL: OnceCell<Vec<u8>> = OnceCell::new();
+// Create a string to test functions with.  This includes unicode to test tricky situations where
+// the distrinction between number of bytes and number of codepoints matters
+static STRING_BUFFER: &str = "🦊test-string🦊";
+
+fn get_read_buffer() -> &'static Vec<u8> {
+    READ_BUFFER_CELL.get_or_init(|| {
+        let mut buf = Vec::new();
+        // Fill up the buffer with a bunch of primitive data so that we can test reading it
+        buf.put_u8(1);
+        buf.put_i8(-1);
+        buf.put_u16(2);
+        buf.put_i16(-2);
+        buf.put_u32(4);
+        buf.put_i32(-4);
+        buf.put_u64(8);
+        buf.put_i64(-8);
+        buf.put_f32(1.5);
+        buf.put_f64(-0.5);
+        buf.put_u64(buf.as_ptr() as u64);
+        buf
+    })
+}
+
+fn get_write_buffer() -> &'static Vec<u8> {
+    WRITE_BUFFER_CELL.get_or_init(|| {
+        let mut write_buffer = Vec::new();
+        for _ in 0..get_read_buffer().len() {
+            write_buffer.push(0)
+        }
+        write_buffer
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn get_read_buffer_ptr() -> *const c_void {
+    get_read_buffer().as_ptr() as *const c_void
+}
+
+#[no_mangle]
+pub extern "C" fn get_read_buffer_size() -> i32 {
+    get_read_buffer().len() as i32
+}
+
+#[no_mangle]
+pub extern "C" fn is_read_buffer_ptr(ptr: *const c_void) -> u8 {
+    (ptr == get_read_buffer_ptr()) as u8
+}
+
+#[no_mangle]
+pub extern "C" fn get_write_buffer_ptr() -> *const c_void {
+    get_write_buffer().as_ptr() as *const c_void
+}
+
+#[no_mangle]
+pub extern "C" fn get_write_buffer_size() -> i32 {
+    get_write_buffer().len() as i32
+}
+
+#[no_mangle]
+pub extern "C" fn write_buffer_matches_read_buffer() -> u8 {
+    (get_write_buffer() == get_read_buffer()) as u8
+}
+
+#[no_mangle]
+pub extern "C" fn write_buffer_matches_string_buffer() -> u8 {
+    match std::str::from_utf8(&get_write_buffer()[..STRING_BUFFER.len()]) {
+        Ok(value) => (value == STRING_BUFFER) as u8,
+        Err(_) => 0,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn get_string_buffer_ptr() -> *const c_void {
+    STRING_BUFFER.as_ptr() as *const c_void
+}
+
+#[no_mangle]
+pub extern "C" fn get_string_buffer_size() -> i32 {
+    STRING_BUFFER.len() as i32
+}
+
+// structs
+#[repr(C)]
+#[derive(Debug)]
+pub struct Numbers {
+    a: i32,
+    b: i32,
+}
+
+#[no_mangle]
+pub extern "C" fn make_numbers(a: i32, b: i32) -> Numbers {
+    Numbers { a, b }
+}
+
+#[no_mangle]
+pub extern "C" fn add_numbers(numbers: Numbers) -> i32 {
+    numbers.a + numbers.b
+}
+
+#[no_mangle]
+pub extern "C" fn add_numbers_ref(numbers: &Numbers) -> i32 {
+    numbers.a + numbers.b
+}
+
+#[no_mangle]
+pub extern "C" fn double_each_number(numbers: &mut Numbers) {
+    numbers.a *= 2;
+    numbers.b *= 2;
+}
+
+pub struct Adder {
+    amount: i32,
+}
+
+static mut FREE_COUNT: u32 = 0;
+
+#[no_mangle]
+pub extern "C" fn adder_create(amount: i32) -> *mut Adder {
+    Box::into_raw(Box::new(Adder { amount }))
+}
+
+#[no_mangle]
+pub extern "C" fn adder_add(adder: *mut Adder, value: i32) -> i32 {
+    let adder = unsafe { &*adder };
+    value + adder.amount
+}
+
+#[no_mangle]
+pub extern "C" fn adder_destroy(adder: *mut Adder) {
+    // This causes the box to drop, freeing the memory
+    unsafe {
+        FREE_COUNT += 1;
+        Box::from_raw(adder);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn adder_consume(adder: *mut Adder) {
+    // Do the exact same thing as `adder_destroy`, but don't increment the free count.  This
+    // simulates a function that inputs an Owned adder, transfering ownership from the bindings
+    // back to Rust.
+    unsafe {
+        Box::from_raw(adder);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn adder_reset_free_count() {
+    unsafe {
+        FREE_COUNT = 0;
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn adder_get_free_count() -> u32 {
+    unsafe { FREE_COUNT }
+}
+
+pub(crate) fn test_module() -> Module {
+    let mut module = Module::new();
+    let functions = [
+        ("i8", int8()),
+        ("u8", uint8()),
+        ("i16", int16()),
+        ("u16", uint16()),
+        ("i32", int32()),
+        ("u32", uint32()),
+        ("i64", int64()),
+        ("u64", uint64()),
+        ("f32", float32()),
+        ("f64", float64()),
+    ]
+    .into_iter()
+    .map(|(name, type_)| FFIFunctionDef {
+        name: format!("roundtrip_{name}").into(),
+        args: vec![arg("value", type_.clone())],
+        return_type: type_.into(),
+    })
+    .chain(
+        [
+            // Buffers
+            FFIFunctionDef {
+                name: "get_read_buffer_ptr".into(),
+                args: vec![],
+                return_type: pointer("BufPtr").into(),
+            },
+            FFIFunctionDef {
+                name: "get_read_buffer_size".into(),
+                args: vec![],
+                return_type: int32().into(),
+            },
+            FFIFunctionDef {
+                name: "is_read_buffer_ptr".into(),
+                args: vec![arg("ptr", pointer("BufPtr"))],
+                return_type: uint8().into(),
+            },
+            FFIFunctionDef {
+                name: "get_write_buffer_ptr".into(),
+                args: vec![],
+                return_type: pointer("BufPtr").into(),
+            },
+            FFIFunctionDef {
+                name: "get_write_buffer_size".into(),
+                args: vec![],
+                return_type: int32().into(),
+            },
+            FFIFunctionDef {
+                name: "get_string_buffer_ptr".into(),
+                args: vec![],
+                return_type: pointer("BufPtr").into(),
+            },
+            FFIFunctionDef {
+                name: "get_string_buffer_size".into(),
+                args: vec![],
+                return_type: int32().into(),
+            },
+            FFIFunctionDef {
+                name: "write_buffer_matches_read_buffer".into(),
+                args: vec![],
+                return_type: uint8().into(),
+            },
+            FFIFunctionDef {
+                name: "write_buffer_matches_string_buffer".into(),
+                args: vec![],
+                return_type: uint8().into(),
+            },
+            FFIFunctionDef {
+                name: "make_numbers".into(),
+                args: vec![arg("a", int32()), arg("b", int32())],
+                return_type: cstruct("Numbers").into(),
+            },
+            FFIFunctionDef {
+                name: "add_numbers".into(),
+                args: vec![arg("numbers", cstruct("Numbers"))],
+                return_type: int32().into(),
+            },
+            FFIFunctionDef {
+                name: "add_numbers_ref".into(),
+                args: vec![arg("numbers", reference(cstruct("Numbers")))],
+                return_type: int32().into(),
+            },
+            FFIFunctionDef {
+                name: "double_each_number".into(),
+                args: vec![arg("numbers", reference_mut(cstruct("Numbers")))],
+                return_type: None,
+            },
+            FFIFunctionDef {
+                name: "adder_create".into(),
+                args: vec![arg("amount", int32())],
+                return_type: pointer("Adder").into(),
+            },
+            FFIFunctionDef {
+                name: "adder_add".into(),
+                args: vec![arg("adder", pointer("Adder")), arg("value", int32())],
+                return_type: int32().into(),
+            },
+            FFIFunctionDef {
+                name: "adder_destroy".into(),
+                args: vec![arg("adder", pointer("Adder"))],
+                return_type: None,
+            },
+            FFIFunctionDef {
+                name: "adder_consume".into(),
+                args: vec![arg("adder", pointer("Adder"))],
+                return_type: None,
+            },
+            FFIFunctionDef {
+                name: "adder_reset_free_count".into(),
+                args: vec![],
+                return_type: None,
+            },
+            FFIFunctionDef {
+                name: "adder_get_free_count".into(),
+                args: vec![],
+                return_type: uint32().into(),
+            },
+        ]
+        .into_iter(),
+    );
+
+    module.add_buffer_stream_class("BufStream");
+    module.add_native_library("bindings_ir_tests", functions);
+    module.add_cstruct(CStructDef {
+        name: "Numbers".into(),
+        fields: vec![mut_field("a", int32()), mut_field("b", int32())],
+    });
+    // Define a CStruct with all possible types, just to make sure the definition is legal
+    module.add_cstruct(CStructDef {
+        name: "CStructWithAllTypes".into(),
+        fields: vec![
+            mut_field("i8", int8()),
+            mut_field("u8", uint8()),
+            mut_field("i16", int16()),
+            mut_field("u16", uint16()),
+            mut_field("i32", int32()),
+            mut_field("u32", uint32()),
+            mut_field("i64", int64()),
+            mut_field("u64", uint64()),
+            mut_field("f32", float32()),
+            mut_field("f64", float64()),
+            mut_field("numbers", cstruct("Numbers")),
+            mut_field("pointer", pointer("BufPtr")),
+            mut_field("nullable_pointer", nullable(pointer("BufPtr"))),
+        ],
+    });
+
+    module
+}

--- a/bindings-ir/Cargo.toml
+++ b/bindings-ir/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bindings-ir"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bytes = "1.0"
+camino = "1.0.8"
+heck = "0.4"
+once_cell = "1"
+regex = "1"
+render-macro = { path = "../render-macro" }
+paste = "1"
+serde = { version = "1", features=["derive"] }
+tera = { version = "1", default-features = false }

--- a/bindings-ir/src/ir/definitions.rs
+++ b/bindings-ir/src/ir/definitions.rs
@@ -1,0 +1,371 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use super::*;
+/// Toplevel AST items
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::iter::IntoIterator;
+
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub enum Definition {
+    BufferStream(BufferStreamDef),
+    Function(FunctionDef),
+    CStruct(CStructDef),
+    Class(ClassDef),
+    DataClass(DataClassDef),
+    Enum(EnumDef),
+    ExceptionBase(ExceptionBaseDef),
+    Exception(ExceptionDef),
+}
+
+impl Definition {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::BufferStream(buf) => &buf.name,
+            Self::Function(func) => &func.name,
+            Self::CStruct(cstruct) => &cstruct.name,
+            Self::Class(class) => &class.name,
+            Self::DataClass(data_class) => &data_class.name,
+            Self::Enum(enum_) => &enum_.name,
+            Self::ExceptionBase(base) => &base.name,
+            Self::Exception(exc) => &exc.name,
+        }
+    }
+
+    pub fn as_buffer(&self) -> Option<&BufferStreamDef> {
+        match self {
+            Self::BufferStream(inner) => Some(inner),
+            _ => None,
+        }
+    }
+    pub fn as_cstruct(&self) -> Option<&CStructDef> {
+        match self {
+            Self::CStruct(inner) => Some(inner),
+            _ => None,
+        }
+    }
+
+    pub fn as_function(&self) -> Option<&FunctionDef> {
+        match self {
+            Self::Function(inner) => Some(inner),
+            _ => None,
+        }
+    }
+
+    pub fn as_class(&self) -> Option<&ClassDef> {
+        match self {
+            Self::Class(inner) => Some(inner),
+            _ => None,
+        }
+    }
+
+    pub fn as_data_class(&self) -> Option<&DataClassDef> {
+        match self {
+            Self::DataClass(inner) => Some(inner),
+            _ => None,
+        }
+    }
+
+    pub fn as_enum(&self) -> Option<&EnumDef> {
+        match self {
+            Self::Enum(inner) => Some(inner),
+            _ => None,
+        }
+    }
+
+    pub fn as_exception_base(&self) -> Option<&ExceptionBaseDef> {
+        match self {
+            Self::ExceptionBase(inner) => Some(inner),
+            _ => None,
+        }
+    }
+
+    pub fn as_exception(&self) -> Option<&ExceptionDef> {
+        match self {
+            Self::Exception(inner) => Some(inner),
+            _ => None,
+        }
+    }
+}
+
+/// Built-in object type that supports reading from/writing to a data buffer.
+///
+/// BufferStreams have an interal position that tracks where in the buffer the next read/write will
+/// happen.  Use `BufStreamRead*` and `BufStreamWrite*` expressions to perform the
+/// read/write.
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct BufferStreamDef {
+    /// Name of the buffer class, must match the value in `Type::Pointer { name }`
+    pub name: ClassName,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct CStructDef {
+    pub name: CStructName,
+    pub fields: Vec<Field>,
+}
+
+#[derive(Clone, Debug, Default, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct FunctionDef {
+    pub vis: Visibility,
+    pub name: FunctionName,
+    /// Name of the exception class that this function may throw.  May be an Exception or
+    /// ExceptionBase
+    pub throws: Option<ClassName>,
+    pub args: Vec<Argument>,
+    pub return_type: Option<Type>,
+    pub body: Block,
+}
+
+#[derive(Clone, Debug, Default, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct ClassDef {
+    pub vis: Visibility,
+    pub name: ClassName,
+    pub fields: Vec<Field>,
+    pub constructor: Option<Constructor>,
+    pub methods: Vec<Method>,
+    pub destructor: Option<Destructor>,
+    pub into_rust: Option<IntoRustMethod>,
+}
+
+/// Data classes simply store other objects as fields.  Languages often offer special support for
+/// them, for example auto-deriving hash functions, equality tests etc.
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct DataClassDef {
+    pub vis: Visibility,
+    pub name: ClassName,
+    pub fields: Vec<Field>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct EnumDef {
+    pub vis: Visibility,
+    pub name: ClassName,
+    pub variants: Vec<Variant>,
+}
+
+/// Base class for an exception
+///
+/// In general, bindings-ir to avoid inheritance since languages can treat it very
+/// differently or not support it at all.  However, supporting exception hierarchies is very
+/// useful.  To balance those 2 goals, we support base classes, but don't allow any fields or
+/// methods on them.
+///
+/// Exceptions are the only type that supports variance.  If a function inputs an argument with the
+/// exception base class, then any descendent classes can be passed in.
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct ExceptionBaseDef {
+    /// Depth of this base in the exception hierarchy.  Having this as the first field ensures that
+    /// parent bases ordered before their children, which simplifies rendering.  This gets set when
+    /// the exception base is added as a definition.
+    pub(crate) depth: u32,
+    /// Name of the parent ExceptionBase if there is one
+    pub parent: Option<ClassName>,
+    pub name: ClassName,
+}
+
+/// Exception class
+///
+/// Like ExceptionBase, exceptions are another OO concept that we need to support, but we can't
+/// assume much about how languages will treat them.  So, we support defining and throwing
+/// exceptions, but not catching them.
+///
+/// Exceptions always have public visibility.
+#[derive(Clone, Debug, Default, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct ExceptionDef {
+    /// Name of the parent ExceptionBase
+    pub parent: ClassName,
+    /// Name of the Exception
+    pub name: ClassName,
+    pub fields: Vec<Field>,
+    pub as_string: Option<AsStringMethod>,
+}
+
+#[derive(
+    Clone, Copy, Debug, Default, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize,
+)]
+#[serde(tag = "ir_type")]
+pub enum Visibility {
+    /// Visible to consumer code
+    Public,
+    /// Visible to the generated bindings only (note this means it's closer to Kotlin's `internal`
+    /// than `private`
+    #[default]
+    Private,
+}
+
+#[derive(Clone, Debug, Default, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct Method {
+    pub vis: Visibility,
+    // Does this method mutate the object?
+    pub method_type: MethodType,
+    pub name: FunctionName,
+    /// Name of the exception class that this function may throw.  May be an Exception or
+    /// ExceptionBase
+    pub throws: Option<ClassName>,
+    pub args: Vec<Argument>,
+    pub return_type: Option<Type>,
+    pub body: Block,
+}
+
+#[derive(Clone, Debug, Default, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub enum MethodType {
+    #[default]
+    Normal,
+    Mutable,
+    Static,
+}
+
+/// Main constructor for the class.
+#[derive(Clone, Debug, Default, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct Constructor {
+    pub vis: Visibility,
+    pub args: Vec<Argument>,
+    /// Initial value for for each class field
+    pub initializers: Vec<Expression>,
+}
+
+/// Destructor which should free any Rust resources from this class.
+///
+/// All fields of the class will be available as owned variables in the body of the destructor.
+/// Different languages handle destruction differently and there may be a long delay before
+/// destructor calls. As a general rule, destructors should be used to free memory, but not
+/// resources like file handles.
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct Destructor {
+    pub body: Block,
+}
+
+/// Transfer ownership of class data into Rust
+///
+/// This function handles the `IntoRust` expression, which passes ownership of an object into Rust.
+/// We can't directly a class directly, so this function must convert the object data into a
+/// pointer, CStruct, or other FFI type that can be passed in. Like destructors, all fields of the
+/// class will be available as owned variables in the body.
+///
+/// If the into rust method runs, then the object is considered not owned by the bindings code and
+/// the destructor will not run.
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct IntoRustMethod {
+    pub return_type: Type,
+    pub body: Block,
+}
+
+/// Get a string representation for an object
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct AsStringMethod {
+    pub body: Block,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct Argument {
+    pub name: ArgName,
+    #[serde(rename = "type")]
+    pub type_: Type,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct Field {
+    pub name: FieldName,
+    #[serde(rename = "type")]
+    pub type_: Type,
+    pub mutable: bool,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct Variant {
+    pub name: ClassName,
+    pub fields: Vec<Field>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct NativeLibrary {
+    pub name: String,
+    pub functions: BTreeMap<String, FFIFunctionDef>,
+}
+
+/// Function defined in an FFI Library
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct FFIFunctionDef {
+    // Note that name is a bare string here, since FFI function names come from the C API
+    pub name: String,
+    pub args: Vec<Argument>,
+    pub return_type: Option<Type>,
+}
+
+impl NativeLibrary {
+    pub fn new(
+        name: impl Into<String>,
+        functions: impl IntoIterator<Item = FFIFunctionDef>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            functions: functions
+                .into_iter()
+                .map(|f| (f.name.to_string(), f))
+                .collect(),
+        }
+    }
+
+    pub fn iter_functions(&self) -> impl Iterator<Item = &FFIFunctionDef> {
+        self.functions.values()
+    }
+}
+
+impl EnumDef {
+    pub fn get_variant(&self, variant_name: &str) -> Option<&Variant> {
+        self.variants.iter().find(|v| v.name.equals(variant_name))
+    }
+
+    pub fn has_fields(&self) -> bool {
+        self.variants.iter().any(Variant::has_fields)
+    }
+}
+
+impl Variant {
+    pub fn has_fields(&self) -> bool {
+        !self.fields.is_empty()
+    }
+}
+
+impl ExceptionBaseDef {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            depth: 0,
+            name: ClassName::new(name.into()),
+            parent: None,
+        }
+    }
+
+    pub fn new_child(parent_name: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            depth: 0,
+            name: ClassName::new(name.into()),
+            parent: Some(ClassName::new(parent_name.into())),
+        }
+    }
+}

--- a/bindings-ir/src/ir/expression.rs
+++ b/bindings-ir/src/ir/expression.rs
@@ -1,0 +1,401 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use super::{names::*, Statement, Type};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub enum Expression {
+    /// Identifier for a variable in the current scope.  Evaluates to the value of the variable
+    Ident {
+        name: VarName,
+    },
+    /// Get a value from a field of a Class, DataClass, CStruct
+    ///
+    /// For non-copy types, this will return a reference.
+    Get {
+        container: Box<Expression>,
+        field: FieldName,
+    },
+    /// Get a reference of the current object.  Can only be used in methods.
+    This,
+    /// Call a function
+    Call {
+        name: FunctionName,
+        /// Must match the types from the corresponding Function
+        values: Vec<Expression>,
+    },
+    /// Call a method on an object
+    MethodCall {
+        obj: Box<Expression>,
+        /// Name of the method
+        name: FunctionName,
+        /// Must match the types from the corresponding Method
+        values: Vec<Expression>,
+    },
+    /// Call a static method on a class
+    StaticMethodCall {
+        class: ClassName,
+        /// Name of the method
+        name: FunctionName,
+        /// Must match the types from the corresponding Method
+        values: Vec<Expression>,
+    },
+    /// Call an FFI function
+    FFICall {
+        name: String,
+        /// Must match the types from the corresponding FFIFunction
+        values: Vec<Expression>,
+    },
+    /// Get a reference to a variable
+    ///
+    /// This is only valid as a call argument.
+    Ref {
+        name: VarName,
+        mutable: bool,
+    },
+    /// Create a Nullable value from a regular value
+    Some {
+        inner: Box<Expression>,
+    },
+    /// Unwrap a nullable value, raising a runtime exception if it's null
+    Unwrap {
+        nullable: Box<Expression>,
+        message: Box<Expression>,
+    },
+    /// Convert an object into a Rust value
+    ///
+    /// This runs the `into_rust` method for the object, which transfers ownership of the object
+    /// into Rust.  This expression is only valid as an argument of an FFI function call.  After
+    /// this runs, the object will no longer be considered owned by the bindings code.  It can no
+    /// longer be used and it's destructor will not run.
+    ///
+    /// The object variable must be declared mutable.
+    IntoRust {
+        obj: Box<Expression>,
+    },
+    /// Create a new Class instance
+    ClassCreate {
+        name: ClassName,
+        /// Values for each field in the class
+        values: Vec<Expression>,
+    },
+    /// Create a new DataClass instance
+    DataClassCreate {
+        name: ClassName,
+        /// Must match the types from the field list or contructor args
+        values: Vec<Expression>,
+    },
+    /// Create a new CStruct instance
+    CStructCreate {
+        name: String,
+        /// Must match the types from the field list or contructor args
+        values: Vec<Expression>,
+    },
+    /// Create an enum variant
+    EnumCreate {
+        name: ClassName,
+        variant: ClassName,
+        /// Values must match the fields from the variant fields
+        values: Vec<Expression>,
+    },
+    /// Create an exception
+    ExceptionCreate {
+        name: ClassName,
+        values: Vec<Expression>,
+    },
+    /// Get the size of a pointer in bytes
+    PointerSize,
+    /// Cast to an Int8 value
+    ///
+    /// Casting a value that doesn't fit into an Int8 is undefined behavior.
+    CastInt8 {
+        value: Box<Expression>,
+    },
+    /// Cast to an Int16 value
+    ///
+    /// Casting a value that doesn't fit into an Int16 is undefined behavior.
+    CastInt16 {
+        value: Box<Expression>,
+    },
+    /// Cast to an Int32 value
+    ///
+    /// Casting a value that doesn't fit into an Int32 is undefined behavior.
+    CastInt32 {
+        value: Box<Expression>,
+    },
+    /// Cast to an Int64 value
+    ///
+    /// Casting a value that doesn't fit into an Int64 is undefined behavior.
+    CastInt64 {
+        value: Box<Expression>,
+    },
+    /// Cast to an UInt8 value
+    ///
+    /// Casting a value that doesn't fit into an UInt8 is undefined behavior.
+    CastUInt8 {
+        value: Box<Expression>,
+    },
+    /// Cast to an UInt16 value
+    ///
+    /// Casting a value that doesn't fit into an UInt16 is undefined behavior.
+    CastUInt16 {
+        value: Box<Expression>,
+    },
+    /// Cast to an UInt32 value
+    ///
+    /// Casting a value that doesn't fit into an UInt32 is undefined behavior.
+    CastUInt32 {
+        value: Box<Expression>,
+    },
+    /// Cast to an UInt64 value
+    ///
+    /// Casting a value that doesn't fit into an UInt64 is undefined behavior.
+    CastUInt64 {
+        value: Box<Expression>,
+    },
+    /// (T, T) -> Boolean, where T is any numeric type including FFI types
+    Eq {
+        first: Box<Expression>,
+        second: Box<Expression>,
+    },
+    /// (T, T) -> Boolean, where T is any numeric type including FFI types
+    Gt {
+        first: Box<Expression>,
+        second: Box<Expression>,
+    },
+    /// (T, T) -> Boolean, where T is any numeric type including FFI types
+    Lt {
+        first: Box<Expression>,
+        second: Box<Expression>,
+    },
+    /// (T, T) -> Boolean, where T is any numeric type including FFI types
+    Ge {
+        first: Box<Expression>,
+        second: Box<Expression>,
+    },
+    /// (T, T) -> Boolean, where T is any numeric type including FFI types
+    Le {
+        first: Box<Expression>,
+        second: Box<Expression>,
+    },
+    /// (Boolean, Boolean) -> Boolean
+    And {
+        first: Box<Expression>,
+        second: Box<Expression>,
+    },
+    /// (Boolean, Boolean) -> Boolean
+    Or {
+        first: Box<Expression>,
+        second: Box<Expression>,
+    },
+    /// (Boolean) -> Boolean
+    Not {
+        value: Box<Expression>,
+    },
+    /// (Int, Int) -> Int
+    Add {
+        /// Integer type being operated on, this is needed becaause Kotlin/Java does some weird
+        /// things with integer arithmetic, automatically casting things to a different type.
+        ///
+        /// It's unfortunate that users need to specify the type, I'm hoping that we can avoid that
+        /// by doing some static analysis on the code that calculates this.
+        #[serde(rename = "type")]
+        type_: Type,
+        first: Box<Expression>,
+        second: Box<Expression>,
+    },
+    /// (Int, Int) -> Int
+    Sub {
+        #[serde(rename = "type")]
+        type_: Type,
+        first: Box<Expression>,
+        second: Box<Expression>,
+    },
+    /// (Int, Int) -> Int
+    Mul {
+        #[serde(rename = "type")]
+        type_: Type,
+        first: Box<Expression>,
+        second: Box<Expression>,
+    },
+    /// (Int, Int) -> Int
+    Div {
+        #[serde(rename = "type")]
+        type_: Type,
+        first: Box<Expression>,
+        second: Box<Expression>,
+    },
+    /// Check if a value is an instance of a class
+    IsInstance {
+        value: Box<Expression>,
+        class: ClassName,
+    },
+    /// Get a lower bound on the number of bytes needed to store a string, when encoded as UTF-8
+    ///
+    /// This is used to allocate buffers that strings will be written to.  The value is generally
+    /// the number of codepoints * 3, which is pessimistic but easy to calculate.
+    StrMinByteLen {
+        string: Box<Expression>,
+    },
+    /// Concatinate a list of values into a single string
+    ///
+    /// Each value can be a string, integer, or float value
+    StrConcat {
+        values: Vec<Expression>,
+    },
+    /// Create a new list
+    ListCreate {
+        inner: Type,
+    },
+    /// Get the number of elements in a list
+    ListLen {
+        list: Box<Expression>,
+    },
+    /// Get a value from the middle of the list
+    ListGet {
+        list: Box<Expression>,
+        index: Box<Expression>,
+    },
+    /// Pop the value from the end of a list.  The list varable must be declared mutable.  Throws
+    /// an exception if there are no elements in the list.
+    ListPop {
+        list: Box<Expression>,
+    },
+    /// Create a new map
+    MapCreate {
+        key: Type,
+        value: Type,
+    },
+    /// Get the number of elements in a map
+    MapLen {
+        map: Box<Expression>,
+    },
+    /// Get a value a map.  Returns a nullable value.
+    MapGet {
+        map: Box<Expression>,
+        key: Box<Expression>,
+    },
+    LiteralBoolean {
+        value: bool,
+    },
+    LiteralString {
+        value: String,
+    },
+    LiteralInt {
+        value: String,
+    },
+    LiteralInt16 {
+        value: String,
+    },
+    LiteralInt32 {
+        value: String,
+    },
+    LiteralInt64 {
+        value: String,
+    },
+    LiteralInt8 {
+        value: String,
+    },
+    LiteralUInt16 {
+        value: String,
+    },
+    LiteralUInt32 {
+        value: String,
+    },
+    LiteralUInt64 {
+        value: String,
+    },
+    LiteralUInt8 {
+        value: String,
+    },
+    LiteralFloat32 {
+        value: String,
+    },
+    LiteralFloat64 {
+        value: String,
+    },
+    LiteralNull,
+    /// Create a new BufferStream, consuming the pointer.
+    BufStreamCreate {
+        // Must match the name field in BufferStreamDef
+        name: ClassName,
+        pointer: Box<Expression>,
+        size: Box<Expression>,
+    },
+    /// Consume a BufferStream instance and return the raw pointer
+    BufStreamIntoPointer {
+        // Must match the name field in BufferStreamDef
+        name: ClassName,
+        buf: Box<Expression>,
+    },
+    /// Get the current position of a buffer stream
+    BufStreamPos {
+        buf: Box<Expression>,
+    },
+    /// Get the size of a buffer stream
+    BufStreamSize {
+        buf: Box<Expression>,
+    },
+    // Read a u8 value from a buffer stream.  The variable must be declared mutable.
+    BufStreamReadUInt8 {
+        buf: Box<Expression>,
+    },
+    // Read a u16 value from a buffer stream.  The variable must be declared mutable.
+    BufStreamReadUInt16 {
+        buf: Box<Expression>,
+    },
+    // Read a u32 value from a buffer stream.  The variable must be declared mutable.
+    BufStreamReadUInt32 {
+        buf: Box<Expression>,
+    },
+    // Read a u64 value from a buffer stream.  The variable must be declared mutable.
+    BufStreamReadUInt64 {
+        buf: Box<Expression>,
+    },
+    // Read a i8 value from a buffer stream.  The variable must be declared mutable.
+    BufStreamReadInt8 {
+        buf: Box<Expression>,
+    },
+    // Read a i16 value from a buffer stream.  The variable must be declared mutable.
+    BufStreamReadInt16 {
+        buf: Box<Expression>,
+    },
+    // Read a i32 value from a buffer stream.  The variable must be declared mutable.
+    BufStreamReadInt32 {
+        buf: Box<Expression>,
+    },
+    // Read a i64 value from a buffer stream.  The variable must be declared mutable.
+    BufStreamReadInt64 {
+        buf: Box<Expression>,
+    },
+    // Read a f32 value from a buffer stream.  The variable must be declared mutable.
+    BufStreamReadFloat32 {
+        buf: Box<Expression>,
+    },
+    // Read a f64 value from a buffer stream.  The variable must be declared mutable.
+    BufStreamReadFloat64 {
+        buf: Box<Expression>,
+    },
+    // Read a string value from a buffer stream.  The variable must be declared mutable.
+    BufStreamReadString {
+        buf: Box<Expression>,
+        /// Number of bytes to read
+        size: Box<Expression>,
+    },
+    // Read a pointer value from a buffer stream.  The variable must be declared mutable.
+    BufStreamReadPointer {
+        name: String,
+        buf: Box<Expression>,
+    },
+}
+
+impl Expression {
+    pub fn into_statement(self) -> Statement {
+        Statement::Expression { expr: self }
+    }
+}

--- a/bindings-ir/src/ir/helpers.rs
+++ b/bindings-ir/src/ir/helpers.rs
@@ -1,0 +1,991 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/// Helper functions to create AST items
+use super::*;
+
+pub fn ident(name: impl Into<String>) -> Expression {
+    let name = name.into();
+    let mut components = name.split('.');
+    // First component is the main variable
+    let mut expr = Expression::Ident {
+        name: VarName::new(components.next().unwrap()),
+    };
+    // Future components are fields
+    for name in components {
+        expr = get(expr, name);
+    }
+    expr
+}
+
+pub fn call(name: impl Into<String>, values: impl IntoIterator<Item = Expression>) -> Expression {
+    Expression::Call {
+        name: FunctionName::new(name.into()),
+        values: values.into_iter().collect(),
+    }
+}
+
+pub fn method_call(
+    obj: Expression,
+    name: impl Into<String>,
+    values: impl IntoIterator<Item = Expression>,
+) -> Expression {
+    Expression::MethodCall {
+        obj: Box::new(obj),
+        name: FunctionName::new(name.into()),
+        values: values.into_iter().collect(),
+    }
+}
+
+pub fn static_method_call(
+    class: impl Into<String>,
+    name: impl Into<String>,
+    values: impl IntoIterator<Item = Expression>,
+) -> Expression {
+    Expression::StaticMethodCall {
+        class: ClassName::new(class.into()),
+        name: FunctionName::new(name.into()),
+        values: values.into_iter().collect(),
+    }
+}
+
+pub fn ffi_call(
+    name: impl Into<String>,
+    values: impl IntoIterator<Item = Expression>,
+) -> Expression {
+    Expression::FFICall {
+        name: name.into(),
+        values: values.into_iter().collect(),
+    }
+}
+
+pub fn create_class(
+    name: impl Into<String>,
+    values: impl IntoIterator<Item = Expression>,
+) -> Expression {
+    Expression::ClassCreate {
+        name: ClassName::new(name.into()),
+        values: values.into_iter().collect(),
+    }
+}
+
+pub fn create_data_class(
+    name: impl Into<String>,
+    values: impl IntoIterator<Item = Expression>,
+) -> Expression {
+    Expression::DataClassCreate {
+        name: ClassName::new(name.into()),
+        values: values.into_iter().collect(),
+    }
+}
+
+pub fn create_cstruct(
+    name: impl Into<String>,
+    values: impl IntoIterator<Item = Expression>,
+) -> Expression {
+    Expression::CStructCreate {
+        name: name.into(),
+        values: values.into_iter().collect(),
+    }
+}
+
+pub fn create_enum(
+    name: impl Into<String>,
+    variant: impl Into<String>,
+    values: impl IntoIterator<Item = Expression>,
+) -> Expression {
+    Expression::EnumCreate {
+        name: ClassName::new(name.into()),
+        variant: ClassName::new(variant.into()),
+        values: values.into_iter().collect(),
+    }
+}
+
+pub fn create_exception(
+    name: impl Into<String>,
+    values: impl IntoIterator<Item = Expression>,
+) -> Expression {
+    Expression::ExceptionCreate {
+        name: ClassName::new(name.into()),
+        values: values.into_iter().collect(),
+    }
+}
+
+pub fn some(inner: Expression) -> Expression {
+    Expression::Some {
+        inner: Box::new(inner),
+    }
+}
+
+pub fn unwrap(nullable: Expression, message: Expression) -> Expression {
+    Expression::Unwrap {
+        nullable: Box::new(nullable),
+        message: Box::new(message),
+    }
+}
+
+pub fn into_rust(obj: Expression) -> Expression {
+    Expression::IntoRust { obj: Box::new(obj) }
+}
+
+pub fn get(container: Expression, field: impl Into<String>) -> Expression {
+    Expression::Get {
+        container: Box::new(container),
+        field: FieldName::new(field.into()),
+    }
+}
+
+pub fn this() -> Expression {
+    Expression::This
+}
+
+pub fn add(type_: Type, first: Expression, second: Expression) -> Expression {
+    Expression::Add {
+        type_,
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+pub fn sub(type_: Type, first: Expression, second: Expression) -> Expression {
+    Expression::Sub {
+        type_,
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+pub fn div(type_: Type, first: Expression, second: Expression) -> Expression {
+    Expression::Div {
+        type_,
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+pub fn mul(type_: Type, first: Expression, second: Expression) -> Expression {
+    Expression::Mul {
+        type_,
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+pub fn eq(first: Expression, second: Expression) -> Expression {
+    Expression::Eq {
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+pub fn ne(first: Expression, second: Expression) -> Expression {
+    not(eq(first, second))
+}
+
+pub fn gt(first: Expression, second: Expression) -> Expression {
+    Expression::Gt {
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+pub fn lt(first: Expression, second: Expression) -> Expression {
+    Expression::Lt {
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+pub fn ge(first: Expression, second: Expression) -> Expression {
+    Expression::Ge {
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+pub fn le(first: Expression, second: Expression) -> Expression {
+    Expression::Le {
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+pub fn and(first: Expression, second: Expression) -> Expression {
+    Expression::And {
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+pub fn or(first: Expression, second: Expression) -> Expression {
+    Expression::Or {
+        first: Box::new(first),
+        second: Box::new(second),
+    }
+}
+
+pub fn not(value: Expression) -> Expression {
+    Expression::Not {
+        value: Box::new(value),
+    }
+}
+
+pub fn ref_(name: impl Into<String>) -> Expression {
+    Expression::Ref {
+        name: VarName::new(name.into()),
+        mutable: false,
+    }
+}
+
+pub fn ref_mut(name: impl Into<String>) -> Expression {
+    Expression::Ref {
+        name: VarName::new(name.into()),
+        mutable: true,
+    }
+}
+
+pub fn val(name: impl Into<String>, type_: Type, initial: Expression) -> Statement {
+    Statement::Val {
+        name: VarName::new(name.into()),
+        type_,
+        initial,
+        mutable: false,
+    }
+}
+
+pub fn mut_val(name: impl Into<String>, type_: Type, initial: Expression) -> Statement {
+    Statement::Val {
+        name: VarName::new(name.into()),
+        type_,
+        initial,
+        mutable: true,
+    }
+}
+
+pub fn var(name: impl Into<String>, type_: Type, initial: Expression) -> Statement {
+    Statement::Var {
+        name: VarName::new(name.into()),
+        type_,
+        initial,
+        mutable: false,
+    }
+}
+
+pub fn mut_var(name: impl Into<String>, type_: Type, initial: Expression) -> Statement {
+    Statement::Var {
+        name: VarName::new(name.into()),
+        type_,
+        initial,
+        mutable: true,
+    }
+}
+
+pub fn set(container: Expression, field: impl Into<String>, value: Expression) -> Statement {
+    Statement::Set {
+        container,
+        field: FieldName::new(field.into()),
+        value,
+    }
+}
+
+pub fn destructure(
+    name: impl Into<String>,
+    cstruct: Expression,
+    vars: impl IntoIterator<Item = &'static str>,
+) -> Statement {
+    Statement::Destructure {
+        name: ClassName::new(name.into()),
+        cstruct,
+        vars: vars.into_iter().map(VarName::new).collect(),
+    }
+}
+
+pub fn assign(name: impl Into<String>, value: Expression) -> Statement {
+    Statement::Assign {
+        name: VarName::new(name.into()),
+        value,
+    }
+}
+
+pub fn add_assign(type_: Type, name: impl Into<String>, amount: Expression) -> Statement {
+    let name = name.into();
+    assign(name.clone(), add(type_, ident(name), amount))
+}
+
+pub fn sub_assign(type_: Type, name: impl Into<String>, amount: Expression) -> Statement {
+    let name = name.into();
+    assign(name.clone(), sub(type_, ident(name), amount))
+}
+
+pub fn mul_assign(type_: Type, name: impl Into<String>, amount: Expression) -> Statement {
+    let name = name.into();
+    assign(name.clone(), mul(type_, ident(name), amount))
+}
+
+pub fn div_assign(type_: Type, name: impl Into<String>, amount: Expression) -> Statement {
+    let name = name.into();
+    assign(name.clone(), div(type_, ident(name), amount))
+}
+
+pub fn if_(expr: Expression, then: impl IntoIterator<Item = Statement>) -> Statement {
+    Statement::If {
+        expr,
+        then: block(then),
+        else_: None,
+    }
+}
+
+pub fn if_else(
+    expr: Expression,
+    then: impl IntoIterator<Item = Statement>,
+    else_: impl IntoIterator<Item = Statement>,
+) -> Statement {
+    Statement::If {
+        expr,
+        then: block(then),
+        else_: Some(block(else_)),
+    }
+}
+
+pub fn for_(
+    var: impl Into<String>,
+    start: Expression,
+    end: Expression,
+    statements: impl IntoIterator<Item = Statement>,
+) -> Statement {
+    Statement::For {
+        var: VarName::new(var.into()),
+        start,
+        end,
+        block: block(statements),
+    }
+}
+
+pub fn loop_(statements: impl IntoIterator<Item = Statement>) -> Statement {
+    Statement::Loop {
+        block: block(statements),
+    }
+}
+
+pub fn break_() -> Statement {
+    Statement::Break
+}
+
+pub fn match_enum(
+    value: Expression,
+    name: impl Into<String>,
+    arms: impl IntoIterator<Item = MatchEnumArm>,
+) -> Statement {
+    Statement::MatchEnum {
+        value,
+        name: ClassName::new(name.into()),
+        arms: arms.into_iter().collect(),
+    }
+}
+
+pub fn is_instance(value: Expression, base_class: impl Into<String>) -> Expression {
+    Expression::IsInstance {
+        value: Box::new(value),
+        class: ClassName::new(base_class.into()),
+    }
+}
+
+pub fn match_int(type_: Type, value: Expression, arms: impl IntoIterator<Item = MatchIntArm>) -> Statement {
+    Statement::MatchInt {
+        type_,
+        value,
+        arms: arms.into_iter().collect(),
+    }
+}
+
+pub fn match_nullable(
+    value: Expression,
+    some_arm: MatchArmSome,
+    null_arm: MatchArmNull,
+) -> Statement {
+    Statement::MatchNullable {
+        value,
+        some_arm,
+        null_arm,
+    }
+}
+
+pub fn raise(exception: Expression) -> Statement {
+    Statement::Raise { exception }
+}
+
+pub fn raise_internal_exception(message: Expression) -> Statement {
+    Statement::RaiseInternalException { message }
+}
+
+pub fn assert(value: Expression) -> Statement {
+    Statement::Assert { value }
+}
+
+pub fn assert_eq(first: Expression, second: Expression) -> Statement {
+    assert(eq(first, second))
+}
+
+pub fn assert_ne(first: Expression, second: Expression) -> Statement {
+    assert(ne(first, second))
+}
+
+pub fn assert_raises(name: impl Into<String>, stmt: Statement) -> Statement {
+    Statement::AssertRaises {
+        name: ClassName::new(name.into()),
+        stmt: Box::new(stmt),
+    }
+}
+
+pub fn assert_raises_with_string(string_value: Expression, stmt: Statement) -> Statement {
+    Statement::AssertRaisesWithString {
+        string_value,
+        stmt: Box::new(stmt),
+    }
+}
+
+pub fn gc() -> Statement {
+    Statement::Gc
+}
+
+pub fn return_(value: impl Into<Expression>) -> Statement {
+    Statement::Return {
+        value: Some(value.into()),
+    }
+}
+
+pub fn return_void() -> Statement {
+    Statement::Return { value: None }
+}
+
+pub fn empty_block() -> Block {
+    Block { statements: vec![] }
+}
+
+pub fn block(statements: impl IntoIterator<Item = Statement>) -> Block {
+    Block {
+        statements: statements.into_iter().collect(),
+    }
+}
+
+pub fn public() -> Visibility {
+    Visibility::Public
+}
+
+pub fn private() -> Visibility {
+    Visibility::Private
+}
+
+pub fn field(name: impl Into<String>, type_: Type) -> Field {
+    Field {
+        name: FieldName::new(name.into()),
+        type_,
+        mutable: false,
+    }
+}
+
+pub fn mut_field(name: impl Into<String>, type_: Type) -> Field {
+    Field {
+        name: FieldName::new(name.into()),
+        type_,
+        mutable: true,
+    }
+}
+
+pub fn arg(name: impl Into<String>, type_: Type) -> Argument {
+    Argument {
+        name: ArgName::new(name.into()),
+        type_,
+    }
+}
+
+pub fn exception_base_def(name: impl Into<String>) -> ExceptionBaseDef {
+    ExceptionBaseDef::new(name.into())
+}
+
+pub fn exception_base_def_child(
+    parent: impl Into<String>,
+    name: impl Into<String>,
+) -> ExceptionBaseDef {
+    ExceptionBaseDef::new_child(parent, name)
+}
+
+pub fn uint8() -> Type {
+    Type::UInt8
+}
+
+pub fn int8() -> Type {
+    Type::Int8
+}
+
+pub fn uint16() -> Type {
+    Type::UInt16
+}
+
+pub fn int16() -> Type {
+    Type::Int16
+}
+
+pub fn uint32() -> Type {
+    Type::UInt32
+}
+
+pub fn int32() -> Type {
+    Type::Int32
+}
+
+pub fn uint64() -> Type {
+    Type::UInt64
+}
+
+pub fn int64() -> Type {
+    Type::Int64
+}
+
+pub fn float32() -> Type {
+    Type::Float32
+}
+
+pub fn float64() -> Type {
+    Type::Float64
+}
+
+pub fn pointer(name: impl Into<String>) -> Type {
+    Type::Pointer { name: name.into() }
+}
+
+pub fn cstruct(name: impl Into<String>) -> Type {
+    Type::CStruct {
+        name: CStructName::new(name.into()),
+    }
+}
+
+pub fn boolean() -> Type {
+    Type::Boolean
+}
+
+pub fn string() -> Type {
+    Type::String
+}
+
+pub fn object(class: impl Into<String>) -> Type {
+    Type::Object {
+        class: ClassName::new(class.into()),
+    }
+}
+
+pub fn list(type_: Type) -> Type {
+    Type::List {
+        inner: Box::new(type_),
+    }
+}
+
+pub fn map(key: Type, value: Type) -> Type {
+    Type::Map {
+        key: Box::new(key),
+        value: Box::new(value),
+    }
+}
+
+pub fn nullable(type_: Type) -> Type {
+    Type::Nullable {
+        inner: Box::new(type_),
+    }
+}
+
+pub fn reference(type_: Type) -> Type {
+    Type::Reference {
+        inner: Box::new(type_),
+        mutable: false,
+    }
+}
+
+pub fn reference_mut(type_: Type) -> Type {
+    Type::Reference {
+        inner: Box::new(type_),
+        mutable: true,
+    }
+}
+
+pub fn pointer_size() -> Expression {
+    Expression::PointerSize
+}
+
+pub mod cast {
+    use super::*;
+
+    macro_rules! cast_fn {
+        ($name:ident, $kind:ident) => {
+            pub fn $name(value: Expression) -> Expression {
+                Expression::$kind {
+                    value: Box::new(value),
+                }
+            }
+        };
+    }
+
+    cast_fn!(int8, CastInt8);
+    cast_fn!(int16, CastInt16);
+    cast_fn!(int32, CastInt32);
+    cast_fn!(int64, CastInt64);
+    cast_fn!(uint8, CastUInt8);
+    cast_fn!(uint16, CastUInt16);
+    cast_fn!(uint32, CastUInt32);
+    cast_fn!(uint64, CastUInt64);
+}
+
+pub mod string {
+    use super::*;
+
+    pub fn min_byte_len(string: Expression) -> Expression {
+        Expression::StrMinByteLen {
+            string: Box::new(string),
+        }
+    }
+
+    pub fn concat(values: impl IntoIterator<Item = Expression>) -> Expression {
+        Expression::StrConcat {
+            values: values.into_iter().collect(),
+        }
+    }
+}
+
+pub mod list {
+    use super::*;
+
+    pub fn create(inner: Type) -> Expression {
+        Expression::ListCreate { inner }
+    }
+
+    pub fn len(list: impl Into<String>) -> Expression {
+        Expression::ListLen {
+            list: Box::new(ident(list)),
+        }
+    }
+
+    pub fn get(list: impl Into<String>, index: Expression) -> Expression {
+        Expression::ListGet {
+            list: Box::new(ident(list)),
+            index: Box::new(index),
+        }
+    }
+
+    pub fn pop(list: impl Into<String>) -> Expression {
+        Expression::ListPop {
+            list: Box::new(ident(list)),
+        }
+    }
+
+    pub fn push(list: impl Into<String>, value: Expression) -> Statement {
+        Statement::ListPush {
+            list: ident(list),
+            value,
+        }
+    }
+
+    pub fn set(list: impl Into<String>, index: Expression, value: Expression) -> Statement {
+        Statement::ListSet {
+            list: ident(list),
+            index,
+            value,
+        }
+    }
+
+    pub fn empty(list: impl Into<String>) -> Statement {
+        Statement::ListEmpty { list: ident(list) }
+    }
+
+    pub fn iterate(
+        list: impl Into<String>,
+        var: impl Into<String>,
+        statements: impl IntoIterator<Item = Statement>,
+    ) -> Statement {
+        Statement::ListIterate {
+            list: ident(list),
+            var: VarName::new(var.into()),
+            block: block(statements),
+        }
+    }
+}
+
+pub mod map {
+    use super::*;
+
+    pub fn create(key: Type, value: Type) -> Expression {
+        Expression::MapCreate { key, value }
+    }
+
+    pub fn len(map: impl Into<String>) -> Expression {
+        Expression::MapLen {
+            map: Box::new(ident(map)),
+        }
+    }
+
+    pub fn get(map: impl Into<String>, key: Expression) -> Expression {
+        Expression::MapGet {
+            map: Box::new(ident(map)),
+            key: Box::new(key),
+        }
+    }
+
+    pub fn set(map: impl Into<String>, key: Expression, value: Expression) -> Statement {
+        Statement::MapSet {
+            map: ident(map),
+            key,
+            value,
+        }
+    }
+
+    pub fn remove(map: impl Into<String>, key: Expression) -> Statement {
+        Statement::MapRemove {
+            map: ident(map),
+            key,
+        }
+    }
+
+    pub fn empty(map: impl Into<String>) -> Statement {
+        Statement::MapEmpty { map: ident(map) }
+    }
+
+    pub fn iterate(
+        map: impl Into<String>,
+        key_var: impl Into<String>,
+        val_var: impl Into<String>,
+        statements: impl IntoIterator<Item = Statement>,
+    ) -> Statement {
+        Statement::MapIterate {
+            map: ident(map),
+            key_var: VarName::new(key_var.into()),
+            val_var: VarName::new(val_var.into()),
+            block: block(statements),
+        }
+    }
+}
+
+/// BufferStream helpers
+pub mod buf {
+    use super::*;
+
+    pub fn create(name: impl Into<String>, pointer: Expression, size: Expression) -> Expression {
+        Expression::BufStreamCreate {
+            name: ClassName::new(name.into()),
+            pointer: Box::new(pointer),
+            size: Box::new(size),
+        }
+    }
+
+    pub fn into_ptr(name: impl Into<String>, buf: Expression) -> Expression {
+        Expression::BufStreamIntoPointer {
+            name: ClassName::new(name.into()),
+            buf: Box::new(buf),
+        }
+    }
+
+    pub fn pos(buf: Expression) -> Expression {
+        Expression::BufStreamPos { buf: Box::new(buf) }
+    }
+
+    pub fn set_pos(buf: Expression, pos: Expression) -> Statement {
+        Statement::BufStreamSetPos { buf: buf, pos: pos }
+    }
+
+    pub fn size(buf: Expression) -> Expression {
+        Expression::BufStreamSize { buf: Box::new(buf) }
+    }
+
+    pub fn read_string(buf: Expression, size: Expression) -> Expression {
+        Expression::BufStreamReadString {
+            buf: Box::new(buf),
+            size: Box::new(size),
+        }
+    }
+
+    pub fn write_string(buf: Expression, value: Expression) -> Statement {
+        Statement::BufStreamWriteString {
+            buf: buf,
+            value: value,
+        }
+    }
+
+    pub fn read_pointer(name: impl Into<String>, buf: Expression) -> Expression {
+        Expression::BufStreamReadPointer {
+            name: name.into(),
+            buf: Box::new(buf),
+        }
+    }
+
+    pub fn write_pointer(name: impl Into<String>, buf: Expression, value: Expression) -> Statement {
+        Statement::BufStreamWritePointer {
+            name: name.into(),
+            buf: buf,
+            value: value,
+        }
+    }
+
+    macro_rules! read_write_number_fns {
+        ($type:ident, $type_camel:ident) => {
+            paste::paste! {
+                pub fn [<read_ $type>](buf: Expression) -> Expression {
+                    Expression::[<BufStreamRead $type_camel>] {
+                        buf: Box::new(buf),
+                    }
+                }
+
+                pub fn [<write_ $type>](buf: Expression, value: Expression) -> Statement {
+                    Statement::[<BufStreamWrite $type_camel>] {
+                        buf: buf,
+                        value: value,
+                    }
+                }
+            }
+        };
+    }
+    read_write_number_fns!(uint8, UInt8);
+    read_write_number_fns!(uint16, UInt16);
+    read_write_number_fns!(uint32, UInt32);
+    read_write_number_fns!(uint64, UInt64);
+    read_write_number_fns!(int8, Int8);
+    read_write_number_fns!(int16, Int16);
+    read_write_number_fns!(int32, Int32);
+    read_write_number_fns!(int64, Int64);
+    read_write_number_fns!(float32, Float32);
+    read_write_number_fns!(float64, Float64);
+}
+
+pub mod arm {
+    use super::*;
+
+    pub fn variant(
+        variant: impl Into<String>,
+        vars: impl IntoIterator<Item = String>,
+        statements: impl IntoIterator<Item = Statement>,
+    ) -> MatchEnumArm {
+        MatchEnumArm::Variant {
+            variant: ClassName::new(variant.into()),
+            vars: vars.into_iter().map(VarName::new).collect(),
+            block: block(statements),
+        }
+    }
+
+    pub fn variant_default(statements: impl IntoIterator<Item = Statement>) -> MatchEnumArm {
+        MatchEnumArm::Default {
+            block: block(statements),
+        }
+    }
+
+    pub fn int(value: i32, statements: impl IntoIterator<Item = Statement>) -> MatchIntArm {
+        MatchIntArm::Value {
+            value,
+            block: block(statements),
+        }
+    }
+
+    pub fn int_default(statements: impl IntoIterator<Item = Statement>) -> MatchIntArm {
+        MatchIntArm::Default {
+            block: block(statements),
+        }
+    }
+
+    pub fn null(statements: impl IntoIterator<Item = Statement>) -> MatchArmNull {
+        MatchArmNull {
+            block: block(statements),
+        }
+    }
+
+    pub fn some(
+        var: impl Into<String>,
+        statements: impl IntoIterator<Item = Statement>,
+    ) -> MatchArmSome {
+        MatchArmSome {
+            var: VarName::new(var.into()),
+            block: block(statements),
+        }
+    }
+}
+
+pub mod lit {
+    use super::*;
+
+    pub fn boolean(value: bool) -> Expression {
+        Expression::LiteralBoolean { value }
+    }
+
+    pub fn int(value: i32) -> Expression {
+        Expression::LiteralInt {
+            value: value.to_string(),
+        }
+    }
+
+    pub fn int8(value: i8) -> Expression {
+        Expression::LiteralInt8 {
+            value: value.to_string(),
+        }
+    }
+
+    pub fn uint8(value: u8) -> Expression {
+        Expression::LiteralUInt8 {
+            value: value.to_string(),
+        }
+    }
+
+    pub fn int16(value: i16) -> Expression {
+        Expression::LiteralInt16 {
+            value: value.to_string(),
+        }
+    }
+
+    pub fn uint16(value: u16) -> Expression {
+        Expression::LiteralUInt16 {
+            value: value.to_string(),
+        }
+    }
+
+    pub fn int32(value: i32) -> Expression {
+        Expression::LiteralInt32 {
+            value: value.to_string(),
+        }
+    }
+
+    pub fn uint32(value: u32) -> Expression {
+        Expression::LiteralUInt32 {
+            value: value.to_string(),
+        }
+    }
+
+    pub fn int64(value: i64) -> Expression {
+        Expression::LiteralInt64 {
+            value: value.to_string(),
+        }
+    }
+
+    pub fn uint64(value: u64) -> Expression {
+        Expression::LiteralUInt64 {
+            value: value.to_string(),
+        }
+    }
+
+    pub fn float32(value: &str) -> Expression {
+        Expression::LiteralFloat32 {
+            value: value.to_string(),
+        }
+    }
+
+    pub fn float64(value: &str) -> Expression {
+        Expression::LiteralFloat64 {
+            value: value.to_string(),
+        }
+    }
+
+    pub fn string(value: impl Into<String>) -> Expression {
+        Expression::LiteralString {
+            value: value.into(),
+        }
+    }
+
+    pub fn null() -> Expression {
+        Expression::LiteralNull
+    }
+}

--- a/bindings-ir/src/ir/mod.rs
+++ b/bindings-ir/src/ir/mod.rs
@@ -1,0 +1,21 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+mod definitions;
+mod expression;
+mod helpers;
+mod module;
+mod names;
+mod statement;
+mod types;
+
+pub use definitions::*;
+pub use expression::*;
+pub use helpers::*;
+pub use module::*;
+pub use names::*;
+pub use statement::*;
+pub use types::*;

--- a/bindings-ir/src/ir/module.rs
+++ b/bindings-ir/src/ir/module.rs
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::definitions::*;
+use super::helpers::*;
+use super::names::*;
+use super::statement::*;
+use serde::{Deserialize, Serialize};
+use std::collections::{hash_map::Entry, BTreeSet, HashMap};
+
+/// Foreign bindings module
+#[derive(Clone, Default, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct Module {
+    pub native_library: Option<NativeLibrary>,
+    pub definitions: HashMap<String, Definition>,
+    pub tests: Vec<FunctionDef>,
+}
+
+impl Module {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_native_library(
+        &mut self,
+        name: impl Into<String>,
+        functions: impl IntoIterator<Item = FFIFunctionDef>,
+    ) {
+        if self.native_library.is_some() {
+            panic!("NativeLibrary already set");
+        }
+        self.native_library
+            .replace(NativeLibrary::new(name, functions));
+    }
+
+    fn _add_user_def(&mut self, def: Definition) -> &Definition {
+        match self.definitions.entry(def.name().to_string()) {
+            Entry::Occupied(inner) => panic!("{} already in use by {:?}", def.name(), inner),
+            Entry::Vacant(e) => e.insert(def),
+        }
+    }
+
+    pub fn add_buffer_stream_class(&mut self, name: impl Into<String>) {
+        self._add_user_def(Definition::BufferStream(BufferStreamDef {
+            name: ClassName::new(name.into()),
+        }));
+    }
+
+    pub fn add_cstruct(&mut self, cstruct: CStructDef) {
+        self._add_user_def(Definition::CStruct(cstruct));
+    }
+
+    pub fn add_function(&mut self, func: FunctionDef) {
+        self._add_user_def(Definition::Function(func));
+    }
+
+    pub fn add_class(&mut self, class: ClassDef) {
+        self._add_user_def(Definition::Class(class));
+    }
+
+    pub fn add_data_class(&mut self, data_class: DataClassDef) {
+        self._add_user_def(Definition::DataClass(data_class));
+    }
+
+    pub fn add_enum(&mut self, enum_: EnumDef) {
+        self._add_user_def(Definition::Enum(enum_));
+    }
+
+    pub fn add_exception_base(&mut self, mut exc_base: ExceptionBaseDef) {
+        match &exc_base.parent {
+            None => exc_base.depth = 0,
+            Some(parent_name) => {
+                let parent = self
+                    .get_exception_base(parent_name)
+                    .expect("ExceptionBase {parent_name} not found");
+                exc_base.depth = parent.depth + 1
+            }
+        }
+        self._add_user_def(Definition::ExceptionBase(exc_base));
+    }
+
+    pub fn add_exception(&mut self, exc: ExceptionDef) {
+        self._add_user_def(Definition::Exception(exc));
+    }
+
+    pub fn get_cstruct(&self, name: &str) -> Option<&CStructDef> {
+        self.get_def(name).and_then(Definition::as_cstruct)
+    }
+
+    pub fn get_function(&self, name: &str) -> Option<&FunctionDef> {
+        self.get_def(name).and_then(Definition::as_function)
+    }
+
+    pub fn get_class(&self, name: &str) -> Option<&ClassDef> {
+        self.get_def(name).and_then(Definition::as_class)
+    }
+
+    pub fn get_enum(&self, name: &str) -> Option<&EnumDef> {
+        self.get_def(name).and_then(Definition::as_enum)
+    }
+
+    pub fn get_exception_base(&self, name: &str) -> Option<&ExceptionBaseDef> {
+        self.get_def(name).and_then(Definition::as_exception_base)
+    }
+
+    pub fn get_exception(&self, name: &str) -> Option<&ExceptionDef> {
+        self.get_def(name).and_then(Definition::as_exception)
+    }
+
+    pub fn get_def(&self, name: &str) -> Option<&Definition> {
+        self.definitions.get(name)
+    }
+
+    pub fn iter_definitions(&self) -> impl Iterator<Item = &Definition> {
+        self.definitions
+            .values()
+            .into_iter()
+            // Collect into a BTreeSet to order the definitions.  This groups each kind together.
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+    }
+
+    pub fn add_test(&mut self, name: impl Into<String>, body: impl IntoIterator<Item = Statement>) {
+        self.tests.push(FunctionDef {
+            vis: private(),
+            name: name.into().into(),
+            throws: None,
+            args: vec![],
+            return_type: None,
+            body: block(body),
+        })
+    }
+}

--- a/bindings-ir/src/ir/names.rs
+++ b/bindings-ir/src/ir/names.rs
@@ -1,0 +1,68 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/// Name types
+///
+/// These all use the newtype pattern to wrap a string.  This allows renderers to customize the
+/// naming style when rendering them.
+use serde::{Deserialize, Serialize};
+use std::ops::Deref;
+
+macro_rules! define_names {
+    ($($type_name:ident),* $(,)?) => {
+        $(
+            #[derive(Clone, Debug, Default, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+            #[serde(tag = "ir_type")]
+            pub struct $type_name {
+                pub name: String,
+            }
+
+            impl $type_name {
+                pub fn new(name: impl Into<String>) -> Self {
+                    Self { name: name.into() }
+                }
+
+                pub fn equals(&self, other: &str) -> bool {
+                    self.name == other
+                }
+            }
+
+            impl Deref for $type_name {
+                type Target = String;
+
+                fn deref(&self) -> &String {
+                    &self.name
+                }
+            }
+            impl std::fmt::Display for $type_name {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    write!(f, "{}", self.name)
+                }
+            }
+
+            impl From<String> for $type_name {
+                fn from(name: String) -> Self {
+                    Self { name }
+                }
+            }
+
+            impl From<&str> for $type_name {
+                fn from(name: &str) -> Self {
+                    Self { name: name.to_string() }
+                }
+            }
+        )*
+    }
+}
+
+define_names!(
+    ArgName,
+    FunctionName,
+    FieldName,
+    ClassName,
+    CStructName,
+    VarName
+);

--- a/bindings-ir/src/ir/statement.rs
+++ b/bindings-ir/src/ir/statement.rs
@@ -1,0 +1,301 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use super::{names::*, Expression, Type};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub enum Statement {
+    /// Declare a non-reassignable variable
+    Val {
+        /// Name of the variable
+        name: VarName,
+        /// Type of the variable
+        #[serde(rename = "type")]
+        type_: Type,
+        /// Must match [Type]
+        initial: Expression,
+        /// Can the data inside this variable be changed?
+        mutable: bool,
+    },
+    /// Declare a reassignable varable
+    Var {
+        /// Name of the variable
+        name: VarName,
+        /// Type of the variable
+        #[serde(rename = "type")]
+        type_: Type,
+        /// Must match [Type]
+        initial: Expression,
+        /// Can the data inside this variable be changed?
+        mutable: bool,
+    },
+    /// Assign a new value to a variable.  This is only allowed for primitive types that are
+    /// declared mutable.
+    Assign {
+        name: VarName,
+        value: Expression,
+    },
+    /// Set a value in a CStruct, Record, or Class instance.  This is only allowed for if both the
+    /// variable storing the container and the field are declared mutable.
+    Set {
+        /// Owned CStruct, Record, or Class instance
+        container: Expression,
+        /// name of the field
+        field: FieldName,
+        /// Must match the type of [field]
+        value: Expression,
+    },
+    /// Conditionally execute code based on a boolean value
+    If {
+        expr: Expression,
+        then: Block,
+        #[serde(rename = "else")]
+        else_: Option<Block>,
+    },
+    /// Loop over the range [start, end), both must evaluate to ints.
+    For {
+        var: VarName,
+        start: Expression,
+        end: Expression,
+        block: Block,
+    },
+    /// Contiuously loop until a break statement
+    Loop {
+        block: Block,
+    },
+    /// Break out of a For/Loop/ListIterate/MapIterate statement
+    Break,
+    /// Push a value to the end of a list.  The list variable must be declared mutable.
+    ListPush {
+        list: Expression,
+        value: Expression,
+    },
+    /// Set a value from the middle of the list.  The list variable must be declared mutable.
+    ListSet {
+        list: Expression,
+        index: Expression,
+        value: Expression,
+    },
+    /// Remove all elements from a map.  The list variable must be declared mutable.
+    ListEmpty {
+        list: Expression,
+    },
+    /// Iterate through all elements in a list
+    ListIterate {
+        list: Expression,
+        var: VarName,
+        block: Block,
+    },
+    /// Push a value to the end of a list.  The map variable must be declared mutable.
+    MapSet {
+        map: Expression,
+        key: Expression,
+        value: Expression,
+    },
+    /// Remove one element. from a map.  The map variable must be declared mutable.
+    MapRemove {
+        map: Expression,
+        key: Expression,
+    },
+    // Remove all elements from a map.  The map variable must be declared mutable.
+    MapEmpty {
+        map: Expression,
+    },
+    /// Iterate through all elements in a map
+    MapIterate {
+        map: Expression,
+        key_var: VarName,
+        val_var: VarName,
+        block: Block,
+    },
+    /// Set the current position of a buffer stream
+    BufStreamSetPos {
+        buf: Expression,
+        pos: Expression,
+    },
+    // Write a u8 value to a buffer stream.  The variable must be declared mutable.
+    BufStreamWriteUInt8 {
+        buf: Expression,
+        value: Expression,
+    },
+    // Write a u16 value to a buffer stream.  The variable must be declared mutable.
+    BufStreamWriteUInt16 {
+        buf: Expression,
+        value: Expression,
+    },
+    // Write a u32 value to a buffer stream.  The variable must be declared mutable.
+    BufStreamWriteUInt32 {
+        buf: Expression,
+        value: Expression,
+    },
+    // Write a u64 value to a buffer stream.  The variable must be declared mutable.
+    BufStreamWriteUInt64 {
+        buf: Expression,
+        value: Expression,
+    },
+    // Write a i8 value to a buffer stream.  The variable must be declared mutable.
+    BufStreamWriteInt8 {
+        buf: Expression,
+        value: Expression,
+    },
+    // Write a i16 value to a buffer stream.  The variable must be declared mutable.
+    BufStreamWriteInt16 {
+        buf: Expression,
+        value: Expression,
+    },
+    // Write a i32 value to a buffer stream.  The variable must be declared mutable.
+    BufStreamWriteInt32 {
+        buf: Expression,
+        value: Expression,
+    },
+    // Write a i64 value to a buffer stream.  The variable must be declared mutable.
+    BufStreamWriteInt64 {
+        buf: Expression,
+        value: Expression,
+    },
+    // Write a f32 value to a buffer stream.  The variable must be declared mutable.
+    BufStreamWriteFloat32 {
+        buf: Expression,
+        value: Expression,
+    },
+    // Write a f64 value to a buffer stream.  The variable must be declared mutable.
+    BufStreamWriteFloat64 {
+        buf: Expression,
+        value: Expression,
+    },
+    // Write a string value to a buffer stream.  The variable must be declared mutable.
+    BufStreamWriteString {
+        buf: Expression,
+        value: Expression,
+    },
+    // Write a pointer value to a buffer stream.  The variable must be declared mutable.
+    BufStreamWritePointer {
+        name: String,
+        buf: Expression,
+        value: Expression,
+    },
+    /// Conditionally execute code based on an enum variant
+    MatchEnum {
+        value: Expression,
+        name: ClassName,
+        /// Arms of of the match, each variant must be matched by an arm
+        arms: Vec<MatchEnumArm>,
+    },
+    /// Conditionally execute code based on an int value
+    MatchInt {
+        #[serde(rename = "type")]
+        type_: Type,
+        value: Expression,
+        /// Arms of of the match, each possible value must be matched by an arm
+        arms: Vec<MatchIntArm>,
+    },
+    /// Conditionally execute code based on if a value is null or not
+    MatchNullable {
+        value: Expression,
+        some_arm: MatchArmSome,
+        null_arm: MatchArmNull,
+    },
+    /// Destructure a CStruct into it's individual fields.
+    ///
+    /// This allows you to get owned values for the fields.
+    Destructure {
+        // Name of the CStruct
+        name: ClassName,
+        cstruct: Expression,
+        /// Variables to store each field, the length of this should match the number of fields
+        vars: Vec<VarName>,
+    },
+    /// Return a value, only valid inside a function or method
+    Return {
+        value: Option<Expression>,
+    },
+    /// Raise an exception
+    Raise {
+        exception: Expression,
+    },
+    /// Raise a internal exception
+    ///
+    /// Internal exceptions are similar to Rust panics and should be used for bugs that can't be
+    /// recovered from.  Internal exceptions can be thrown from any function and don't need to be
+    /// declared in the `throws` field.
+    RaiseInternalException {
+        message: Expression,
+    },
+    /// Assert that an expression is true.  Only valid in test cases
+    ///
+    Assert {
+        value: Expression,
+    },
+    /// AssertRaises that a statement raises an exception.  Only valid in test cases.
+    AssertRaises {
+        name: ClassName,
+        stmt: Box<Statement>,
+    },
+    /// Test the AsString method of a raised exception.  Only valid in test cases
+    AssertRaisesWithString {
+        string_value: Expression,
+        stmt: Box<Statement>,
+    },
+    /// For garbage collected languages, run a garbage collection pass
+    Gc,
+    /// Execute an expression
+    #[serde(rename = "ExpressionStatement")]
+    Expression {
+        expr: Expression,
+    },
+}
+
+/// A single arm of a MatchEnum statement.
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub enum MatchEnumArm {
+    /// Match a particular variant
+    Variant {
+        // Name of the Variant
+        variant: ClassName,
+        /// Variables for each variant field.  These will be available inside the code block
+        vars: Vec<VarName>,
+        /// Block of code to execute for this arm
+        block: Block,
+    },
+    /// Match any other variants.  This must always come last in the list
+    Default { block: Block },
+}
+
+/// A single arm of a MatchInt statement.
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub enum MatchIntArm {
+    /// Match a particular value
+    Value {
+        value: i32,
+        /// Block of code to execute for this arm
+        block: Block,
+    },
+    /// Match any other values.  This must always come last in the list
+    Default { block: Block },
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct MatchArmSome {
+    pub var: VarName,
+    pub block: Block,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct MatchArmNull {
+    pub block: Block,
+}
+
+#[derive(Clone, Debug, Default, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub struct Block {
+    pub statements: Vec<Statement>,
+}

--- a/bindings-ir/src/ir/types.rs
+++ b/bindings-ir/src/ir/types.rs
@@ -1,0 +1,171 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::ir::names::*;
+use serde::{Deserialize, Serialize};
+
+/// Type used in the AST
+///
+/// Types can have several properties which are listed in the docstring for their variant:
+///   - Primitive: primitive data like ints and floats.  Primitive types are passed by copy and
+///     do not support references and can not be nullable.  Non-primitive types are passed by move
+///     and support references when a move is not desirable.
+///   - FFI: Can be used in FFI functions that call into the native C-API library.
+///   - User: User-friendly" types that will feel familiar to developers if they are returned from
+///     a bindings function.
+///
+/// This type system needs to be compatible with the type system of the target language, which
+/// leads to two tricky issues:
+///
+/// # Mutability
+///
+/// Many languages have a concept of const vs mutable variables, but the meaning differs.  For JS
+/// const means a variable can't be reassigned, but its contains can change.  For Kotlin val means
+/// a variable can't be reassigned, but lists/maps can be mutated and object fields can be mutated
+/// if they're declared as var.  For Rust, normal variables can't be mutated or reassigned while
+/// both are valid for mutable variables.
+///
+/// In order to support all models, we need to distinguish all cases:
+///   - `Var` declares a re-assignable variable, while `Val` declares a non-reassignable variable
+///   - For both of those, the `mutable` property determines if the value inside the variable can be
+///     mutated.
+///   - For class fields, the `mutable` property determines if the field can be changed (both
+///     the varable and the field must be declared mutable).
+///
+/// # Ownership
+///
+/// Since we're dealing with raw pointers, we need to figure out some system of ownership that
+/// avoids things like use-after-free errrors. After we pass an pointer into a function, can we use
+/// it or not?  The same question arises for classes/cstructs that contain a pointer field.
+///
+/// A related question is how to pass around list/map/string instances without copying them?  We
+/// need some way to determine which piece of code is responsible for freeing the data at the end
+/// of all of it.
+///
+/// I can think of several solutions to this:
+///
+/// - Wild-west style.  Copy around pointers and objects that contain them without regard to
+///   ownership and make freeing the data the generated code's responsibility. This would keep the
+///   AST simple, but is obviously dangerous and would make the generated code harder to reason
+///   about.
+///
+/// - Ref-counting.  We could pass around ref-counted pointers and free things once the ref-count
+///   becomes zero.  This would cover the list/map/string cases great in ref-counted languages, but
+///   it wouldn't be so great if we wanted to add support for non-ref counted languages. For
+///   example in C++ its faster and more idiomatic to use `vector<T>` for lists rather than
+///   `shared_ptr<vector<T>>`.  Another issue is how to handle pointers being passed to Rust FFI
+///   functions that consume the value, like `rust_buffer_reserve()`. That said, this is a
+///   reasonable alternative that we should consider.
+///
+/// - Ownership system.  Use a Rust-style ownership system where we identify when we're borrowing
+///   data vs when we've moving it.  This adds complexity to the AST code, but it gives a lot of
+///   flexbility and I think that will lead to the nicest generated APIs (for example the C++
+///   bindings can return `vector<T>`. To keep things simple, we impose the requirement that
+///   references can never be stored or returned.
+///
+///   Right now this ownership system is just described in comments, but not actually enforced.
+///   Hovewer, I believe that we can use a simple/restricted system for borrowing and that will
+///   enable us to write simple borrow checker to enforce the rules.
+///
+///   I think it should be pretty straightforward to translate the borrow system into our target
+///   languages.  Ref-counted languages can just treat a borrow as a regular reference, but they
+///   will still get the benefits of the borrow checker -- for example after passing an object into
+///   an FFI function that takes ownership of it, that object will still be in scope, but the
+///   borrow checker can ensure that it's not used.  Other languages will need to do some
+///   translation, but I think it should be easy.  In C++, passing a reference to a function will
+///   be rendered as `foo` and passing an owned value will be rendered as `std::move(foo)`.
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+#[serde(tag = "ir_type")]
+pub enum Type {
+    /// 8-bit unsigned int.
+    ///
+    /// Primitive/User/FFI
+    UInt8,
+    /// 8-bit signed int.
+    ///
+    /// Primitive/User/FFI
+    Int8,
+    /// 16-bit unsigned int.
+    ///
+    /// Primitive/User/FFI
+    UInt16,
+    /// 16-bit signed int.
+    ///
+    /// Primitive/User/FFI
+    Int16,
+    /// 32-bit unsigned int.
+    ///
+    /// Primitive/User/FFI
+    UInt32,
+    /// 32-bit signed int.
+    ///
+    /// Primitive/User/FFI
+    Int32,
+    /// 64-bit unsigned int.
+    ///
+    /// Primitive/User/FFI
+    UInt64,
+    /// 64-bit signed int.
+    ///
+    /// Primitive/User/FFI
+    Int64,
+    /// 32-bit float.
+    ///
+    /// Primitive/User/FFI
+    Float32,
+    /// 64-bit float
+    ///
+    /// Primitive/User/FFI
+    Float64,
+    /// Pointer to a Rust object.
+    ///
+    /// Name is a unique string that identifies the type of pointer.  Eventually we should add a
+    /// static type check that functions are called with the correct type of pointers.
+    ///
+    /// FFI functions should be intentional about inputting a Pointer or Reference<Pointer>.  Both
+    /// have the same representation, but Pointer should be used when the function consumes the
+    /// underlying value and Reference<Pointer> should be used when it doesn't.
+    ///
+    /// FFI
+    Pointer { name: String },
+    /// C struct value
+    ///
+    /// This is basically the same as Record and some languages will use the same type for both.
+    /// But for many languages, the type that can be passed across the FFI is not very
+    /// user-friendly, In Kotlin, it's the difference between `com.sun.jna.Structure` and a data
+    /// class.
+    ///
+    /// FFI
+    CStruct { name: CStructName },
+    /// True/false value
+    ///
+    /// Primitive/User
+    Boolean,
+    /// String value
+    ///
+    /// User
+    String,
+    /// Instance of a Class, DataClass, Enum, CStruct, BufferStream, etc.
+    ///
+    /// User
+    Object { class: ClassName },
+    /// Nullable type
+    ///
+    /// The inner type can not be another `Nullable`.
+    ///
+    /// User.  FFI when the inner type is a Pointer.
+    Nullable { inner: Box<Type> },
+    /// List of homogenious data
+    ///
+    /// User
+    List { inner: Box<Type> },
+    /// Key-Value map.  Keys can either be Int or String types.
+    ///
+    /// User
+    Map { key: Box<Type>, value: Box<Type> },
+    /// Reference to a type
+    Reference { inner: Box<Type>, mutable: bool },
+}

--- a/bindings-ir/src/lib.rs
+++ b/bindings-ir/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod ir;
+pub mod renderer;
+
+pub use renderer::{Renderer, TeraArgs};

--- a/bindings-ir/src/renderer.rs
+++ b/bindings-ir/src/renderer.rs
@@ -1,0 +1,568 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::ir::{ClassName, EnumDef, Module, VarName};
+use heck::{
+    ToKebabCase, ToLowerCamelCase, ToShoutyKebabCase, ToShoutySnakeCase, ToSnakeCase,
+    ToUpperCamelCase,
+};
+use regex::Captures;
+use serde::Serialize;
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Weak};
+use tera::{to_value, try_get_value, Context, Error, Map, Result, Tera, Value};
+
+pub type TeraArgs = HashMap<std::string::String, Value>;
+
+// Copied from the once-cell docs
+macro_rules! regex {
+    ($re:literal $(,)?) => {{
+        static RE: once_cell::sync::OnceCell<regex::Regex> = once_cell::sync::OnceCell::new();
+        RE.get_or_init(|| regex::Regex::new($re).unwrap())
+    }};
+}
+
+/// Renders AST items
+///
+/// This struct wraps Tera and adds some extra features:
+///   - Registers some useful functions and filters (see [setup_tera])
+///   - Supports "AST templates", which are tera templates that can recursively render AST items
+///     (see [Self::add_ast_templates])
+///   - Adds tera functions to lookup definitions from a [Module] (see [setup_definition_getters])
+pub struct Renderer {
+    tera: Tera,
+}
+
+impl Renderer {
+    pub fn new() -> Self {
+        let mut tera = Tera::default();
+        setup_tera(&mut tera);
+        Self { tera }
+    }
+
+    pub fn tera(&mut self) -> &Tera {
+        &self.tera
+    }
+
+    pub fn tera_mut(&mut self) -> &mut Tera {
+        &mut self.tera
+    }
+
+    /// Add AST templates
+    ///
+    /// AST templates are Tera templates that get pre-processing make recursive rendering simpler.
+    /// Templates are passed in as (`ir_type_name`, `template_source`) tuples.  `ir_type_name` is
+    /// the `ast_type` field set by our `serde::Serialize` implementations.  `template_source` is
+    /// usually either a very short string or comes from an `include_str!` call.
+    ///
+    /// In the template source other AST items can be recursively rendered by putting them in a
+    /// Tera expression.  For example the Add expression can be defined using
+    /// `"{{ first }} + {{ second }}"`.
+    ///
+    /// If an expression appears by itself on a line and is rendered as multiple lines, each
+    /// non-empty line after the first will get an extra indent based on the position of the first
+    /// line.  This allows blocks to be rendered correctly in lanugages like Python where the
+    /// indentation is part of the syntax.  For example:
+    ///
+    /// ```jinja
+    /// for {{ var }} in {{ expression }}:
+    ///     {{ block }}
+    /// ```
+    ///
+    /// Finally, if an recursively rendered expression ends in a newline, it will be trimmed.  This
+    /// is almost always what you want.  In the `Add` example you don't want a newline after the
+    /// sub-expressions and in the `For` example you dont want an 2 newlines after the block.  Only
+    /// 1 newline will be trimmed, which allows for templates to end in a newline if they really
+    /// want to.
+    pub fn add_ast_templates(
+        &mut self,
+        templates: impl IntoIterator<Item = (&'static str, &'static str)>,
+    ) -> Result<()> {
+        self.tera.add_raw_templates(
+            templates
+                .into_iter()
+                .map(|(name, source)| (name, add_implicit_render_filters(source))),
+        )
+    }
+
+    /// Render an AST module
+    pub fn render_module(&mut self, module: Module) -> Result<String> {
+        let serialized_module = to_value(&module)?;
+        self.render_value(module, &serialized_module)
+    }
+
+    // Does the work for render_module, but is split out for easier testing
+    fn render_value(&mut self, module: Module, value: &Value) -> Result<String> {
+        setup_definition_getters(&mut self.tera, module);
+
+        // There's a very annoying circular reference between Tera and the render filter.  To work
+        // around that we:
+        //   - Put our Tera into an `Arc<>`
+        //   - Give the render filter a weakref to Tera.  This creates the circular reference, so
+        //     we need to use Arc::new_cyclic to make this work.
+        //   - We still need a `Tera` value inside the `Renderer` struct.  Put a dummy value
+        //     there while the rendering is happened, then unwrap the Arc at the end of everything
+        //     to restore it.
+        let arc_tera = Arc::new_cyclic(|weakref| {
+            setup_render_filters(&mut self.tera, weakref);
+            std::mem::take(&mut self.tera)
+        });
+        let result = render_value(&arc_tera, value);
+        self.tera = Arc::try_unwrap(arc_tera).unwrap();
+        result
+    }
+}
+
+fn add_implicit_render_filters(template_source: &str) -> String {
+    let expression_re = regex!(r"(\{\{\s*)(.*?)(\s*}})");
+    // Matches a line with just one expression
+    let single_expression_re = regex!(r"^(\s*)(\{\{\s*)([^}]*?)(\s*}})\s*$");
+
+    template_source
+        .split('\n')
+        .map(|line| {
+            if let Some(caps) = single_expression_re.captures(line) {
+                // If a line consists of a single expression only, pass an indent to render so that
+                // subsequent lines are indented
+                Cow::from(format!(
+                    "{}{}{} | render(indent={}){}",
+                    &caps[1],
+                    &caps[2],
+                    &caps[3],
+                    &caps[1].chars().count(),
+                    &caps[4]
+                ))
+            } else {
+                expression_re.replace_all(line, |caps: &Captures| {
+                    format!("{}{} | render{}", &caps[1], &caps[2], &caps[3])
+                })
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Add filters and functions that are generally useful for AST rendering
+///
+/// This includes:
+///   - Heck-based case functions (`to_lower_camel_case`, `to_snake_case`, etc).
+///   - The `has_fields()` filter, which forwards to `EnumDef::has_fields`
+///   - The zip function which zips items from multiple vecs together.  Each argument should be a
+///     Value::Array.  A new array will be created with items from each argument, where each item
+///     is an `Value::Object` with the items from each array.  The field names will match the
+///     argument names passed in to `zip()`.
+///   - The `temp_var_name` function which outputs a VarName that should not collide with other
+///     names.
+pub fn setup_tera(tera: &mut Tera) {
+    tera.register_filter("to_kebab_case", |value: &Value, _: &'_ TeraArgs| {
+        let s = try_get_value!("to_kebab_case", "value", String, value);
+        Ok(to_value(&s.to_kebab_case()).unwrap())
+    });
+    tera.register_filter("to_lower_camel_case", |value: &Value, _: &'_ TeraArgs| {
+        let s = try_get_value!("to_lower_camel_case", "value", String, value);
+        Ok(to_value(&s.to_lower_camel_case()).unwrap())
+    });
+    tera.register_filter("to_shouty_kebab_case", |value: &Value, _: &'_ TeraArgs| {
+        let s = try_get_value!("to_shouty_kebab_case", "value", String, value);
+        Ok(to_value(&s.to_shouty_kebab_case()).unwrap())
+    });
+    tera.register_filter("to_shouty_snake_case", |value: &Value, _: &'_ TeraArgs| {
+        let s = try_get_value!("to_shouty_snake_case", "value", String, value);
+        Ok(to_value(&s.to_shouty_snake_case()).unwrap())
+    });
+    tera.register_filter("to_snake_case", |value: &Value, _: &'_ TeraArgs| {
+        let s = try_get_value!("to_snake_case", "value", String, value);
+        Ok(to_value(&s.to_snake_case()).unwrap())
+    });
+    tera.register_filter("to_upper_camel_case", |value: &Value, _: &'_ TeraArgs| {
+        let s = try_get_value!("to_upper_camel_case", "value", String, value);
+        Ok(to_value(&s.to_upper_camel_case()).unwrap())
+    });
+
+    tera.register_filter("has_fields", |value: &'_ Value, _: &_| {
+        let enum_ = try_get_value!("has_fields", "value", EnumDef, value);
+        Ok(to_value(enum_.has_fields())?)
+    });
+
+    tera.register_function("zip", |args: &'_ TeraArgs| {
+        let mut iters = vec![];
+        for (name, value) in args {
+            let v = try_get_value!("zip", name, Vec<Value>, value);
+            iters.push((name, v.into_iter()));
+        }
+        let mut ziped_values = vec![];
+        'outer: loop {
+            let mut item = Map::new();
+            for (name, ref mut iter) in &mut iters {
+                match iter.next() {
+                    Some(v) => item.insert(name.to_string(), v),
+                    None => break 'outer,
+                };
+            }
+            ziped_values.push(Value::Object(item));
+        }
+
+        Ok(Value::Array(ziped_values))
+    });
+
+    tera.register_function("temp_var_name", |_: &_| {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let val = COUNTER.fetch_add(1, Ordering::Relaxed);
+        Ok(to_value(VarName::new(format!("bindingsIrTmp{val}")))?)
+    });
+}
+
+/// Setup definition getter functions.
+///
+/// This registers functions that fetch definition items from the Module, for example `get_class`,
+/// `get_function`, etc.
+///
+/// Also the `variant` filter will be added, which can be used to lookup a variant from an
+/// `EnumDef`.  The name of the variant should be passed in as the `name` argument.
+///
+/// Each call to [Renderer.render_module()] will call this, replaces any previous registered
+/// definition getters.
+pub fn setup_definition_getters(tera: &mut Tera, module: Module) {
+    // Create an Arc to the module for each DefinitionGetter to share
+    let module = Arc::new(module);
+    setup_definition_getter(tera, &module, "get_cstruct", |module, name| {
+        module.get_cstruct(name)
+    });
+    setup_definition_getter(tera, &module, "get_function", |module, name| {
+        module.get_function(name)
+    });
+    setup_definition_getter(tera, &module, "get_class", |module, name| {
+        module.get_class(name)
+    });
+    setup_definition_getter(tera, &module, "get_enum", |module, name| {
+        module.get_enum(name)
+    });
+    setup_definition_getter(tera, &module, "get_cstruct", |module, name| {
+        module.get_cstruct(name)
+    });
+    setup_definition_getter(tera, &module, "get_exception_base", |module, name| {
+        module.get_exception_base(name)
+    });
+    setup_definition_getter(tera, &module, "get_exception", |module, name| {
+        module.get_exception(name)
+    });
+    setup_definition_getter(tera, &module, "get_def", |module, name| {
+        module.get_def(name)
+    });
+    setup_definition_getter(tera, &module, "get_ffi_function", |module, name| {
+        module
+            .native_library
+            .as_ref()
+            .map(|lib| lib.functions.get(name))
+            .flatten()
+    });
+    tera.register_filter("variant", move |value: &Value, args: &'_ TeraArgs| {
+        let enum_ = try_get_value!("variant", "value", EnumDef, value);
+        let variant_name = try_get_value!(
+            "variant",
+            "name",
+            ClassName,
+            args.get("name").unwrap_or(&Value::Null)
+        );
+        let variant = enum_.get_variant(&variant_name.name);
+        match variant {
+            Some(v) => Ok(to_value(v)?),
+            None => Err(Error::msg(format!("Variant not found: {variant_name}"))),
+        }
+    });
+}
+
+fn setup_definition_getter<F, T>(
+    tera: &mut Tera,
+    module: &Arc<Module>,
+    func_name: &'static str,
+    getter: F,
+) where
+    F: for<'a, 'b> Fn(&'a Module, &'b str) -> Option<&'a T> + Send + Sync + 'static,
+    T: Serialize + 'static,
+{
+    let module = module.clone();
+    tera.register_function(func_name, move |args: &TeraArgs| {
+        let name = match args.get("name") {
+            Some(Value::String(s)) => s,
+            Some(Value::Object(map)) => match map.get("name") {
+                Some(Value::String(s)) => s,
+                Some(_) => {
+                    return Err(Error::msg(format!(
+                    "Function {func_name} was called with an object with a non-string `name` field",
+                )))
+                }
+                None => {
+                    return Err(Error::msg(format!(
+                        "Function {func_name} was called with an object without a `name` field",
+                    )))
+                }
+            },
+            Some(val) => {
+                return Err(Error::msg(format!(
+                "Function {func_name} was called with an invalid type for arg name (got `{val}`)",
+            )))
+            }
+            None => {
+                return Err(Error::msg(format!(
+                    "Function {func_name} was called without a name arg",
+                )))
+            }
+        };
+        match getter(module.as_ref(), name) {
+            Some(v) => Ok(to_value(v)?),
+            None => Err(Error::msg(format!("{name} not defined"))),
+        }
+    });
+}
+
+fn setup_render_filters(tera: &mut Tera, weakref: &Weak<Tera>) {
+    let render_weakref = Weak::clone(weakref);
+    tera.register_filter("render", move |value: &Value, args: &'_ TeraArgs| {
+        let tera = render_weakref
+            .upgrade()
+            .ok_or_else(|| Error::msg("Weakref no longer valid"))?;
+        let indent_str = args
+            .get("indent")
+            .map(|v| " ".repeat(v.as_u64().unwrap_or(0) as usize));
+        render_value(&tera, value).map(|s| match indent_str {
+            Some(indent_str) => {
+                let mut s = s
+                    .split('\n')
+                    .enumerate()
+                    .map(|(i, line)| {
+                        if i == 0 || line.is_empty() {
+                            Cow::from(line)
+                        } else {
+                            Cow::from(format!("{}{}", indent_str, line))
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                if let Some('\n') = s.chars().last() {
+                    s.pop();
+                }
+                Value::String(s)
+            }
+            None => Value::String(s),
+        })
+    });
+    // Also register comma_join, which depends on render
+    let comma_join_weakref = weakref.clone();
+    tera.register_filter("comma_join", move |value: &Value, _: &'_ TeraArgs| {
+        let tera = comma_join_weakref
+            .upgrade()
+            .ok_or_else(|| Error::msg("Weakref no longer valid"))?;
+        let values = try_get_value!("comma_join", "value", Vec<Value>, value);
+        Ok(Value::String(
+            values
+                .into_iter()
+                .map(|v| {
+                    render_value(&tera, &v).map(|mut s| {
+                        if let Some('\n') = s.chars().last() {
+                            s.pop();
+                        }
+                        s
+                    })
+                })
+                .collect::<Result<Vec<String>>>()?
+                .join(", "),
+        ))
+    });
+}
+
+fn render_value(tera: &Tera, value: &Value) -> Result<String> {
+    Ok(match value {
+        Value::String(v) => v.clone(),
+        Value::Number(v) => v.to_string(),
+        Value::Bool(v) => v.to_string(),
+        Value::Null => "null".to_string(),
+        Value::Array(_) => "[array]".to_string(),
+        Value::Object(o) => {
+            if let Some(Value::String(ir_type)) = o.get("ir_type") {
+                let mut context = Context::from_value(value.clone())?;
+                context.insert("self", value);
+                tera.render(ir_type, &context)?
+            } else {
+                "[object]".to_string()
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ast::helpers::*;
+
+    // Render a single AST item instead of a whole module, which makes the tests simpler
+    fn render_ast_item(renderer: &mut Renderer, item: impl Serialize) -> String {
+        render_ast_item_with_module(renderer, Module::new(), item)
+    }
+
+    fn render_ast_item_with_module(
+        renderer: &mut Renderer,
+        module: Module,
+        item: impl Serialize,
+    ) -> String {
+        renderer
+            .render_value(module, &to_value(&item).unwrap())
+            .unwrap()
+    }
+
+    #[test]
+    fn test_add_implicit_render_filters() {
+        let test_cases = [
+            ("no_substitutions_needed", "no_substitutions_needed"),
+            ("{{ foo }}", "{{ foo | render(indent=0) }}"),
+            ("{{ foo.bar }}", "{{ foo.bar | render(indent=0) }}"),
+            (
+                "{{ foo.bar|filter }}",
+                "{{ foo.bar|filter | render(indent=0) }}",
+            ),
+            (
+                r#"{{ foo.bar | replace(from="a", "to"b") }}"#,
+                r#"{{ foo.bar | replace(from="a", "to"b") | render(indent=0) }}"#,
+            ),
+            (
+                "{{ foo }}\n{{ bar }}",
+                "{{ foo | render(indent=0) }}\n{{ bar | render(indent=0) }}",
+            ),
+            ("    {{ foo }}", "    {{ foo | render(indent=4) }}"),
+            (
+                "    {{ foo }} {{ bar }}",
+                "    {{ foo | render }} {{ bar | render }}",
+            ),
+            (
+                "{{ dont_add_render \n when_split_over_lines }}",
+                "{{ dont_add_render \n when_split_over_lines }}",
+            ),
+        ];
+        for (source, rendered) in test_cases {
+            assert_eq!(add_implicit_render_filters(source), rendered)
+        }
+    }
+
+    #[test]
+    fn test_renderer() {
+        let mut renderer = Renderer::new();
+        renderer
+            .add_ast_templates([
+                ("Add", "{{ first }} + {{ second }}"),
+                ("Var", "{{ name }}"),
+                ("VarName", "{{ name|to_lower_camel_case }}"),
+            ])
+            .unwrap();
+
+        assert_eq!(
+            render_ast_item(
+                &mut renderer,
+                &add(ident("number_one"), ident("number_two"))
+            ),
+            "numberOne + numberTwo"
+        )
+    }
+
+    #[test]
+    fn test_definition_getters() {
+        let mut renderer = Renderer::new();
+        renderer.add_ast_templates([
+            (
+                "ClassName",
+                "{%- set cstruct_def = get_cstruct(name=name) -%}{{ cstruct_def.fields|map(attribute='name')|comma_join }}"
+            ),
+        ])
+        .unwrap();
+        let mut module = Module::new();
+        module.add_cstruct(cstruct::def(
+            "MyStruct",
+            [
+                cstruct::field("field_one", types::int32()),
+                cstruct::field("field_two", types::int32()),
+            ],
+        ));
+
+        assert_eq!(
+            render_ast_item_with_module(&mut renderer, module, &ClassName::new("MyStruct")),
+            "field_one, field_two"
+        )
+    }
+
+    #[test]
+    fn test_comma_join() {
+        let mut renderer = Renderer::new();
+        renderer
+            .add_ast_templates([
+                ("Var", "{{ name }}"),
+                ("VarName", "{{ name|to_lower_camel_case }}"),
+                ("FunctionName", "{{ name|to_lower_camel_case }}"),
+                ("Call", "{{ name }}({{ values|comma_join }})"),
+            ])
+            .unwrap();
+
+        assert_eq!(
+            render_ast_item(
+                &mut renderer,
+                &call("foo", [ident("x"), ident("y"), ident("z")])
+            ),
+            "foo(x, y, z)"
+        )
+    }
+
+    #[test]
+    fn test_zip() {
+        let mut renderer = Renderer::new();
+        let rendered = renderer.tera_mut().render_str(
+            r#"{% for item in zip(one=["a", "b", "c"], two=[1, 2, 3]) %}{{ item.one }}-{{ item.two }}{% if not loop.last %}, {% endif %}{% endfor %}"#,
+            &Context::new(),
+        ).unwrap();
+        assert_eq!(rendered, "a-1, b-2, c-3",)
+    }
+
+    #[test]
+    fn test_indent_expressions() {
+        let mut renderer = Renderer::new();
+        renderer
+            .add_ast_templates([
+                ("FunctionName", "{{ name|to_lower_camel_case }}"),
+                ("VarName", "{{ name|to_lower_camel_case }}"),
+                ("LiteralInt", "{{ value }}"),
+                ("Init", "{{ name }} = {{ initial }}"),
+                ("Var", "{{ name }}"),
+                ("Return", "return {{ value }}"),
+                ("FunctionDef", "def {{ name }}():\n    {{ body }}"),
+                (
+                    "Block",
+                    "{% for stmt in statements %}{{ stmt }}\n{% endfor %}",
+                ),
+            ])
+            .unwrap();
+
+        assert_eq!(
+            render_ast_item(
+                &mut renderer,
+                &func("foo").body([var("x", types::int(), lit::int(1)), return_(ident("x")),])
+            ),
+            vec!["def foo():", "    x = 1", "    return x",].join("\n")
+        )
+    }
+
+    #[test]
+    fn test_remove_trailing_newline() {
+        let mut renderer = Renderer::new();
+        renderer
+            .add_ast_templates([
+                ("Var", "{{ name }}"),
+                ("VarName", "{{ name|to_lower_camel_case }}\n"),
+            ])
+            .unwrap();
+
+        assert_eq!(
+            render_ast_item(&mut renderer, ident("number_one")),
+            "numberOne",
+        )
+    }
+}

--- a/examples/sprites/tests/bindings/test_sprites.kts
+++ b/examples/sprites/tests/bindings/test_sprites.kts
@@ -12,14 +12,6 @@ assert( s.getPosition() == Point(1.0, 2.0) )
 s.moveBy(Vector(-4.0, 2.0))
 assert( s.getPosition() == Point(-3.0, 4.0) )
 
-s.destroy()
-try {
-    s.moveBy(Vector(0.0, 0.0))
-    assert(false) { "Should not be able to call anything after `destroy`" }
-} catch(e: IllegalStateException) {
-    assert(true)
-}
-
 val srel = Sprite.newRelativeTo(Point(0.0, 1.0), Vector(1.0, 1.5))
 assert( srel.getPosition() == Point(1.0, 2.5) )
 

--- a/render-macro/Cargo.toml
+++ b/render-macro/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "render-macro"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+once_cell = "1"
+itertools = "0.10"
+regex = "1"
+syn = { version = "1", features = ["extra-traits", "full"] }

--- a/render-macro/src/lib.rs
+++ b/render-macro/src/lib.rs
@@ -1,0 +1,159 @@
+//! Crate with macro implementations of `expression_format`.
+//!
+//! A separete crate is required to test procedural macros.
+
+extern crate proc_macro;
+
+use itertools::Itertools;
+use proc_macro::TokenStream;
+use regex::Captures;
+use syn::{parse_macro_input, ExprLit, Lit};
+
+// Taken from the once-cell docs
+macro_rules! regex {
+    ($re:literal $(,)?) => {{
+        static RE: once_cell::sync::OnceCell<regex::Regex> = once_cell::sync::OnceCell::new();
+        RE.get_or_init(|| regex::Regex::new($re).unwrap())
+    }};
+}
+
+#[proc_macro]
+pub fn render(tokens: TokenStream) -> TokenStream {
+    let expr = parse_macro_input!(tokens as ExprLit);
+    match expr.lit {
+        Lit::Str(s) => format_render(&s.value()).parse().unwrap(),
+        _ => panic!("String literal expected"),
+    }
+}
+
+#[proc_macro]
+pub fn render_indoc(tokens: TokenStream) -> TokenStream {
+    let expr = parse_macro_input!(tokens as ExprLit);
+    match expr.lit {
+        Lit::Str(s) => format_render_indoc(&s.value()).parse().unwrap(),
+        _ => panic!("String literal expected"),
+    }
+}
+
+enum FormatArg {
+    Plain(String),
+    CommaJoin(String),
+}
+
+fn format_render(render_string: &str) -> String {
+    // Start by quoting all `{`, `}`, and `"` chars
+    let quoted_string = render_string
+        .replace('{', "{{")
+        .replace('}', "}}")
+        .replace('"', r#"\""#);
+    // Handle named parameters
+    let named_param = regex!(r"\{\{([[:alpha:]][[:alnum:]\._]*)(,?)}}");
+    let mut args = vec![];
+    let format_string = named_param.replace_all(&quoted_string, |caps: &Captures| {
+        let name = caps[1].to_string();
+        args.push(match &caps[2] {
+            "" => FormatArg::Plain(name),
+            "," => FormatArg::CommaJoin(name),
+            _ => unreachable!(),
+        });
+        "{}"
+    });
+    let format_args: String = args
+        .iter()
+        .map(|arg| match arg {
+            FormatArg::Plain(name) => format!(", self.render(&{name})"),
+            FormatArg::CommaJoin(name) => {
+                format!(r#", (&{name}).into_iter().map(|i| self.render(i)).collect::<Vec<_>>().join(", ")"#)
+            }
+        })
+        .collect();
+    format!(r#"format!("{format_string}"{format_args})"#)
+}
+
+fn format_render_indoc(render_string: &str) -> String {
+    let mut lines = render_string.lines().peekable();
+    // Skip over the first newline
+    if matches!(lines.peek(), Some(l) if l.is_empty()) {
+        lines.next();
+    }
+
+    let min_leading_whitespace = lines
+        .clone()
+        .map(count_leading_whitespace)
+        .filter(|v| *v > 0)
+        .min();
+    let to_strip = match min_leading_whitespace {
+        None => return format_render(""),
+        Some(value) => value,
+    };
+
+    format_render(
+        &lines
+            .map(|line| {
+                if line.is_empty() {
+                    line
+                } else {
+                    &line[to_strip..]
+                }
+            })
+            .join("\n"),
+    )
+}
+
+fn count_leading_whitespace(value: &str) -> usize {
+    value.chars().take_while(|c| *c == ' ').count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_render() {
+        assert_eq!(format_render("hello world"), r#"format!("hello world")"#);
+        assert_eq!(
+            format_render("hello {world}"),
+            r#"format!("hello {}", self.render(&world))"#
+        );
+        assert_eq!(
+            format_render("{a} == {b}"),
+            r#"format!("{} == {}", self.render(&a), self.render(&b))"#
+        );
+        assert_eq!(
+            format_render("{hello.world}"),
+            r#"format!("{}", self.render(&hello.world))"#
+        );
+        assert_eq!(
+            format_render("{ {a} == {b} }"),
+            r#"format!("{{ {} == {} }}", self.render(&a), self.render(&b))"#
+        );
+        assert_eq!(
+            format_render("\"{foo}\""),
+            r#"format!("\"{}\"", self.render(&foo))"#
+        );
+    }
+
+    #[test]
+    fn test_comma_join() {
+        assert_eq!(
+            format_render("\"{foo,}\""),
+            r#"format!("\"{}\"", (&foo).into_iter().map(|i| self.render(i)).collect::<Vec<_>>().join(", "))"#
+        );
+    }
+
+    #[test]
+    fn test_render_indoc() {
+        assert_eq!(
+            format_render_indoc("  hello\n  world"),
+            "format!(\"hello\nworld\")"
+        );
+        assert_eq!(
+            format_render_indoc("  hello\n    world"),
+            "format!(\"hello\n  world\")"
+        );
+        assert_eq!(
+            format_render_indoc("\n  hello\n    world"),
+            "format!(\"hello\n  world\")"
+        );
+    }
+}

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -20,6 +20,7 @@ askama = { version = "0.11", default-features = false, features = ["config"] }
 bincode = "1.3"
 camino = "1.0.8"
 clap = { version = "3.1", features = ["cargo", "std", "derive"] }
+extend = "1.1"
 fs-err = "2.7.0"
 goblin = "0.5"
 heck = "0.4"
@@ -30,3 +31,5 @@ serde_json = "1.0.80"
 toml = "0.5"
 weedle2 = { version = "4.0.0", path = "../weedle2" }
 uniffi_meta = { path = "../uniffi_meta", version = "=0.20.0" }
+bindings-ir = { path = "../bindings-ir" }
+bindings-ir-kotlin = { path = "../bindings-ir-kotlin" }

--- a/uniffi_bindgen/src/bindings/ir/compounds.rs
+++ b/uniffi_bindgen/src/bindings/ir/compounds.rs
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::*;
+use crate::interface;
+use bindings_ir::ir::*;
+
+pub(super) fn build_module(module: &mut Module, ci: &interface::ComponentInterface) {
+    for type_ in ci.iter_types() {
+        match type_ {
+            interface::Type::Optional(inner) => {
+                add_optional_ffi_converter(module, ci, type_, inner)
+            }
+            interface::Type::Sequence(inner) => {
+                unimplemented!()
+            }
+            interface::Type::Map(key, value) => {
+                unimplemented!()
+            }
+            _ => (),
+        }
+    }
+}
+
+fn add_optional_ffi_converter(
+    module: &mut Module,
+    ci: &interface::ComponentInterface,
+    type_: &interface::Type,
+    inner: &interface::Type,
+) {
+    add_allocation_size_func(
+        module,
+        &type_,
+        [match_nullable(
+            ident("value"),
+            arm::some(
+                "inner_value",
+                [return_(add(
+                    int32(),
+                    lit::int32(1),
+                    inner.call_allocation_size(ident("inner_value")),
+                ))],
+            ),
+            arm::null([return_(lit::int32(1))]),
+        )],
+    );
+    add_read_func(
+        module,
+        &type_,
+        [if_else(
+            eq(lit::int8(1), buf::read_int8(ident("stream"))),
+            [return_(inner.call_read(ident("stream")))],
+            [return_(lit::null())],
+        )],
+    );
+    add_write_func(
+        module,
+        &type_,
+        [match_nullable(
+            ident("value"),
+            arm::some(
+                "inner_value",
+                [
+                    buf::write_int8(ident("stream"), lit::int8(1)),
+                    inner
+                        .call_write(ident("stream"), ident("inner_value"))
+                        .into_statement(),
+                ],
+            ),
+            arm::null([buf::write_int8(ident("stream"), lit::int8(0))]),
+        )],
+    );
+    add_rust_buffer_lift_and_lower_funcs(module, ci, type_);
+}

--- a/uniffi_bindgen/src/bindings/ir/errors.rs
+++ b/uniffi_bindgen/src/bindings/ir/errors.rs
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::*;
+use crate::interface;
+use bindings_ir::ir::*;
+
+pub(super) fn build_module(module: &mut Module, ci: &interface::ComponentInterface) {
+    for error in ci.error_definitions() {
+        module.add_exception_base(exception_base_def(error.name()));
+        for variant in error.variants() {
+            module.add_exception(ExceptionDef {
+                name: variant.name().into(),
+                parent: error.name().into(),
+                fields: variant.fields().into_ir(),
+                ..ExceptionDef::default()
+            });
+        }
+        add_error_write_func(module, error);
+        add_error_allocation_size_func(module, error);
+        add_error_read_func(module, error);
+        add_rust_buffer_lift_and_lower_funcs(module, ci, &error.type_());
+    }
+}
+
+fn add_error_read_func(module: &mut Module, error: &interface::Error) {
+    let mut read_body = vec![val("variant_num", int32(), buf::read_int32(ident("stream")))];
+    for (i, variant) in error.variants().into_iter().enumerate() {
+        read_body.push(if_(
+            eq(lit::int32((i + 1) as i32), ident("variant_num")),
+            [return_(create_exception(
+                variant.name(),
+                variant
+                    .fields()
+                    .into_iter()
+                    .map(|f| f.type_().call_read(ident("stream"))),
+            ))],
+        ));
+    }
+    read_body.push(raise_internal_exception(string::concat([
+        lit::string(format!("{}.read: invalid variant num: ", error.name())),
+        ident("variant_num"),
+    ])));
+    add_read_func(module, &error.type_(), read_body);
+}
+
+fn add_error_write_func(module: &mut Module, error: &interface::Error) {
+    let write_variant = |variant_num, variant: &interface::Variant| {
+        let mut block = vec![buf::write_int32(
+            ident("stream"),
+            lit::int32(variant_num as i32),
+        )];
+        for f in variant.fields() {
+            block.push(
+                f.type_()
+                    .call_write(ident("stream"), get(ident("value"), f.name()))
+                    .into_statement(),
+            );
+        }
+        block
+    };
+
+    add_write_func(
+        module,
+        &error.type_(),
+        error
+            .variants()
+            .into_iter()
+            .enumerate()
+            .map(|(i, variant)| {
+                if_(
+                    is_instance(ident("value"), variant.name()),
+                    write_variant(i + 1, variant),
+                )
+            }),
+    );
+}
+
+fn add_error_allocation_size_func(module: &mut Module, error: &interface::Error) {
+    let mut body = vec![];
+    for variant in error.variants() {
+        body.push(if_(
+            is_instance(ident("value"), variant.name()),
+            [return_(
+                variant
+                    .fields()
+                    .iter()
+                    .map(|f| {
+                        f.type_()
+                            .call_allocation_size(get(ident("value"), f.name()))
+                    })
+                    .fold(
+                        // 4 bytes for the i32 to specify the variast
+                        lit::int32(4),
+                        // Then add the size of each individual field for the variant
+                        |a, b| add(int32(), a, b),
+                    ),
+            )],
+        ));
+    }
+    body.push(raise_internal_exception(lit::string(format!(
+        "{}.allocation_size: unknown variant",
+        error.name()
+    ))));
+    add_allocation_size_func(module, &error.type_(), body);
+}

--- a/uniffi_bindgen/src/bindings/ir/ext.rs
+++ b/uniffi_bindgen/src/bindings/ir/ext.rs
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::func_names;
+use crate::interface;
+/// Extension traits for interface items
+use bindings_ir::ir::*;
+use extend::ext;
+
+/// Toolkit of internal functions, like lift/lower
+
+#[ext]
+pub(super) impl interface::Type {
+    fn call_lift(&self, value: Expression) -> Expression {
+        call(func_names::lift(self), [value])
+    }
+
+    fn call_lower(&self, value: Expression) -> Expression {
+        call(func_names::lower(self), [value])
+    }
+
+    fn call_allocation_size(&self, value: Expression) -> Expression {
+        call(func_names::allocation_size(self), [value])
+    }
+
+    fn call_read(&self, value: Expression) -> Expression {
+        call(func_names::read(self), [value])
+    }
+
+    fn call_write(&self, buf: Expression, value: Expression) -> Expression {
+        call(func_names::write(self), [buf, value])
+    }
+}
+
+#[ext]
+pub(super) impl interface::FFIType {
+    /// Get the IR type used when lifting types received across the FFI
+    fn ir_lift_type(&self) -> Type {
+        match self {
+            Self::UInt8 => uint8(),
+            Self::Int8 => int8(),
+            Self::UInt16 => uint16(),
+            Self::Int16 => int16(),
+            Self::UInt32 => uint32(),
+            Self::Int32 => int32(),
+            Self::UInt64 => uint64(),
+            Self::Int64 => int64(),
+            Self::Float32 => float32(),
+            Self::Float64 => float64(),
+            // Rust buffers are passed in as an owned CStruct
+            Self::RustBuffer => cstruct("RustBuffer"),
+            // Objects are received in an owned pointer
+            interface::FFIType::RustArcPtr(name) => pointer(name),
+            _ => unimplemented!("{:?}", self),
+        }
+    }
+
+    /// Get the IR type used when lowering this type to send across the FFI
+    fn ir_lower_type(&self) -> Type {
+        match self {
+            // The only difference between lower and lift types is that lowered pointers are passed
+            // as a reference rather than an owned pointer.  The UDL doesn't specify mutable or
+            // not, so we need to assume it here.
+            Self::RustArcPtr(name) => reference_mut(pointer(name)),
+            _ => self.ir_lift_type(),
+        }
+    }
+}

--- a/uniffi_bindgen/src/bindings/ir/ffi_calls.rs
+++ b/uniffi_bindgen/src/bindings/ir/ffi_calls.rs
@@ -1,0 +1,188 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::*;
+use crate::interface;
+use bindings_ir::ir::*;
+
+pub(super) fn build_module(
+    module: &mut Module,
+    ci: &interface::ComponentInterface,
+    cdylib_name: &str,
+) {
+    // Define FFI Functions
+    //
+    // Note: we can't use iter_ffi_function_definitions() since those definitions don't track
+    // things like mutability or if pointers are consumed or not
+    let mut ffi_functions = vec![
+        FFIFunctionDef {
+            name: ci.ffi_rustbuffer_alloc().name().into(),
+            args: vec![arg("size", int32()), arg_call_status()],
+            return_type: cstruct("RustBuffer").into(),
+        },
+        FFIFunctionDef {
+            name: ci.ffi_rustbuffer_free().name().into(),
+            args: vec![arg("buf", cstruct("RustBuffer")), arg_call_status()],
+            return_type: None,
+        },
+    ];
+
+    for func in ci.function_definitions() {
+        ffi_functions.push(func.ffi_func().into_ir());
+    }
+
+    for obj in ci.object_definitions() {
+        ffi_functions.push(FFIFunctionDef {
+            name: obj.ffi_object_free().name().into(),
+            args: vec![arg("ptr", pointer(obj.name())), arg_call_status()],
+            return_type: None,
+        });
+        for cons in obj.constructors() {
+            ffi_functions.push(cons.ffi_func().into_ir());
+        }
+        for meth in obj.methods() {
+            ffi_functions.push(meth.ffi_func().into_ir());
+        }
+    }
+
+    // TODO
+    // for cb in ci.callback_interface_definitions() {
+    // }
+
+    module.add_native_library(cdylib_name, ffi_functions);
+
+    module.add_cstruct(CStructDef {
+        name: "RustBuffer".into(),
+        fields: vec![
+            field("capacity", int32()),
+            field("len", int32()),
+            field("ptr", nullable(pointer("RustBufferPtr"))),
+        ],
+    });
+    module.add_cstruct(CStructDef {
+        name: "RustCallStatus".into(),
+        fields: vec![
+            field("code", int32()),
+            field("error_buf", cstruct("RustBuffer")),
+        ],
+    });
+    module.add_cstruct(CStructDef {
+        name: "ForeignBytes".into(),
+        fields: vec![
+            field("len", int32()),
+            field("data", pointer("ForeignBytesPtr")),
+        ],
+    });
+    module.add_function(free_rust_buffer_fn(ci));
+    build_error_handlers(module, ci);
+}
+
+fn build_error_handlers(module: &mut Module, ci: &interface::ComponentInterface) {
+    module.add_function(FunctionDef {
+        name: func_names::throw_if_error().into(),
+        vis: private(),
+        throws: None,
+        args: vec![arg("status", cstruct("RustCallStatus"))],
+        return_type: None,
+        body: block([match_int(
+            int32(),
+            ident("status.code"),
+            [
+                arm::int(0, [return_void()]),
+                arm::int(
+                    1,
+                    [
+                        // We shouldn't see this status code for functions that don't throw, free
+                        // the RustBuffer and raise a generic error.
+                        match_nullable(
+                            ident("status.error_buf"),
+                            arm::some("error_buf", [call_rustbuffer_free(ident("error_buf"))]),
+                            arm::null([]),
+                        ),
+                        raise_internal_exception(lit::string("Unexpected CALL_ERROR")),
+                    ],
+                ),
+                arm::int(
+                    2,
+                    [
+                        // when the rust code sees a panic, it tries to construct a rustbuffer
+                        // with the message.  but if that code panics, then it just sends back
+                        // an empty buffer.
+                        if_else(
+                            gt(ident("status.error_buf.len"), lit::int32(0)),
+                            [raise_internal_exception(call(
+                                "uniffi_lift_string",
+                                [ident("status.error_buf")],
+                            ))],
+                            [raise_internal_exception(lit::string("Rust panic"))],
+                        ),
+                    ],
+                ),
+                arm::int_default([raise_internal_exception(string::concat([
+                    lit::string("Unkown Rust call status: "),
+                    ident("status.code"),
+                ]))]),
+            ],
+        )]),
+    });
+
+    for error in ci.error_definitions() {
+        let error_type = error.type_();
+        module.add_function(FunctionDef {
+            name: func_names::throw_if_error_with_throws_type(&error_type).into(),
+            vis: private(),
+            throws: None,
+            args: vec![arg("status", cstruct("RustCallStatus"))],
+            return_type: None,
+            body: block([match_int(
+                int32(),
+                ident("status.code"),
+                [
+                    arm::int(0, [return_void()]),
+                    arm::int(1, [raise(error_type.call_lift(ident("status.error_buf")))]),
+                    arm::int(
+                        2,
+                        [
+                            // when the rust code sees a panic, it tries to construct a rustbuffer
+                            // with the message.  but if that code panics, then it just sends back
+                            // an empty buffer.
+                            if_else(
+                                gt(ident("status.error_buf.len"), lit::int32(0)),
+                                [raise_internal_exception(call(
+                                    "uniffi_lift_string",
+                                    [ident("status.error_buf")],
+                                ))],
+                                [raise_internal_exception(lit::string("Rust panic"))],
+                            ),
+                        ],
+                    ),
+                    arm::int_default([raise_internal_exception(string::concat([
+                        lit::string("Unkown Rust call status: "),
+                        ident("status.code"),
+                    ]))]),
+                ],
+            )]),
+        })
+    }
+}
+
+fn free_rust_buffer_fn(ci: &interface::ComponentInterface) -> FunctionDef {
+    FunctionDef {
+        name: "uniffi_rustbuffer_free".into(),
+        throws: None,
+        vis: private(),
+        args: vec![arg("buf", cstruct("RustBuffer"))],
+        return_type: None,
+        body: block([
+            empty_rust_status_var("status"),
+            ffi_call(
+                ci.ffi_rustbuffer_free().name(),
+                [ident("buf"), ref_mut("status")],
+            )
+            .into_statement(),
+            // Note: don't check status, ffi_rustbuffer_free should never fail and if it did
+            // there's nothing we can do anyways.
+        ]),
+    }
+}

--- a/uniffi_bindgen/src/bindings/ir/ffi_converters.rs
+++ b/uniffi_bindgen/src/bindings/ir/ffi_converters.rs
@@ -1,0 +1,185 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::*;
+use crate::interface;
+/// Base functionality for FFI Converters
+///
+/// This module sets up the generic code.  The actual functions are defined in type-specific module
+/// (enum_, record, etc.)
+use bindings_ir::ir::*;
+
+/// Add lift function definition
+pub(super) fn add_lift_func(
+    module: &mut Module,
+    type_: &interface::Type,
+    body: impl IntoIterator<Item = Statement>,
+) {
+    module.add_function(FunctionDef {
+        name: func_names::lift(&type_).into(),
+        throws: None,
+        vis: private(),
+        args: vec![arg("value", type_.ffi_type().ir_lift_type())],
+        return_type: Some(type_.clone().into_ir()),
+        body: block(body),
+    });
+}
+
+// Add a lower function definition
+pub(super) fn add_lower_func(
+    module: &mut Module,
+    type_: &interface::Type,
+    body: impl IntoIterator<Item = Statement>,
+) {
+    module.add_function(FunctionDef {
+        name: func_names::lower(&type_).into(),
+        throws: None,
+        vis: private(),
+        args: vec![arg("value", type_.clone().into_ir())],
+        return_type: Some(type_.ffi_type().ir_lower_type()),
+        body: block(body),
+    });
+}
+
+/// Add an allocation size function definition
+pub(super) fn add_allocation_size_func(
+    module: &mut Module,
+    type_: &interface::Type,
+    body: impl IntoIterator<Item = Statement>,
+) {
+    module.add_function(FunctionDef {
+        name: func_names::allocation_size(&type_).into(),
+        throws: None,
+        vis: private(),
+        args: vec![arg("value", type_.clone().into_ir())],
+        return_type: int32().into(),
+        body: block(body),
+    });
+}
+
+/// Add a read function definition
+pub(super) fn add_read_func(
+    module: &mut Module,
+    type_: &interface::Type,
+    body: impl IntoIterator<Item = Statement>,
+) {
+    module.add_function(FunctionDef {
+        name: func_names::read(&type_).into(),
+        throws: None,
+        vis: private(),
+        args: vec![arg("stream", reference_mut(object("RustBufferStream")))],
+        return_type: Some(type_.clone().into_ir()),
+        body: block(body),
+    });
+}
+
+// Add a write function definition
+pub(super) fn add_write_func(
+    module: &mut Module,
+    type_: &interface::Type,
+    body: impl IntoIterator<Item = Statement>,
+) {
+    module.add_function(FunctionDef {
+        name: func_names::write(&type_).into(),
+        throws: None,
+        vis: private(),
+        args: vec![
+            arg("stream", reference_mut(object("RustBufferStream"))),
+            arg("value", type_.clone().into_ir()),
+        ],
+        return_type: None,
+        body: block(body),
+    });
+}
+
+// Add lift and lower functions that leverage the read/write function when the FFI type is
+// RustBuffer
+pub(super) fn add_rust_buffer_lift_and_lower_funcs(
+    module: &mut Module,
+    ci: &interface::ComponentInterface,
+    type_: &interface::Type,
+) {
+    add_lower_func(
+        module,
+        type_,
+        [
+            empty_rust_status_var("status"),
+            destructure(
+                "RustBuffer",
+                ffi_call(
+                    ci.ffi_rustbuffer_alloc().name(),
+                    [
+                        cast::int32(type_.call_allocation_size(ident("value"))),
+                        ref_mut("status"),
+                    ],
+                ),
+                ["capacity", "len", "ptr_maybe_null"],
+            ),
+            call_throw_if_error("status"),
+            val(
+                "ptr",
+                pointer("RustBufferPtr"),
+                unwrap(
+                    ident("ptr_maybe_null"),
+                    lit::string(format!(
+                        "{}.lower: ffi_rustbuffer_alloc returned null pointer",
+                        func_names::lower(type_)
+                    )),
+                ),
+            ),
+            // Throw if the pointer is null
+            var(
+                "stream",
+                object("RustBufferStream"),
+                buf::create("RustBufferStream", ident("ptr"), ident("len")),
+            ),
+            type_
+                .call_write(ref_mut("stream"), ident("value"))
+                .into_statement(),
+            return_(create_cstruct(
+                "RustBuffer",
+                [
+                    ident("capacity"),
+                    // The new length is the position of the buffer stream after writing
+                    buf::pos(ident("stream")),
+                    buf::into_ptr("RustBufferPtr", ident("stream")),
+                ],
+            )),
+        ],
+    );
+    add_lift_func(
+        module,
+        type_,
+        [
+            destructure(
+                "RustBuffer",
+                ident("value"),
+                ["capacity", "len", "ptr_maybe_null"],
+            ),
+            val(
+                "ptr",
+                pointer("RustBufferPtr"),
+                unwrap(
+                    ident("ptr_maybe_null"),
+                    lit::string(format!(
+                        "{}.lift called with null RustBuffer pointer",
+                        func_names::lower(type_)
+                    )),
+                ),
+            ),
+            var(
+                "stream",
+                object("RustBufferStream"),
+                buf::create("RustBufferStream", ident("ptr"), ident("len")),
+            ),
+            val(
+                "return_value",
+                type_.clone().into_ir(),
+                type_.call_read(ref_mut("stream")),
+            ),
+            call_rustbuffer_free_from_components(ident("capacity"), ident("len"), ident("ptr")),
+            return_(ident("return_value")),
+        ],
+    )
+}

--- a/uniffi_bindgen/src/bindings/ir/func_names.rs
+++ b/uniffi_bindgen/src/bindings/ir/func_names.rs
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/// Names for internal functions
+use crate::interface::Type;
+use heck::ToSnakeCase;
+
+/// Lift a value from the FFI
+pub fn lift(type_: &Type) -> String {
+    format!("uniffi_lift_{}", type_.canonical_name().to_snake_case())
+}
+
+/// Lower a value for the FFI
+pub fn lower(type_: &Type) -> String {
+    format!("uniffi_lower_{}", type_.canonical_name().to_snake_case())
+}
+
+/// Calculate the size of the RustBuffer needed to fit this type
+pub fn allocation_size(type_: &Type) -> String {
+    format!(
+        "uniffi_allocation_size_{}",
+        type_.canonical_name().to_snake_case()
+    )
+}
+
+/// Read a value from a RustBuffer
+pub fn read(type_: &Type) -> String {
+    format!("uniffi_read_{}", type_.canonical_name().to_snake_case())
+}
+
+/// Write a value to a RustBuffer
+pub fn write(type_: &Type) -> String {
+    format!("uniffi_write_{}", type_.canonical_name().to_snake_case())
+}
+
+/// Check RustCallStatus and throw on errors
+pub fn throw_if_error() -> String {
+    "throw_if_error".into()
+}
+
+/// Check RustCallStatus and throw on errors using an error type to handle STATUS_ERROR
+pub fn throw_if_error_with_throws_type(type_: &Type) -> String {
+    match type_ {
+        Type::Error(name) => format!("throw_if_error_{}", name.to_snake_case()),
+        _ => panic!("throw_if_error_with_throws_type called for {type_:?}"),
+    }
+}

--- a/uniffi_bindgen/src/bindings/ir/functions.rs
+++ b/uniffi_bindgen/src/bindings/ir/functions.rs
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::*;
+use crate::interface;
+use bindings_ir::ir::*;
+use std::iter::once;
+
+pub(super) fn build_module(module: &mut Module, ci: &interface::ComponentInterface) {
+    for func in ci.function_definitions() {
+        let make_ffi_call = ffi_call(
+            func.ffi_func().name(),
+            func.arguments()
+                .into_iter()
+                .map(|a| a.type_().call_lower(ident(a.name())))
+                .chain(once(ref_mut("uniffi_call_status"))),
+        );
+
+        // Create statements to make the FFI call and return the result on success
+        let (ffi_call_stmt, success_return) = match func.return_type() {
+            None => (make_ffi_call.into_statement(), return_void()),
+            Some(return_type) => (
+                val(
+                    "uniffi_call_return",
+                    return_type.clone().into_ir(),
+                    return_type.call_lift(make_ffi_call),
+                ),
+                return_(ident("uniffi_call_return")),
+            ),
+        };
+
+        let body = vec![
+            var(
+                "uniffi_call_status",
+                cstruct("RustCallStatus"),
+                create_cstruct(
+                    "RustCallStatus",
+                    [
+                        lit::int32(0),
+                        create_cstruct("RustBuffer", [lit::int32(0), lit::int32(0), lit::null()]),
+                    ],
+                ),
+            ),
+            ffi_call_stmt,
+            // Throw an error if `uniffi_call_status` indicates we should
+            match func.throws_type() {
+                Some(error_type) => {
+                    call_throw_if_error_with_type(&error_type, "uniffi_call_status")
+                }
+                None => call_throw_if_error("uniffi_call_status"),
+            },
+            // If not, return success
+            success_return,
+        ];
+
+        module.add_function(FunctionDef {
+            vis: public(),
+            name: func.name().into(),
+            throws: func.throws_name().map(ClassName::from),
+            args: func.arguments().into_ir(),
+            return_type: func.return_type().into_ir(),
+            body: block(body),
+        })
+    }
+}

--- a/uniffi_bindgen/src/bindings/ir/into_ir.rs
+++ b/uniffi_bindgen/src/bindings/ir/into_ir.rs
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::ext::*;
+use super::util::arg_call_status;
+/// IntoIr trait -- Convert ComponentInterface items to bindings-ir items
+///
+/// IntoIr is basically Into<> trait, but using a local trait allows us to define in on things like
+/// Option<T>.
+use crate::interface;
+use bindings_ir::ir::*;
+use std::iter::once;
+
+pub trait IntoIr {
+    type IrType;
+    fn into_ir(self) -> Self::IrType;
+}
+
+impl IntoIr for interface::Type {
+    type IrType = Type;
+
+    fn into_ir(self) -> Self::IrType {
+        match self {
+            Self::UInt8 => Type::UInt8,
+            Self::Int8 => Type::Int8,
+            Self::UInt16 => Type::UInt16,
+            Self::Int16 => Type::Int16,
+            Self::UInt32 => Type::UInt32,
+            Self::Int32 => Type::Int32,
+            Self::UInt64 => Type::UInt64,
+            Self::Int64 => Type::Int64,
+            Self::Float32 => Type::Float32,
+            Self::Float64 => Type::Float64,
+            Self::Boolean => Type::Boolean,
+            Self::String => Type::String,
+            Self::Enum(name) => Type::Object { class: name.into() },
+            Self::Object(name) => Type::Object { class: name.into() },
+            Self::Record(name) => Type::Object { class: name.into() },
+            Self::Error(name) => Type::Object { class: name.into() },
+            Self::Optional(inner) => Type::Nullable {
+                inner: Box::new(inner.into_ir()),
+            },
+            Self::Sequence(inner) => Type::List {
+                inner: Box::new(inner.into_ir()),
+            },
+            Self::Map(key, value) => Type::Map {
+                key: Box::new(key.into_ir()),
+                value: Box::new(value.into_ir()),
+            },
+            Self::Timestamp => unimplemented!("Type::Timestamp"),
+            Self::Duration => unimplemented!("Type::Duration"),
+            Self::CallbackInterface(_) => unimplemented!("Type::CallbackInterface"),
+            Self::External { .. } => unimplemented!("Type::External"),
+            Self::Custom { .. } => unimplemented!("Type::Custom"),
+        }
+    }
+}
+
+impl IntoIr for interface::Argument {
+    type IrType = Argument;
+
+    fn into_ir(self) -> Self::IrType {
+        arg(self.name(), self.type_().into_ir())
+    }
+}
+
+impl IntoIr for Vec<&interface::Argument> {
+    type IrType = Vec<Argument>;
+
+    fn into_ir(self) -> Self::IrType {
+        self.into_iter().cloned().map(IntoIr::into_ir).collect()
+    }
+}
+
+impl IntoIr for interface::Field {
+    type IrType = Field;
+
+    fn into_ir(self) -> Self::IrType {
+        field(self.name(), self.type_().into_ir())
+    }
+}
+
+impl IntoIr for Vec<&interface::Field> {
+    type IrType = Vec<Field>;
+
+    fn into_ir(self) -> Self::IrType {
+        self.into_iter().cloned().map(IntoIr::into_ir).collect()
+    }
+}
+
+impl IntoIr for Option<&interface::Type> {
+    type IrType = Option<Type>;
+
+    fn into_ir(self) -> Self::IrType {
+        self.cloned().map(interface::Type::into_ir)
+    }
+}
+
+impl IntoIr for &interface::FFIFunction {
+    type IrType = FFIFunctionDef;
+
+    fn into_ir(self) -> Self::IrType {
+        FFIFunctionDef {
+            name: self.name().into(),
+            args: self
+                .arguments()
+                .into_iter()
+                .map(|a| arg(a.name(), a.type_().ir_lower_type()))
+                .chain(once(arg_call_status()))
+                .collect(),
+            return_type: self.return_type().map(|type_| type_.ir_lift_type()),
+        }
+    }
+}

--- a/uniffi_bindgen/src/bindings/ir/mod.rs
+++ b/uniffi_bindgen/src/bindings/ir/mod.rs
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+mod compounds;
+mod errors;
+mod ext;
+mod ffi_calls;
+mod ffi_converters;
+mod func_names;
+mod functions;
+mod into_ir;
+mod objects;
+mod primitives;
+mod records;
+mod util;
+
+use crate::interface::ComponentInterface;
+use bindings_ir::ir;
+use ext::*;
+use ffi_converters::*;
+use into_ir::IntoIr;
+use util::*;
+
+pub(crate) fn generate_module(ci: &ComponentInterface, cdylib_name: &str) -> ir::Module {
+    let mut module = ir::Module::new();
+    module.add_buffer_stream_class("RustBufferStream");
+    compounds::build_module(&mut module, ci);
+    errors::build_module(&mut module, ci);
+    ffi_calls::build_module(&mut module, ci, cdylib_name);
+    functions::build_module(&mut module, ci);
+    objects::build_module(&mut module, ci);
+    primitives::build_module(&mut module, ci);
+    records::build_module(&mut module, ci);
+    module
+}

--- a/uniffi_bindgen/src/bindings/ir/objects.rs
+++ b/uniffi_bindgen/src/bindings/ir/objects.rs
@@ -1,0 +1,204 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::*;
+use crate::interface;
+use bindings_ir::ir::*;
+use heck::ToSnakeCase;
+use std::iter::once;
+
+pub(super) fn build_module(module: &mut Module, ci: &interface::ComponentInterface) {
+    for obj in ci.object_definitions() {
+        let type_ = obj.type_();
+        add_class_def(module, obj);
+        add_allocation_size_func(module, &type_, [return_(pointer_size())]);
+        add_lift_func(
+            module,
+            &type_,
+            [return_(create_class(obj.name(), [ident("value")]))],
+        );
+        add_read_func(
+            module,
+            &type_,
+            [return_(create_class(
+                obj.name(),
+                [buf::read_pointer(obj.name(), ident("stream"))],
+            ))],
+        );
+        add_lower_func(module, &type_, [return_(ident("value.ptr"))]);
+        add_write_func(
+            module,
+            &type_,
+            [buf::write_pointer(
+                obj.name(),
+                ident("stream"),
+                ident("value.ptr"),
+            )],
+        );
+    }
+}
+
+fn add_class_def(module: &mut Module, obj: &interface::Object) {
+    let mut class_def = ClassDef {
+        vis: public(),
+        name: obj.name().into(),
+        fields: vec![field("ptr", pointer(obj.name()))],
+        methods: obj
+            .methods()
+            .into_iter()
+            .map(|meth| define_method(obj, meth))
+            .collect(),
+        destructor: Destructor {
+            body: block([
+                empty_rust_status_var("status"),
+                ffi_call(
+                    obj.ffi_object_free().name(),
+                    [ident("ptr"), ident("status")],
+                )
+                .into_statement(),
+                // Don't check status, if the call fails we can't really do anything about it since
+                // we're in a destructor.
+            ]),
+        }
+        .into(),
+        ..ClassDef::default()
+    };
+    if let Some(cons) = obj.primary_constructor() {
+        add_constructor(module, &mut class_def, obj, &cons);
+    }
+    for cons in obj.constructors() {
+        add_secondary_constructor(&mut class_def, obj, &cons);
+    }
+    module.add_class(class_def);
+}
+
+fn add_constructor(
+    module: &mut Module,
+    class_def: &mut ClassDef,
+    obj: &interface::Object,
+    cons: &interface::Constructor,
+) {
+    // Define a helper function to make the FFI call, check for errors, etc.
+    let helper_name = format!("uniffi_construct_{}", obj.name().to_snake_case());
+    module.add_function(FunctionDef {
+        name: helper_name.clone().into(),
+        vis: private(),
+        args: cons.arguments().into_ir(),
+        return_type: pointer(obj.name()).into(),
+        throws: None,
+        body: block([
+            empty_rust_status_var("status"),
+            val(
+                "ptr",
+                pointer(obj.name()),
+                ffi_call(
+                    cons.ffi_func().name(),
+                    cons.arguments()
+                        .into_iter()
+                        .map(|a| a.type_().call_lower(ident(a.name())))
+                        .chain(once(ident("status"))),
+                ),
+            ),
+            call_throw_if_error("status"),
+            return_(ident("ptr")),
+        ]),
+    });
+    // Define the constructor using the helper func
+    class_def.constructor = Constructor {
+        vis: public(),
+        args: cons.arguments().into_ir(),
+        initializers: vec![call(
+            helper_name,
+            cons.arguments().into_iter().map(|a| ident(a.name())),
+        )],
+    }
+    .into();
+}
+
+fn add_secondary_constructor(
+    class_def: &mut ClassDef,
+    obj: &interface::Object,
+    cons: &interface::Constructor,
+) {
+    // Implement secondary constructors as static factory methods
+    class_def.methods.push(Method {
+        vis: public(),
+        name: cons.name().into(),
+        method_type: MethodType::Static,
+        args: cons.arguments().into_ir(),
+        return_type: object(obj.name()).into(),
+        throws: None,
+        body: block([
+            empty_rust_status_var("status"),
+            val(
+                "ptr",
+                pointer(obj.name()),
+                ffi_call(
+                    cons.ffi_func().name(),
+                    cons.arguments()
+                        .into_iter()
+                        .map(|a| a.type_().call_lower(ident(a.name())))
+                        .chain(once(ident("status"))),
+                ),
+            ),
+            call_throw_if_error("status"),
+            return_(create_class(obj.name(), [ident("ptr")])),
+        ]),
+    });
+}
+
+fn define_method(obj: &interface::Object, meth: &interface::Method) -> Method {
+    let mut ffi_call_args = vec![obj.type_().call_lower(this())];
+    for arg in meth.arguments() {
+        ffi_call_args.push(arg.type_().call_lower(ident(arg.name())))
+    }
+    ffi_call_args.push(ref_mut("uniffi_call_status"));
+
+    let make_ffi_call = ffi_call(meth.ffi_func().name(), ffi_call_args);
+
+    // Create statements to make the FFI call and return the result on success
+    let (ffi_call_stmt, success_return) = match meth.return_type() {
+        None => (make_ffi_call.into_statement(), return_void()),
+        Some(return_type) => (
+            val(
+                "uniffi_call_return",
+                return_type.clone().into_ir(),
+                return_type.call_lift(make_ffi_call),
+            ),
+            return_(ident("uniffi_call_return")),
+        ),
+    };
+
+    let body = block([
+        var(
+            "uniffi_call_status",
+            cstruct("RustCallStatus"),
+            create_cstruct(
+                "RustCallStatus",
+                [
+                    lit::int32(0),
+                    create_cstruct("RustBuffer", [lit::int32(0), lit::int32(0), lit::null()]),
+                ],
+            ),
+        ),
+        ffi_call_stmt,
+        // Throw an error if `uniffi_call_status` indicates we should
+        match meth.throws_type() {
+            Some(error_type) => call_throw_if_error_with_type(&error_type, "uniffi_call_status"),
+            None => call_throw_if_error("uniffi_call_status"),
+        },
+        // If not, return success
+        success_return,
+    ]);
+
+    Method {
+        vis: public(),
+        method_type: MethodType::Normal,
+        name: meth.name().into(),
+        args: meth.arguments().into_ir(),
+        return_type: meth.return_type().into_ir(),
+        throws: meth.throws_name().map(ClassName::from),
+        body,
+    }
+}

--- a/uniffi_bindgen/src/bindings/ir/primitives.rs
+++ b/uniffi_bindgen/src/bindings/ir/primitives.rs
@@ -1,0 +1,214 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::*;
+use crate::interface;
+use bindings_ir::ir::*;
+
+pub(super) fn build_module(module: &mut Module, ci: &ComponentInterface) {
+    for type_ in ci.iter_types() {
+        match type_ {
+            interface::Type::Int8 => {
+                add_simple_ffi_converters(module, type_, buf::read_int8, buf::write_int8, 1)
+            }
+            interface::Type::UInt8 => {
+                add_simple_ffi_converters(module, type_, buf::read_uint8, buf::write_uint8, 1)
+            }
+            interface::Type::Int16 => {
+                add_simple_ffi_converters(module, type_, buf::read_int16, buf::write_int16, 2)
+            }
+            interface::Type::UInt16 => {
+                add_simple_ffi_converters(module, type_, buf::read_uint16, buf::write_uint16, 2)
+            }
+            interface::Type::Int32 => {
+                add_simple_ffi_converters(module, type_, buf::read_int32, buf::write_int32, 4)
+            }
+            interface::Type::UInt32 => {
+                add_simple_ffi_converters(module, type_, buf::read_uint32, buf::write_uint32, 4)
+            }
+            interface::Type::Int64 => {
+                add_simple_ffi_converters(module, type_, buf::read_int64, buf::write_int64, 8)
+            }
+            interface::Type::UInt64 => {
+                add_simple_ffi_converters(module, type_, buf::read_uint64, buf::write_uint64, 8)
+            }
+            interface::Type::Float32 => {
+                add_simple_ffi_converters(module, type_, buf::read_float32, buf::write_float32, 4)
+            }
+            interface::Type::Float64 => {
+                add_simple_ffi_converters(module, type_, buf::read_float64, buf::write_float64, 8)
+            }
+            interface::Type::Boolean => add_boolean_ffi_converters(module),
+            _ => (),
+        }
+    }
+    // Unconditionally add the string FFI converters, since we use them for error handling.
+    add_string_ffi_converters(module, ci);
+}
+
+fn add_simple_ffi_converters(
+    module: &mut Module,
+    type_: &interface::Type,
+    read_fn: impl Fn(Expression) -> Expression,
+    write_fn: impl Fn(Expression, Expression) -> Statement,
+    allocation_size: i32,
+) {
+    add_lift_func(module, &type_, [return_(ident("value"))]);
+    add_lower_func(module, &type_, [return_(ident("value"))]);
+    add_allocation_size_func(module, &type_, [return_(lit::int32(allocation_size))]);
+    add_read_func(module, &type_, [return_(read_fn(ident("stream")))]);
+    add_write_func(module, &type_, [write_fn(ident("stream"), ident("value"))]);
+}
+
+// Handle booleans by converting to/from a u8
+fn add_boolean_ffi_converters(module: &mut Module) {
+    let type_ = interface::Type::Boolean;
+    add_lift_func(module, &type_, [return_(eq(lit::int8(1), ident("value")))]);
+    add_lower_func(
+        module,
+        &type_,
+        [if_else(
+            ident("value"),
+            [return_(lit::int8(1))],
+            [return_(lit::int8(0))],
+        )],
+    );
+    add_allocation_size_func(module, &type_, [return_(lit::int32(1))]);
+    add_read_func(
+        module,
+        &type_,
+        [return_(type_.call_lift(buf::read_int8(ident("stream"))))],
+    );
+    add_write_func(
+        module,
+        &type_,
+        [buf::write_int8(
+            ident("stream"),
+            type_.call_lower(ident("value")),
+        )],
+    );
+}
+
+// Handle booleans by converting to/from a u8
+fn add_string_ffi_converters(module: &mut Module, ci: &ComponentInterface) {
+    let type_ = interface::Type::String;
+    add_allocation_size_func(
+        module,
+        &type_,
+        [return_(add(
+            int32(),
+            // Size needed for the length data
+            lit::int32(4),
+            // Size needed for the string
+            string::min_byte_len(ident("value")),
+        ))],
+    );
+    add_read_func(
+        module,
+        &type_,
+        [
+            val("size", int32(), buf::read_int32(ident("stream"))),
+            return_(buf::read_string(ident("stream"), ident("size"))),
+        ],
+    );
+    add_write_func(
+        module,
+        &type_,
+        [
+            // Write a placeholder for the string size
+            val("start_pos", int32(), buf::pos(ident("stream"))),
+            buf::write_int32(ident("stream"), lit::int32(0)),
+            // Write the string, noting the size
+            buf::write_string(ident("stream"), ident("value")),
+            // Go back, write the correct string size, then reposition
+            val("current_pos", int32(), buf::pos(ident("stream"))),
+            buf::set_pos(ident("stream"), ident("start_pos")),
+            buf::write_int32(
+                ident("stream"),
+                sub(
+                    int32(),
+                    ident("current_pos"),
+                    add(int32(), ident("start_pos"), lit::int32(4)),
+                ),
+            ),
+            buf::set_pos(ident("stream"), ident("current_pos")),
+        ],
+    );
+    // We could almost use add_rust_buffer_lift_and_lower_funcs here, however there's a subtle
+    // difference.  When lifting/lowering strings directly, we don't write the size of the string
+    // to the buffer since it's redundant with the `len` field of the buffer
+    add_lower_func(
+        module,
+        &type_,
+        [
+            empty_rust_status_var("status"),
+            destructure(
+                "RustBuffer",
+                ffi_call(
+                    ci.ffi_rustbuffer_alloc().name(),
+                    [
+                        type_.call_allocation_size(ident("value")),
+                        ref_mut("status"),
+                    ],
+                ),
+                ["capacity", "len", "ptr_maybe_null"],
+            ),
+            call_throw_if_error("status"),
+            val(
+                "ptr",
+                pointer("RustBufferPtr"),
+                unwrap(
+                    ident("ptr_maybe_null"),
+                    lit::string("String.lower: ffi_rustbuffer_alloc returned null pointer"),
+                ),
+            ),
+            // Throw if the pointer is null
+            var(
+                "stream",
+                object("RustBufferStream"),
+                buf::create("RustBufferStream", ident("ptr"), ident("len")),
+            ),
+            buf::write_string(ident("stream"), ident("value")),
+            return_(create_cstruct(
+                "RustBuffer",
+                [
+                    ident("capacity"),
+                    buf::pos(ident("stream")),
+                    buf::into_ptr("RustBufferPtr", ident("stream")),
+                ],
+            )),
+        ],
+    );
+    add_lift_func(
+        module,
+        &type_,
+        [
+            destructure(
+                "RustBuffer",
+                ident("value"),
+                ["capacity", "len", "ptr_maybe_null"],
+            ),
+            val(
+                "ptr",
+                pointer("RustBufferPtr"),
+                unwrap(
+                    ident("ptr_maybe_null"),
+                    lit::string("String.lift called with null RustBuffer pointer"),
+                ),
+            ),
+            var(
+                "stream",
+                object("RustBufferStream"),
+                buf::create("RustBufferStream", ident("ptr"), ident("len")),
+            ),
+            val(
+                "return_value",
+                string(),
+                buf::read_string(ident("stream"), ident("len")),
+            ),
+            call_rustbuffer_free_from_components(ident("capacity"), ident("len"), ident("ptr")),
+            return_(ident("return_value")),
+        ],
+    );
+}

--- a/uniffi_bindgen/src/bindings/ir/records.rs
+++ b/uniffi_bindgen/src/bindings/ir/records.rs
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::*;
+use crate::interface;
+use bindings_ir::ir::*;
+
+pub(super) fn build_module(module: &mut Module, ci: &interface::ComponentInterface) {
+    for rec in ci.record_definitions() {
+        let type_ = rec.type_();
+        let fields = rec.fields();
+
+        module.add_data_class(DataClassDef {
+            vis: public(),
+            name: rec.name().into(),
+            fields: fields.clone().into_ir(),
+        });
+        add_allocation_size_func(
+            module,
+            &type_,
+            [return_(
+                fields
+                    .iter()
+                    .map(|f| {
+                        f.type_()
+                            .call_allocation_size(get(ident("value"), f.name()))
+                    })
+                    .reduce(|a, b| add(int32(), a, b))
+                    .unwrap_or(lit::int32(0)),
+            )],
+        );
+        add_read_func(
+            module,
+            &type_,
+            [return_(create_data_class(
+                rec.name(),
+                fields.iter().map(|f| f.type_().call_read(ident("stream"))),
+            ))],
+        );
+        add_write_func(
+            module,
+            &type_,
+            fields.iter().map(|f| {
+                f.type_()
+                    .call_write(ident("stream"), get(ident("value"), f.name()))
+                    .into_statement()
+            }),
+        );
+        add_rust_buffer_lift_and_lower_funcs(module, ci, &type_);
+    }
+}

--- a/uniffi_bindgen/src/bindings/ir/util.rs
+++ b/uniffi_bindgen/src/bindings/ir/util.rs
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::func_names;
+use crate::interface;
+use bindings_ir::ir::*;
+
+pub(super) fn empty_rust_status_var(name: &str) -> Statement {
+    var(
+        name,
+        cstruct("RustCallStatus"),
+        create_cstruct(
+            "RustCallStatus",
+            [
+                lit::int32(0),
+                create_cstruct("RustBuffer", [lit::int32(0), lit::int32(0), lit::null()]),
+            ],
+        ),
+    )
+}
+
+pub(super) fn arg_call_status() -> Argument {
+    arg(
+        "uniffi_out_status",
+        reference_mut(cstruct("RustCallStatus")),
+    )
+}
+
+pub(super) fn call_rustbuffer_free(buf: Expression) -> Statement {
+    call("uniffi_rustbuffer_free", [buf]).into_statement()
+}
+
+pub(super) fn call_rustbuffer_free_from_components(
+    capacity: Expression,
+    len: Expression,
+    ptr: Expression,
+) -> Statement {
+    call_rustbuffer_free(create_cstruct("RustBuffer", [capacity, len, ptr]))
+}
+
+pub(super) fn call_throw_if_error(status_var: &str) -> Statement {
+    call(func_names::throw_if_error(), [ident(status_var)]).into_statement()
+}
+
+pub(super) fn call_throw_if_error_with_type(
+    error_type: &interface::Type,
+    status_var: &str,
+) -> Statement {
+    call(
+        func_names::throw_if_error_with_throws_type(error_type),
+        [ident(status_var)],
+    )
+    .into_statement()
+}

--- a/uniffi_bindgen/src/bindings/mod.rs
+++ b/uniffi_bindgen/src/bindings/mod.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::interface::ComponentInterface;
 use crate::MergeWith;
 
+pub mod ir;
 pub mod kotlin;
 pub mod python;
 pub mod ruby;

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -61,7 +61,7 @@ mod attributes;
 mod callbacks;
 pub use callbacks::CallbackInterface;
 mod enum_;
-pub use enum_::Enum;
+pub use enum_::{Enum, Variant};
 mod error;
 pub use error::Error;
 mod function;


### PR DESCRIPTION
I've been trying to brew this one up for a while and I now feel like it's in a place that's worth sharing.  This PR contains the outline of what it could look like to use an intermediate representation for bindings generation.  Credit to @jhugman for suggesting this a while ago.

The Big Idea 🌈™ here is to we define something like an [AST for a language specially tailored for bindings generation](https://github.com/mozilla/uniffi-rs/tree/99ad06c227ed62fc012ab0a86b4c5b7421080e39/bindings-ir/src/ir).  `uniffi-bindgen` transforms the `ComponentInterface` into an AST with the bindings then a language-specific bindings-generate transforms that AST into actual code.  As an example, [uniffi-bindgen transforms object definitions from the UDL into class definitions in the IR](https://github.com/mozilla/uniffi-rs/blob/99ad06c227ed62fc012ab0a86b4c5b7421080e39/uniffi_bindgen/src/bindings/ir/objects.rs) then [bindings-ir-kotlin transforms those class definitions into actual Kotlin classes.](https://github.com/mozilla/uniffi-rs/blob/99ad06c227ed62fc012ab0a86b4c5b7421080e39/bindings-ir-kotlin/src/templates/ClassDef.kt).  The IR is all Serde-serializable and the plan would be to serialize it in the library file, like we do with the proc-macro metadata now.

The current state is an IR system with a Kotlin implementation, and a `uniffi-bindgen` implementation that handles functions, objects, records, and errors.  I got the `geometry`, `arithmetic`, and `sprites` example tests to pass.  It definitely needs a lot more work, but hopefully enough is there that we can talk about the idea concretely.

## Benefits

- **Sharing code**.  There's a large overlap between UniFFI and diplomat.  I just learned about [wpgu](https://github.com/gfx-rs/wgpu-native#bindings) which is also written in Rust with it's own bindings generation system.  In the mozilla app-services circle, we also have Glean and Nimbul-FML generating bindings for their own language.  Each of these projects targets different problems and I'm doubtful that we could merge them all into one big bindings generator, but maybe we could use a shared IR.  That would let us pool our langugage-specific bindings generators and all get access to the languages that the other projects support.  It also seems very likely that we will want to work on new projects that want to generate code and they could use this system to give themselves a huge jump-start.
- **Fixes a lot of versioning issues**.  Our versioning story is pretty sad right now, especially with regards to external bindings and Desktop JS.  In order to land a UniFFI upgrade on Desktop we need to first need to update Glean to use the new version, plus all the app-services components, make a release for both, then vendor all of those upgrades in.  This new system would fix a lot of these problems.  We would be compiling the bindings IR in to the library file, so there's no chance of an FFI versioning mismatch.  The language bindings generators would depend on the IR code, not `uniffi-bindgen` directly, which means we updates to `uniffi-bindgen` wouldn't always need to be breaking changes.  In the new world, Glean and app-services, could leave the patch version unspecified in their `Cargo.toml` files, and we could ship an update to UniFFI, even one that changes the FFI contract, without having to touch Glean/app-services.
- **Makes it easier to change UniFFI**.  Right now any change to UniFFI means updating the bindings for the 4.5 languages we officially support.  If we get external bindings contributions, we would need to take them into consideration as well.  In the new world, we could update how UniFFI generates the IR, then we instantly get the new functionality on all supported languages.
- **IR transforms**.  It would be possible to transform the IR that UniFFI outputs before the bindings generator sees it, which could lead to some nice features.  The first one that comes to mind how we generate a lot of duplicated code for each app-services component (FFIConverters, RustBuffer functionality, etc.), then package it all together in the megazord.  This wastes space/memory and also makes things like external bindings trickier to implement.  We could fix this by having a transform step, where we extract that duplicated code, put it in a shared module, then have each component import from that module.  Another possibility would be to implement things features that extend the base UniFFI functionality like decorators.
- **Safety checks**.  One thing that Nika pointed out with the Desktop JS project is that we're kind of loosy-goosy with our pointers.  Pointers aren't typed so you could potentially use the wrong pointer when calling a method and each language has its own ad-hoc methods to prevent use-after-free bugs.  This IR makes each pointer specify a type and each function call specifies if it's borrowing or consuming the pointer.  At this point there's no enforcement mechanism, but we could add static analysis that ensures generated IR code follow the rules.
- **Improves external bindings**.  Instead of having to understand and implement things like how UniFFI lowers and lifts pointers, external bindings authors would only need to translate the IR to their language.  In order to implement Kotlin, I wrote a basic test suite of IR code which I think could be a nice way for bindings authors to implement things step-by-step.  Bindings authors would have to care much less about UniFFI changes.  I'm hoping that most of the time they could ignore them.  If other projects adopt this, then it's also a much better value proposition for external bindings authors.

## Risks

- **Potential time sink**.  It will take a lot of work to get this to the finish line we need to make sure that it's worth it.  @mhammond points out that this would be a good time to take a step back and make sure that the overall strategy is sound.  Maybe one of those other bindings generators actually has nailed it and we should just join them.  Is there prior art with an FFI IR that we could use?  Are we really going to be adding many more features to UniFFI and/or starting new projects that want to generate bindings, or are we close to feature complete?
- **Not clear that we really get the benefits**.  The benefits statements above are dependent on a few things.  First off, is this IR flexible enough to be implemented in other languages?  I'm hopeful but unsure, especially with Desktop JS.  Secondly, can we keep the IR relatively stable?  A lot of the benefits depend on us being able to add features to UniFFI without needing to add a new expression/statement/definition or whatever to the IR.  If that's not true, then versioning story gets worse, teaming up with the other teams is going to require a lot more maintenance, etc..
- **The IR generation code is kind of ugly**.  At a high-level the `uniffi-bindgen` code is much more pleasant to work with, since you can write Rust rather than askama templates.  However, actually writing out the AST generation is a bit of a pain.  There's a lot of nested AST items, and even nesting in a single item, for example function calls are written as `call(fn_name, [arg1, arg2, ..])`.  `arg1` and `arg2` are often nested AST expressions and I loose track at if I need to close the paren or the bracket.  I thought a lot about improving this, like maybe you could define a psuedo-language then parse it with a macro.  The issue there is that a) it's a lot of work and b) you're editing can no longer help you with code-completion.  In the end, it wasn't that bad once I got used to it and maybe I just need to start using auto-close parens/brackets feature on my editor.
- **Something was a bit weird with the Kotlin compilation**.  I'm not sure exactly what's going on, but every once in a while Kotlin would get confused and say methods weren't defined that I could see defined in the source code.  Once I ran `cargo clean` everything would magically work again.  I doubt this is a serious problem, but we should understand it before we commit to this approach.
- **Lots of cloning**.  Since we're serializing everything, there's lots of cloning going on.  I highly doubt this will matter, especially when you compare it to the time that `kotlinc` takes, but I guess I should put it out there.

## Is the IR at the correct level?

We have a ton of flexibility with the IR and it's very possible that it should be structured differently.  There are a couple design decisions that I wonder about.

One is that I tried to make it very general so that we could write bindings generators for Rust or C.  That very well might be a mistake and maybe it would clean up the code if we should assume more things about the target language like OO,  garbage collection, etc.  Also, maybe the IR is not general enough since it basically assumes an imperative language.  Based on the little I know about Haskell, I don't think we could support a bindings generator for that.

A related question is if the IR could be more declarative.  I kept trying to figure out a way where you could describe the structure of an FFI call and the bindings generator could figure out what to do.  All my attempts failed, but maybe one of you smart people can get the idea to succeed.

## Ideas that we could salvage if this fails

There are a couple ideas here that could be adopted even if we don't decide to go with the big change here.  I think I found a decent way to implement destructors on Kotlin using the `Cleaner` object.  This seems much better than requiring users to manually call `destroy`.  Also, the bindings generation templating system is based on `tera` rather than `askama` which lets you do some nice things at runtime.  This lets us implement a very nice (IMO) version of the CodeOracle system.  There's not a lot of mega-matches, templates can be easily split up over multiple modules, templates for one item can be defined based on it's child items and everything is recursively rendered, small templates can be defined inline and big ones can be in their own file,  event whitespace handling is decent.

## The name

I chose a very boring name of `bindings-ir` that I would love to have replaced with something as creative as `UniFFI`.  Any suggestions?