### PR TITLE
Update add_known_type to add inner types of generic builtins

### DIFF
--- a/fixtures/simple-fns/src/lib.rs
+++ b/fixtures/simple-fns/src/lib.rs
@@ -41,6 +41,11 @@ fn set_contains(set: Arc<MyHashSet>, value: String) -> bool {
     set.lock().unwrap().contains(&value)
 }
 
+// This used to generate broken bindings because the type inside `Option` (and
+// other generic builtin types) wasn't being added as a known type.
+#[uniffi::export]
+fn dummy(_arg: Option<i8>) {}
+
 mod uniffi_types {
     use std::{collections::HashSet, sync::Mutex};
 

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -252,6 +252,20 @@ impl TypeUniverse {
         // Types are more likely to already be known than not, so avoid unnecessary cloning.
         if !self.all_known_types.contains(type_) {
             self.all_known_types.insert(type_.to_owned());
+
+            // Add inner types. For UDL, this is actually pointless extra work (as is calling
+            // add_known_type from add_function_definition), but for the proc-macro frontend
+            // this is important if the inner type isn't ever mentioned outside one of these
+            // generic builtin types.
+            match type_ {
+                Type::Optional(t) => self.add_known_type(t),
+                Type::Sequence(t) => self.add_known_type(t),
+                Type::Map(k, v) => {
+                    self.add_known_type(k);
+                    self.add_known_type(v);
+                }
+                _ => {}
+            }
         }
     }
 


### PR DESCRIPTION
For some reason the fix didn't work when I tried it on matrix-rust-sdk last week, but now I've added a dedicated test to UniFFI directly and that works. So this at least partially fixes the broken bindings I've been having issues with.