### PR TITLE
Move most `uniffi` dependencies behind feature gates

### DIFF
--- a/docs/manual/src/tutorial/Rust_scaffolding.md
+++ b/docs/manual/src/tutorial/Rust_scaffolding.md
@@ -4,14 +4,14 @@
 
 Now we generate some Rust helper code to make the `add` method available to foreign-language bindings.  
 
-First, add `uniffi` to your crate as both a dependency and build-dependency.  This adds the runtime support code that powers UniFFI and build-time support for generating the Rust scaffolding code.
+First, add `uniffi` to your crate as both a dependency and build-dependency.  Enable the `build` feature for the build-dependencies.  This adds the runtime support code that powers UniFFI and build-time support for generating the Rust scaffolding code.
 
 ```toml
 [dependencies]
-uniffi = "1.0.0"
+uniffi = "0.XX.0"
 
 [build-dependencies]
-uniffi = "1.0.0"
+uniffi = { version = "0.XX.0", features = ["build"] }
 ```
 
 Then create a `build.rs` file next to `Cargo.toml` that uses `uniffi` to generate the Rust scaffolding code.

--- a/docs/manual/src/tutorial/foreign_language_bindings.md
+++ b/docs/manual/src/tutorial/foreign_language_bindings.md
@@ -22,19 +22,21 @@ path = "run-uniffi-bindgen.rs"
 Create `run-uniffi-bindgen.rs`:
 ```rust
 fn main() {
-    uniffi::run_uniffi_bindgen().unwrap()
+    uniffi::uniffi_bindgen_main()
 }
 ```
 
-You can now run `uniffi-bindgen` from your project using `cargo run --bin run-uniffi-bindgen`
+You can now run `uniffi-bindgen` from your project using `cargo run --features=uniffi/cli --bin run-uniffi-bindgen`
 
 ### Multi-crate workspaces
 
 If your project consists of multiple crates in a Cargo workspace, then the process outlined above would require you
-creating a binary for each crate that uses UniFFI.  You can avoid this by creating a single crate named
-`run-uniffi-bindgen` that depends on `uniffi` and has the `run-uniffi-bindgen.rs` binary.  Then your can run
-`uniffi-bindgen` from any create in your project using `cargo run -p run-uniffi-bindgen`
+creating a binary for each crate that uses UniFFI.  You can avoid this by creating a separate crate for running `uniffi-bindgen`:
+  - Name the crate `run-uniffi-bindgen`
+  - Add this dependency to `Cargo.toml`: `uniffi = {version = "0.XX.0", features = ["cli"] }`
+  - Follow the steps from the previous seciton to add the `run-uniffi-bindgen` binary target
 
+Then your can run `uniffi-bindgen` from any create in your project using `cargo run -p run-uniffi-bindgen`
 
 ## Running uniffi-bindgen
 

--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -15,4 +15,7 @@ uniffi = {path = "../../uniffi"}
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi"}
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }

--- a/examples/callbacks/Cargo.toml
+++ b/examples/callbacks/Cargo.toml
@@ -15,4 +15,7 @@ uniffi = {path = "../../uniffi"}
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi"}
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }

--- a/examples/custom-types/Cargo.toml
+++ b/examples/custom-types/Cargo.toml
@@ -18,4 +18,7 @@ uniffi = {path = "../../uniffi"}
 url = "2.2"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi"}
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }

--- a/examples/geometry/Cargo.toml
+++ b/examples/geometry/Cargo.toml
@@ -14,4 +14,7 @@ name = "uniffi_geometry"
 uniffi = {path = "../../uniffi"}
 
 [build-dependencies]
-uniffi = {path = "../../uniffi"}
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }

--- a/examples/rondpoint/Cargo.toml
+++ b/examples/rondpoint/Cargo.toml
@@ -14,4 +14,7 @@ name = "uniffi_rondpoint"
 uniffi = {path = "../../uniffi"}
 
 [build-dependencies]
-uniffi = {path = "../../uniffi"}
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }

--- a/examples/sprites/Cargo.toml
+++ b/examples/sprites/Cargo.toml
@@ -14,4 +14,7 @@ name = "uniffi_sprites"
 uniffi = {path = "../../uniffi"}
 
 [build-dependencies]
-uniffi = {path = "../../uniffi"}
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }

--- a/examples/todolist/Cargo.toml
+++ b/examples/todolist/Cargo.toml
@@ -16,4 +16,7 @@ once_cell = "1.12"
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi"}
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/callbacks/Cargo.toml
+++ b/fixtures/callbacks/Cargo.toml
@@ -15,4 +15,7 @@ uniffi = {path = "../../uniffi"}
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi"}
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/coverall/Cargo.toml
+++ b/fixtures/coverall/Cargo.toml
@@ -16,4 +16,7 @@ once_cell = "1.12"
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi"}
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/ext-types/guid/Cargo.toml
+++ b/fixtures/ext-types/guid/Cargo.toml
@@ -18,4 +18,7 @@ thiserror = "1.0"
 uniffi = {path = "../../../uniffi"}
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi"}
+uniffi = {path = "../../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/ext-types/lib/Cargo.toml
+++ b/fixtures/ext-types/lib/Cargo.toml
@@ -31,4 +31,7 @@ uniffi-example-custom-types = {path = "../../../examples/custom-types"}
 url = "2.2"
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi"}
+uniffi = {path = "../../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/ext-types/uniffi-one/Cargo.toml
+++ b/fixtures/ext-types/uniffi-one/Cargo.toml
@@ -16,4 +16,4 @@ bytes = "1.0"
 uniffi = {path = "../../../uniffi"}
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi"}
+uniffi = {path = "../../../uniffi", features = ["build"] }

--- a/fixtures/external-types/lib/Cargo.toml
+++ b/fixtures/external-types/lib/Cargo.toml
@@ -18,4 +18,7 @@ crate_one = {path = "../crate-one"}
 crate_two = {path = "../crate-two"}
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi"}
+uniffi = {path = "../../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/keywords/kotlin/Cargo.toml
+++ b/fixtures/keywords/kotlin/Cargo.toml
@@ -14,4 +14,7 @@ thiserror = "1.0"
 uniffi = {path = "../../../uniffi"}
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi"}
+uniffi = {path = "../../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/keywords/rust/Cargo.toml
+++ b/fixtures/keywords/rust/Cargo.toml
@@ -14,4 +14,7 @@ thiserror = "1.0"
 uniffi = {path = "../../../uniffi"}
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi"}
+uniffi = {path = "../../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/keywords/swift/Cargo.toml
+++ b/fixtures/keywords/swift/Cargo.toml
@@ -14,4 +14,7 @@ thiserror = "1.0"
 uniffi = {path = "../../../uniffi"}
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi"}
+uniffi = {path = "../../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/proc-macro/Cargo.toml
+++ b/fixtures/proc-macro/Cargo.toml
@@ -16,4 +16,7 @@ thiserror = "1.0"
 lazy_static = "1.4"
 
 [build-dependencies]
-uniffi = { path = "../../uniffi" }
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
+++ b/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
@@ -15,4 +15,7 @@ uniffi = {path = "../../../../uniffi"}
 uniffi-fixture-regression-cdylib-dependency = {path = "../cdylib-dependency"}
 
 [build-dependencies]
-uniffi = {path = "../../../../uniffi"}
+uniffi = {path = "../../../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
+++ b/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
@@ -14,4 +14,7 @@ name = "uniffi_regression_test_i356"
 uniffi = {path = "../../../uniffi"}
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi"}
+uniffi = {path = "../../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/regressions/fully-qualified-types/Cargo.toml
+++ b/fixtures/regressions/fully-qualified-types/Cargo.toml
@@ -14,4 +14,4 @@ name = "uniffi_regression_test_i1015"
 uniffi = {path = "../../../uniffi"}
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi"}
+uniffi = {path = "../../../uniffi", features = ["build"] }

--- a/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
+++ b/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
@@ -14,4 +14,7 @@ name = "uniffi_regression_test_kt_unsigned_types"
 uniffi = {path = "../../../uniffi"}
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi"}
+uniffi = {path = "../../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/regressions/logging-callback-interface/Cargo.toml
+++ b/fixtures/regressions/logging-callback-interface/Cargo.toml
@@ -14,4 +14,7 @@ log = "0.4"
 uniffi = {path = "../../../uniffi"}
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi"}
+uniffi = {path = "../../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/regressions/missing-newline/Cargo.toml
+++ b/fixtures/regressions/missing-newline/Cargo.toml
@@ -13,4 +13,7 @@ name = "uniffi_regression_test_missing_newline"
 uniffi = {path = "../../../uniffi"}
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi"}
+uniffi = {path = "../../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/regressions/swift-callbacks-omit-labels/Cargo.toml
+++ b/fixtures/regressions/swift-callbacks-omit-labels/Cargo.toml
@@ -13,4 +13,7 @@ name = "uniffi_regression_test_callbacks_omit_labels"
 uniffi = {path = "../../../uniffi"}
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi"}
+uniffi = {path = "../../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/regressions/swift-dictionary-nesting/Cargo.toml
+++ b/fixtures/regressions/swift-dictionary-nesting/Cargo.toml
@@ -13,4 +13,7 @@ name = "uniffi_regression_test_swift_dictionary_nesting"
 uniffi = {path = "../../../uniffi"}
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi"}
+uniffi = {path = "../../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/simple-fns/Cargo.toml
+++ b/fixtures/simple-fns/Cargo.toml
@@ -14,4 +14,7 @@ crate-type = ["lib", "cdylib"]
 uniffi = { path = "../../uniffi" }
 
 [build-dependencies]
-uniffi = { path = "../../uniffi" }
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/simple-iface/Cargo.toml
+++ b/fixtures/simple-iface/Cargo.toml
@@ -16,4 +16,7 @@ thiserror = "1.0"
 lazy_static = "1.4"
 
 [build-dependencies]
-uniffi = { path = "../../uniffi" }
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/swift-omit-labels/Cargo.toml
+++ b/fixtures/swift-omit-labels/Cargo.toml
@@ -14,4 +14,7 @@ name = "uniffi_omit_argument_labels"
 uniffi = {path = "../../uniffi"}
 
 [build-dependencies]
-uniffi = {path = "../../uniffi"}
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/uniffi-fixture-time/Cargo.toml
+++ b/fixtures/uniffi-fixture-time/Cargo.toml
@@ -15,4 +15,7 @@ uniffi = {path = "../../uniffi"}
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi"}
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -14,12 +14,12 @@ edition = "2021"
 keywords = ["ffi", "bindgen"]
 
 [dependencies]
-uniffi_bindgen = { path = "../uniffi_bindgen", version = "=0.22.0" }
-uniffi_build = { path = "../uniffi_build", version = "=0.22.0" }
+uniffi_bindgen = { path = "../uniffi_bindgen", version = "=0.22.0", optional = true }
+uniffi_build = { path = "../uniffi_build", version = "=0.22.0", optional = true }
 uniffi_core = { path = "../uniffi_core", version = "=0.22.0" }
 uniffi_macros = { path = "../uniffi_macros", version = "=0.22.0" }
 anyhow = "1"
-camino = "1.0.8"
+camino = { version = "1.0.8", optional = true }
 clap = { version = "3.1", features = ["cargo", "std", "derive"], optional = true }
 
 [dev-dependencies]
@@ -28,7 +28,16 @@ trybuild = "1"
 [[bin]]
 name = "run-uniffi-bindgen"
 path = "run-uniffi-bindgen.rs"
-required-features = ["clap"]
+required-features = ["cli"]
 
 [features]
-default = ["clap"]
+default = []
+# Support for features needed by the `build.rs` script. Enable this in your
+# `build-dependencies`.
+build = [ "dep:uniffi_build" ]
+# Support for `uniffi_bindgen_run_main()`. Enable this feature for your
+# `uniffi-bindgen` binaries.
+cli = [ "dep:uniffi_bindgen", "dep:clap", "dep:camino" ]
+# Support for running example/fixture tests for `uniffi-bindgen`.  You probably
+# don't need to enable this.
+bindgen-tests = [ "dep:uniffi_bindgen" ]

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -2,19 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#[cfg(feature = "clap")]
-mod cli;
 /// Reexport items from other uniffi creates
-pub use uniffi_bindgen::bindings::kotlin::run_test as kotlin_run_test;
-pub use uniffi_bindgen::bindings::python::run_test as python_run_test;
-pub use uniffi_bindgen::bindings::ruby::run_test as ruby_run_test;
-pub use uniffi_bindgen::bindings::swift::run_test as swift_run_test;
-pub use uniffi_bindgen::{generate_bindings, generate_component_scaffolding, print_json};
-pub use uniffi_build::generate_scaffolding;
 pub use uniffi_core::*;
-pub use uniffi_macros::{
-    build_foreign_language_testcases, export, include_scaffolding, Enum, Error, Object, Record,
-};
+pub use uniffi_macros::{export, include_scaffolding, Enum, Error, Object, Record};
+#[cfg(feature = "cli")]
+mod cli;
+#[cfg(feature = "bindgen-tests")]
+pub use uniffi_bindgen::bindings::kotlin::run_test as kotlin_run_test;
+#[cfg(feature = "bindgen-tests")]
+pub use uniffi_bindgen::bindings::python::run_test as python_run_test;
+#[cfg(feature = "bindgen-tests")]
+pub use uniffi_bindgen::bindings::ruby::run_test as ruby_run_test;
+#[cfg(feature = "bindgen-tests")]
+pub use uniffi_bindgen::bindings::swift::run_test as swift_run_test;
+#[cfg(feature = "cli")]
+pub use uniffi_bindgen::{generate_bindings, generate_component_scaffolding, print_json};
+#[cfg(feature = "build")]
+pub use uniffi_build::generate_scaffolding;
+#[cfg(feature = "bindgen-tests")]
+pub use uniffi_macros::build_foreign_language_testcases;
 
 #[cfg(test)]
 mod test {
@@ -25,7 +31,7 @@ mod test {
     }
 }
 
-#[cfg(feature = "clap")]
+#[cfg(feature = "cli")]
 pub fn uniffi_bindgen_main() {
     cli::run_main().unwrap();
 }


### PR DESCRIPTION
I was thinking about making a UniFFI release with the changes from #1374, but one issue was making me hesitate and I wanted to address it.

One disadvantage of making `uniffi` the frontend crate is that any crate that depended on it would pull in all its dependencies, which could lead to binary bloat.

This change makes many dependencies optional and defines feature gates to enable them.

Updated the tutorial section based on the changes.