### PR TITLE
proc-macro: unused-qualifications lint cleanup

### DIFF
--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -278,11 +278,7 @@ unsafe impl FfiConverter for bool {
     type FfiType = i8;
 
     fn lower(obj: Self::RustType) -> Self::FfiType {
-        if obj {
-            1
-        } else {
-            0
-        }
+        i8::from(obj)
     }
 
     fn try_lift(v: Self::FfiType) -> Result<Self::RustType> {

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -28,6 +28,8 @@
 //! In addition to the core `FfiConverter` trait, we provide a handful of struct definitions useful
 //! for passing core rust types over the FFI, such as [`RustBuffer`].
 
+#![warn(rust_2018_idioms, unused_qualifications)]
+
 use anyhow::bail;
 use bytes::buf::{Buf, BufMut};
 use paste::paste;

--- a/uniffi/tests/ui/proc_macro_arc.stderr
+++ b/uniffi/tests/ui/proc_macro_arc.stderr
@@ -1,8 +1,8 @@
-error[E0271]: type mismatch resolving `<Arc<child::Foo> as child::_::{closure#0}::TypeEq>::This == Arc<Foo>`
+error[E0271]: type mismatch resolving `<Arc<child::Foo> as child::_::_::{closure#0}::TypeEq>::This == Arc<Foo>`
   --> tests/ui/proc_macro_arc.rs:18:22
    |
 18 |     fn take_foo(foo: Arc<Foo>) {
-   |                      ^^^ type mismatch resolving `<Arc<child::Foo> as child::_::{closure#0}::TypeEq>::This == Arc<Foo>`
+   |                      ^^^ type mismatch resolving `<Arc<child::Foo> as child::_::_::{closure#0}::TypeEq>::This == Arc<Foo>`
    |
 note: expected this to be `Arc<Foo>`
   --> tests/ui/proc_macro_arc.rs:18:22
@@ -11,12 +11,12 @@ note: expected this to be `Arc<Foo>`
    |                      ^^^
    = note: expected struct `Arc<Foo>`
               found struct `Arc<child::Foo>`
-note: required by a bound in `child::_::{closure#0}::assert_type_eq_all`
+note: required by a bound in `child::_::_::{closure#0}::assert_type_eq_all`
   --> tests/ui/proc_macro_arc.rs:18:22
    |
 18 |     fn take_foo(foo: Arc<Foo>) {
    |                      ^^^
    |                      |
    |                      required by a bound in this
-   |                      required by this bound in `child::_::{closure#0}::assert_type_eq_all`
+   |                      required by this bound in `child::_::_::{closure#0}::assert_type_eq_all`
    = note: this error originates in the macro `::uniffi::deps::static_assertions::assert_type_eq_all` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -89,7 +89,7 @@
 //! to load and use the compiled rust code via its C-compatible FFI.
 //!
 
-#![warn(rust_2018_idioms)]
+#![warn(rust_2018_idioms, unused_qualifications)]
 #![allow(unknown_lints)]
 
 const BINDGEN_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -229,7 +229,7 @@ pub trait BindingGenerator: Sized {
         ci: ComponentInterface,
         config: Self::Config,
         out_dir: &Utf8Path,
-    ) -> anyhow::Result<()>;
+    ) -> Result<()>;
 }
 
 /// Generate bindings for an external binding generator
@@ -596,7 +596,7 @@ pub fn run_main() -> Result<()> {
             config,
             lib_file,
             udl_file,
-        } => crate::generate_bindings(
+        } => generate_bindings(
             udl_file,
             config.as_deref(),
             language.iter().map(String::as_str).collect(),
@@ -609,7 +609,7 @@ pub fn run_main() -> Result<()> {
             config,
             no_format,
             udl_file,
-        } => crate::generate_component_scaffolding(
+        } => generate_component_scaffolding(
             udl_file,
             config.as_deref(),
             out_dir.as_deref(),
@@ -620,7 +620,7 @@ pub fn run_main() -> Result<()> {
             udl_file,
             test_scripts,
             config,
-        } => crate::run_tests(library_file, &[udl_file], test_scripts, config.as_deref()),
+        } => run_tests(library_file, &[udl_file], test_scripts, config.as_deref()),
         Commands::PrintJson { path } => print_json(path),
     }?;
     Ok(())

--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -6,7 +6,6 @@ use std::collections::BTreeMap;
 
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote, quote_spanned};
-use syn::spanned::Spanned;
 use uniffi_meta::{checksum, FnMetadata, MethodMetadata, Type};
 
 pub(crate) mod metadata;
@@ -14,7 +13,10 @@ mod scaffolding;
 
 pub use self::metadata::gen_metadata;
 use self::scaffolding::{gen_fn_scaffolding, gen_method_scaffolding};
-use crate::{export::metadata::convert::convert_type, util::create_metadata_static_var};
+use crate::{
+    export::metadata::convert::convert_type,
+    util::{assert_type_eq, create_metadata_static_var},
+};
 
 // TODO(jplatte): Ensure no generics, no async, …
 // TODO(jplatte): Aggregate errors instead of short-circuiting, whereever possible
@@ -151,9 +153,7 @@ fn fn_type_assertions(sig: &syn::Signature) -> TokenStream {
         .filter_map(|ty| {
             convert_type(ty).ok().map(|meta_ty| {
                 let expected_ty = convert_type_back(&meta_ty);
-                let assert = quote_spanned! {ty.span()=>
-                    ::uniffi::deps::static_assertions::assert_type_eq_all!(#ty, #expected_ty);
-                };
+                let assert = assert_type_eq(ty, expected_ty);
                 (meta_ty, assert)
             })
         })

--- a/uniffi_macros/src/object.rs
+++ b/uniffi_macros/src/object.rs
@@ -1,9 +1,9 @@
 use proc_macro2::{Ident, Span, TokenStream};
-use quote::{quote, quote_spanned};
+use quote::quote;
 use syn::DeriveInput;
 use uniffi_meta::ObjectMetadata;
 
-use crate::util::create_metadata_static_var;
+use crate::util::{assert_type_eq, create_metadata_static_var};
 
 pub fn expand_object(input: DeriveInput, module_path: Vec<String>) -> TokenStream {
     let ident = &input.ident;
@@ -11,9 +11,7 @@ pub fn expand_object(input: DeriveInput, module_path: Vec<String>) -> TokenStrea
     let metadata = ObjectMetadata { module_path, name };
     let free_fn_ident = Ident::new(&metadata.free_ffi_symbol_name(), Span::call_site());
     let meta_static_var = create_metadata_static_var(ident, metadata.into());
-    let type_assertion = quote_spanned! {ident.span()=>
-        ::uniffi::deps::static_assertions::assert_type_eq_all!(#ident, crate::uniffi_types::#ident);
-    };
+    let type_assertion = assert_type_eq(ident, quote! { crate::uniffi_types::#ident });
 
     quote! {
         #[doc(hidden)]

--- a/uniffi_macros/src/record.rs
+++ b/uniffi_macros/src/record.rs
@@ -3,7 +3,10 @@ use quote::quote;
 use syn::{Data, DeriveInput};
 use uniffi_meta::{FieldMetadata, RecordMetadata};
 
-use crate::{export::metadata::convert::convert_type, util::create_metadata_static_var};
+use crate::{
+    export::metadata::convert::convert_type,
+    util::{assert_type_eq, create_metadata_static_var},
+};
 
 pub fn expand_record(input: DeriveInput, module_path: Vec<String>) -> TokenStream {
     let fields = match input.data {
@@ -76,6 +79,8 @@ pub fn expand_record(input: DeriveInput, module_path: Vec<String>) -> TokenStrea
             .into_compile_error()
         });
 
+    let type_assertion = assert_type_eq(ident, quote! { crate::uniffi_types::#ident });
+
     quote! {
         impl ::uniffi::RustBufferFfiConverter for #ident {
             type RustType = Self;
@@ -89,8 +94,7 @@ pub fn expand_record(input: DeriveInput, module_path: Vec<String>) -> TokenStrea
             }
         }
 
-        ::uniffi::deps::static_assertions::assert_type_eq_all!(#ident, crate::uniffi_types::#ident);
-
         #meta_static_var
+        #type_assertion
     }
 }

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use proc_macro2::{Ident, Span, TokenStream};
-use quote::{format_ident, quote};
-use syn::{visit_mut::VisitMut, Item, Type};
+use quote::{format_ident, quote, quote_spanned, ToTokens};
+use syn::{spanned::Spanned, visit_mut::VisitMut, Item, Type};
 use uniffi_meta::Metadata;
 
 #[cfg(not(feature = "nightly"))]
@@ -132,5 +132,14 @@ pub fn create_metadata_static_var(name: &Ident, val: Metadata) -> TokenStream {
     quote! {
         #[no_mangle]
         pub static #var_name: [u8; #count] = [#(#data),*];
+    }
+}
+
+pub fn assert_type_eq(a: impl ToTokens + Spanned, b: impl ToTokens) -> TokenStream {
+    quote_spanned! {a.span()=>
+        #[allow(unused_qualifications)]
+        const _: () = {
+            ::uniffi::deps::static_assertions::assert_type_eq_all!(#a, #b);
+        };
     }
 }

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -131,6 +131,7 @@ pub fn create_metadata_static_var(name: &Ident, val: Metadata) -> TokenStream {
 
     quote! {
         #[no_mangle]
+        #[doc(hidden)]
         pub static #var_name: [u8; #count] = [#(#data),*];
     }
 }


### PR DESCRIPTION
We have this lint enabled in our project and for some reason while it doesn't trigger for generated code in one crate, it does in another. This should clean that up.