### PR TITLE
Use [Error] rather than [Enum] on rich errors.

### DIFF
--- a/docs/manual/src/udl/errors.md
+++ b/docs/manual/src/udl/errors.md
@@ -37,7 +37,7 @@ On the other side (Kotlin, Swift etc.), a proper exception will be thrown if `Re
 If you want to expose the assocated data as fields on the exception, use this syntax:
 
 ```
-[Enum]
+[Error]
 interface ArithmeticError {
   IntegerOverflow(u64 a, u64 b);
 };

--- a/docs/manual/src/udl/errors.md
+++ b/docs/manual/src/udl/errors.md
@@ -34,7 +34,7 @@ namespace arithmetic {
 
 On the other side (Kotlin, Swift etc.), a proper exception will be thrown if `Result::is_err()` is `true`.
 
-If you want to expose the assocated data as fields on the exception, use this syntax:
+If you want to expose the associated data as fields on the exception, use this syntax:
 
 ```
 [Error]


### PR DESCRIPTION
Fixes #1380

When `[Enum]` is used, the Rust code compiles fine and the code generation completes, but it leads to an error in Swift:

```
...: error build: Global function 'rustCallWithError' requires that 'FfiConverterTypeLeadsError.SwiftType' (aka 'LeadsError') conform to 'Error'
```

Changing the annotation to `[Error]` works as expected (in v 0.21).

... and a small typo fixed.