### PR TITLE
Upgrade cargo_metadata to 0.15

### DIFF
--- a/fixtures/reexport-scaffolding-macro/Cargo.toml
+++ b/fixtures/reexport-scaffolding-macro/Cargo.toml
@@ -18,6 +18,6 @@ uniffi-fixture-coverall = { path = "../coverall" }
 uniffi = { path = "../../uniffi", features=["builtin-bindgen"] }
 
 [dev-dependencies]
-cargo_metadata = "0.14"
+cargo_metadata = "0.15"
 libloading = "0.7"
 uniffi_bindgen = { path = "../../uniffi_bindgen" }

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -18,7 +18,6 @@ camino = "1.0.8"
 log = "0.4"
 once_cell = "1.12"
 # Regular dependencies
-cargo_metadata = "0.15.0"
 paste = "1.0"
 uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "=0.21.0" }
 uniffi_macros = { path = "../uniffi_macros", version = "=0.21.0" }

--- a/uniffi_testing/Cargo.toml
+++ b/uniffi_testing/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 camino = "1.0.8"
-cargo_metadata = "0.14"
+cargo_metadata = "0.15"
 fs-err = "2.7.0"
 once_cell = "1.12"
 serde = "1"


### PR DESCRIPTION
https://github.com/mozilla/uniffi-rs/pull/1357 didn't upgrade all of them.