### PR TITLE
Permit redundant definition of records and enums

### DIFF
--- a/fixtures/proc-macro/src/proc-macro.udl
+++ b/fixtures/proc-macro/src/proc-macro.udl
@@ -1,1 +1,7 @@
 namespace uniffi_proc_macro {};
+
+// Test that redundant definition of a dictionary works
+dictionary Two {
+    string a;
+    sequence<boolean>? b;
+};

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -87,7 +87,7 @@ use super::{APIConverter, ComponentInterface};
 ///
 /// Enums are passed across the FFI by serializing to a bytebuffer, with a
 /// i32 indicating the variant followed by the serialization of each field.
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Enum {
     pub(super) name: String,
     pub(super) variants: Vec<Variant>,
@@ -185,7 +185,7 @@ impl APIConverter<Enum> for weedle::InterfaceDefinition<'_> {
 /// Represents an individual variant in an Enum.
 ///
 /// Each variant has a name and zero or more fields.
-#[derive(Debug, Clone, Default, Hash)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct Variant {
     pub(super) name: String,
     pub(super) fields: Vec<Field>,
@@ -300,7 +300,7 @@ mod test {
             enum Testing { "one", "two", "one" };
         "#;
         let ci = ComponentInterface::from_webidl(UDL).unwrap();
-        assert_eq!(ci.enum_definitions().len(), 1);
+        assert_eq!(ci.enum_definitions().count(), 1);
         assert_eq!(
             ci.get_enum_definition("Testing").unwrap().variants().len(),
             3
@@ -333,7 +333,7 @@ mod test {
             };
         "##;
         let ci = ComponentInterface::from_webidl(UDL).unwrap();
-        assert_eq!(ci.enum_definitions().len(), 3);
+        assert_eq!(ci.enum_definitions().count(), 3);
         assert_eq!(ci.function_definitions().len(), 4);
 
         // The "flat" enum with no associated data.

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -281,7 +281,6 @@ impl APIConverter<Field> for weedle::argument::SingleArgument<'_> {
         Ok(Field {
             name: self.identifier.0.to_string(),
             type_,
-            required: false,
             default: None,
         })
     }

--- a/uniffi_bindgen/src/interface/literal.rs
+++ b/uniffi_bindgen/src/interface/literal.rs
@@ -13,7 +13,7 @@ use super::types::Type;
 
 // Represents a literal value.
 // Used for e.g. default argument values.
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Literal {
     Boolean(bool),
     String(String),
@@ -35,7 +35,7 @@ pub enum Literal {
 
 // Represent the radix of integer literal values.
 // We preserve the radix into the generated bindings for readability reasons.
-#[derive(Debug, Clone, Copy, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Radix {
     Decimal = 10,
     Octal = 8,

--- a/uniffi_bindgen/src/interface/record.rs
+++ b/uniffi_bindgen/src/interface/record.rs
@@ -58,7 +58,7 @@ use super::{APIConverter, ComponentInterface};
 /// In the FFI these are represented as a byte buffer, which one side explicitly
 /// serializes the data into and the other serializes it out of. So I guess they're
 /// kind of like "pass by clone" values.
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Record {
     pub(super) name: String,
     pub(super) fields: Vec<Field>,
@@ -109,7 +109,7 @@ impl APIConverter<Record> for weedle::DictionaryDefinition<'_> {
 }
 
 // Represents an individual field on a Record.
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Field {
     pub(super) name: String,
     pub(super) type_: Type,
@@ -182,7 +182,7 @@ mod test {
             };
         "#;
         let ci = ComponentInterface::from_webidl(UDL).unwrap();
-        assert_eq!(ci.record_definitions().len(), 3);
+        assert_eq!(ci.record_definitions().count(), 3);
 
         let record = ci.get_record_definition("Empty").unwrap();
         assert_eq!(record.name(), "Empty");
@@ -225,7 +225,7 @@ mod test {
             };
         "#;
         let ci = ComponentInterface::from_webidl(UDL).unwrap();
-        assert_eq!(ci.record_definitions().len(), 1);
+        assert_eq!(ci.record_definitions().count(), 1);
         let record = ci.get_record_definition("Testing").unwrap();
         assert_eq!(record.fields().len(), 2);
         assert_eq!(record.fields()[0].name(), "maybe_name");

--- a/uniffi_bindgen/src/interface/record.rs
+++ b/uniffi_bindgen/src/interface/record.rs
@@ -113,7 +113,6 @@ impl APIConverter<Record> for weedle::DictionaryDefinition<'_> {
 pub struct Field {
     pub(super) name: String,
     pub(super) type_: Type,
-    pub(super) required: bool,
     pub(super) default: Option<Literal>,
 }
 
@@ -140,7 +139,6 @@ impl From<uniffi_meta::FieldMetadata> for Field {
         Self {
             name: meta.name,
             type_: convert_type(&meta.ty),
-            required: true,
             default: None,
         }
     }
@@ -159,7 +157,6 @@ impl APIConverter<Field> for weedle::dictionary::DictionaryMember<'_> {
         Ok(Field {
             name: self.identifier.0.to_string(),
             type_,
-            required: self.required.is_some(),
             default,
         })
     }
@@ -196,7 +193,6 @@ mod test {
         assert_eq!(record.fields().len(), 1);
         assert_eq!(record.fields()[0].name(), "field");
         assert_eq!(record.fields()[0].type_().canonical_name(), "u32");
-        assert!(!record.fields()[0].required);
         assert!(record.fields()[0].default_value().is_none());
 
         let record = ci.get_record_definition("Complex").unwrap();
@@ -207,18 +203,15 @@ mod test {
             record.fields()[0].type_().canonical_name(),
             "Optionalstring"
         );
-        assert!(!record.fields()[0].required);
         assert!(record.fields()[0].default_value().is_none());
         assert_eq!(record.fields()[1].name(), "value");
         assert_eq!(record.fields()[1].type_().canonical_name(), "u32");
-        assert!(!record.fields()[1].required);
         assert!(matches!(
             record.fields()[1].default_value(),
             Some(Literal::UInt(0, Radix::Decimal, Type::UInt32))
         ));
         assert_eq!(record.fields()[2].name(), "spin");
         assert_eq!(record.fields()[2].type_().canonical_name(), "bool");
-        assert!(record.fields()[2].required);
         assert!(record.fields()[2].default_value().is_none());
     }
 

--- a/uniffi_bindgen/src/macro_metadata/ci.rs
+++ b/uniffi_bindgen/src/macro_metadata/ci.rs
@@ -67,7 +67,7 @@ pub fn add_to_ci(
                 for field in record.fields() {
                     iface.types.add_known_type(field.type_());
                 }
-                iface.add_record_definition(record);
+                iface.add_record_definition(record)?;
             }
             Metadata::Enum(meta) => {
                 let ty = Type::Enum(meta.name.clone());
@@ -78,7 +78,7 @@ pub fn add_to_ci(
                 for field in enum_.variants().iter().flat_map(|v| v.fields()) {
                     iface.types.add_known_type(field.type_());
                 }
-                iface.add_enum_definition(enum_);
+                iface.add_enum_definition(enum_)?;
             }
             Metadata::Object(meta) => {
                 iface.add_object_free_fn(meta);


### PR DESCRIPTION
… as long as all definitions are exactly the same. Required to use an enum or record in the signatures of both proc-macro-exported functions as well as UDL functions within one API.

Related to #1257.