### PR TITLE
Require later cargo-release

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -2,7 +2,7 @@
 ## Release Process
 
 We use [cargo-release](https://crates.io/crates/cargo-release) to simplify the release process.
-(We rely on v0.18 or later because it has support for workspaces. Install this with
+(We rely on v0.22 or later because it has support for workspaces. Install this with
 `cargo install cargo-release`, not to be confused with the different `cargo install release`!)
 It's not (yet) quite an ideal fit for our workflow, but it helps! Steps:
 

--- a/release.toml
+++ b/release.toml
@@ -1,7 +1,5 @@
 tag-name = "v{{version}}"
-dev-version = false
 consolidate-commits = true
-consolidate-pushes = true
 
 shared-version=true
 

--- a/uniffi_testing/Cargo.toml
+++ b/uniffi_testing/Cargo.toml
@@ -4,7 +4,6 @@ authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 version = "0.21.0"
 edition = "2021"
 license = "MPL-2.0"
-publish = false
 
 [dependencies]
 anyhow = "1"


### PR DESCRIPTION
v0.22 removed some config options (as they are now the default or not needed)