### PR TITLE
Make clap optional in uniffi_bindgen

### DIFF
--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4"
 once_cell = "1.12"
 # Regular dependencies
 paste = "1.0"
-uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "=0.21.0" }
+uniffi_bindgen = { path = "../uniffi_bindgen", default-features = false, optional = true, version = "=0.21.0" }
 uniffi_macros = { path = "../uniffi_macros", version = "=0.21.0" }
 static_assertions = "1.1.0"
 

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -13,13 +13,14 @@ keywords = ["ffi", "bindgen"]
 [[bin]]
 name = "uniffi-bindgen"
 path = "src/main.rs"
+required-features = ["clap"]
 
 [dependencies]
 anyhow = "1"
 askama = { version = "0.11", default-features = false, features = ["config"] }
 bincode = "1.3"
 camino = "1.0.8"
-clap = { version = "3.1", features = ["cargo", "std", "derive"] }
+clap = { version = "3.1", features = ["cargo", "std", "derive"], optional = true }
 fs-err = "2.7.0"
 glob = "0.3"
 goblin = "0.6"
@@ -32,3 +33,6 @@ toml = "0.5"
 weedle2 = { version = "4.0.0", path = "../weedle2" }
 uniffi_meta = { path = "../uniffi_meta", version = "=0.21.0" }
 uniffi_testing = { path = "../uniffi_testing", version = "=0.21.0" }
+
+[features]
+default = ["clap"]

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -96,6 +96,7 @@ const BINDGEN_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 use anyhow::{anyhow, bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
+#[cfg(feature = "clap")]
 use clap::{Parser, Subcommand};
 use fs_err::{self as fs, File};
 use serde::{Deserialize, Serialize};
@@ -452,6 +453,7 @@ impl<V: Clone> MergeWith for HashMap<String, V> {
 // structs to help our cmdline parsing. Note that docstrings below form part
 // of the "help" output.
 /// Scaffolding and bindings generator for Rust
+#[cfg(feature = "clap")]
 #[derive(Parser)]
 #[clap(name = "uniffi-bindgen")]
 #[clap(version = clap::crate_version!())]
@@ -461,6 +463,7 @@ struct Cli {
     command: Commands,
 }
 
+#[cfg(feature = "clap")]
 #[derive(Subcommand)]
 enum Commands {
     /// Generate foreign language bindings
@@ -514,6 +517,7 @@ enum Commands {
     },
 }
 
+#[cfg(feature = "clap")]
 pub fn run_main() -> Result<()> {
     let cli = Cli::parse();
     match &cli.command {

--- a/uniffi_build/Cargo.toml
+++ b/uniffi_build/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["ffi", "bindgen"]
 [dependencies]
 anyhow = "1"
 camino = "1.0.8"
-uniffi_bindgen = { path = "../uniffi_bindgen", optional = true, version = "=0.21.0" }
+uniffi_bindgen = { path = "../uniffi_bindgen", default-features = false, optional = true, version = "=0.21.0" }
 
 [features]
 default = []


### PR DESCRIPTION
A less disruptive approach compared to #1416, same as https://github.com/eqrion/cbindgen/pull/363