### PR TITLE
CHANGELOG/documentation updates for 0.23

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,13 @@
+[alias]
+# Cargo command to release a new version for all packages, except uniffi
+release-backend-crates = [
+    "release",
+    "-p", "uniffi_core",
+    "-p", "uniffi_bindgen",
+    "-p", "uniffi_build",
+    "-p", "uniffi_checksum_derive",
+    "-p", "uniffi_macros",
+    "-p", "uniffi_meta",
+    "-p", "uniffi_testing",
+]
+release-uniffi = ["release", "-p", "uniffi"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 Cargo.lock
 target
-.cargo
 .*.swp
 *.jar
 .vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
+### Migrating to UniFFI 0.23
+
+- Update your `Cargo.toml` file to only depend on the `uniffi` crate.  Follow the directions from the [Prerequisites section of the manual](https://mozilla.github.io/uniffi-rs/tutorial/Prerequisites.html)
+- Create a `uniffi-bindgen` binary for your project.  Follow the directions from the [Foreign language bindings section of the manual](https://mozilla.github.io/uniffi-rs/tutorial/foreign_language_bindings.html).
+- Uninstall the system-wide `uniffi_bindgen`: `cargo uninstall uniffi_bindgen`.  (Not strictly necessary, but you won't be using it anymore).
+
 <!-- The sections in this file are managed automatically by `cargo release` -->
 <!-- See our [internal release process docs](docs/release-process.md) and for more general -->
 <!-- guidance, see https://github.com/sunng87/cargo-release/blob/master/docs/faq.md#maintaining-changelog -->
 
 <!-- next-header -->
 
-## [[UnreleasedVersion]] - (_[[ReleaseDate]]_)
+## [[UnreleasedUniFFIVersion]] (backend crates: [[UnreleasedBackendVersion]] - (_[[ReleaseDate]]_)
 
 [All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.22.0...HEAD).
 
@@ -19,12 +25,6 @@
   - Projects that use UniFFI for binding/scaffolding generation now only need to depend on the `uniffi` crate and no longer need to depend on `uniffi_bindgen`, `uniffi_build`, etc.
   - The version numbers for each crate will no longer by kept in sync after this release.  In particular `uniffi` will have breaking changes less often than `uniffi_bindgen` and other crates.  This means that UniFFI consumers that specify their versions like `uniffi = "0.23"` will not need to bump their `uniffi` version as often as before.
 - Callback interface method calls are no longer logged (#1439)
-
-### Migrating to UniFFI 0.23
-
-- Update your `Cargo.toml` file to only depend on the `uniffi` crate.  Follow the directions from the [Prerequisites section of the manual](https://mozilla.github.io/uniffi-rs/tutorial/Prerequisites.html)
-- Create a `uniffi-bindgen` binary for your project.  Follow the directions from the [Foreign language bindings section of the manual](https://mozilla.github.io/uniffi-rs/tutorial/foreign_language_bindings.html).
-- Uninstall the system-wide `uniffi_bindgen`: `cargo uninstall uniffi_bindgen`.  (Not strictly necessary, but you won't be using it anymore).
 
 ## v0.22.0 - (_2022-12-16_)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,21 @@
 
 ### ⚠️ Breaking Changes ⚠️
 
-- `uniffi_bindgen`: Removed the `run_main` function.  It's moved to `uniffi::uniffi_bindgen_main` and now unconditionally succeeds rather than return a `Result<()>`
+- `uniffi_bindgen` no longer provides a standalone binary.  Having a standalone binary resulted in version mismatches when the `uniffi` version specified in `Cargo.toml` didn't match the `uniffi_bindgen` version installed on the system.  Read [The foreign language bindings](https://mozilla.github.io/uniffi-rs/tutorial/foreign_language_bindings.html) section of the manual for how to set up a `uniffi-bindgen` binary that's local to your workspace.
+- `uniffi_bindgen`: Removed the `run_main` function.  It's moved to `uniffi::uniffi_bindgen_main` and now unconditionally succeeds rather than return a `Result<()>`.
 
 ### What's changed
 
+- The UniFFI crate organization has been significantly reworked:
+  - Projects that use UniFFI for binding/scaffolding generation now only need to depend on the `uniffi` crate and no longer need to depend on `uniffi_bindgen`, `uniffi_build`, etc.
+  - The version numbers for each crate will no longer by kept in sync after this release.  In particular `uniffi` will have breaking changes less often than `uniffi_bindgen` and other crates.  This means that UniFFI consumers that specify their versions like `uniffi = "0.23"` will not need to bump their `uniffi` version as often as before.
 - Callback interface method calls are no longer logged (#1439)
+
+### Migrating to UniFFI 0.23
+
+- Update your `Cargo.toml` file to only depend on the `uniffi` crate.  Follow the directions from the [Prerequisites section of the manual](https://mozilla.github.io/uniffi-rs/tutorial/Prerequisites.html)
+- Create a `uniffi-bindgen` binary for your project.  Follow the directions from the [Foreign language bindings section of the manual](https://mozilla.github.io/uniffi-rs/tutorial/foreign_language_bindings.html).
+- Uninstall the system-wide `uniffi_bindgen`: `cargo uninstall uniffi_bindgen`.  (Not strictly necessary, but you won't be using it anymore).
 
 ## v0.22.0 - (_2022-12-16_)
 

--- a/docs/manual/src/tutorial/Prerequisites.md
+++ b/docs/manual/src/tutorial/Prerequisites.md
@@ -1,30 +1,18 @@
 # Prerequisites
 
-## The uniffi-bindgen cli tool
+## Add `uniffi` as a dependency and build-depedency
 
-Install the `uniffi-bindgen` binary on your system using:
+In your crate's `Cargo.toml` add:
 
-```
-cargo install uniffi_bindgen
-```
+```toml
+[dependencies]
+uniffi = { version = "[latest-version]" }
 
-You can see what it can do with `uniffi-bindgen --help`, but let's leave it aside for now.
-
-### Running from a source checkout
-
-It's also possible to run `uniffi-bindgen` from a source checkout of uniffi - this might
-be useful if you are experimenting with changes to uniffi and want to test them out.
-
-In this case, just use `cargo run` in the `uniffi_bindgen` crate directory.
-For example, from the root of the `uniffi-rs` repo, execute:
-
-```shell
-% cd uniffi_bindgen
-% cargo run -- --help
+[build-dependencies]
+uniffi = { version = "[latest-version]", features = [ "build" ] }
 ```
 
-and you will see the help output from running `uniffi-bindgen` locally. Refer to
-the docs for `cargo run` for more information and options.
+UniFFI has not reached version `1.0` yet.  Versions are typically specified as "0.[minor-version]".
 
 ## Build your crate as a cdylib
 

--- a/docs/manual/src/tutorial/foreign_language_bindings.md
+++ b/docs/manual/src/tutorial/foreign_language_bindings.md
@@ -10,33 +10,32 @@ Ideally you would then run the `uniffi-bindgen` binary from the `uniffi` crate t
 is only available with [Cargo nightly](https://doc.rust-lang.org/cargo/reference/unstable.html#artifact-dependencies).
 To work around this, you need to create a binary in your project that does the same thing.
 
-
 Add the following to your `Cargo.toml`:
 
 ```toml
 [[bin]]
-name = "run-uniffi-bindgen"
-path = "run-uniffi-bindgen.rs"
+name = "uniffi-bindgen"
+path = "uniffi-bindgen.rs"
 ```
 
-Create `run-uniffi-bindgen.rs`:
+Create `uniffi-bindgen.rs`:
 ```rust
 fn main() {
     uniffi::uniffi_bindgen_main()
 }
 ```
 
-You can now run `uniffi-bindgen` from your project using `cargo run --features=uniffi/cli --bin run-uniffi-bindgen`
+You can now run `uniffi-bindgen` from your project using `cargo run --features=uniffi/cli --bin uniffi-bindgen [args]`
 
 ### Multi-crate workspaces
 
 If your project consists of multiple crates in a Cargo workspace, then the process outlined above would require you
 creating a binary for each crate that uses UniFFI.  You can avoid this by creating a separate crate for running `uniffi-bindgen`:
-  - Name the crate `run-uniffi-bindgen`
+  - Name the crate `uniffi-bindgen`
   - Add this dependency to `Cargo.toml`: `uniffi = {version = "0.XX.0", features = ["cli"] }`
-  - Follow the steps from the previous seciton to add the `run-uniffi-bindgen` binary target
+  - Follow the steps from the previous seciton to add the `uniffi-bindgen` binary target
 
-Then your can run `uniffi-bindgen` from any create in your project using `cargo run -p run-uniffi-bindgen`
+Then your can run `uniffi-bindgen` from any create in your project using `cargo run -p uniffi-bindgen [args]`
 
 ## Running uniffi-bindgen
 
@@ -44,7 +43,7 @@ Then your can run `uniffi-bindgen` from any create in your project using `cargo 
 
 Run
 ```
-cargo run --bin run-uniffi-bindgen generate src/math.udl --language kotlin
+cargo run --bin uniffi-bindgen generate src/math.udl --language kotlin
 ```
 then have a look at `src/uniffi/math/math.kt`
 
@@ -52,7 +51,7 @@ then have a look at `src/uniffi/math/math.kt`
 
 Run
 ```
-cargo run --bin run-uniffi-bindgen generate src/math.udl --language swift
+cargo run --bin uniffi-bindgen generate src/math.udl --language swift
 ```
 then check out `src/math.swift`
 

--- a/docs/manual/src/tutorial/foreign_language_bindings.md
+++ b/docs/manual/src/tutorial/foreign_language_bindings.md
@@ -14,6 +14,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [[bin]]
+# This can be whatever name makes sense for your project, but the rest of this tutorial assumes uniffi-bindgen.
 name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 ```
@@ -33,7 +34,7 @@ If your project consists of multiple crates in a Cargo workspace, then the proce
 creating a binary for each crate that uses UniFFI.  You can avoid this by creating a separate crate for running `uniffi-bindgen`:
   - Name the crate `uniffi-bindgen`
   - Add this dependency to `Cargo.toml`: `uniffi = {version = "0.XX.0", features = ["cli"] }`
-  - Follow the steps from the previous seciton to add the `uniffi-bindgen` binary target
+  - Follow the steps from the previous section to add the `uniffi-bindgen` binary target
 
 Then your can run `uniffi-bindgen` from any create in your project using `cargo run -p uniffi-bindgen [args]`
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -4,17 +4,40 @@
 We use [cargo-release](https://crates.io/crates/cargo-release) to simplify the release process.
 (We rely on v0.22 or later because it has support for workspaces. Install this with
 `cargo install cargo-release`, not to be confused with the different `cargo install release`!)
-It's not (yet) quite an ideal fit for our workflow, but it helps! Steps:
+It's not (yet) quite an ideal fit for our workflow, but it helps!
 
-1. Take a look over `CHANGELOG.md` and make sure the "unreleased" section accurately reflects the
-   contents of the new release.
-   * Anything that could cause a consumer project to behave differently if it upgraded
-     to the new version, should be called out as a breaking change and should trigger
-     a minor version bump (we're below `v1.0` for semver purposes).
+We use a separate version number for `uniffi` compared to all the other crates:
+
+  - The `uniffi_*` crates are intended for either internal use or by external bindings generators.
+    These crates get breaking version bumps regularly.
+  - `uniffi` acts as a frontend to the other crates and re-exports the top-level UniFFI
+    functionality.  `uniffi` gets breaking version bumps less often than the other crates (see below
+    for details).
+
+Steps:
+
+1. Take a look over `CHANGELOG.md` and make sure the "unreleased" section lists all changes for
+   the release.
+   * Anything that affects any UniFFI consumers should be listed, this includes consumers that
+     use UniFFI to generate their scaffolding/bindings, external bindings generators, etc.
+
+1. Take a look over `uniffi/CHANGELOG.md` and make sure the "unreleased" section lists changes for
+   the release that affect users of the top-level `uniffi` crate.
+   * This should be a copy of the items from the top-level `CHANGELOG.md` that affects
+     scaffolding/bindings generation.
+   * Note that breaking changes for a particular `uniffi_*` crate are not necessarily breaking for
+     the `uniffi` crate.  See `./uniffi-versioning.md` for a discussion of this.
+
+1. Decide on a new version number for `uniffi` crate.  Since we are pre-`1.0`, if there are breaking
+   changes then this should be a minor version bump, otherwise a patch version bump.
+
+1. Decide on a new version number for the other `uniffi_*` crates.  Our current
+   policy is to keep all of these version numbers in sync.
 
 1. Identify the branch for the release. We typically use a single branch for all point releases,
-   so it should be named something like `release-v0.6.x`. This also means that if you are
-   making a point release, the branch will already exist.
+   so it should be named something like `release-v0.6.x`. This also means that if you are making a point release, the branch
+   will already exist. **The release number should match the `uniffi` version number**, not the
+   version number for the `uniffi_*` crates.
 
    * If this is the first minor release, then create the branch:
       * `git checkout -b release-v{MAJOR}.{MINOR}.x`
@@ -26,14 +49,50 @@ It's not (yet) quite an ideal fit for our workflow, but it helps! Steps:
       * `git merge --ff-only origin/release-v{MAJOR}.{MINOR}.x` # to pull in the latest on the branch
       * `git merge origin/main` # to pull in the changes you want to release
 
-1. Run `cargo release {MAJOR}.{MINOR}.{PATCH}` to perform a dry-run and check that the things
-   it is proposing to do seem reasonable. (XXX - note that the output here isn't actually
-   helpful - the `cargo` output will reflect the old previous version because it will be
-   building without having touched the version numbers in the `Cargo.toml`, and it doesn't
-   actually propose that it's going to do anything! But it's probably worthwhile anyway!)
-1. Run `cargo release -x {MAJOR}.{MINOR}.{PATCH}` to perform real run and to
-   bump version numbers and *publish the release to crates.io* and *create the tag*.
-   It does not push the tag or branch to github, but it will publish to crates.io, so
-   take care!
-1. Push your branch, and make a PR to request it be merged to the main branch.
-    * `git push origin --tags`
+1. Test the release using a dry-run:
+   * `cargo release-backend-crates {MAJOR}.{MINOR}.{PATCH}` to test the `uniffi_*` crates
+   * `cargo release-uniffi {MAJOR}.{MINOR}.{PATCH}` to test the `uniffi` crates
+   * Note: The MAJOR/MINOR/PATCH numbers will be different for the two runs
+   * Note: some of the output here isn't actually helpful - the `cargo` output will reflect the old
+     previous version because it will be building without having touched the version numbers in the
+     `Cargo.toml`, and it doesn't actually propose that it's going to do anything! But it's probably
+     worthwhile anyway!.
+
+1. Perform a real run to pump the version numbers, *publish the release to crates.io* and *create
+   the git tag*.
+   * Take care because this will publish the new releases on crates.io.
+   * This will create a local git tag, but does not push it to github.
+   * `cargo release-backend-crates -x {MAJOR}.{MINOR}.{PATCH}` to release the `uniffi_*` crates.
+   * `cargo release-uniffi -x {MAJOR}.{MINOR}.{PATCH}` to release the `uniffi` crates.
+     - *Do not execute this before `cargo release-backend-crates`*.  That command publishes the
+       backend crates on crates.io and updates the version numbers in `uniffi/Cargo.toml`.  Things
+       will likely break if you don't do this before releasing the new `uniffi` version.
+
+1. Push your branch: `git push origin --tags`
+1. Make a PR to request it be merged to the main branch.
+
+## Why avoid breaking changes for the uniffi crate?
+
+UniFFI breaking changes are especially bad when you have a diamond-shaped dependency between uniffi,
+multiple UniFFIed library crates, and an application.  We used to have this situation with Firefox:
+
+- Firefox depended on the Glean and application-services libraries
+- Both of those libraries depended on UniFFI for their bindings
+
+This meant that whenever there was a breaking change in UniFFI, we would need to the "release
+dance":
+ - Release a new UniFFI version.
+ - Release new Glean and application-services versions, with the new UniFFI dependency.
+ - Vendor in the new Glean and application-services code into the Firefox repository.
+
+We sometimes would need to do the release dance when the Glean and application-services weren't
+really affected by the changes.  For example [this change](
+https://github.com/mozilla/uniffi-rs/commit/0bf18394a49856ce0705a7eae3cb1c0127d6ffb9), which was
+breaking for external bindings generators, but doesn't affect "normal" UniFFI consumers at all.
+
+To avoid this, we came up with the following system:
+ - UniFFI consumers typically only depend on the `uniffi` crate.
+ - The `uniffi` crate exports the functionality from other crates needed for "normal" UniFFI
+   consumers.
+ - This means that breaking changes in the other crates don't need to be breaking changes for
+   `uniffi`, if they don't affect the API  that `uniffi` reexports.

--- a/release.toml
+++ b/release.toml
@@ -1,7 +1,7 @@
 tag-name = "v{{version}}"
 consolidate-commits = true
 
-shared-version=true
+shared-version=false
 
 # Disabling auto pushing for now to avoid accidents (although we can still "accidentally" publish
 # to crates.io, so it's not clear this is saving us anything?)

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -25,11 +25,6 @@ clap = { version = "3.1", features = ["cargo", "std", "derive"], optional = true
 [dev-dependencies]
 trybuild = "1"
 
-[[bin]]
-name = "run-uniffi-bindgen"
-path = "run-uniffi-bindgen.rs"
-required-features = ["cli"]
-
 [features]
 default = []
 # Support for features needed by the `build.rs` script. Enable this in your

--- a/uniffi/release.toml
+++ b/uniffi/release.toml
@@ -1,0 +1,13 @@
+# Note that this `release.toml` exists to capture things that must only be
+# done once for `cargo release-uniffi`.
+#
+# [../uniffi_core/release.toml](../uniffi_core/release.toml) captures things that must only be done for `cargo release-backend-crates`
+#
+# All other config exists in [../release.toml](../release.toml).
+
+tag = true
+
+# This is how we manage the sections in CHANGELOG.md
+pre-release-replacements = [
+  {file="../CHANGELOG.md", search="\\[\\[UnreleasedUniFFIVersion\\]\\]", replace="v{{version}}", exactly=2},
+]

--- a/uniffi/run-uniffi-bindgen.rs
+++ b/uniffi/run-uniffi-bindgen.rs
@@ -1,3 +1,0 @@
-fn main() {
-    uniffi::uniffi_bindgen_main()
-}

--- a/uniffi_core/release.toml
+++ b/uniffi_core/release.toml
@@ -1,12 +1,16 @@
 # Note that this `release.toml` exists to capture things that must only be
-# done once per workspace - but all other config exists in [../release.toml](../release.toml).
+# done once for `cargo release-backend-crates`.
+#
+# [../uniffi/release.toml](../uniffi/release.toml) captures things that must only be done for `cargo release-uniffi`
+#
+# All other config exists in [../release.toml](../release.toml).
 
 tag = true
 
 # This is how we manage the sections in CHANGELOG.md
 pre-release-replacements = [
-  {file="../CHANGELOG.md", search="\\[\\[UnreleasedVersion\\]\\]", replace="v{{version}}", exactly=2},
+  {file="../CHANGELOG.md", search="\\[\\[UnreleasedBackendVersion\\]\\]", replace="v{{version}}", exactly=2},
   {file="../CHANGELOG.md", search="\\[\\[ReleaseDate\\]\\]", replace="{{date}}", exactly=1},
   {file="../CHANGELOG.md", search="\\.\\.\\.HEAD\\)", replace="...{{tag_name}})", exactly=1},
-  {file="../CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [[UnreleasedVersion]] - (_[[ReleaseDate]]_)\n\n[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v{{version}}...HEAD).", exactly=1},
+  {file="../CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [[UnreleasedUniFFIVersion]] (backend crates: [[UnreleasedBackendVersion]]) - (_[[ReleaseDate]]_)\n\n[All changes in [[UnreleasedVersion]]](https://github.com/mozilla/uniffi-rs/compare/v{{version}}...HEAD).", exactly=1},
 ]


### PR DESCRIPTION
- Added CHANGELOG sections to describe the new crate structure and breaking changes from PR #1374
- Updated the manual sections describing how to set up `uniffi-bindgen` binaries.  In particular, we're now suggesting naming the binaries `uniffi-bindgen` instead of `run-uniffi-bindgen`.  The "run" part seemed unnecessary to me, especially since `uniffi-bindgen` no longer provides a standalone binary.

My plan is to make a new UniFFI release once this is approved and merged.