### PR TITLE
Add support for records (dictionaries / structs) to the proc-macro frontend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
   "fixtures/keywords/kotlin",
   "fixtures/keywords/rust",
   "fixtures/keywords/swift",
+  "fixtures/proc-macro",
   "fixtures/reexport-scaffolding-macro",
   "fixtures/regressions/enum-without-i32-helpers",
   "fixtures/regressions/fully-qualified-types",

--- a/fixtures/proc-macro/Cargo.toml
+++ b/fixtures/proc-macro/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "uniffi-fixture-proc-macro"
+version = "0.20.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+edition = "2018"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+name = "uniffi_proc_macro"
+crate-type = ["cdylib"]
+
+[dependencies]
+uniffi = { path = "../../uniffi", features = ["builtin-bindgen"] }
+thiserror = "1.0"
+lazy_static = "1.4"
+
+[build-dependencies]
+uniffi_build = { path = "../../uniffi_build", features = ["builtin-bindgen"] }
+
+[dev-dependencies]
+uniffi_macros = { path = "../../uniffi_macros" }

--- a/fixtures/proc-macro/README.md
+++ b/fixtures/proc-macro/README.md
@@ -1,0 +1,3 @@
+# A basic test for uniffi components
+
+This test covers basic free-standing functions.

--- a/fixtures/proc-macro/build.rs
+++ b/fixtures/proc-macro/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/proc-macro.udl").unwrap();
+}

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::sync::Arc;
+
+#[derive(uniffi::Record)]
+pub struct One {
+    inner: i32,
+}
+
+#[derive(uniffi::Record)]
+pub struct Two {
+    a: String,
+    b: Option<Vec<bool>>,
+}
+
+#[derive(uniffi::Record)]
+pub struct Three {
+    obj: Arc<Object>,
+}
+
+#[derive(uniffi::Object)]
+pub struct Object;
+
+#[uniffi::export]
+fn make_one(inner: i32) -> One {
+    One { inner }
+}
+
+#[uniffi::export]
+fn take_two(two: Two) -> String {
+    two.a
+}
+
+#[uniffi::export]
+fn make_object() -> Arc<Object> {
+    Arc::new(Object)
+}
+
+include!(concat!(env!("OUT_DIR"), "/proc-macro.uniffi.rs"));
+
+mod uniffi_types {
+    pub use crate::{Object, One, Three, Two};
+}

--- a/fixtures/proc-macro/src/proc-macro.udl
+++ b/fixtures/proc-macro/src/proc-macro.udl
@@ -1,0 +1,1 @@
+namespace uniffi_proc_macro {};

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import uniffi.fixture.proc_macro.*;
+
+val one = makeOne(123)
+assert(one.inner == 123)
+
+val two = Two("a", null)
+assert(takeTwo(two) == "a")
+
+// just make sure this works / doesn't crash
+val three = Three(makeObject())

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from uniffi_proc_macro import *
+
+one = make_one(123)
+assert one.inner == 123
+
+two = Two("a", None)
+assert take_two(two) == "a"
+
+# just make sure this works / doesn't crash
+three = Three(make_object())

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import uniffi_proc_macro
+
+let one = makeOne(inner: 123)
+assert(one.inner == 123)
+
+let two = Two(a: "a", b: nil)
+assert(takeTwo(two: two) == "a")
+
+// just make sure this works / doesn't crash
+let three = Three(obj: makeObject())

--- a/fixtures/proc-macro/tests/test_generated_bindings.rs
+++ b/fixtures/proc-macro/tests/test_generated_bindings.rs
@@ -1,0 +1,8 @@
+uniffi_macros::build_foreign_language_testcases!(
+    ["src/proc-macro.udl"],
+    [
+        "tests/bindings/test_proc_macro.kts",
+        "tests/bindings/test_proc_macro.swift",
+        "tests/bindings/test_proc_macro.py",
+    ]
+);

--- a/fixtures/proc-macro/uniffi.toml
+++ b/fixtures/proc-macro/uniffi.toml
@@ -1,0 +1,9 @@
+[bindings.kotlin]
+package_name = "uniffi.fixture.proc_macro"
+cdylib_name = "uniffi_proc_macro"
+
+[bindings.python]
+cdylib_name = "uniffi_proc_macro"
+
+[bindings.swift]
+cdylib_name = "uniffi_proc_macro"

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -56,7 +56,7 @@ pub mod deps {
     pub use static_assertions;
 }
 
-pub use uniffi_macros::{export, Object};
+pub use uniffi_macros::{export, Object, Record};
 
 mod panichook;
 

--- a/uniffi_bindgen/src/backend/types.rs
+++ b/uniffi_bindgen/src/backend/types.rs
@@ -168,13 +168,13 @@ impl CodeTypeDispatch for CallbackInterface {
 
 impl CodeTypeDispatch for Field {
     fn code_type_impl(&self, oracle: &dyn CodeOracle) -> Box<dyn CodeType> {
-        oracle.find(&self.type_())
+        oracle.find(self.type_())
     }
 }
 
 impl CodeTypeDispatch for Argument {
     fn code_type_impl(&self, oracle: &dyn CodeOracle) -> Box<dyn CodeType> {
-        oracle.find(&self.type_())
+        oracle.find(self.type_())
     }
 }
 

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -224,6 +224,9 @@ impl KotlinCodeOracle {
             Type::Map(key, value) => Box::new(compounds::MapCodeType::new(*key, *value)),
             Type::External { name, .. } => Box::new(external::ExternalCodeType::new(name)),
             Type::Custom { name, .. } => Box::new(custom::CustomCodeType::new(name)),
+            Type::Unresolved { .. } => {
+                unreachable!("Type must be resolved before calling create_code_type")
+            }
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -246,6 +246,9 @@ impl PythonCodeOracle {
             Type::Map(key, value) => Box::new(compounds::MapCodeType::new(*key, *value)),
             Type::External { name, .. } => Box::new(external::ExternalCodeType::new(name)),
             Type::Custom { name, .. } => Box::new(custom::CustomCodeType::new(name)),
+            Type::Unresolved { .. } => {
+                unreachable!("Type must be resolved before calling create_code_type")
+            }
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -191,6 +191,9 @@ mod filters {
             }
             Type::External { .. } => panic!("No support for external types, yet"),
             Type::Custom { .. } => panic!("No support for custom types, yet"),
+            Type::Unresolved { .. } => {
+                unreachable!("Type must be resolved before calling coerce_rb")
+            }
         })
     }
 
@@ -224,6 +227,9 @@ mod filters {
             ),
             Type::External { .. } => panic!("No support for lowering external types, yet"),
             Type::Custom { .. } => panic!("No support for lowering custom types, yet"),
+            Type::Unresolved { .. } => {
+                unreachable!("Type must be resolved before calling lower_rb")
+            }
         })
     }
 
@@ -256,6 +262,9 @@ mod filters {
             ),
             Type::External { .. } => panic!("No support for lifting external types, yet"),
             Type::Custom { .. } => panic!("No support for lifting custom types, yet"),
+            Type::Unresolved { .. } => {
+                unreachable!("Type must be resolved before calling lift_rb")
+            }
         })
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -325,6 +325,9 @@ impl SwiftCodeOracle {
             Type::Map(key, value) => Box::new(compounds::MapCodeType::new(*key, *value)),
             Type::External { .. } => panic!("no support for external types yet"),
             Type::Custom { name, .. } => Box::new(custom::CustomCodeType::new(name)),
+            Type::Unresolved { .. } => {
+                unreachable!("Type must be resolved before calling create_code_type")
+            }
         }
     }
 }

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -350,7 +350,7 @@ mod test {
                 .iter()
                 .map(|f| f.type_())
                 .collect::<Vec<_>>(),
-            vec![Type::UInt32]
+            vec![&Type::UInt32]
         );
         assert_eq!(
             ed.variants()[2]
@@ -366,7 +366,7 @@ mod test {
                 .iter()
                 .map(|f| f.type_())
                 .collect::<Vec<_>>(),
-            vec![Type::UInt32, Type::String]
+            vec![&Type::UInt32, &Type::String]
         );
 
         // The enum declared via interface, but with no associated data.
@@ -384,7 +384,7 @@ mod test {
         // (It might be nice to optimize these to pass as plain integers, but that's
         // difficult atop the current factoring of `ComponentInterface` and friends).
         let farg = ci.get_function_definition("takes_an_enum").unwrap();
-        assert_eq!(farg.arguments()[0].type_(), Type::Enum("TestEnum".into()));
+        assert_eq!(*farg.arguments()[0].type_(), Type::Enum("TestEnum".into()));
         assert_eq!(farg.ffi_func().arguments()[0].type_(), FFIType::RustBuffer);
         let fret = ci.get_function_definition("returns_an_enum").unwrap();
         assert!(matches!(fret.return_type(), Some(Type::Enum(nm)) if nm == "TestEnum"));
@@ -398,7 +398,7 @@ mod test {
             .get_function_definition("takes_an_enum_with_data")
             .unwrap();
         assert_eq!(
-            farg.arguments()[0].type_(),
+            *farg.arguments()[0].type_(),
             Type::Enum("TestEnumWithData".into())
         );
         assert_eq!(farg.ffi_func().arguments()[0].type_(), FFIType::RustBuffer);

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -199,16 +199,16 @@ impl Argument {
         &self.name
     }
 
-    pub fn type_(&self) -> Type {
-        self.type_.clone()
+    pub fn type_(&self) -> &Type {
+        &self.type_
     }
 
     pub fn by_ref(&self) -> bool {
         self.by_ref
     }
 
-    pub fn default_value(&self) -> Option<Literal> {
-        self.default.clone()
+    pub fn default_value(&self) -> Option<&Literal> {
+        self.default.as_ref()
     }
 
     pub fn iter_types(&self) -> TypeIterator<'_> {

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -89,7 +89,7 @@ pub struct ComponentInterface {
     /// using a different version, which might introduce unsafety.
     uniffi_version: String,
     /// All of the types used in the interface.
-    types: TypeUniverse,
+    pub(super) types: TypeUniverse,
     /// The unique prefix that we'll use for namespacing when exposing this component's API.
     namespace: String,
     /// The internal unique prefix used to namespace FFI symbols
@@ -490,7 +490,7 @@ impl ComponentInterface {
     }
 
     /// Called by `APIBuilder` impls to add a newly-parsed record definition to the `ComponentInterface`.
-    fn add_record_definition(&mut self, defn: Record) {
+    pub(super) fn add_record_definition(&mut self, defn: Record) {
         // Note that there will be no duplicates thanks to the previous type-finding pass.
         self.records.push(defn);
     }

--- a/uniffi_bindgen/src/interface/record.rs
+++ b/uniffi_bindgen/src/interface/record.rs
@@ -46,8 +46,11 @@
 
 use anyhow::{bail, Result};
 
-use super::literal::{convert_default_value, Literal};
 use super::types::{Type, TypeIterator};
+use super::{
+    convert_type,
+    literal::{convert_default_value, Literal},
+};
 use super::{APIConverter, ComponentInterface};
 
 /// Represents a "data class" style object, for passing around complex values.
@@ -78,6 +81,15 @@ impl Record {
 
     pub fn iter_types(&self) -> TypeIterator<'_> {
         Box::new(self.fields.iter().flat_map(Field::iter_types))
+    }
+}
+
+impl From<uniffi_meta::RecordMetadata> for Record {
+    fn from(meta: uniffi_meta::RecordMetadata) -> Self {
+        Self {
+            name: meta.name,
+            fields: meta.fields.into_iter().map(Into::into).collect(),
+        }
     }
 }
 
@@ -120,6 +132,17 @@ impl Field {
 
     pub fn iter_types(&self) -> TypeIterator<'_> {
         self.type_.iter_types()
+    }
+}
+
+impl From<uniffi_meta::FieldMetadata> for Field {
+    fn from(meta: uniffi_meta::FieldMetadata) -> Self {
+        Self {
+            name: meta.name,
+            type_: convert_type(&meta.ty),
+            required: true,
+            default: None,
+        }
     }
 }
 

--- a/uniffi_bindgen/src/interface/record.rs
+++ b/uniffi_bindgen/src/interface/record.rs
@@ -72,8 +72,8 @@ impl Record {
         Type::Record(self.name.clone())
     }
 
-    pub fn fields(&self) -> Vec<&Field> {
-        self.fields.iter().collect()
+    pub fn fields(&self) -> &[Field] {
+        &self.fields
     }
 
     pub fn iter_types(&self) -> TypeIterator<'_> {
@@ -110,12 +110,12 @@ impl Field {
         &self.name
     }
 
-    pub fn type_(&self) -> Type {
-        self.type_.clone()
+    pub fn type_(&self) -> &Type {
+        &self.type_
     }
 
-    pub fn default_value(&self) -> Option<Literal> {
-        self.default.clone()
+    pub fn default_value(&self) -> Option<&Literal> {
+        self.default.as_ref()
     }
 
     pub fn iter_types(&self) -> TypeIterator<'_> {

--- a/uniffi_bindgen/src/macro_metadata/ci.rs
+++ b/uniffi_bindgen/src/macro_metadata/ci.rs
@@ -56,6 +56,7 @@ pub fn add_to_ci(
         }
     }
 
+    iface.resolve_types()?;
     iface.check_consistency()?;
     iface.derive_ffi_funcs()?;
 

--- a/uniffi_bindgen/src/macro_metadata/ci.rs
+++ b/uniffi_bindgen/src/macro_metadata/ci.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::interface::ComponentInterface;
+use crate::interface::{ComponentInterface, Record, Type};
 use anyhow::anyhow;
 use uniffi_meta::Metadata;
 
@@ -28,6 +28,10 @@ pub fn add_to_ci(
                 format!("method `{}.{}`", meta.self_name, meta.name),
                 meta.module_path.first().unwrap(),
             ),
+            Metadata::Record(meta) => (
+                format!("record `{}`", meta.name),
+                meta.module_path.first().unwrap(),
+            ),
             Metadata::Object(meta) => (
                 format!("object `{}`", meta.name),
                 meta.module_path.first().unwrap(),
@@ -49,6 +53,17 @@ pub fn add_to_ci(
             }
             Metadata::Method(meta) => {
                 iface.add_method_definition(meta);
+            }
+            Metadata::Record(meta) => {
+                let ty = Type::Record(meta.name.clone());
+                iface.types.add_known_type(&ty);
+                iface.types.add_type_definition(&meta.name, ty)?;
+
+                let record: Record = meta.into();
+                for field in record.fields() {
+                    iface.types.add_known_type(field.type_());
+                }
+                iface.add_record_definition(record);
             }
             Metadata::Object(meta) => {
                 iface.add_object_free_fn(meta);

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -54,6 +54,9 @@ mod filters {
             ),
             Type::Custom { name, .. } => format!("r#{}", name),
             Type::External { .. } => panic!("External types coming to a uniffi near you soon!"),
+            Type::Unresolved { .. } => {
+                unreachable!("UDL scaffolding code never contains unresolved types")
+            }
         })
     }
 
@@ -126,6 +129,9 @@ mod filters {
             Type::Float64 => "f64".into(),
             Type::String => "String".into(),
             Type::Boolean => "bool".into(),
+            Type::Unresolved { .. } => {
+                unreachable!("UDL scaffolding code never contains unresolved types")
+            }
         })
     }
 

--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -126,6 +126,10 @@ fn fn_type_assertions(sig: &syn::Signature) -> TokenStream {
                 let object_ident = format_ident!("{object_name}");
                 quote! { ::std::sync::Arc<crate::uniffi_types::#object_ident> }
             }
+            Type::Unresolved { name } => {
+                let ident = format_ident!("{name}");
+                quote! { crate::uniffi_types::#ident }
+            }
         }
     }
 

--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -9,7 +9,7 @@ use quote::{format_ident, quote, quote_spanned};
 use syn::spanned::Spanned;
 use uniffi_meta::{checksum, FnMetadata, MethodMetadata, Type};
 
-mod metadata;
+pub(crate) mod metadata;
 mod scaffolding;
 
 pub use self::metadata::gen_metadata;

--- a/uniffi_macros/src/export/metadata.rs
+++ b/uniffi_macros/src/export/metadata.rs
@@ -6,7 +6,7 @@ use proc_macro2::Span;
 
 use super::ExportItem;
 
-pub(super) mod convert;
+pub(crate) mod convert;
 mod function;
 mod impl_;
 

--- a/uniffi_macros/src/export/metadata/convert.rs
+++ b/uniffi_macros/src/export/metadata/convert.rs
@@ -63,7 +63,7 @@ pub(crate) fn convert_type(ty: &syn::Type) -> syn::Result<Type> {
 
     match &type_path.path.segments.first() {
         Some(seg) => match &seg.arguments {
-            syn::PathArguments::None => convert_bare_type_name(&seg.ident),
+            syn::PathArguments::None => Ok(convert_bare_type_name(&seg.ident)),
             syn::PathArguments::AngleBracketed(a) => convert_generic_type(&seg.ident, a),
             syn::PathArguments::Parenthesized(_) => Err(type_not_supported(type_path)),
         },
@@ -81,7 +81,7 @@ fn convert_generic_type(
     let mut it = a.args.iter();
     match it.next() {
         // `u8<>` is a valid way to write `u8` in the type namespace, so why not?
-        None => convert_bare_type_name(ident),
+        None => Ok(convert_bare_type_name(ident)),
         Some(arg1) => match it.next() {
             None => convert_generic_type1(ident, arg1),
             Some(arg2) => match it.next() {
@@ -96,21 +96,22 @@ fn convert_generic_type(
     }
 }
 
-fn convert_bare_type_name(ident: &Ident) -> syn::Result<Type> {
-    match ident.to_string().as_str() {
-        "u8" => Ok(Type::U8),
-        "u16" => Ok(Type::U16),
-        "u32" => Ok(Type::U32),
-        "u64" => Ok(Type::U64),
-        "i8" => Ok(Type::I8),
-        "i16" => Ok(Type::I16),
-        "i32" => Ok(Type::I32),
-        "i64" => Ok(Type::I64),
-        "f32" => Ok(Type::F32),
-        "f64" => Ok(Type::F64),
-        "bool" => Ok(Type::Bool),
-        "String" => Ok(Type::String),
-        _ => Err(type_not_supported(ident)),
+fn convert_bare_type_name(ident: &Ident) -> Type {
+    let name = ident.to_string();
+    match name.as_str() {
+        "u8" => Type::U8,
+        "u16" => Type::U16,
+        "u32" => Type::U32,
+        "u64" => Type::U64,
+        "i8" => Type::I8,
+        "i16" => Type::I16,
+        "i32" => Type::I32,
+        "i64" => Type::I64,
+        "f32" => Type::F32,
+        "f64" => Type::F64,
+        "bool" => Type::Bool,
+        "String" => Type::String,
+        _ => Type::Unresolved { name },
     }
 }
 

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -17,9 +17,10 @@ use util::rewrite_self_type;
 
 mod export;
 mod object;
+mod record;
 mod util;
 
-use self::{export::expand_export, object::expand_object};
+use self::{export::expand_export, object::expand_object, record::expand_record};
 
 #[proc_macro_attribute]
 pub fn export(_attr: TokenStream, input: TokenStream) -> TokenStream {
@@ -45,6 +46,17 @@ pub fn export(_attr: TokenStream, input: TokenStream) -> TokenStream {
         #output
     }
     .into()
+}
+
+#[proc_macro_derive(Record)]
+pub fn derive_record(input: TokenStream) -> TokenStream {
+    let mod_path = match util::mod_path() {
+        Ok(p) => p,
+        Err(e) => return e.into_compile_error().into(),
+    };
+    let input = parse_macro_input!(input);
+
+    expand_record(input, mod_path).into()
 }
 
 #[proc_macro_derive(Object)]

--- a/uniffi_macros/src/record.rs
+++ b/uniffi_macros/src/record.rs
@@ -1,0 +1,96 @@
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{Data, DeriveInput};
+use uniffi_meta::{FieldMetadata, RecordMetadata};
+
+use crate::{export::metadata::convert::convert_type, util::create_metadata_static_var};
+
+pub fn expand_record(input: DeriveInput, module_path: Vec<String>) -> TokenStream {
+    let fields = match input.data {
+        Data::Struct(s) => Some(s.fields),
+        _ => None,
+    };
+
+    let ident = &input.ident;
+
+    let (write_impl, try_read_fields) = match &fields {
+        Some(fields) => fields
+            .iter()
+            .map(|f| {
+                let ident = &f.ident;
+                let ty = &f.ty;
+
+                let write_field = quote! {
+                    <#ty as ::uniffi::FfiConverter>::write(obj.#ident, buf);
+                };
+                let try_read_field = quote! {
+                    #ident: <#ty as ::uniffi::FfiConverter>::try_read(buf)?,
+                };
+
+                (write_field, try_read_field)
+            })
+            .unzip(),
+        None => {
+            let unimplemented = quote! { ::std::unimplemented!() };
+            (unimplemented.clone(), unimplemented)
+        }
+    };
+
+    let meta_static_var = fields
+        .map(|fields| {
+            let name = ident.to_string();
+            let fields_res: syn::Result<_> = fields
+                .iter()
+                .map(|f| {
+                    let name = f
+                        .ident
+                        .as_ref()
+                        .expect("We only allow record structs")
+                        .to_string();
+
+                    Ok(FieldMetadata {
+                        name,
+                        ty: convert_type(&f.ty)?,
+                    })
+                })
+                .collect();
+
+            match fields_res {
+                Ok(fields) => {
+                    let metadata = RecordMetadata {
+                        module_path,
+                        name,
+                        fields,
+                    };
+
+                    create_metadata_static_var(ident, metadata.into())
+                }
+                Err(e) => e.into_compile_error(),
+            }
+        })
+        .unwrap_or_else(|| {
+            syn::Error::new(
+                Span::call_site(),
+                "This derive must only be used on structs",
+            )
+            .into_compile_error()
+        });
+
+    quote! {
+        impl ::uniffi::RustBufferFfiConverter for #ident {
+            type RustType = Self;
+
+            fn write(obj: Self, buf: &mut ::std::vec::Vec<u8>) {
+                #write_impl
+            }
+
+            fn try_read(buf: &mut &[::std::primitive::u8]) -> ::uniffi::deps::anyhow::Result<Self> {
+                Ok(Self { #try_read_fields })
+            }
+        }
+
+        ::uniffi::deps::static_assertions::assert_type_eq_all!(#ident, crate::uniffi_types::#ident);
+
+        #meta_static_var
+    }
+}

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -79,6 +79,20 @@ pub enum Type {
 }
 
 #[derive(Clone, Debug, Hash, Deserialize, Serialize)]
+pub struct RecordMetadata {
+    pub module_path: Vec<String>,
+    pub name: String,
+    pub fields: Vec<FieldMetadata>,
+}
+
+#[derive(Clone, Debug, Hash, Deserialize, Serialize)]
+pub struct FieldMetadata {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub ty: Type,
+}
+
+#[derive(Clone, Debug, Hash, Deserialize, Serialize)]
 pub struct ObjectMetadata {
     pub module_path: Vec<String>,
     pub name: String,
@@ -114,6 +128,7 @@ pub fn fn_ffi_symbol_name(mod_path: &[String], name: &str, checksum: u16) -> Str
 pub enum Metadata {
     Func(FnMetadata),
     Method(MethodMetadata),
+    Record(RecordMetadata),
     Object(ObjectMetadata),
 }
 
@@ -126,6 +141,12 @@ impl From<FnMetadata> for Metadata {
 impl From<MethodMetadata> for Metadata {
     fn from(m: MethodMetadata) -> Self {
         Self::Method(m)
+    }
+}
+
+impl From<RecordMetadata> for Metadata {
+    fn from(r: RecordMetadata) -> Self {
+        Self::Record(r)
     }
 }
 

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -73,6 +73,9 @@ pub enum Type {
     ArcObject {
         object_name: String,
     },
+    Unresolved {
+        name: String,
+    },
 }
 
 #[derive(Clone, Debug, Hash, Deserialize, Serialize)]


### PR DESCRIPTION
Part of #1257.

Adds a `#[derive(uniffi::Record)]` macro and updates `#[uniffi::export]` to allow usage of arbitrary types as long as they don't have generics and are available under `crate::uniffi_types` and have the right trait implementation.

Outside of `uniffi::export`, when generating bindings, the names of such types are resolved against the known type definitions from both UDL and derives like `Record` (`Enum` might come next).