### PR TITLE
Fix another case where trailing space that breaks rustfmt

### DIFF
--- a/uniffi_bindgen/src/scaffolding/templates/macros.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/macros.rs
@@ -26,7 +26,7 @@ r#{{ func.name() }}({% call _arg_list_rs_call(func) -%})
             Err(err) => panic!("Failed to convert arg '{}': {}", "{{ arg.name() }}", err),
         {%- endmatch %}
         }
-        {%- if !loop.last %}, {% endif %}
+        {%- if !loop.last %},{% endif %}
     {%- endfor %}
 {%- endmacro -%}
 


### PR DESCRIPTION
One more fix like #1399. It breaks with multiple arguments that are too long.