### PR TITLE
Rotates the Circle CI key used to deploy docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
       - run: mdbook build docs/manual
       - gh-pages/deploy:
           build-dir: docs/manual/book
-          ssh-fingerprints: "9d:06:af:45:32:f9:71:b7:57:00:81:7f:70:6b:d1:49"
+          ssh-fingerprints: "ac:68:a3:78:ea:ee:00:05:30:e1:dc:1f:2e:2f:7c:81"
 
 workflows:
   version: 2


### PR DESCRIPTION
The new key is already added in Circle and in github's deploy keys. Old key is already invalidated