### PR TITLE
Fix ruby time support

### DIFF
--- a/fixtures/uniffi-fixture-time/src/chronological.udl
+++ b/fixtures/uniffi-fixture-time/src/chronological.udl
@@ -16,4 +16,10 @@ namespace chronological {
   boolean equal(timestamp a, timestamp b);
 
   boolean optional(timestamp? a, duration? b);
+
+  [Throws=ChronologicalError]
+  u64 get_seconds_before_unix_epoch(timestamp a);
+
+  [Throws=ChronologicalError]
+  timestamp set_seconds_before_unix_epoch(u64 seconds);
 };

--- a/fixtures/uniffi-fixture-time/src/lib.rs
+++ b/fixtures/uniffi-fixture-time/src/lib.rs
@@ -34,6 +34,18 @@ fn optional(a: Option<SystemTime>, b: Option<Duration>) -> bool {
     a.is_some() && b.is_some()
 }
 
+fn get_seconds_before_unix_epoch(b: SystemTime) -> Result<u64> {
+    diff(SystemTime::UNIX_EPOCH, b).map(|duration| duration.as_secs())
+}
+
+fn set_seconds_before_unix_epoch(seconds: u64) -> Result<SystemTime> {
+    let a = SystemTime::UNIX_EPOCH;
+    let b = Duration::from_secs(seconds);
+
+    a.checked_sub(b)
+        .ok_or(ChronologicalError::TimeOverflow { a, b })
+}
+
 type Result<T, E = ChronologicalError> = std::result::Result<T, E>;
 
 include!(concat!(env!("OUT_DIR"), "/chronological.uniffi.rs"));

--- a/fixtures/uniffi-fixture-time/tests/bindings/test_chronological.rb
+++ b/fixtures/uniffi-fixture-time/tests/bindings/test_chronological.rb
@@ -40,6 +40,18 @@ class TestChronological < Test::Unit::TestCase
     assert_equal Time.parse('1955-11-05T00:06:01.283002 UTC'), Chronological.add(time, delta)
   end
 
+  def test_ruby_to_rust_time_conversion
+    minute_before_unix_epoch = Time.parse '1969-12-31T23:59:00.000000 UTC'
+
+    assert_equal 60, Chronological.get_seconds_before_unix_epoch(minute_before_unix_epoch)
+  end
+
+  def test_rust_to_ruby_time_conversion
+    minute_before_unix_epoch = Time.parse '1969-12-31T23:59:00.000000 UTC'
+
+    assert_equal minute_before_unix_epoch, Chronological.set_seconds_before_unix_epoch(60)
+  end
+
   def test_exceptions_are_propagated
     assert_raises Chronological::ChronologicalError::TimeDiffError do
       Chronological.diff Time.at(100), Time.at(101)

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -113,7 +113,12 @@ class RustBufferBuilder
     seconds = v.tv_sec
     nanoseconds = v.tv_nsec
 
-    if seconds < 0
+    # UniFFi conventions assume that nanoseconds part has to represent nanoseconds portion of
+    # duration between epoch and the timestamp moment. Ruby `Time#tv_nsec` returns the number of
+    # nanoseconds for the subsecond part, which is sort of opposite to "duration" meaning.
+    # Hence we need to convert value returned by `Time#tv_nsec` back and forth with the following
+    # logic:
+    if seconds < 0 && nanoseconds != 0
       # In order to get duration nsec we shift by 1 second:
       nanoseconds = ONE_SECOND_IN_NANOSECONDS - nanoseconds
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -114,7 +114,11 @@ class RustBufferBuilder
     nanoseconds = v.tv_nsec
 
     if seconds < 0
+      # In order to get duration nsec we shift by 1 second:
       nanoseconds = ONE_SECOND_IN_NANOSECONDS - nanoseconds
+
+      # Then we compensate 1 second shift:
+      seconds += 1
     end
 
     pack_into 8, 'q>', seconds

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
@@ -115,7 +115,11 @@ class RustBufferStream
     nanoseconds = unpack_from 4, 'L>'
 
     if seconds < 0
+      # In order to get duration nsec we shift by 1 second:
       nanoseconds = ONE_SECOND_IN_NANOSECONDS - nanoseconds
+
+      # Then we compensate 1 second shift:
+      seconds -= 1
     end
 
     Time.at(seconds, nanoseconds, :nanosecond, in: '+00:00').utc

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
@@ -114,7 +114,12 @@ class RustBufferStream
     seconds = unpack_from 8, 'q>'
     nanoseconds = unpack_from 4, 'L>'
 
-    if seconds < 0
+    # UniFFi conventions assume that nanoseconds part has to represent nanoseconds portion of
+    # duration between epoch and the timestamp moment. Ruby `Time#tv_nsec` returns the number of
+    # nanoseconds for the subsecond part, which is sort of opposite to "duration" meaning.
+    # Hence we need to convert value returned by `Time#tv_nsec` back and forth with the following
+    # logic:
+    if seconds < 0 && nanoseconds != 0
       # In order to get duration nsec we shift by 1 second:
       nanoseconds = ONE_SECOND_IN_NANOSECONDS - nanoseconds
 


### PR DESCRIPTION
When using a ruby adapter we noticed an issue with 1 second difference. I was able to reproduce the issue with tests but had to add more methods into `chronological.udl`. Please let me know if you have any questions.