### PR TITLE
Update to cargo_metadata 0.15

### DIFF
--- a/fixtures/uitests/Cargo.toml
+++ b/fixtures/uitests/Cargo.toml
@@ -14,4 +14,4 @@ uniffi = {path = "../../uniffi"}
 uniffi_macros = {path = "../../uniffi_macros"}
 
 [dev-dependencies]
-trybuild = "1.0.53"
+trybuild = "1.0.76"

--- a/fixtures/uitests/tests/ui/fieldless_errors_used_in_callbacks_cant_have_fields.rs
+++ b/fixtures/uitests/tests/ui/fieldless_errors_used_in_callbacks_cant_have_fields.rs
@@ -1,5 +1,5 @@
 // Unfortunately, path is relative to a temporary build directory :-/
-uniffi_macros::generate_and_include_scaffolding!("../../../fixtures/uitests/src/errors.udl");
+uniffi_macros::generate_and_include_scaffolding!("../../../../fixtures/uitests/src/errors.udl");
 
 fn main() { /* empty main required by `trybuild` */}
 

--- a/fixtures/uitests/tests/ui/interface_cannot_use_mut_self.rs
+++ b/fixtures/uitests/tests/ui/interface_cannot_use_mut_self.rs
@@ -1,6 +1,6 @@
 
 // Unfortunately, path is relative to a temporary build directory :-/
-uniffi_macros::generate_and_include_scaffolding!("../../../fixtures/uitests/src/counter.udl");
+uniffi_macros::generate_and_include_scaffolding!("../../../../fixtures/uitests/src/counter.udl");
 
 fn main() { /* empty main required by `trybuild` */}
 

--- a/fixtures/uitests/tests/ui/interface_not_sync_and_send.rs
+++ b/fixtures/uitests/tests/ui/interface_not_sync_and_send.rs
@@ -2,7 +2,7 @@
 use std::cell::Cell;
 
 // Unfortunately, path is relative to a temporary build directory :-/
-uniffi_macros::generate_and_include_scaffolding!("../../../fixtures/uitests/src/counter.udl");
+uniffi_macros::generate_and_include_scaffolding!("../../../../fixtures/uitests/src/counter.udl");
 
 fn main() { /* empty main required by `trybuild` */}
 

--- a/fixtures/uitests/tests/ui/non_hashable_record_key.rs
+++ b/fixtures/uitests/tests/ui/non_hashable_record_key.rs
@@ -1,4 +1,4 @@
 // Unfortunately, path is relative to a temporary build directory :-/
-uniffi_macros::generate_and_include_scaffolding!("../../../fixtures/uitests/src/records.udl");
+uniffi_macros::generate_and_include_scaffolding!("../../../../fixtures/uitests/src/records.udl");
 
 fn main() { /* empty main required by `trybuild` */}

--- a/uniffi_core/Cargo.toml
+++ b/uniffi_core/Cargo.toml
@@ -18,7 +18,7 @@ camino = "1.0.8"
 log = "0.4"
 once_cell = "1.12"
 # Regular dependencies
-cargo_metadata = "0.14"
+cargo_metadata = "0.15"
 paste = "1.0"
 static_assertions = "1.1.0"
 


### PR DESCRIPTION
This is the same as in uniffi_testing and thus avoids a dependency duplication.
