### PR TITLE
Use nested `canonical_name` for Swift dictionaries

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/gen_swift/compounds.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/compounds.rs
@@ -84,8 +84,8 @@ impl CodeType for MapCodeType {
     fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
         format!(
             "Dictionary{}{}",
-            oracle.find(&self.key).type_label(oracle),
-            oracle.find(&self.value).type_label(oracle)
+            oracle.find(&self.key).canonical_name(oracle),
+            oracle.find(&self.value).canonical_name(oracle)
         )
     }
 


### PR DESCRIPTION
This change allows the disambiguation of multiply-nested compound structures, such as `[String: [String: String]]` and `[String: [String: [String]]]`. At the moment both of these types are represented as `FfiConverterDictionaryStringStringString` in the generated swift file, which leads to a compilation issue due to conflicting definitions.

After this change the generated names are as follows:
- `[String: String]` => `...DictionaryStringString`
- `[String: [String]]` => `...DictionaryStringSequenceString`
- `[String: [String: String]]` => `...DictionaryStringDictionaryStringString`
- `[String: [String: [String]]]` => `...DictionaryStringDictionaryStringSequenceString`
- etc

Note that `SequenceCodeType` and `OptionalCodeType` already use nested `cannonical_name`, whereas `MapCodeType` does not, until this change.