### PR TITLE
Fix XCode exmaple not working.

### DIFF
--- a/examples/app/ios/IOSApp.xcodeproj/project.pbxproj
+++ b/examples/app/ios/IOSApp.xcodeproj/project.pbxproj
@@ -208,6 +208,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 395A8838251A062D00562F33 /* Build configuration list for PBXNativeTarget "IOSApp" */;
 			buildPhases = (
+				6C1D133F295C9B5600275D4D /* Generate Binding (incase build rule never ran) */,
 				CEEB59EB25263ECE003C87D1 /* Build Universal Binary for todolist */,
 				39ADC3D125E980F1000EE485 /* Build Universal Binary for arithmetic */,
 				395A880F251A062C00562F33 /* Sources */,
@@ -347,6 +348,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "bash $SRCROOT/xc-universal-binary.sh libarithmetical.a uniffi-example-arithmetic $SRCROOT/../../.. $CONFIGURATION\n";
+		};
+		6C1D133F295C9B5600275D4D /* Generate Binding (incase build rule never ran) */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Generate Binding (incase build rule never ran)";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "bash $SRCROOT/xc-generate-binding.sh\n";
 		};
 		CEEB59EB25263ECE003C87D1 /* Build Universal Binary for todolist */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -537,6 +556,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"IOSApp/Preview Content\"";
 				DEVELOPMENT_TEAM = 43AQ936H96;
 				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = IOSApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -561,6 +581,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"IOSApp/Preview Content\"";
 				DEVELOPMENT_TEAM = 43AQ936H96;
 				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=*]" = arm64;
 				INFOPLIST_FILE = IOSApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/examples/app/ios/xc-generate-binding.sh
+++ b/examples/app/ios/xc-generate-binding.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eEuvx
+
+function error_help()
+{
+    ERROR_MSG="It looks like something went wrong building the Example App Universal Binary."
+    echo "error: ${ERROR_MSG}"
+}
+trap error_help ERR
+
+EXAMPLES="$SRCROOT/../../../examples/"
+for UDL in "$EXAMPLES/arithmetic/src/arithmetic.udl" "$EXAMPLES/todolist/src/todolist.udl"; do
+  echo "Generating files for $UDL"
+  "$SRCROOT/../../../target/debug/uniffi-bindgen" generate "$UDL" --language swift --out-dir "$SRCROOT/Generated"
+done

--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib", "cdylib", "staticlib"]
 name = "arithmetical"
 
 [dependencies]

--- a/examples/todolist/Cargo.toml
+++ b/examples/todolist/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib", "cdylib", "staticlib"]
 name = "uniffi_todolist"
 
 [dependencies]


### PR DESCRIPTION
This resolves 3 things that were not working on my fresh clone of the repo:

1. [As specified here](https://stackoverflow.com/questions/63607158/xcode-building-for-ios-simulator-but-linking-in-an-object-file-built-for-ios-f) arm64 macOS machines required (still) that the you add `"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;` that's done in Xcode, under the main target's **Build settings** in **Excluded Architecture**. 
2. Since the *Generated* folder in the Xcode is not tracked, and for my own lack of understanding of Xcode's build rules, I added a build scripts that to run `uniffi-bindgen` for both the `todolist` and `arithmetics` targets.
3. Both `todolist` and `arithmetics` are missing "staticlib" in their cargo .toml file.

Note:

You must run `cargo build` from the root directory in order to use the local `uniffi-bingen` that's in the `target/debug` folder