### PR TITLE
Merge back release v0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## [[UnreleasedVersion]] - (_[[ReleaseDate]]_)
 
-[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.21.0...HEAD).
+[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.21.1...HEAD).
 
 ### ⚠️ Breaking Changes ⚠️
 
@@ -16,6 +16,10 @@
 ### What's changed
 
 - Added support for Swift external types
+
+## v0.21.1 - (_2022-12-16_)
+
+[All changes in v0.21.1](https://github.com/mozilla/uniffi-rs/compare/v0.21.0...v0.21.1).
 
 ### What's changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 
 - Added support for Swift external types
 
+### What's changed
+
+- Replace checksum mechanism for function naming to give consistent results, independent of the target's endianness and bit width.
+  This should have no visible effect on the outside.
+
 ## v0.21.0 - (_2022-10-14_)
 
 [All changes in v0.21.0](https://github.com/mozilla/uniffi-rs/compare/v0.20.0...v0.21.0).

--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-arithmetic"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/callbacks/Cargo.toml
+++ b/examples/callbacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-callbacks"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/custom-types/Cargo.toml
+++ b/examples/custom-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-custom-types"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/geometry/Cargo.toml
+++ b/examples/geometry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-geometry"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/rondpoint/Cargo.toml
+++ b/examples/rondpoint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-rondpoint"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/sprites/Cargo.toml
+++ b/examples/sprites/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-sprites"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/examples/todolist/Cargo.toml
+++ b/examples/todolist/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-example-todolist"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/callbacks/Cargo.toml
+++ b/fixtures/callbacks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-callbacks"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/coverall/Cargo.toml
+++ b/fixtures/coverall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-coverall"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/ext-types/guid/Cargo.toml
+++ b/fixtures/ext-types/guid/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-ext-types-guid"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/ext-types/lib/Cargo.toml
+++ b/fixtures/ext-types/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-ext-types"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/ext-types/uniffi-one/Cargo.toml
+++ b/fixtures/ext-types/uniffi-one/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-ext-types-lib-one"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/external-types/crate-one/Cargo.toml
+++ b/fixtures/external-types/crate-one/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crate_one"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/external-types/crate-two/Cargo.toml
+++ b/fixtures/external-types/crate-two/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crate_two"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/external-types/lib/Cargo.toml
+++ b/fixtures/external-types/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-external-types"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/keywords/kotlin/Cargo.toml
+++ b/fixtures/keywords/kotlin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-keywords-kotlin"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 publish = false

--- a/fixtures/keywords/rust/Cargo.toml
+++ b/fixtures/keywords/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-keywords-rust"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 publish = false

--- a/fixtures/keywords/swift/Cargo.toml
+++ b/fixtures/keywords/swift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-keywords-swift"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 publish = false

--- a/fixtures/proc-macro/Cargo.toml
+++ b/fixtures/proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-proc-macro"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/fixtures/reexport-scaffolding-macro/Cargo.toml
+++ b/fixtures/reexport-scaffolding-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-reexport-scaffolding-macro"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency/Cargo.toml
+++ b/fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-regression-cdylib-dependency"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["king6cong <king6cong@gmail.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
+++ b/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-regression-cdylib-dependency-ffi-crate"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
+++ b/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-regression-i356-enum-without-int-helpers"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/fully-qualified-types/Cargo.toml
+++ b/fixtures/regressions/fully-qualified-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-regression-i1015-fully-qualified-types"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
+++ b/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-regression-kotlin-experimental-unsigned-types"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/missing-newline/Cargo.toml
+++ b/fixtures/regressions/missing-newline/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-regression-missing-newline"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 license = "MPL-2.0"
 publish = false
 

--- a/fixtures/regressions/swift-callbacks-omit-labels/Cargo.toml
+++ b/fixtures/regressions/swift-callbacks-omit-labels/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-regression-callbacks-omit-labels"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 license = "MPL-2.0"
 publish = false
 

--- a/fixtures/regressions/swift-dictionary-nesting/Cargo.toml
+++ b/fixtures/regressions/swift-dictionary-nesting/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-regression-swift-dictionary-nesting"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 license = "MPL-2.0"
 publish = false
 

--- a/fixtures/simple-fns/Cargo.toml
+++ b/fixtures/simple-fns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-simple-fns"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/fixtures/simple-iface/Cargo.toml
+++ b/fixtures/simple-iface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-simple-iface"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/fixtures/swift-omit-labels/Cargo.toml
+++ b/fixtures/swift-omit-labels/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-fixture-swift-omit-argument-labels"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/uitests/Cargo.toml
+++ b/fixtures/uitests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_uitests"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/uniffi-fixture-time/Cargo.toml
+++ b/fixtures/uniffi-fixture-time/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi-fixture-time"
 edition = "2021"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -4,7 +4,7 @@ description = "a multi-language bindings generator for rust (runtime support cod
 documentation = "https://mozilla.github.io/uniffi-rs"
 homepage = "https://mozilla.github.io/uniffi-rs"
 repository = "https://github.com/mozilla/uniffi-rs"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 edition = "2021"
@@ -19,8 +19,8 @@ log = "0.4"
 once_cell = "1.12"
 # Regular dependencies
 paste = "1.0"
-uniffi_bindgen = { path = "../uniffi_bindgen", default-features = false, optional = true, version = "=0.21.0" }
-uniffi_macros = { path = "../uniffi_macros", version = "=0.21.0" }
+uniffi_bindgen = { path = "../uniffi_bindgen", default-features = false, optional = true, version = "=0.21.1" }
+uniffi_macros = { path = "../uniffi_macros", version = "=0.21.1" }
 static_assertions = "1.1.0"
 
 [features]

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_bindgen"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (codegen and cli tooling)"
 documentation = "https://mozilla.github.io/uniffi-rs"
@@ -31,8 +31,8 @@ serde = "1"
 serde_json = "1.0.80"
 toml = "0.5"
 weedle2 = { version = "4.0.0", path = "../weedle2" }
-uniffi_meta = { path = "../uniffi_meta", version = "=0.21.0" }
-uniffi_testing = { path = "../uniffi_testing", version = "=0.21.0" }
+uniffi_meta = { path = "../uniffi_meta", version = "=0.21.1" }
+uniffi_testing = { path = "../uniffi_testing", version = "=0.21.1" }
 
 [features]
 default = ["clap"]

--- a/uniffi_build/Cargo.toml
+++ b/uniffi_build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_build"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (build script helpers)"
 documentation = "https://mozilla.github.io/uniffi-rs"
@@ -13,7 +13,7 @@ keywords = ["ffi", "bindgen"]
 [dependencies]
 anyhow = "1"
 camino = "1.0.8"
-uniffi_bindgen = { path = "../uniffi_bindgen", default-features = false, optional = true, version = "=0.21.0" }
+uniffi_bindgen = { path = "../uniffi_bindgen", default-features = false, optional = true, version = "=0.21.1" }
 
 [features]
 default = []

--- a/uniffi_checksum_derive/Cargo.toml
+++ b/uniffi_checksum_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_checksum_derive"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (checksum custom derive)"
 documentation = "https://mozilla.github.io/uniffi-rs"

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_macros"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (convenience macros)"
 documentation = "https://mozilla.github.io/uniffi-rs"
@@ -23,8 +23,8 @@ quote = "1.0"
 serde = "1.0.136"
 syn = { version = "1.0", features = ["full", "visit-mut"] }
 toml = "0.5.9"
-uniffi_build = { path = "../uniffi_build", version = "=0.21.0" }
-uniffi_meta = { path = "../uniffi_meta", version = "=0.21.0" }
+uniffi_build = { path = "../uniffi_build", version = "=0.21.1" }
+uniffi_meta = { path = "../uniffi_meta", version = "=0.21.1" }
 
 [features]
 default = []

--- a/uniffi_meta/Cargo.toml
+++ b/uniffi_meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_meta"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 description = "uniffi_meta"
 homepage = "https://mozilla.github.io/uniffi-rs"

--- a/uniffi_testing/Cargo.toml
+++ b/uniffi_testing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uniffi_testing"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 license = "MPL-2.0"
 publish = false


### PR DESCRIPTION
Tag is here: https://github.com/mozilla/uniffi-rs/releases/tag/v0.21.1

Because this was a patch release with only a subset of the changes this is a new branch with the minimal changes neede for main now.