### PR TITLE
Make external types work with interfaces (#1435)

### DIFF
--- a/docs/manual/src/udl/ext_types_external.md
+++ b/docs/manual/src/udl/ext_types_external.md
@@ -50,6 +50,15 @@ Your `Cargo.toml` must reference the external crate as normal.
 
 The `External` attribute can be specified on dictionaries, enums and errors.
 
+## External interface types
+
+If the external type is an [Interface](./interfaces.md), then use the `[ExternalInterface]` attribute instead of `[External]`:
+
+```idl
+[ExternalInterface="demo-crate"]
+typedef extern DemoInterface;
+```
+
 ## Foreign bindings
 
 The foreign bindings will also need to know how to access the external type,

--- a/fixtures/ext-types/lib/src/ext-types-lib.udl
+++ b/fixtures/ext-types/lib/src/ext-types-lib.udl
@@ -15,6 +15,8 @@ namespace imported_types_lib {
     sequence<UniffiOneEnum> get_uniffi_one_enums(sequence<UniffiOneEnum> es);
     UniffiOneEnum? get_maybe_uniffi_one_enum(UniffiOneEnum? e);
     sequence<UniffiOneEnum?> get_maybe_uniffi_one_enums(sequence<UniffiOneEnum?> es);
+
+    UniffiOneInterface get_uniffi_one_interface();
 };
 
 // A type defined in a .udl file in the `uniffi-one` crate (ie, in
@@ -24,6 +26,9 @@ typedef extern UniffiOneType;
 // An enum in the same crate
 [External="uniffi-one"]
 typedef extern UniffiOneEnum;
+// An interface in the same crate
+[ExternalInterface="uniffi-one"]
+typedef extern UniffiOneInterface;
 
 // A "wrapped" type defined in the guid crate (ie, defined in `../../guid/src/lib.rs` and
 // "declared" in `../../guid/src/guid.udl`). But it's still "external" from our POV,

--- a/fixtures/ext-types/lib/src/lib.rs
+++ b/fixtures/ext-types/lib/src/lib.rs
@@ -1,6 +1,7 @@
 use custom_types::Handle;
 use ext_types_guid::Guid;
-use uniffi_one::{UniffiOneEnum, UniffiOneType};
+use std::sync::Arc;
+use uniffi_one::{UniffiOneEnum, UniffiOneInterface, UniffiOneType};
 use url::Url;
 
 pub struct CombinedType {
@@ -101,6 +102,10 @@ fn get_maybe_uniffi_one_enum(e: Option<UniffiOneEnum>) -> Option<UniffiOneEnum> 
 
 fn get_maybe_uniffi_one_enums(es: Vec<Option<UniffiOneEnum>>) -> Vec<Option<UniffiOneEnum>> {
     es
+}
+
+fn get_uniffi_one_interface() -> Arc<UniffiOneInterface> {
+    Arc::new(UniffiOneInterface::new())
 }
 
 include!(concat!(env!("OUT_DIR"), "/ext-types-lib.uniffi.rs"));

--- a/fixtures/ext-types/uniffi-one/src/lib.rs
+++ b/fixtures/ext-types/uniffi-one/src/lib.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicI32, Ordering};
+
 pub struct UniffiOneType {
     pub sval: String,
 }
@@ -5,6 +7,21 @@ pub struct UniffiOneType {
 pub enum UniffiOneEnum {
     One,
     Two,
+}
+
+#[derive(Default)]
+pub struct UniffiOneInterface {
+    current: AtomicI32,
+}
+
+impl UniffiOneInterface {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn increment(&self) -> i32 {
+        self.current.fetch_add(1, Ordering::Relaxed) + 1
+    }
 }
 
 include!(concat!(env!("OUT_DIR"), "/uniffi-one.uniffi.rs"));

--- a/fixtures/ext-types/uniffi-one/src/uniffi-one.udl
+++ b/fixtures/ext-types/uniffi-one/src/uniffi-one.udl
@@ -8,3 +8,9 @@ enum UniffiOneEnum {
     "One",
     "Two",
 };
+
+interface UniffiOneInterface {
+    constructor();
+
+    i32 increment();
+};

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
@@ -86,7 +86,7 @@
 {%- when Type::Custom { name, builtin } %}
 {% include "CustomTypeTemplate.kt" %}
 
-{%- when Type::External { crate_name, name } %}
+{%- when Type::External { crate_name, name, kind } %}
 {% include "ExternalTypeTemplate.kt" %}
 
 {%- else %}

--- a/uniffi_bindgen/src/bindings/python/templates/Types.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Types.py
@@ -85,7 +85,7 @@
 {%- when Type::Custom { name, builtin } %}
 {%- include "CustomType.py" %}
 
-{%- when Type::External { name, crate_name } %}
+{%- when Type::External { name, crate_name, kind } %}
 {%- include "ExternalTemplate.py" %}
 
 {%- else %}

--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -86,3 +86,15 @@ public struct {{ ffi_converter_name }}: FfiConverter {
         return value.pointer
     }
 }
+
+{#
+We always write these public functions just in case the enum is used as
+an external type by another crate.
+#}
+public func {{ ffi_converter_name }}_lift(_ pointer: UnsafeMutableRawPointer) throws -> {{ type_name }} {
+    return try {{ ffi_converter_name }}.lift(pointer)
+}
+
+public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> UnsafeMutableRawPointer {
+    return {{ ffi_converter_name }}.lower(value)
+}

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -53,7 +53,7 @@ use std::{
 use anyhow::{bail, ensure, Result};
 
 pub mod types;
-pub use types::Type;
+pub use types::{ExternalKind, Type};
 use types::{TypeIterator, TypeUniverse};
 
 mod attributes;
@@ -245,9 +245,13 @@ impl ComponentInterface {
     }
 
     /// Get details about all `Type::External` types
-    pub fn iter_external_types(&self) -> impl Iterator<Item = (&String, &String)> {
+    pub fn iter_external_types(&self) -> impl Iterator<Item = (&String, &String, ExternalKind)> {
         self.types.iter_known_types().filter_map(|t| match t {
-            Type::External { name, crate_name } => Some((name, crate_name)),
+            Type::External {
+                name,
+                crate_name,
+                kind,
+            } => Some((name, crate_name, *kind)),
             _ => None,
         })
     }

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -79,12 +79,23 @@ mod filters {
         })
     }
 
-    // Map types to their fully-qualified `FfiConverter` impl.
+    // Map a type to Rust code that specifies the FfiConverter implementation.
+    //
+    // This outputs something like `<TheFfiConverterStruct as FfiConverter>`
     pub fn ffi_converter(type_: &Type) -> Result<String, askama::Error> {
-        Ok(format!(
-            "<{} as uniffi::FfiConverter<crate::UniFfiTag>>",
-            type_rs(type_)?
-        ))
+        Ok(match type_ {
+            Type::External {
+                name,
+                kind: ExternalKind::Interface,
+                ..
+            } => {
+                format!("<::std::sync::Arc<r#{name}> as uniffi::FfiConverter<crate::UniFfiTag>>")
+            }
+            _ => format!(
+                "<{} as uniffi::FfiConverter<crate::UniFfiTag>>",
+                type_rs(type_)?
+            ),
+        })
     }
 
     // Turns a `crate-name` into the `crate_name` the .rs code needs to specify.

--- a/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
@@ -1,9 +1,15 @@
 // Support for external types.
 
 // Types with an external `FfiConverter`...
-{% for (name, crate_name) in ci.iter_external_types() %}
+{% for (name, crate_name, kind) in ci.iter_external_types() %}
+{# For non-interface types, we need to import the FfiConverter for them.  Interface types use the generic `Arc<T>` impl. #}
+{%- match kind %}
+{%- when ExternalKind::DataClass %}
+// `{{ name }}` is defined in `{{ crate_name }}`
 ::uniffi::ffi_converter_forward!(r#{{ name }}, ::{{ crate_name|crate_name_rs }}::UniFfiTag, crate::UniFfiTag);
-{% endfor %}
+{%- else %}
+{%- endmatch %}
+{%- endfor %}
 
 // For custom scaffolding types we need to generate an FfiConverter impl based on the
 // UniffiCustomTypeConverter implementation that the library supplies


### PR DESCRIPTION
I though #1444 might fix this, since it improves some of the `FfiConverter` name handling, but there was a bigger issue:  interfaces have fundamental differences compared to enums/records when it comes to moving them across the FFI since. Interfaces use `Arc<>` on the Rust side and `void *` on the FFI side.

Added way to flag that external types are interfaces, updated the code to handle these correctly.

This feels a little hacky to me, but I think this won't be needed once we move to proc-macros:
  -   The proc-macros see the type names used in the function, so they can always figure out the correct `FfiConverter`
  - Using the `FfiConverter`, they can always know the correct argument and return types.  ([example](https://github.com/mozilla/uniffi-rs/blob/670eb225ab1742af44ab93c3e378ecd2c642432c/uniffi_macros/src/export/scaffolding.rs#L133))