### PR TITLE
Remove trailing spaces that break rustfmt

### DIFF
--- a/uniffi_bindgen/src/scaffolding/templates/macros.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/macros.rs
@@ -11,14 +11,14 @@ r#{{ func.name() }}({% call _arg_list_rs_call(func) -%})
         match {{- arg.type_().borrow()|ffi_converter }}::try_lift(r#{{ arg.name() }}) {
         {%- if arg.by_ref() %}
             Ok(ref val) => val,
-        {% else %}
+        {%- else %}
             Ok(val) => val,
-        {% endif %}
+        {%- endif %}
 
-        {# If this function returns an error, we attempt to downcast errors doing arg
+        {#- If this function returns an error, we attempt to downcast errors doing arg
             conversions to this error. If the downcast fails or the function doesn't
             return an error, we just panic.
-        #}
+        -#}
         {%- match func.throws_type() -%}
         {%- when Some with (e) %}
             Err(err) => return Err(uniffi::lower_anyhow_error_or_panic::<{{ e|ffi_converter_name }}>(err, "{{ arg.name() }}")),


### PR DESCRIPTION
Callback interfaces with long names break formatting with the latest version of `uniffi_bindgen` and `rustfmt`.

Example `.udl` file:

```
callback interface CallbackWithALongName {
  void test();
};

namespace test {
  void test(CallbackWithALongName callback);
};
```


<img width="877" alt="Screenshot 2022-11-10 at 12 34 22" src="https://user-images.githubusercontent.com/367440/201080585-55e89652-36d0-4d8e-abea-7f8de51a1ea8.png">

```sh
$ uniffi-bindgen scaffolding src/test.udl
error[internal]: left behind trailing whitespace
  --> .../src/test.uniffi.rs:71:71:1
   |
71 |         
   | ^^^^^^^^
   |

error[internal]: left behind trailing whitespace
  --> .../src/test.uniffi.rs:73:73:1
   |
73 |         
   | ^^^^^^^^
   |

warning: rustfmt has failed to format. See previous 2 errors.

Error: rustmt failed when formatting scaffolding. Note: --no-format can be used to skip formatting

$ uniffi-bindgen --version
uniffi-bindgen 0.21.0

$ rustfmt --version
rustfmt 1.5.1-stable (a55dd71d 2022-09-19)
```

This is a bug in `rustfmt` but it will be faster to fix it here.

https://github.com/rust-lang/rustfmt/issues/2896
https://github.com/rust-lang/rustfmt/issues/5391