### PR TITLE
Change FFI to Ffi in type names

### DIFF
--- a/docs/diplomat-and-macros.md
+++ b/docs/diplomat-and-macros.md
@@ -78,13 +78,13 @@ Let's look at diplomat's simple example:
 ```rust
 #[diplomat::bridge]
 mod ffi {
-    pub struct MyFFIType {
+    pub struct MyFfiType {
         pub a: i32,
         pub b: bool,
     }
 
-    impl MyFFIType {
-        pub fn create() -> MyFFIType { ... }
+    impl MyFfiType {
+        pub fn create() -> MyFfiType { ... }
         ...
     }
 }
@@ -93,15 +93,15 @@ mod ffi {
 This works fine, but starts to come unstuck if you want the types defined somewhere else. In this trivial example, something like:
 
 ```Rust
-pub struct MyFFIType {
+pub struct MyFfiType {
     pub a: i32,
     pub b: bool,
 }
 
 #[diplomat::bridge]
 mod ffi {
-    impl MyFFIType {
-        pub fn create() -> MyFFIType { ... }
+    impl MyFfiType {
+        pub fn create() -> MyFfiType { ... }
         ...
     }
 }
@@ -114,7 +114,7 @@ From the Rust side of the world, this is probably solvable by sprinkling more ma
 
 ```Rust
 #[uniffi::magic]
-pub struct MyFFIType {
+pub struct MyFfiType {
     pub a: i32,
     pub b: bool,
 }
@@ -152,7 +152,7 @@ actually *process* the entire crate, just modules tagged as a bridge), but could
 extended to do so.
 
 But in both cases, for our problematic example above, this process never sees the layout of the
-`MyFFIType` struct because it's not inside the processed module, so that layout can't be
+`MyFfiType` struct because it's not inside the processed module, so that layout can't be
 communicated to the foreign bindings.
 As noted above, this is considered a feature for diplomat, but a limitation for UniFFI.
 
@@ -184,7 +184,7 @@ In other words, borrowing the example above:
 
 ```Rust
 #[uniffi::magic]
-pub struct MyFFIType {
+pub struct MyFfiType {
     pub a: i32,
     pub b: bool,
 }
@@ -204,12 +204,12 @@ in UDL and in Rust. So instead of having:
 
 ```
 // In a UDL file:
-dictionary MyFFIType {
+dictionary MyFfiType {
     i32 a;
     bool b;
 };
 // Then in Rust:
-pub struct MyFFIType {
+pub struct MyFfiType {
     pub a: i32,
     pub b: bool,
 }
@@ -218,7 +218,7 @@ pub struct MyFFIType {
 we could have:
 ```rust
 // In the Rust implementation, in some other module.
-pub struct MyFFIType {
+pub struct MyFfiType {
     pub a: i32,
     pub b: bool,
 }
@@ -228,13 +228,13 @@ pub struct MyFFIType {
 mod ffi {
 
     #[ffi::magic_external_type_declaration]
-    pub struct MyFFIType {
+    pub struct MyFfiType {
         pub a: i32,
         pub b: bool,
     }
 
-    impl MyFFIType {
-        pub fn create() -> MyFFIType { ... }
+    impl MyFfiType {
+        pub fn create() -> MyFfiType { ... }
         ...
     }
 }
@@ -242,7 +242,7 @@ mod ffi {
 
 So while we haven't exactly reduced the duplication, we have removed the UDL.
 We probably also haven't helped with documentation, because the natural location for
-the documentation of `MyFFIType` is probably at the *actual* implementation.
+the documentation of `MyFfiType` is probably at the *actual* implementation.
 
 While it might not solve all our problems, it is worthy of serious consideration - fewer problems
 is still a worthwhile goal, and needing a UDL file and parser seems like one worth removing.

--- a/docs/manual/src/internals/rendering_foreign_bindings.md
+++ b/docs/manual/src/internals/rendering_foreign_bindings.md
@@ -25,7 +25,7 @@ Our current system for handling this is to have exactly 2 matches against `Type`
      - Base classes and helper classes, for example
        [`ObjectRuntime.kt`](https://github.com/mozilla/uniffi-rs/blob/main/uniffi_bindgen/src/bindings/kotlin/templates/ObjectRuntime.kt)
        contains shared functionality for all the `Type::Object` types.
-     - The FFIConverter class definition.  This handles [lifting and lowering
+     - The FfiConverter class definition.  This handles [lifting and lowering
        types across the FFI](./lifting_and_lowering.md) for the type.
      - Initialization functions
      - Importing dependencies
@@ -35,7 +35,7 @@ Our current system for handling this is to have exactly 2 matches against `Type`
   - The other match lives in the Rust code.  We map each `Type` variant to a implementation of the `CodeType` trait that
     renders identifiers and names related to the type, including:
     - The name of the type in the foreign language
-    - The name of the `FFIConverter` class
+    - The name of the `FfiConverter` class
     - The name of the initialization function
     - See
       [`KotlinCodeOracle::create_code_type()`](https://github.com/mozilla/uniffi-rs/blob/470740289258e1f06171a976d8e15978f028e391/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs#L198-L230)
@@ -55,8 +55,8 @@ Why is the code organized like this?  For a few reasons:
     example, at one point the logic to lift/lower a type lived in the Rust code as a function that generated the
     expression in the foreign language.  However, it was not clear at all how to make this work for external types,
     it would probably require parsing multiple UDL files and managing multiple ComponentInterfaces.  Putting the logic
-    to lift/lower the type in the `FFIConverter` class simplifies this, because we can import the external
-    `FFIConverter` class and use that. We only need to know the name of the `FFIConverter` class which is a simpler
+    to lift/lower the type in the `FfiConverter` class simplifies this, because we can import the external
+    `FfiConverter` class and use that. We only need to know the name of the `FfiConverter` class which is a simpler
     task.
 
 ## Askama extensions

--- a/uniffi_bindgen/src/backend/oracle.rs
+++ b/uniffi_bindgen/src/backend/oracle.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::{CodeType, TypeIdentifier};
-use crate::interface::FFIType;
+use crate::interface::FfiType;
 
 /// An object to look up a foreign language code specific renderer for a given type used.
 /// Every `Type` referred to in the `ComponentInterface` should map to a corresponding
@@ -31,5 +31,5 @@ pub trait CodeOracle {
     /// Get the idiomatic rendering of an error name.
     fn error_name(&self, nm: &str) -> String;
 
-    fn ffi_type_label(&self, ffi_type: &FFIType) -> String;
+    fn ffi_type_label(&self, ffi_type: &FfiType) -> String;
 }

--- a/uniffi_bindgen/src/backend/types.rs
+++ b/uniffi_bindgen/src/backend/types.rs
@@ -8,7 +8,7 @@
 //!
 //! A `CodeType` is needed for each type that will cross the FFI. It should provide helper machinery
 //! in the target language to lift from and lower into a value of that type into a primitive type
-//! (the FFIType), and foreign language expressions that call into the machinery. This helper code
+//! (the FfiType), and foreign language expressions that call into the machinery. This helper code
 //! can be provided by a template file.
 //!
 //! A `CodeDeclaration` is needed for each type that is declared in the UDL file. This has access to

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -270,21 +270,21 @@ impl CodeOracle for KotlinCodeOracle {
         }
     }
 
-    fn ffi_type_label(&self, ffi_type: &FFIType) -> String {
+    fn ffi_type_label(&self, ffi_type: &FfiType) -> String {
         match ffi_type {
             // Note that unsigned integers in Kotlin are currently experimental, but java.nio.ByteBuffer does not
             // support them yet. Thus, we use the signed variants to represent both signed and unsigned
             // types from the component API.
-            FFIType::Int8 | FFIType::UInt8 => "Byte".to_string(),
-            FFIType::Int16 | FFIType::UInt16 => "Short".to_string(),
-            FFIType::Int32 | FFIType::UInt32 => "Int".to_string(),
-            FFIType::Int64 | FFIType::UInt64 => "Long".to_string(),
-            FFIType::Float32 => "Float".to_string(),
-            FFIType::Float64 => "Double".to_string(),
-            FFIType::RustArcPtr(_) => "Pointer".to_string(),
-            FFIType::RustBuffer => "RustBuffer.ByValue".to_string(),
-            FFIType::ForeignBytes => "ForeignBytes.ByValue".to_string(),
-            FFIType::ForeignCallback => "ForeignCallback".to_string(),
+            FfiType::Int8 | FfiType::UInt8 => "Byte".to_string(),
+            FfiType::Int16 | FfiType::UInt16 => "Short".to_string(),
+            FfiType::Int32 | FfiType::UInt32 => "Int".to_string(),
+            FfiType::Int64 | FfiType::UInt64 => "Long".to_string(),
+            FfiType::Float32 => "Float".to_string(),
+            FfiType::Float64 => "Double".to_string(),
+            FfiType::RustArcPtr(_) => "Pointer".to_string(),
+            FfiType::RustBuffer => "RustBuffer.ByValue".to_string(),
+            FfiType::ForeignBytes => "ForeignBytes.ByValue".to_string(),
+            FfiType::ForeignCallback => "ForeignCallback".to_string(),
         }
     }
 }
@@ -338,8 +338,8 @@ pub mod filters {
         Ok(codetype.literal(oracle(), literal))
     }
 
-    /// Get the Kotlin syntax for representing a given low-level `FFIType`.
-    pub fn ffi_type_name(type_: &FFIType) -> Result<String, askama::Error> {
+    /// Get the Kotlin syntax for representing a given low-level `FfiType`.
+    pub fn ffi_type_name(type_: &FfiType) -> Result<String, askama::Error> {
         Ok(oracle().ffi_type_label(type_))
     }
 

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -288,22 +288,22 @@ impl CodeOracle for PythonCodeOracle {
         }
     }
 
-    fn ffi_type_label(&self, ffi_type: &FFIType) -> String {
+    fn ffi_type_label(&self, ffi_type: &FfiType) -> String {
         match ffi_type {
-            FFIType::Int8 => "ctypes.c_int8".to_string(),
-            FFIType::UInt8 => "ctypes.c_uint8".to_string(),
-            FFIType::Int16 => "ctypes.c_int16".to_string(),
-            FFIType::UInt16 => "ctypes.c_uint16".to_string(),
-            FFIType::Int32 => "ctypes.c_int32".to_string(),
-            FFIType::UInt32 => "ctypes.c_uint32".to_string(),
-            FFIType::Int64 => "ctypes.c_int64".to_string(),
-            FFIType::UInt64 => "ctypes.c_uint64".to_string(),
-            FFIType::Float32 => "ctypes.c_float".to_string(),
-            FFIType::Float64 => "ctypes.c_double".to_string(),
-            FFIType::RustArcPtr(_) => "ctypes.c_void_p".to_string(),
-            FFIType::RustBuffer => "RustBuffer".to_string(),
-            FFIType::ForeignBytes => "ForeignBytes".to_string(),
-            FFIType::ForeignCallback => "FOREIGN_CALLBACK_T".to_string(),
+            FfiType::Int8 => "ctypes.c_int8".to_string(),
+            FfiType::UInt8 => "ctypes.c_uint8".to_string(),
+            FfiType::Int16 => "ctypes.c_int16".to_string(),
+            FfiType::UInt16 => "ctypes.c_uint16".to_string(),
+            FfiType::Int32 => "ctypes.c_int32".to_string(),
+            FfiType::UInt32 => "ctypes.c_uint32".to_string(),
+            FfiType::Int64 => "ctypes.c_int64".to_string(),
+            FfiType::UInt64 => "ctypes.c_uint64".to_string(),
+            FfiType::Float32 => "ctypes.c_float".to_string(),
+            FfiType::Float64 => "ctypes.c_double".to_string(),
+            FfiType::RustArcPtr(_) => "ctypes.c_void_p".to_string(),
+            FfiType::RustBuffer => "RustBuffer".to_string(),
+            FfiType::ForeignBytes => "ForeignBytes".to_string(),
+            FfiType::ForeignCallback => "FOREIGN_CALLBACK_T".to_string(),
         }
     }
 }
@@ -354,8 +354,8 @@ pub mod filters {
         Ok(codetype.literal(oracle, literal))
     }
 
-    /// Get the Python syntax for representing a given low-level `FFIType`.
-    pub fn ffi_type_name(type_: &FFIType) -> Result<String, askama::Error> {
+    /// Get the Python syntax for representing a given low-level `FfiType`.
+    pub fn ffi_type_name(type_: &FfiType) -> Result<String, askama::Error> {
         Ok(oracle().ffi_type_label(type_))
     }
 

--- a/uniffi_bindgen/src/bindings/python/templates/Helpers.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Helpers.py
@@ -36,7 +36,7 @@ def rust_call_with_error(error_ffi_converter, fn, *args):
     # Call a rust function and handle any errors
     #
     # This function is used for rust calls that return Result<> and therefore can set the CALL_ERROR status code.
-    # error_ffi_converter must be set to the FFIConverter for the error class that corresponds to the result.
+    # error_ffi_converter must be set to the FfiConverter for the error class that corresponds to the result.
     call_status = RustCallStatus(code=RustCallStatus.CALL_SUCCESS, error_buf=RustBuffer(0, 0, None))
 
     args_with_error = args + (ctypes.byref(call_status),)

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -80,22 +80,22 @@ impl<'a> RubyWrapper<'a> {
 mod filters {
     use super::*;
 
-    pub fn type_ffi(type_: &FFIType) -> Result<String, askama::Error> {
+    pub fn type_ffi(type_: &FfiType) -> Result<String, askama::Error> {
         Ok(match type_ {
-            FFIType::Int8 => ":int8".to_string(),
-            FFIType::UInt8 => ":uint8".to_string(),
-            FFIType::Int16 => ":int16".to_string(),
-            FFIType::UInt16 => ":uint16".to_string(),
-            FFIType::Int32 => ":int32".to_string(),
-            FFIType::UInt32 => ":uint32".to_string(),
-            FFIType::Int64 => ":int64".to_string(),
-            FFIType::UInt64 => ":uint64".to_string(),
-            FFIType::Float32 => ":float".to_string(),
-            FFIType::Float64 => ":double".to_string(),
-            FFIType::RustArcPtr(_) => ":pointer".to_string(),
-            FFIType::RustBuffer => "RustBuffer.by_value".to_string(),
-            FFIType::ForeignBytes => "ForeignBytes".to_string(),
-            FFIType::ForeignCallback => unimplemented!("Callback interfaces are not implemented"),
+            FfiType::Int8 => ":int8".to_string(),
+            FfiType::UInt8 => ":uint8".to_string(),
+            FfiType::Int16 => ":int16".to_string(),
+            FfiType::UInt16 => ":uint16".to_string(),
+            FfiType::Int32 => ":int32".to_string(),
+            FfiType::UInt32 => ":uint32".to_string(),
+            FfiType::Int64 => ":int64".to_string(),
+            FfiType::UInt64 => ":uint64".to_string(),
+            FfiType::Float32 => ":float".to_string(),
+            FfiType::Float64 => ":double".to_string(),
+            FfiType::RustArcPtr(_) => ":pointer".to_string(),
+            FfiType::RustBuffer => "RustBuffer.by_value".to_string(),
+            FfiType::ForeignBytes => "ForeignBytes".to_string(),
+            FfiType::ForeignCallback => unimplemented!("Callback interfaces are not implemented"),
         })
     }
 

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -363,22 +363,22 @@ impl CodeOracle for SwiftCodeOracle {
         format!("`{}`", self.class_name(nm))
     }
 
-    fn ffi_type_label(&self, ffi_type: &FFIType) -> String {
+    fn ffi_type_label(&self, ffi_type: &FfiType) -> String {
         match ffi_type {
-            FFIType::Int8 => "int8_t".into(),
-            FFIType::UInt8 => "uint8_t".into(),
-            FFIType::Int16 => "int16_t".into(),
-            FFIType::UInt16 => "uint16_t".into(),
-            FFIType::Int32 => "int32_t".into(),
-            FFIType::UInt32 => "uint32_t".into(),
-            FFIType::Int64 => "int64_t".into(),
-            FFIType::UInt64 => "uint64_t".into(),
-            FFIType::Float32 => "float".into(),
-            FFIType::Float64 => "double".into(),
-            FFIType::RustArcPtr(_) => "void*_Nonnull".into(),
-            FFIType::RustBuffer => "RustBuffer".into(),
-            FFIType::ForeignBytes => "ForeignBytes".into(),
-            FFIType::ForeignCallback => "ForeignCallback  _Nonnull".to_string(),
+            FfiType::Int8 => "int8_t".into(),
+            FfiType::UInt8 => "uint8_t".into(),
+            FfiType::Int16 => "int16_t".into(),
+            FfiType::UInt16 => "uint16_t".into(),
+            FfiType::Int32 => "int32_t".into(),
+            FfiType::UInt32 => "uint32_t".into(),
+            FfiType::Int64 => "int64_t".into(),
+            FfiType::UInt64 => "uint64_t".into(),
+            FfiType::Float32 => "float".into(),
+            FfiType::Float64 => "double".into(),
+            FfiType::RustArcPtr(_) => "void*_Nonnull".into(),
+            FfiType::RustBuffer => "RustBuffer".into(),
+            FfiType::ForeignBytes => "ForeignBytes".into(),
+            FfiType::ForeignCallback => "ForeignCallback  _Nonnull".to_string(),
         }
     }
 }
@@ -428,29 +428,29 @@ pub mod filters {
         Ok(codetype.literal(oracle, literal))
     }
 
-    /// Get the Swift syntax for representing a given low-level `FFIType`.
-    pub fn ffi_type_name(type_: &FFIType) -> Result<String, askama::Error> {
+    /// Get the Swift syntax for representing a given low-level `FfiType`.
+    pub fn ffi_type_name(type_: &FfiType) -> Result<String, askama::Error> {
         Ok(oracle().ffi_type_label(type_))
     }
 
     /// Get the type that a type is lowered into.  This is subtly different than `type_ffi`, see
     /// #1106 for details
-    pub fn type_ffi_lowered(ffi_type: &FFIType) -> Result<String, askama::Error> {
+    pub fn type_ffi_lowered(ffi_type: &FfiType) -> Result<String, askama::Error> {
         Ok(match ffi_type {
-            FFIType::Int8 => "Int8".into(),
-            FFIType::UInt8 => "UInt8".into(),
-            FFIType::Int16 => "Int16".into(),
-            FFIType::UInt16 => "UInt16".into(),
-            FFIType::Int32 => "Int32".into(),
-            FFIType::UInt32 => "UInt32".into(),
-            FFIType::Int64 => "Int64".into(),
-            FFIType::UInt64 => "UInt64".into(),
-            FFIType::Float32 => "float".into(),
-            FFIType::Float64 => "double".into(),
-            FFIType::RustArcPtr(_) => "void*_Nonnull".into(),
-            FFIType::RustBuffer => "RustBuffer".into(),
-            FFIType::ForeignBytes => "ForeignBytes".into(),
-            FFIType::ForeignCallback => "ForeignCallback  _Nonnull".to_string(),
+            FfiType::Int8 => "Int8".into(),
+            FfiType::UInt8 => "UInt8".into(),
+            FfiType::Int16 => "Int16".into(),
+            FfiType::UInt16 => "UInt16".into(),
+            FfiType::Int32 => "Int32".into(),
+            FfiType::UInt32 => "UInt32".into(),
+            FfiType::Int64 => "Int64".into(),
+            FfiType::UInt64 => "UInt64".into(),
+            FfiType::Float32 => "float".into(),
+            FfiType::Float64 => "double".into(),
+            FfiType::RustArcPtr(_) => "void*_Nonnull".into(),
+            FfiType::RustBuffer => "RustBuffer".into(),
+            FfiType::ForeignBytes => "ForeignBytes".into(),
+            FfiType::ForeignCallback => "ForeignCallback  _Nonnull".to_string(),
         })
     }
 

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
@@ -125,7 +125,7 @@ fileprivate struct {{ ffi_converter_name }} {
 
 extension {{ ffi_converter_name }} : FfiConverter {
     typealias SwiftType = {{ type_name }}
-    // We can use Handle as the FFIType because it's a typealias to UInt64
+    // We can use Handle as the FfiType because it's a typealias to UInt64
     typealias FfiType = UniFFICallbackHandle
 
     public static func lift(_ handle: UniFFICallbackHandle) throws -> SwiftType {

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
@@ -100,7 +100,7 @@ fileprivate let {{ foreign_callback }} : ForeignCallback =
         }
     }
 
-// FFIConverter protocol for callback interfaces
+// FfiConverter protocol for callback interfaces
 fileprivate struct {{ ffi_converter_name }} {
     // Initialize our callback method with the scaffolding code
     private static var callbackInitialized = false

--- a/uniffi_bindgen/src/interface/callbacks.rs
+++ b/uniffi_bindgen/src/interface/callbacks.rs
@@ -37,7 +37,7 @@ use std::hash::{Hash, Hasher};
 
 use anyhow::{bail, Result};
 
-use super::ffi::{FFIArgument, FfiFunction, FfiType};
+use super::ffi::{FfiArgument, FfiFunction, FfiType};
 use super::object::Method;
 use super::types::{Type, TypeIterator};
 use super::{APIConverter, ComponentInterface};
@@ -76,7 +76,7 @@ impl CallbackInterface {
 
     pub(super) fn derive_ffi_funcs(&mut self, ci_prefix: &str) {
         self.ffi_init_callback.name = format!("ffi_{ci_prefix}_{}_init_callback", self.name);
-        self.ffi_init_callback.arguments = vec![FFIArgument {
+        self.ffi_init_callback.arguments = vec![FfiArgument {
             name: "callback_stub".to_string(),
             type_: FfiType::ForeignCallback,
         }];

--- a/uniffi_bindgen/src/interface/callbacks.rs
+++ b/uniffi_bindgen/src/interface/callbacks.rs
@@ -37,7 +37,7 @@ use std::hash::{Hash, Hasher};
 
 use anyhow::{bail, Result};
 
-use super::ffi::{FFIArgument, FFIFunction, FfiType};
+use super::ffi::{FFIArgument, FfiFunction, FfiType};
 use super::object::Method;
 use super::types::{Type, TypeIterator};
 use super::{APIConverter, ComponentInterface};
@@ -46,7 +46,7 @@ use super::{APIConverter, ComponentInterface};
 pub struct CallbackInterface {
     pub(super) name: String,
     pub(super) methods: Vec<Method>,
-    pub(super) ffi_init_callback: FFIFunction,
+    pub(super) ffi_init_callback: FfiFunction,
 }
 
 impl CallbackInterface {
@@ -70,7 +70,7 @@ impl CallbackInterface {
         self.methods.iter().collect()
     }
 
-    pub fn ffi_init_callback(&self) -> &FFIFunction {
+    pub fn ffi_init_callback(&self) -> &FfiFunction {
         &self.ffi_init_callback
     }
 

--- a/uniffi_bindgen/src/interface/callbacks.rs
+++ b/uniffi_bindgen/src/interface/callbacks.rs
@@ -37,7 +37,7 @@ use std::hash::{Hash, Hasher};
 
 use anyhow::{bail, Result};
 
-use super::ffi::{FFIArgument, FFIFunction, FFIType};
+use super::ffi::{FFIArgument, FFIFunction, FfiType};
 use super::object::Method;
 use super::types::{Type, TypeIterator};
 use super::{APIConverter, ComponentInterface};
@@ -78,7 +78,7 @@ impl CallbackInterface {
         self.ffi_init_callback.name = format!("ffi_{ci_prefix}_{}_init_callback", self.name);
         self.ffi_init_callback.arguments = vec![FFIArgument {
             name: "callback_stub".to_string(),
-            type_: FFIType::ForeignCallback,
+            type_: FfiType::ForeignCallback,
         }];
         self.ffi_init_callback.return_type = None;
     }

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -288,7 +288,7 @@ impl APIConverter<Field> for weedle::argument::SingleArgument<'_> {
 
 #[cfg(test)]
 mod test {
-    use super::super::ffi::FFIType;
+    use super::super::ffi::FfiType;
     use super::*;
 
     #[test]
@@ -405,12 +405,12 @@ mod test {
         // difficult atop the current factoring of `ComponentInterface` and friends).
         let farg = ci.get_function_definition("takes_an_enum").unwrap();
         assert_eq!(*farg.arguments()[0].type_(), Type::Enum("TestEnum".into()));
-        assert_eq!(farg.ffi_func().arguments()[0].type_(), FFIType::RustBuffer);
+        assert_eq!(farg.ffi_func().arguments()[0].type_(), FfiType::RustBuffer);
         let fret = ci.get_function_definition("returns_an_enum").unwrap();
         assert!(matches!(fret.return_type(), Some(Type::Enum(nm)) if nm == "TestEnum"));
         assert!(matches!(
             fret.ffi_func().return_type(),
-            Some(FFIType::RustBuffer)
+            Some(FfiType::RustBuffer)
         ));
 
         // Enums with associated data pass over the FFI as bytebuffers.
@@ -421,14 +421,14 @@ mod test {
             *farg.arguments()[0].type_(),
             Type::Enum("TestEnumWithData".into())
         );
-        assert_eq!(farg.ffi_func().arguments()[0].type_(), FFIType::RustBuffer);
+        assert_eq!(farg.ffi_func().arguments()[0].type_(), FfiType::RustBuffer);
         let fret = ci
             .get_function_definition("returns_an_enum_with_data")
             .unwrap();
         assert!(matches!(fret.return_type(), Some(Type::Enum(nm)) if nm == "TestEnumWithData"));
         assert!(matches!(
             fret.ffi_func().return_type(),
-            Some(FFIType::RustBuffer)
+            Some(FfiType::RustBuffer)
         ));
     }
 }

--- a/uniffi_bindgen/src/interface/ffi.rs
+++ b/uniffi_bindgen/src/interface/ffi.rs
@@ -54,16 +54,16 @@ pub enum FfiType {
 ///
 /// These can't be declared explicitly in the UDL, but rather, are derived automatically
 /// from the high-level interface. Each callable thing in the component API will have a
-/// corresponding `FFIFunction` through which it can be invoked, and UniFFI also provides
-/// some built-in `FFIFunction` helpers for use in the foreign language bindings.
+/// corresponding `FfiFunction` through which it can be invoked, and UniFFI also provides
+/// some built-in `FfiFunction` helpers for use in the foreign language bindings.
 #[derive(Debug, Default, Clone)]
-pub struct FFIFunction {
+pub struct FfiFunction {
     pub(super) name: String,
     pub(super) arguments: Vec<FFIArgument>,
     pub(super) return_type: Option<FfiType>,
 }
 
-impl FFIFunction {
+impl FfiFunction {
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/uniffi_bindgen/src/interface/ffi.rs
+++ b/uniffi_bindgen/src/interface/ffi.rs
@@ -59,7 +59,7 @@ pub enum FfiType {
 #[derive(Debug, Default, Clone)]
 pub struct FfiFunction {
     pub(super) name: String,
-    pub(super) arguments: Vec<FFIArgument>,
+    pub(super) arguments: Vec<FfiArgument>,
     pub(super) return_type: Option<FfiType>,
 }
 
@@ -67,7 +67,7 @@ impl FfiFunction {
     pub fn name(&self) -> &str {
         &self.name
     }
-    pub fn arguments(&self) -> Vec<&FFIArgument> {
+    pub fn arguments(&self) -> Vec<&FfiArgument> {
         self.arguments.iter().collect()
     }
     pub fn return_type(&self) -> Option<&FfiType> {
@@ -79,12 +79,12 @@ impl FfiFunction {
 ///
 /// Each argument has a name and a type.
 #[derive(Debug, Clone)]
-pub struct FFIArgument {
+pub struct FfiArgument {
     pub(super) name: String,
     pub(super) type_: FfiType,
 }
 
-impl FFIArgument {
+impl FfiArgument {
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/uniffi_bindgen/src/interface/ffi.rs
+++ b/uniffi_bindgen/src/interface/ffi.rs
@@ -19,7 +19,7 @@
 /// "owned" types (the recipient must free it, or pass it to someone else) and
 /// "borrowed" types (the sender must keep it alive for the duration of the call).
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub enum FFIType {
+pub enum FfiType {
     // N.B. there are no booleans at this layer, since they cause problems for JNA.
     UInt8,
     Int8,
@@ -60,7 +60,7 @@ pub enum FFIType {
 pub struct FFIFunction {
     pub(super) name: String,
     pub(super) arguments: Vec<FFIArgument>,
-    pub(super) return_type: Option<FFIType>,
+    pub(super) return_type: Option<FfiType>,
 }
 
 impl FFIFunction {
@@ -70,7 +70,7 @@ impl FFIFunction {
     pub fn arguments(&self) -> Vec<&FFIArgument> {
         self.arguments.iter().collect()
     }
-    pub fn return_type(&self) -> Option<&FFIType> {
+    pub fn return_type(&self) -> Option<&FfiType> {
         self.return_type.as_ref()
     }
 }
@@ -81,14 +81,14 @@ impl FFIFunction {
 #[derive(Debug, Clone)]
 pub struct FFIArgument {
     pub(super) name: String,
-    pub(super) type_: FFIType,
+    pub(super) type_: FfiType,
 }
 
 impl FFIArgument {
     pub fn name(&self) -> &str {
         &self.name
     }
-    pub fn type_(&self) -> FFIType {
+    pub fn type_(&self) -> FfiType {
         self.type_.clone()
     }
 }

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -36,7 +36,7 @@ use std::hash::{Hash, Hasher};
 
 use anyhow::{bail, Result};
 
-use super::ffi::{FFIArgument, FfiFunction};
+use super::ffi::{FfiArgument, FfiFunction};
 use super::literal::{convert_default_value, Literal};
 use super::types::{Type, TypeIterator};
 use super::{
@@ -216,9 +216,9 @@ impl Argument {
     }
 }
 
-impl From<&Argument> for FFIArgument {
-    fn from(a: &Argument) -> FFIArgument {
-        FFIArgument {
+impl From<&Argument> for FfiArgument {
+    fn from(a: &Argument) -> FfiArgument {
+        FfiArgument {
             name: a.name.clone(),
             type_: (&a.type_).into(),
         }

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -36,7 +36,7 @@ use std::hash::{Hash, Hasher};
 
 use anyhow::{bail, Result};
 
-use super::ffi::{FFIArgument, FFIFunction};
+use super::ffi::{FFIArgument, FfiFunction};
 use super::literal::{convert_default_value, Literal};
 use super::types::{Type, TypeIterator};
 use super::{
@@ -56,7 +56,7 @@ pub struct Function {
     pub(super) name: String,
     pub(super) arguments: Vec<Argument>,
     pub(super) return_type: Option<Type>,
-    pub(super) ffi_func: FFIFunction,
+    pub(super) ffi_func: FfiFunction,
     pub(super) attributes: FunctionAttributes,
 }
 
@@ -77,7 +77,7 @@ impl Function {
         self.return_type.as_ref()
     }
 
-    pub fn ffi_func(&self) -> &FFIFunction {
+    pub fn ffi_func(&self) -> &FfiFunction {
         &self.ffi_func
     }
 
@@ -127,9 +127,9 @@ impl From<uniffi_meta::FnMetadata> for Function {
         let return_type = meta.return_type.map(|out| convert_type(&out));
         let arguments = meta.inputs.into_iter().map(Into::into).collect();
 
-        let ffi_func = FFIFunction {
+        let ffi_func = FfiFunction {
             name: ffi_name,
-            ..FFIFunction::default()
+            ..FfiFunction::default()
         };
 
         Self {

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -76,7 +76,7 @@ mod record;
 pub use record::{Field, Record};
 
 pub mod ffi;
-pub use ffi::{FFIArgument, FfiFunction, FfiType};
+pub use ffi::{FfiArgument, FfiFunction, FfiType};
 use uniffi_meta::{FnMetadata, MethodMetadata, ObjectMetadata};
 
 /// The main public interface for this module, representing the complete details of an interface exposed
@@ -356,7 +356,7 @@ impl ComponentInterface {
     pub fn ffi_rustbuffer_alloc(&self) -> FfiFunction {
         FfiFunction {
             name: format!("ffi_{}_rustbuffer_alloc", self.ffi_namespace()),
-            arguments: vec![FFIArgument {
+            arguments: vec![FfiArgument {
                 name: "size".to_string(),
                 type_: FfiType::Int32,
             }],
@@ -370,7 +370,7 @@ impl ComponentInterface {
     pub fn ffi_rustbuffer_from_bytes(&self) -> FfiFunction {
         FfiFunction {
             name: format!("ffi_{}_rustbuffer_from_bytes", self.ffi_namespace()),
-            arguments: vec![FFIArgument {
+            arguments: vec![FfiArgument {
                 name: "bytes".to_string(),
                 type_: FfiType::ForeignBytes,
             }],
@@ -384,7 +384,7 @@ impl ComponentInterface {
     pub fn ffi_rustbuffer_free(&self) -> FfiFunction {
         FfiFunction {
             name: format!("ffi_{}_rustbuffer_free", self.ffi_namespace()),
-            arguments: vec![FFIArgument {
+            arguments: vec![FfiArgument {
                 name: "buf".to_string(),
                 type_: FfiType::RustBuffer,
             }],
@@ -399,11 +399,11 @@ impl ComponentInterface {
         FfiFunction {
             name: format!("ffi_{}_rustbuffer_reserve", self.ffi_namespace()),
             arguments: vec![
-                FFIArgument {
+                FfiArgument {
                     name: "buf".to_string(),
                     type_: FfiType::RustBuffer,
                 },
-                FFIArgument {
+                FfiArgument {
                     name: "additional".to_string(),
                     type_: FfiType::Int32,
                 },

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -76,7 +76,7 @@ mod record;
 pub use record::{Field, Record};
 
 pub mod ffi;
-pub use ffi::{FFIArgument, FFIFunction, FFIType};
+pub use ffi::{FFIArgument, FFIFunction, FfiType};
 use uniffi_meta::{FnMetadata, MethodMetadata, ObjectMetadata};
 
 /// The main public interface for this module, representing the complete details of an interface exposed
@@ -358,9 +358,9 @@ impl ComponentInterface {
             name: format!("ffi_{}_rustbuffer_alloc", self.ffi_namespace()),
             arguments: vec![FFIArgument {
                 name: "size".to_string(),
-                type_: FFIType::Int32,
+                type_: FfiType::Int32,
             }],
-            return_type: Some(FFIType::RustBuffer),
+            return_type: Some(FfiType::RustBuffer),
         }
     }
 
@@ -372,9 +372,9 @@ impl ComponentInterface {
             name: format!("ffi_{}_rustbuffer_from_bytes", self.ffi_namespace()),
             arguments: vec![FFIArgument {
                 name: "bytes".to_string(),
-                type_: FFIType::ForeignBytes,
+                type_: FfiType::ForeignBytes,
             }],
-            return_type: Some(FFIType::RustBuffer),
+            return_type: Some(FfiType::RustBuffer),
         }
     }
 
@@ -386,7 +386,7 @@ impl ComponentInterface {
             name: format!("ffi_{}_rustbuffer_free", self.ffi_namespace()),
             arguments: vec![FFIArgument {
                 name: "buf".to_string(),
-                type_: FFIType::RustBuffer,
+                type_: FfiType::RustBuffer,
             }],
             return_type: None,
         }
@@ -401,14 +401,14 @@ impl ComponentInterface {
             arguments: vec![
                 FFIArgument {
                     name: "buf".to_string(),
-                    type_: FFIType::RustBuffer,
+                    type_: FfiType::RustBuffer,
                 },
                 FFIArgument {
                     name: "additional".to_string(),
-                    type_: FFIType::Int32,
+                    type_: FfiType::Int32,
                 },
             ],
-            return_type: Some(FFIType::RustBuffer),
+            return_type: Some(FfiType::RustBuffer),
         }
     }
 

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -76,7 +76,7 @@ mod record;
 pub use record::{Field, Record};
 
 pub mod ffi;
-pub use ffi::{FFIArgument, FFIFunction, FfiType};
+pub use ffi::{FFIArgument, FfiFunction, FfiType};
 use uniffi_meta::{FnMetadata, MethodMetadata, ObjectMetadata};
 
 /// The main public interface for this module, representing the complete details of an interface exposed
@@ -353,8 +353,8 @@ impl ComponentInterface {
     /// Builtin FFI function for allocating a new `RustBuffer`.
     /// This is needed so that the foreign language bindings can create buffers in which to pass
     /// complex data types across the FFI.
-    pub fn ffi_rustbuffer_alloc(&self) -> FFIFunction {
-        FFIFunction {
+    pub fn ffi_rustbuffer_alloc(&self) -> FfiFunction {
+        FfiFunction {
             name: format!("ffi_{}_rustbuffer_alloc", self.ffi_namespace()),
             arguments: vec![FFIArgument {
                 name: "size".to_string(),
@@ -367,8 +367,8 @@ impl ComponentInterface {
     /// Builtin FFI function for copying foreign-owned bytes
     /// This is needed so that the foreign language bindings can create buffers in which to pass
     /// complex data types across the FFI.
-    pub fn ffi_rustbuffer_from_bytes(&self) -> FFIFunction {
-        FFIFunction {
+    pub fn ffi_rustbuffer_from_bytes(&self) -> FfiFunction {
+        FfiFunction {
             name: format!("ffi_{}_rustbuffer_from_bytes", self.ffi_namespace()),
             arguments: vec![FFIArgument {
                 name: "bytes".to_string(),
@@ -381,8 +381,8 @@ impl ComponentInterface {
     /// Builtin FFI function for freeing a `RustBuffer`.
     /// This is needed so that the foreign language bindings can free buffers in which they received
     /// complex data types returned across the FFI.
-    pub fn ffi_rustbuffer_free(&self) -> FFIFunction {
-        FFIFunction {
+    pub fn ffi_rustbuffer_free(&self) -> FfiFunction {
+        FfiFunction {
             name: format!("ffi_{}_rustbuffer_free", self.ffi_namespace()),
             arguments: vec![FFIArgument {
                 name: "buf".to_string(),
@@ -395,8 +395,8 @@ impl ComponentInterface {
     /// Builtin FFI function for reserving extra space in a `RustBuffer`.
     /// This is needed so that the foreign language bindings can grow buffers used for passing
     /// complex data types across the FFI.
-    pub fn ffi_rustbuffer_reserve(&self) -> FFIFunction {
-        FFIFunction {
+    pub fn ffi_rustbuffer_reserve(&self) -> FfiFunction {
+        FfiFunction {
             name: format!("ffi_{}_rustbuffer_reserve", self.ffi_namespace()),
             arguments: vec![
                 FFIArgument {
@@ -416,7 +416,7 @@ impl ComponentInterface {
     ///
     /// The set of FFI functions is derived automatically from the set of higher-level types
     /// along with the builtin FFI helper functions.
-    pub fn iter_ffi_function_definitions(&self) -> impl Iterator<Item = FFIFunction> + '_ {
+    pub fn iter_ffi_function_definitions(&self) -> impl Iterator<Item = FfiFunction> + '_ {
         self.iter_user_ffi_function_definitions()
             .cloned()
             .chain(self.iter_rust_buffer_ffi_function_definitions())
@@ -428,7 +428,7 @@ impl ComponentInterface {
     ///   - Top-level functions
     ///   - Object methods
     ///   - Callback interfaces
-    pub fn iter_user_ffi_function_definitions(&self) -> impl Iterator<Item = &FFIFunction> + '_ {
+    pub fn iter_user_ffi_function_definitions(&self) -> impl Iterator<Item = &FfiFunction> + '_ {
         iter::empty()
             .chain(
                 self.objects
@@ -444,7 +444,7 @@ impl ComponentInterface {
     }
 
     /// List all FFI functions definitions for RustBuffer functionality
-    pub fn iter_rust_buffer_ffi_function_definitions(&self) -> impl Iterator<Item = FFIFunction> {
+    pub fn iter_rust_buffer_ffi_function_definitions(&self) -> impl Iterator<Item = FfiFunction> {
         [
             self.ffi_rustbuffer_alloc(),
             self.ffi_rustbuffer_from_bytes(),

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -63,7 +63,7 @@ use std::{collections::HashSet, iter};
 
 use anyhow::{bail, Result};
 
-use super::ffi::{FFIArgument, FFIFunction, FfiType};
+use super::ffi::{FFIArgument, FfiFunction, FfiType};
 use super::function::Argument;
 use super::types::{Type, TypeIterator};
 use super::{
@@ -91,7 +91,7 @@ pub struct Object {
     pub(super) name: String,
     pub(super) constructors: Vec<Constructor>,
     pub(super) methods: Vec<Method>,
-    pub(super) ffi_func_free: FFIFunction,
+    pub(super) ffi_func_free: FfiFunction,
     pub(super) uses_deprecated_threadsafe_attribute: bool,
 }
 
@@ -143,7 +143,7 @@ impl Object {
         }
     }
 
-    pub fn ffi_object_free(&self) -> &FFIFunction {
+    pub fn ffi_object_free(&self) -> &FfiFunction {
         &self.ffi_func_free
     }
 
@@ -151,7 +151,7 @@ impl Object {
         self.uses_deprecated_threadsafe_attribute
     }
 
-    pub fn iter_ffi_function_definitions(&self) -> impl Iterator<Item = &FFIFunction> {
+    pub fn iter_ffi_function_definitions(&self) -> impl Iterator<Item = &FfiFunction> {
         iter::once(&self.ffi_func_free)
             .chain(self.constructors.iter().map(|f| &f.ffi_func))
             .chain(self.methods.iter().map(|f| &f.ffi_func))
@@ -249,7 +249,7 @@ impl APIConverter<Object> for weedle::InterfaceDefinition<'_> {
 pub struct Constructor {
     pub(super) name: String,
     pub(super) arguments: Vec<Argument>,
-    pub(super) ffi_func: FFIFunction,
+    pub(super) ffi_func: FfiFunction,
     pub(super) attributes: ConstructorAttributes,
 }
 
@@ -266,7 +266,7 @@ impl Constructor {
         self.arguments.to_vec()
     }
 
-    pub fn ffi_func(&self) -> &FFIFunction {
+    pub fn ffi_func(&self) -> &FfiFunction {
         &self.ffi_func
     }
 
@@ -349,7 +349,7 @@ pub struct Method {
     pub(super) object_name: String,
     pub(super) return_type: Option<Type>,
     pub(super) arguments: Vec<Argument>,
-    pub(super) ffi_func: FFIFunction,
+    pub(super) ffi_func: FfiFunction,
     pub(super) attributes: MethodAttributes,
 }
 
@@ -383,7 +383,7 @@ impl Method {
         self.return_type.as_ref()
     }
 
-    pub fn ffi_func(&self) -> &FFIFunction {
+    pub fn ffi_func(&self) -> &FfiFunction {
         &self.ffi_func
     }
 
@@ -434,9 +434,9 @@ impl From<uniffi_meta::MethodMetadata> for Method {
         let return_type = meta.return_type.map(|out| convert_type(&out));
         let arguments = meta.inputs.into_iter().map(Into::into).collect();
 
-        let ffi_func = FFIFunction {
+        let ffi_func = FfiFunction {
             name: ffi_name,
-            ..FFIFunction::default()
+            ..FfiFunction::default()
         };
 
         Self {

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -63,7 +63,7 @@ use std::{collections::HashSet, iter};
 
 use anyhow::{bail, Result};
 
-use super::ffi::{FFIArgument, FFIFunction, FFIType};
+use super::ffi::{FFIArgument, FFIFunction, FfiType};
 use super::function::Argument;
 use super::types::{Type, TypeIterator};
 use super::{
@@ -165,7 +165,7 @@ impl Object {
         }
         self.ffi_func_free.arguments = vec![FFIArgument {
             name: "ptr".to_string(),
-            type_: FFIType::RustArcPtr(self.name().to_string()),
+            type_: FfiType::RustArcPtr(self.name().to_string()),
         }];
         self.ffi_func_free.return_type = None;
 
@@ -291,7 +291,7 @@ impl Constructor {
     fn derive_ffi_func(&mut self, ci_prefix: &str, obj_name: &str) {
         self.ffi_func.name = format!("{ci_prefix}_{obj_name}_{}", self.name);
         self.ffi_func.arguments = self.arguments.iter().map(Into::into).collect();
-        self.ffi_func.return_type = Some(FFIType::RustArcPtr(obj_name.to_string()));
+        self.ffi_func.return_type = Some(FfiType::RustArcPtr(obj_name.to_string()));
     }
 
     pub fn iter_types(&self) -> TypeIterator<'_> {
@@ -342,7 +342,7 @@ impl APIConverter<Constructor> for weedle::interface::ConstructorInterfaceMember
 // Represents an instance method for an object type.
 //
 // The FFI will represent this as a function whose first/self argument is a
-// `FFIType::RustArcPtr` to the instance.
+// `FfiType::RustArcPtr` to the instance.
 #[derive(Debug, Clone)]
 pub struct Method {
     pub(super) name: String,

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -63,7 +63,7 @@ use std::{collections::HashSet, iter};
 
 use anyhow::{bail, Result};
 
-use super::ffi::{FFIArgument, FfiFunction, FfiType};
+use super::ffi::{FfiArgument, FfiFunction, FfiType};
 use super::function::Argument;
 use super::types::{Type, TypeIterator};
 use super::{
@@ -163,7 +163,7 @@ impl Object {
         if self.ffi_func_free.name().is_empty() {
             self.ffi_func_free.name = format!("ffi_{ci_prefix}_{}_object_free", self.name);
         }
-        self.ffi_func_free.arguments = vec![FFIArgument {
+        self.ffi_func_free.arguments = vec![FfiArgument {
             name: "ptr".to_string(),
             type_: FfiType::RustArcPtr(self.name().to_string()),
         }];

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -19,14 +19,14 @@
 //!
 //! As a developer working on UniFFI itself, you're likely to spend a fair bit of time thinking
 //! about how these API-level types map into the lower-level types of the FFI layer as represented
-//! by the [`ffi::FFIType`](super::ffi::FFIType) enum, but that's a detail that is invisible to end users.
+//! by the [`ffi::FfiType`](super::ffi::FfiType) enum, but that's a detail that is invisible to end users.
 
 use std::{collections::hash_map::Entry, collections::BTreeSet, collections::HashMap, iter};
 
 use anyhow::{bail, Result};
 use heck::ToUpperCamelCase;
 
-use super::ffi::FFIType;
+use super::ffi::FfiType;
 
 mod finder;
 pub(super) use finder::TypeFinder;
@@ -127,7 +127,7 @@ impl Type {
         }
     }
 
-    pub fn ffi_type(&self) -> FFIType {
+    pub fn ffi_type(&self) -> FfiType {
         self.into()
     }
 
@@ -142,33 +142,33 @@ impl Type {
 }
 
 /// When passing data across the FFI, each `Type` value will be lowered into a corresponding
-/// `FFIType` value. This conversion tells you which one.
+/// `FfiType` value. This conversion tells you which one.
 ///
-/// Note that the conversion is one-way - given an FFIType, it is not in general possible to
+/// Note that the conversion is one-way - given an FfiType, it is not in general possible to
 /// tell what the corresponding Type is that it's being used to represent.
-impl From<&Type> for FFIType {
-    fn from(t: &Type) -> FFIType {
+impl From<&Type> for FfiType {
+    fn from(t: &Type) -> FfiType {
         match t {
             // Types that are the same map to themselves, naturally.
-            Type::UInt8 => FFIType::UInt8,
-            Type::Int8 => FFIType::Int8,
-            Type::UInt16 => FFIType::UInt16,
-            Type::Int16 => FFIType::Int16,
-            Type::UInt32 => FFIType::UInt32,
-            Type::Int32 => FFIType::Int32,
-            Type::UInt64 => FFIType::UInt64,
-            Type::Int64 => FFIType::Int64,
-            Type::Float32 => FFIType::Float32,
-            Type::Float64 => FFIType::Float64,
+            Type::UInt8 => FfiType::UInt8,
+            Type::Int8 => FfiType::Int8,
+            Type::UInt16 => FfiType::UInt16,
+            Type::Int16 => FfiType::Int16,
+            Type::UInt32 => FfiType::UInt32,
+            Type::Int32 => FfiType::Int32,
+            Type::UInt64 => FfiType::UInt64,
+            Type::Int64 => FfiType::Int64,
+            Type::Float32 => FfiType::Float32,
+            Type::Float64 => FfiType::Float64,
             // Booleans lower into an Int8, to work around a bug in JNA.
-            Type::Boolean => FFIType::Int8,
+            Type::Boolean => FfiType::Int8,
             // Strings are always owned rust values.
             // We might add a separate type for borrowed strings in future.
-            Type::String => FFIType::RustBuffer,
+            Type::String => FfiType::RustBuffer,
             // Objects are pointers to an Arc<>
-            Type::Object(name) => FFIType::RustArcPtr(name.to_owned()),
+            Type::Object(name) => FfiType::RustArcPtr(name.to_owned()),
             // Callback interfaces are passed as opaque integer handles.
-            Type::CallbackInterface(_) => FFIType::UInt64,
+            Type::CallbackInterface(_) => FfiType::UInt64,
             // Other types are serialized into a bytebuffer and deserialized on the other side.
             Type::Enum(_)
             | Type::Error(_)
@@ -178,17 +178,17 @@ impl From<&Type> for FFIType {
             | Type::Map(_, _)
             | Type::Timestamp
             | Type::Duration
-            | Type::External { .. } => FFIType::RustBuffer,
-            Type::Custom { builtin, .. } => FFIType::from(builtin.as_ref()),
+            | Type::External { .. } => FfiType::RustBuffer,
+            Type::Custom { builtin, .. } => FfiType::from(builtin.as_ref()),
             Type::Unresolved { name } => {
-                unreachable!("Type `{name}` must be resolved before lowering to FFIType")
+                unreachable!("Type `{name}` must be resolved before lowering to FfiType")
             }
         }
     }
 }
 
 // Needed for rust scaffolding askama template
-impl From<&&Type> for FFIType {
+impl From<&&Type> for FfiType {
     fn from(ty: &&Type) -> Self {
         (*ty).into()
     }

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -60,22 +60,22 @@ mod filters {
         })
     }
 
-    pub fn type_ffi(type_: &FFIType) -> Result<String, askama::Error> {
+    pub fn type_ffi(type_: &FfiType) -> Result<String, askama::Error> {
         Ok(match type_ {
-            FFIType::Int8 => "i8".into(),
-            FFIType::UInt8 => "u8".into(),
-            FFIType::Int16 => "i16".into(),
-            FFIType::UInt16 => "u16".into(),
-            FFIType::Int32 => "i32".into(),
-            FFIType::UInt32 => "u32".into(),
-            FFIType::Int64 => "i64".into(),
-            FFIType::UInt64 => "u64".into(),
-            FFIType::Float32 => "f32".into(),
-            FFIType::Float64 => "f64".into(),
-            FFIType::RustArcPtr(_) => "*const std::os::raw::c_void".into(),
-            FFIType::RustBuffer => "uniffi::RustBuffer".into(),
-            FFIType::ForeignBytes => "uniffi::ForeignBytes".into(),
-            FFIType::ForeignCallback => "uniffi::ForeignCallback".into(),
+            FfiType::Int8 => "i8".into(),
+            FfiType::UInt8 => "u8".into(),
+            FfiType::Int16 => "i16".into(),
+            FfiType::UInt16 => "u16".into(),
+            FfiType::Int32 => "i32".into(),
+            FfiType::UInt32 => "u32".into(),
+            FfiType::Int64 => "i64".into(),
+            FfiType::UInt64 => "u64".into(),
+            FfiType::Float32 => "f32".into(),
+            FfiType::Float64 => "f64".into(),
+            FfiType::RustArcPtr(_) => "*const std::os::raw::c_void".into(),
+            FfiType::RustBuffer => "uniffi::RustBuffer".into(),
+            FfiType::ForeignBytes => "uniffi::ForeignBytes".into(),
+            FfiType::ForeignCallback => "uniffi::ForeignCallback".into(),
         })
     }
 

--- a/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
@@ -27,7 +27,7 @@ pub struct FfiConverterType{{ name }};
 
 unsafe impl uniffi::FfiConverter for FfiConverterType{{ name }} {
     type RustType = r#{{ name }};
-    type FfiType = {{ FFIType::from(builtin).borrow()|type_ffi }};
+    type FfiType = {{ FfiType::from(builtin).borrow()|type_ffi }};
 
     fn lower(obj: {{ name }} ) -> Self::FfiType {
         <{{ builtin|type_rs }} as uniffi::FfiConverter>::lower(<{{ name }} as UniffiCustomTypeConverter>::from_custom(obj))


### PR DESCRIPTION
In accordance with the Rust API Guidelines: https://rust-lang.github.io/api-guidelines/naming.html

If you agree with this, I'm happy to update this PR to also change `FFIArgument`, `FFIFunction` and any others.