### PR TITLE
Fix some typos in ADRs and manual

### DIFF
--- a/docs/adr/0001-mvp-webidl.md
+++ b/docs/adr/0001-mvp-webidl.md
@@ -63,7 +63,7 @@ code will be allowed to contain inefficiencies and limitations that hand-written
 on the premise that our first consumers are not very performance-sensitive, and that there is a lot of scope for
 improving these implementation details over time.
 
-We are likely to ***revisit every single one of these chocies*** if the MVP of the tool proves successful,
+We are likely to ***revisit every single one of these choices*** if the MVP of the tool proves successful,
 and will attempt to build it in such a what that they're easy to revisit.
 
 ## Pros and Cons of the Options
@@ -93,7 +93,7 @@ using our own custom variant of an IDL syntax.
 * Good, because the syntax can be custom designed to fit well with the developer's mental
   model of the generated code.
 * Good, because we already have several different IDL variants in use at Mozilla (WebIDL, XPIDL),
-  so our changes of building something that feels familiar are high.
+  so our chances of building something that feels familiar are high.
 * Bad, because developers will need to duplicate their API, once in the Rust code and once in the IDL.
 * Bad, because we have to make up and document a whole syntax.
 * Bad, because rust parsing crates such as `nom` do not seem to generate particularly helpful error messages
@@ -148,7 +148,7 @@ tool that integrates it with `cargo build` for convenience.
 ### Option F: Go broad, implementing many data types and API capabilities, even if they're slow or incomplete.
 
 We can focus our initial efforts on fleshing out a broad suite of data types and API capabilities,
-spending less time focussed on performance or edge-cases in the generated code.
+spending less time focused on performance or edge-cases in the generated code.
 
 * Good, because consumers can iterate their API with less chance of being limited by the tool.
 * Good, because it makes more opportunities for team members to get involved in implementing features

--- a/docs/adr/0002-serialize-complex-datatypes.md
+++ b/docs/adr/0002-serialize-complex-datatypes.md
@@ -41,7 +41,7 @@ and expect that we can do so incrementally without changing the consumer-facing 
 ### Option A: Declare complex datatypes using Protocol Buffers, pass them as serialized bytes.
 
 Following the approach currently taken by hand-written component bindings in application-services,
-we could generate a Protocol Buffers schema for each complex data type, and use generated serializtion
+we could generate a Protocol Buffers schema for each complex data type, and use generated serialization
 code to send it across the FFI as a bytebuffer.
 
 * Good, because we're familiar with this approach from our existing components.

--- a/docs/adr/0002-serialize-complex-datatypes.md
+++ b/docs/adr/0002-serialize-complex-datatypes.md
@@ -54,7 +54,7 @@ code to send it across the FFI as a bytebuffer.
 * Bad, because Protocol Buffers contain some complexity that isn't useful for our use-case, such
   as affordances for backwards-compatibility.
 
-A similar set of considerations apply to other third-party serialization schems such as flatbuffers,
+A similar set of considerations apply to other third-party serialization schemes such as flatbuffers,
 with the added disadvantage of unfamiliarity.
 
 Ultimately, the additional build complexity of integrating a code-generator inside our own code generator

--- a/docs/adr/0004-only-threadsafe-interfaces.md
+++ b/docs/adr/0004-only-threadsafe-interfaces.md
@@ -37,7 +37,7 @@ generic "Threadsafe".
   them `Send+Sync`. We consider this a "foot-gun" as it may lead to accidentally
   having method calls unexpectedly block for long periods, such as
   [this Fenix bug](https://github.com/mozilla-mobile/fenix/issues/17086)
-  (with more details available in [this JIRA ticket](https://jira.mozilla.com/browse/SDK-157).)
+  (with more details available in [this JIRA ticket](https://jira.mozilla.com/browse/SDK-157)).
 
 * Supporting such structs will hinder uniffi growing in directions that we've
   found are desired in practice, such as allowing structs to use [alternative

--- a/docs/adr/0004-only-threadsafe-interfaces.md
+++ b/docs/adr/0004-only-threadsafe-interfaces.md
@@ -19,7 +19,7 @@ the only question is who manages this thread-safety. Interfaces which are not
 marked as thread-safe cause uniffi to wrap the interface in a mutex which is
 hidden in the generated code and therefore not obvious to the casual reader.
 
-The [Threadsafe] marker acts as a way for the component author to opt out of
+The `[Threadsafe]` marker acts as a way for the component author to opt out of
 the overhead and blocking behaviour of this mutex, at the cost of opting in to
 managing their own locking internally. This ADR proposes that uniffi forces
 component authors to explicitly manage that locking in all cases - or to put

--- a/docs/adr/0004-only-threadsafe-interfaces.md
+++ b/docs/adr/0004-only-threadsafe-interfaces.md
@@ -63,7 +63,7 @@ Chosen option:
 This decision was taken because our real world experience tells us that
 non-`Send+Sync` interfaces are only useful in toy or example applications (eg,
 the nimbus and autofill projects didn't get very far before needing these
-capabilities), so the extra ongoing work in supporting these interfaces can not
+capabilities), so the extra ongoing work in supporting these interfaces cannot
 be justified.
 
 ### Positive Consequences
@@ -94,7 +94,7 @@ be justified.
   https://github.com/mozilla/uniffi-rs/commit/454dfff6aa560dffad980a9258853108a44d5985).
 
 * Existing applications that are yet to consider how to make their
-  implementations `Send+Sync` can not be wrapped until they have.
+  implementations `Send+Sync` cannot be wrapped until they have.
 
 * The examples which aren't currently marked with the `[Threadsafe]` attribute
   will become more complex as they will all need to implement and explain how

--- a/docs/adr/0004-only-threadsafe-interfaces.md
+++ b/docs/adr/0004-only-threadsafe-interfaces.md
@@ -68,7 +68,7 @@ be justified.
 
 ### Positive Consequences
 
-* The locking in all uniffi supported component will more easily
+* The locking in all uniffi supported components will be more easily
   discoverable - it will be in hand-written rust code and not hidden inside
   generated code. This is a benefit to the developers of the uniffi supported
   component rather than to the consumers of it; while we are considering other

--- a/docs/adr/0005-arc-pointers.md
+++ b/docs/adr/0005-arc-pointers.md
@@ -48,7 +48,7 @@ lifetimes, so that references to structs can be used more widely than currently 
   should be impossible to misuse the generated bindings in a way that triggers
   Rust's "undefined behavior" or otherwise defeats Rust's safety
   characteristics and ownership model (and in particular, avoiding things like
-  use-after-free issues)
+  use-after-free issues).
 
 * We would like to keep the overhead of UniFFI as small as possible so that it
   is a viable solution to more use-cases.

--- a/docs/adr/0005-arc-pointers.md
+++ b/docs/adr/0005-arc-pointers.md
@@ -88,7 +88,7 @@ This decision is taken because:
   `HandleMap`s offer. Ultimately we'd just end up reimplementing `Arc<>` anyway,
   and the one in the stdlib is far more likely to be correct.
 
-* There are useability and familiarity benefits to using the stdlib `Arc<>` rather
+* There are usability and familiarity benefits to using the stdlib `Arc<>` rather
   than a special-purpose container like `triomphe::Arc`, and the way we currently
   do codegen means we're unlikely to notice any potential performance improvements
   from using a more specialized type.

--- a/docs/adr/0005-arc-pointers.md
+++ b/docs/adr/0005-arc-pointers.md
@@ -159,7 +159,7 @@ We may reconsider this decision if future profiling shows the use of stdlib `Arc
 
 ## Links
 
-* Thom discusses this a but in [this issue](https://github.com/mozilla/uniffi-rs/issues/244)
+* Thom discusses this a bit in [this issue](https://github.com/mozilla/uniffi-rs/issues/244)
   and agrees with the assertion that raw pointer make sense when all
   the relevant code is generated.
 

--- a/docs/adr/0005-arc-pointers.md
+++ b/docs/adr/0005-arc-pointers.md
@@ -84,7 +84,7 @@ This decision is taken because:
   generated instead of hand-written.
 
 * Correctly implementing better lifetime management in a thread-safe way is not
-  trivial and subtle errors there would defeat all the safely mechanisms the
+  trivial and subtle errors there would defeat all the safety mechanisms the
   `HandleMap`s offer. Ultimately we'd just end up reimplementing `Arc<>` anyway,
   and the one in the stdlib is far more likely to be correct.
 

--- a/docs/adr/0006-wrapping-types.md
+++ b/docs/adr/0006-wrapping-types.md
@@ -67,7 +67,7 @@ Chosen option:
 
 This decision is taken because:
 
-* It's was relatively easy to implement wrapper types by allowing the external
+* It was relatively easy to implement wrapper types by allowing the external
   crates to add custom scaffolding code.  This code could wrap primitive types
   because all lifting/lowering/reading/writing was handled by Rust code.  If we
   had gone with option 1, then the wrapping code would need to hook into the

--- a/docs/adr/0007-enable-implementing-bindings-seperately.md
+++ b/docs/adr/0007-enable-implementing-bindings-seperately.md
@@ -54,14 +54,14 @@ This ADR proposes enabling third-party crates to implement binding generators, a
 * Good, because ownership will be clear, and members of the community can opt to maintain their own binding generators.
 * Good, because our CI would only need to test the core bindings we maintain, and others can be tested by their own maintainers (for example, a `gecko-js` binding generator should be tested in `mozilla-central` and not here).
 * Good, because a release in external bindings wouldn't have an impact on any internal ones unless it changes internal `uniffi` behavior.
-* Bad, because it's easier to accidentally have a version mismatch. (see [this ADR](https://github.com/mozilla/uniffi-rs/pull/1203)).
+* Bad, because it's easier to accidentally have a version mismatch. (see [this ADR](https://github.com/mozilla/uniffi-rs/pull/1203))
 * Bad, because testability increases in complexity. We are required to publish fixtures and examples we have. (see [PR 1206](https://github.com/mozilla/uniffi-rs/pull/1206))
 
 Overall this option is preferred because:
 
 - It's a requirement to implement bindings for gecko-js, which can't be tested end-to-end without a complex build system.
 - It creates the possibility of community contributors writing and maintaining their own binding generators in their own repositories.
-- The increased risk of version mismatch can be dealt with (see [this ADR](https://github.com/mozilla/uniffi-rs/pull/1203)).
+- The increased risk of version mismatch can be dealt with. (see [this ADR](https://github.com/mozilla/uniffi-rs/pull/1203))
 
 
 ## Decision Outcome

--- a/docs/adr/0007-enable-implementing-bindings-seperately.md
+++ b/docs/adr/0007-enable-implementing-bindings-seperately.md
@@ -85,7 +85,7 @@ The trait would have the following:
 
 See [PR 1201](https://github.com/mozilla/uniffi-rs/pull/1201) for implementation of the above changes.
 
-### Expose fixtures for testings
+### Expose fixtures for testing
 To enable external binding generators to implement tests, we would publish our fixtures and a new `uniffi_testing` crate that is a helper for consumers to build and consume the fixture crates.
 
 See [PR 1206](https://github.com/mozilla/uniffi-rs/pull/1206) for implementation of the testing changes.

--- a/docs/manual/src/tutorial/Rust_scaffolding.md
+++ b/docs/manual/src/tutorial/Rust_scaffolding.md
@@ -99,10 +99,10 @@ For example, you will probably end up with Cargo.toml looking something like:
 
 ```toml
 [dependencies]
-uniffi = { path = "path/to/uniffi-rs/uniffi }
+uniffi = { path = "path/to/uniffi-rs/uniffi" }
 ...
 [build-dependencies]
-uniffi_build = { path = "path/to/uniffi-rs/uniffi_build, features=["builtin-bindgen"] }
+uniffi_build = { path = "path/to/uniffi-rs/uniffi_build", features=["builtin-bindgen"] }
 ```
 
 Note that `path/to/uniffi-rs` should be the path to the root of the `uniffi`


### PR DESCRIPTION
"focussed" is technically an accepted spelling, but it's rather uncommon, so I changed that too.