### PR TITLE
Try adding callback error to panic message

### DIFF
--- a/docs/manual/src/udl/callback_interfaces.md
+++ b/docs/manual/src/udl/callback_interfaces.md
@@ -47,15 +47,15 @@ foreign bindings will lead to a panic.
 In order to support errors in callback interfaces, UniFFI must be able to
 properly [lift the error](../internals/lifting_and_lowering.md).  This means
 that the if the error is described by an `enum` rather than an `interface` in
-the UDL (see (./errors.md)) then all variants of the Rust enum must be unit variants.
+the UDL (see [Errors](./errors.md)) then all variants of the Rust enum must be unit variants.
 
 In addition to expected errors, a callback interface call can result in all kinds of
 unexpected errors.  Some examples are the foreign code throws an exception that's not part
 of the exception type or there was a problem marshalling the data for the call.  UniFFI
 uses `uniffi::UnexpectedUniFFICallbackError` for these cases.  Your code must include a
 `From<uniffi::UnexpectedUniFFICallbackError>` impl for your error type to handle those or
-the UniFFI scaffolding code will fail to compile.  See the `example/callbacks` for an
-exapmle of how to do this.
+the UniFFI scaffolding code will fail to compile.  See `example/callbacks` for an
+example of how to do this.
 
 ## 3. Define a callback interface in the UDL.
 
@@ -101,7 +101,7 @@ impl Authenticator {
 }
 ```
 
-## 4. Create an foreign language implementation of the callback interface.
+## 5. Create an foreign language implementation of the callback interface.
 
 In this example, here's a Kotlin implementation.
 
@@ -133,7 +133,7 @@ class SwiftKeychain: Keychain {
 
 Note: in Swift, this must be a `class`.
 
-## 5. Pass the implementation to Rust.
+## 6. Pass the implementation to Rust.
 
 Again, in Kotlin
 

--- a/examples/callbacks/tests/bindings/test_callbacks.kts
+++ b/examples/callbacks/tests/bindings/test_callbacks.kts
@@ -34,7 +34,7 @@ try {
 
 try {
     telephone.call(CallAnswererImpl("something-else"))
-    throw RuntimeException("Should have thrown a Busy exception!")
+    throw RuntimeException("Should have thrown an internal exception!")
 } catch(e: TelephoneException.InternalTelephoneException) {
     // It's okay
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceTemplate.kt
@@ -50,7 +50,7 @@ internal class {{ foreign_callback }} : ForeignCallback {
                         outBuf.setValue(buffer)
                         -2
                     }
-                    {%- else %} 
+                    {%- else %}
                     val buffer = this.{{ method_name }}(cb, args)
                     // Success
                     outBuf.setValue(buffer)
@@ -73,7 +73,7 @@ internal class {{ foreign_callback }} : ForeignCallback {
                 // See docs of ForeignCallback in `uniffi/src/ffi/foreigncallbacks.rs`
                 try {
                     // Try to serialize the error into a string
-                    outBuf.setValue({{ Type::String.borrow()|ffi_converter_name }}.lower("Invalid Callaback index"))
+                    outBuf.setValue({{ Type::String.borrow()|ffi_converter_name }}.lower("Invalid Callback index"))
                 } catch (e: Throwable) {
                     // If that fails, then it's time to give up and just return
                 }

--- a/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
@@ -146,7 +146,7 @@ impl r#{{ trait_name }} for {{ trait_impl }} {
                     if !ret_rbuf.is_empty() {
                         let reason = match {{ Type::String.borrow()|ffi_converter }}::try_lift(ret_rbuf) {
                             Ok(s) => s,
-                            Err(e) => {
+                            Err(_) => {
                                 String::from("[Error reading reason]")
                             }
                         };

--- a/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
@@ -130,7 +130,7 @@ impl r#{{ trait_name }} for {{ trait_impl }} {
                         match {{ Type::String.borrow()|ffi_converter }}::try_lift(ret_rbuf) {
                             Ok(s) => s,
                             Err(e) => {
-                                println!("{{ trait_name }} Error reading ret_buf: {e}");
+                                uniffi::deps::log::error!("{{ trait_name }} Error reading ret_buf: {e}");
                                 String::from("[Error reading reason]")
                             }
                         }

--- a/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
@@ -142,7 +142,19 @@ impl r#{{ trait_name }} for {{ trait_impl }} {
                     Err(e)
                 }
                 {%- else %}
-                -1 => panic!("Callback failed"),
+                -1 => {
+                    if !ret_rbuf.is_empty() {
+                        let reason = match {{ Type::String.borrow()|ffi_converter }}::try_lift(ret_rbuf) {
+                            Ok(s) => s,
+                            Err(e) => {
+                                String::from("[Error reading reason]")
+                            }
+                        };
+                        panic!("callback failed. Reason: {}", reason);
+                    } else {
+                        panic!("Callback failed")
+                    }
+                },
                 {%- endmatch %}
                 // Other values should never be returned
                 _ => panic!("Callback failed with unexpected return code"),


### PR DESCRIPTION
The recent failures of [updating Glean in Focus](https://github.com/mozilla-mobile/focus-android/pull/7902) were a bit harder to debug than I would have liked to.
The UniFFI update caused a new panic due to some bad interaction of the code (an uncaught exception), but that exception was no where visible.

This PR adds the exception message to the panic message, see the last commit.
Along the way I fixed some typos and docs.

(Note that the _correct_ solution for Glean will be to return a Result, that will be handled in [bug 1797262](https://bugzilla.mozilla.org/show_bug.cgi?id=1797262)).

https://github.com/mozilla/uniffi-rs/commit/909e70a92ca6db10d2a194f8ca2bc6a9be5913a2 has an example to trigger the panic. Probably can't add that as a proper test because ... well, can't catch that panic anywhere.