### PR TITLE
Allow Rust traits to be exposed as an interface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,16 @@
   - UniFFI users will automatically get the benefits of this without any code changes.
   - External bindings authors will need to update their bindings code.  See PR #1494 for details.
 - ABI: Changed API checksum handling.  This affects external bindings authors who will need to update their code to work with the new system.  See PR #1469 for details.
+- Removed the long deprecated `ThreadSafe` attribute.
 
 ### What's changed
 
 - The `include_scaffolding!()` macro must now either be called from your crate root or you must have `use the_mod_that_calls_include_scaffolding::*` in your crate root.  This was always the expectation, but wasn't required before.  This will now start failing with errors that say `crate::UniFfiTag` does not exist.
 - proc-macros now work with many more types including type aliases, type paths, etc.
 - The `uniffi_types` module is no longer needed when using proc-macros.
+
+- Traits can be exposed as a UniFFI `interface` by using a `[Trait]` attribute in the UDL.
+  See [the documentation](https://mozilla.github.io/uniffi-rs/udl/interfaces.html#exposing-traits-as-interfaces).
 
 ## v0.23.0 (backend crates: v0.23.0) - (_2023-01-27_)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,15 @@ members = [
   "uniffi",
   "weedle2",
 
+  "examples/app/uniffi-bindgen-cli",
   "examples/arithmetic",
   "examples/callbacks",
+  "examples/custom-types",
   "examples/geometry",
   "examples/rondpoint",
   "examples/sprites",
   "examples/todolist",
-  "examples/custom-types",
-  "examples/app/uniffi-bindgen-cli",
+  "examples/traits",
 
   "fixtures/benchmarks",
   "fixtures/coverall",

--- a/examples/traits/Cargo.toml
+++ b/examples/traits/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "uniffi-example-traits"
+edition = "2021"
+version = "0.22.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "uniffi_traits"
+
+[dependencies]
+uniffi = {path = "../../uniffi"}
+thiserror = "1.0"
+
+[build-dependencies]
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }
+

--- a/examples/traits/build.rs
+++ b/examples/traits/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::generate_scaffolding("./src/traits.udl").unwrap();
+}

--- a/examples/traits/src/lib.rs
+++ b/examples/traits/src/lib.rs
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::sync::Arc;
+
+// namespace functions.
+fn get_buttons() -> Vec<Arc<dyn Button>> {
+    vec![Arc::new(StopButton {}), Arc::new(GoButton {})]
+}
+
+fn press(button: Arc<dyn Button>) -> Arc<dyn Button> {
+    button
+}
+
+pub trait Button: Send + Sync {
+    fn name(&self) -> String;
+}
+
+struct GoButton {}
+
+impl Button for GoButton {
+    fn name(&self) -> String {
+        "go".to_string()
+    }
+}
+
+struct StopButton {}
+
+impl Button for StopButton {
+    fn name(&self) -> String {
+        "stop".to_string()
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/traits.uniffi.rs"));

--- a/examples/traits/src/traits.udl
+++ b/examples/traits/src/traits.udl
@@ -1,0 +1,12 @@
+namespace traits {
+    // Get all the buttons we can press.
+    sequence<Button> get_buttons();
+    // press a button and return it.
+    Button press(Button button);
+};
+
+// This is a trait in Rust.
+[Trait]
+interface Button {
+    string name();
+};

--- a/examples/traits/tests/bindings/test_traits.py
+++ b/examples/traits/tests/bindings/test_traits.py
@@ -1,0 +1,7 @@
+from traits import *
+
+for button in get_buttons():
+    if button.name() in ["go", "stop"]:
+        press(button)
+    else:
+        print("unknown button", button)

--- a/examples/traits/tests/test_generated_bindings.rs
+++ b/examples/traits/tests/test_generated_bindings.rs
@@ -1,0 +1,1 @@
+uniffi::build_foreign_language_testcases!("tests/bindings/test_traits.py",);

--- a/examples/traits/uniffi.toml
+++ b/examples/traits/uniffi.toml
@@ -1,0 +1,9 @@
+[bindings.kotlin]
+package_name = "uniffi.traits"
+cdylib_name = "uniffi_traits"
+
+[bindings.swift]
+cdylib_name = "uniffi_traits"
+
+[bindings.python]
+cdylib_name = "uniffi_traits"

--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -4,6 +4,8 @@ namespace coverall {
 
     u64 get_num_alive();
 
+    sequence<TestTrait> get_traits();
+
     // void returning error throwing namespace function to catch clippy warnings (eg, #1330)
     [Throws=CoverallError]
     void println(string text);
@@ -29,6 +31,7 @@ dictionary SimpleDict {
     double float64;
     double? maybe_float64;
     Coveralls? coveralls;
+    TestTrait? test_trait;
 };
 
 dictionary DictWithDefaults {
@@ -149,4 +152,24 @@ interface ThreadsafeCounter {
   constructor();
   void busy_wait(i32 ms);
   i32 increment_if_busy();
+};
+
+// This is a trait implemented on the Rust side.
+[Trait]
+interface TestTrait {
+    string name(); // The name of the implementation
+
+    [Self=ByArc]
+    u64 number();
+
+    /// Calls `Arc::strong_count()` on the `Arc` containing `self`.
+    [Self=ByArc]
+    u64 strong_count();
+
+    /// Takes an `Arc<Self>` and stores it in `self`, dropping the existing
+    /// reference. Note you can create circular references by passing `self`.
+    void take_other(TestTrait? other);
+
+    /// Returns what was previously set via `take_other()`, or null.
+    TestTrait? get_other();
 };

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -9,6 +9,9 @@ use std::time::SystemTime;
 
 use once_cell::sync::Lazy;
 
+mod traits;
+pub use traits::{get_traits, TestTrait};
+
 static NUM_ALIVE: Lazy<RwLock<u64>> = Lazy::new(|| RwLock::new(0));
 
 #[derive(Debug, thiserror::Error)]
@@ -41,7 +44,7 @@ pub enum ComplexError {
     PermissionDenied { reason: String },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Default)]
 pub struct SimpleDict {
     text: String,
     maybe_text: Option<String>,
@@ -62,6 +65,7 @@ pub struct SimpleDict {
     float64: f64,
     maybe_float64: Option<f64>,
     coveralls: Option<Arc<Coveralls>>,
+    test_trait: Option<Arc<dyn TestTrait>>,
 }
 
 #[derive(Debug, Clone)]
@@ -98,30 +102,21 @@ fn create_some_dict() -> SimpleDict {
         float64: 0.0,
         maybe_float64: Some(1.0),
         coveralls: Some(Arc::new(Coveralls::new("some_dict".to_string()))),
+        test_trait: Some(Arc::new(traits::Trait2 {})),
     }
 }
 
 fn create_none_dict() -> SimpleDict {
     SimpleDict {
         text: "text".to_string(),
-        maybe_text: None,
         a_bool: true,
-        maybe_a_bool: None,
         unsigned8: 1,
-        maybe_unsigned8: None,
         unsigned16: 3,
-        maybe_unsigned16: None,
         unsigned64: u64::MAX,
-        maybe_unsigned64: None,
         signed8: 8,
-        maybe_signed8: None,
         signed64: i64::MAX,
-        maybe_signed64: None,
         float32: 1.2345,
-        maybe_float32: None,
-        float64: 0.0,
-        maybe_float64: None,
-        coveralls: None,
+        ..Default::default()
     }
 }
 

--- a/fixtures/coverall/src/traits.rs
+++ b/fixtures/coverall/src/traits.rs
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::sync::{Arc, Mutex};
+
+// namespace functions.
+pub fn get_traits() -> Vec<Arc<dyn TestTrait>> {
+    vec![
+        Arc::new(Trait1 {
+            ..Default::default()
+        }),
+        Arc::new(Trait2 {}),
+    ]
+}
+
+pub trait TestTrait: Send + Sync + std::fmt::Debug {
+    fn name(&self) -> String;
+
+    fn number(self: Arc<Self>) -> u64;
+
+    fn strong_count(self: Arc<Self>) -> u64 {
+        Arc::strong_count(&self) as u64
+    }
+
+    fn take_other(&self, other: Option<Arc<dyn TestTrait>>);
+
+    fn get_other(&self) -> Option<Arc<dyn TestTrait>>;
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct Trait1 {
+    // A reference to another trait.
+    other: Mutex<Option<Arc<dyn TestTrait>>>,
+}
+
+impl TestTrait for Trait1 {
+    fn name(&self) -> String {
+        "trait 1".to_string()
+    }
+
+    fn number(self: Arc<Self>) -> u64 {
+        1_u64
+    }
+
+    fn take_other(&self, other: Option<Arc<dyn TestTrait>>) {
+        *self.other.lock().unwrap() = other.map(|arc| Arc::clone(&arc))
+    }
+
+    fn get_other(&self) -> Option<Arc<dyn TestTrait>> {
+        (*self.other.lock().unwrap()).as_ref().map(Arc::clone)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Trait2 {}
+impl TestTrait for Trait2 {
+    fn name(&self) -> String {
+        "trait 2".to_string()
+    }
+
+    fn number(self: Arc<Self>) -> u64 {
+        2_u64
+    }
+
+    // Don't bother implementing these here - the test on the struct above is ok.
+    fn take_other(&self, _other: Option<Arc<dyn TestTrait>>) {
+        unimplemented!();
+    }
+
+    fn get_other(&self) -> Option<Arc<dyn TestTrait>> {
+        unimplemented!()
+    }
+}

--- a/fixtures/coverall/tests/bindings/test_coverall.py
+++ b/fixtures/coverall/tests/bindings/test_coverall.py
@@ -29,6 +29,7 @@ class TestCoverall(unittest.TestCase):
         self.assertEqual(d.signed64, 9223372036854775807)
         self.assertEqual(d.maybe_signed64, 0)
         self.assertEqual(d.coveralls.get_name(), "some_dict")
+        self.assertEqual(d.test_trait.name(), "trait 2")
 
         # floats should be "close enough" - although it's mildly surprising that
         # we need to specify `places=6` whereas the default is 7.
@@ -59,6 +60,7 @@ class TestCoverall(unittest.TestCase):
         self.assertAlmostEqual(d.float64, 0.0)
         self.assertIsNone(d.maybe_float64)
         self.assertIsNone(d.coveralls)
+        self.assertIsNone(d.test_trait)
 
     def test_constructors(self):
         self.assertEqual(get_num_alive(), 0)
@@ -211,6 +213,22 @@ class TestCoverall(unittest.TestCase):
 
         dict3 = coveralls.get_dict3(key=31, value=42)
         assert dict3[31] == 42
+
+class TraitsTest(unittest.TestCase):
+    def test_simple(self):
+        traits = get_traits()
+        self.assertEqual(traits[0].name(), "trait 1")
+        self.assertEqual(traits[0].number(), 1)
+        self.assertEqual(traits[0].strong_count(), 2)
+
+        self.assertEqual(traits[1].name(), "trait 2")
+        self.assertEqual(traits[1].number(), 2)
+        self.assertEqual(traits[1].strong_count(), 2)
+
+        traits[0].take_other(traits[1])
+        self.assertEqual(traits[1].strong_count(), 3)
+        self.assertEqual(traits[0].get_other().name(), "trait 2")
+        traits[0].take_other(None)
 
 if __name__=='__main__':
     unittest.main()

--- a/fixtures/uitests/src/trait.udl
+++ b/fixtures/uitests/src/trait.udl
@@ -1,0 +1,5 @@
+namespace uitests {};
+
+[Trait]
+interface Trait {
+};

--- a/fixtures/uitests/tests/ui/interface_trait_not_sync_and_send.rs
+++ b/fixtures/uitests/tests/ui/interface_trait_not_sync_and_send.rs
@@ -1,0 +1,8 @@
+// Unfortunately, path is relative to a temporary build directory :-/
+uniffi_macros::generate_and_include_scaffolding!("../../../../fixtures/uitests/src/trait.udl");
+
+fn main() { /* empty main required by `trybuild` */}
+
+// This will fail to compile, because the trait is not explicit Send+Sync
+pub trait Trait {
+}

--- a/fixtures/uitests/tests/ui/interface_trait_not_sync_and_send.stderr
+++ b/fixtures/uitests/tests/ui/interface_trait_not_sync_and_send.stderr
@@ -1,0 +1,27 @@
+error[E0277]: `dyn Trait` cannot be shared between threads safely
+ --> $OUT_DIR[uniffi_uitests]/trait.uniffi.rs
+  |
+  | uniffi::deps::static_assertions::assert_impl_all!(dyn r#Trait: Sync, Send);
+  |                                                   ^^^^^^^^^^^ `dyn Trait` cannot be shared between threads safely
+  |
+  = help: the trait `Sync` is not implemented for `dyn Trait`
+note: required by a bound in `assert_impl_all`
+ --> $OUT_DIR[uniffi_uitests]/trait.uniffi.rs
+  |
+  | uniffi::deps::static_assertions::assert_impl_all!(dyn r#Trait: Sync, Send);
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+  = note: this error originates in the macro `uniffi::deps::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `dyn Trait` cannot be sent between threads safely
+ --> $OUT_DIR[uniffi_uitests]/trait.uniffi.rs
+  |
+  | uniffi::deps::static_assertions::assert_impl_all!(dyn r#Trait: Sync, Send);
+  |                                                   ^^^^^^^^^^^ `dyn Trait` cannot be sent between threads safely
+  |
+  = help: the trait `Send` is not implemented for `dyn Trait`
+note: required by a bound in `assert_impl_all`
+ --> $OUT_DIR[uniffi_uitests]/trait.uniffi.rs
+  |
+  | uniffi::deps::static_assertions::assert_impl_all!(dyn r#Trait: Sync, Send);
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+  = note: this error originates in the macro `uniffi::deps::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -247,7 +247,7 @@ impl KotlinCodeOracle {
             Type::Duration => Box::new(miscellany::DurationCodeType),
 
             Type::Enum(id) => Box::new(enum_::EnumCodeType::new(id)),
-            Type::Object(id) => Box::new(object::ObjectCodeType::new(id)),
+            Type::Object { name, .. } => Box::new(object::ObjectCodeType::new(name)),
             Type::Record(id) => Box::new(record::RecordCodeType::new(id)),
             Type::Error(id) => Box::new(error::ErrorCodeType::new(id)),
             Type::CallbackInterface(id) => {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
@@ -59,7 +59,7 @@
 {%- when Type::Error(name) %}
 {% include "ErrorTemplate.kt" %}
 
-{%- when Type::Object(name) %}
+{%- when Type::Object { name, imp } %}
 {% include "ObjectTemplate.kt" %}
 
 {%- when Type::Record(name) %}

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -293,7 +293,7 @@ impl PythonCodeOracle {
             Type::Duration => Box::new(miscellany::DurationCodeType),
 
             Type::Enum(id) => Box::new(enum_::EnumCodeType::new(id)),
-            Type::Object(id) => Box::new(object::ObjectCodeType::new(id)),
+            Type::Object { name, .. } => Box::new(object::ObjectCodeType::new(name)),
             Type::Record(id) => Box::new(record::RecordCodeType::new(id)),
             Type::Error(id) => Box::new(error::ErrorCodeType::new(id)),
             Type::CallbackInterface(id) => {

--- a/uniffi_bindgen/src/bindings/python/templates/Types.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Types.py
@@ -61,7 +61,7 @@
 {%- when Type::Record(name) %}
 {%- include "RecordTemplate.py" %}
 
-{%- when Type::Object(name) %}
+{%- when Type::Object { name, imp } %}
 {%- include "ObjectTemplate.py" %}
 
 {%- when Type::Timestamp %}

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -163,7 +163,9 @@ mod filters {
             | Type::UInt64 => format!("{nm}.to_i"), // TODO: check max/min value
             Type::Float32 | Type::Float64 => format!("{nm}.to_f"),
             Type::Boolean => format!("{nm} ? true : false"),
-            Type::Object(_) | Type::Enum(_) | Type::Error(_) | Type::Record(_) => nm.to_string(),
+            Type::Object { .. } | Type::Enum(_) | Type::Error(_) | Type::Record(_) => {
+                nm.to_string()
+            }
             Type::String => format!("{nm}.to_s"),
             Type::Timestamp | Type::Duration => nm.to_string(),
             Type::CallbackInterface(_) => panic!("No support for coercing callback interfaces yet"),
@@ -207,7 +209,7 @@ mod filters {
             | Type::Float64 => nm.to_string(),
             Type::Boolean => format!("({nm} ? 1 : 0)"),
             Type::String => format!("RustBuffer.allocFromString({nm})"),
-            Type::Object(name) => format!("({}._uniffi_lower {nm})", class_name_rb(name)?),
+            Type::Object { name, .. } => format!("({}._uniffi_lower {nm})", class_name_rb(name)?),
             Type::CallbackInterface(_) => panic!("No support for lowering callback interfaces yet"),
             Type::Error(_) => panic!("No support for lowering errors, yet"),
             Type::Enum(_)
@@ -239,7 +241,7 @@ mod filters {
             Type::Float32 | Type::Float64 => format!("{nm}.to_f"),
             Type::Boolean => format!("1 == {nm}"),
             Type::String => format!("{nm}.consumeIntoString"),
-            Type::Object(name) => format!("{}._uniffi_allocate({nm})", class_name_rb(name)?),
+            Type::Object { name, .. } => format!("{}._uniffi_allocate({nm})", class_name_rb(name)?),
             Type::CallbackInterface(_) => panic!("No support for lifting callback interfaces, yet"),
             Type::Error(_) => panic!("No support for lowering errors, yet"),
             Type::Enum(_)

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -143,7 +143,7 @@ class RustBufferBuilder
     pack_into 4, 'L>', nanoseconds
   end
 
-  {% when Type::Object with (object_name) -%}
+  {% when Type::Object with { name: object_name, imp } -%}
   # The Object type {{ object_name }}.
 
   def write_{{ canonical_type_name }}(obj)

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
@@ -140,7 +140,7 @@ class RustBufferStream
     Time.at(seconds, nanoseconds, :nanosecond, in: '+00:00').utc
   end
 
-  {% when Type::Object with (object_name) -%}
+  {% when Type::Object with { name: object_name, imp } -%}
   # The Object type {{ object_name }}.
 
   def read{{ canonical_type_name }}

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -313,7 +313,7 @@ impl SwiftCodeOracle {
             Type::Duration => Box::new(miscellany::DurationCodeType),
 
             Type::Enum(id) => Box::new(enum_::EnumCodeType::new(id)),
-            Type::Object(id) => Box::new(object::ObjectCodeType::new(id)),
+            Type::Object { name, .. } => Box::new(object::ObjectCodeType::new(name)),
             Type::Record(id) => Box::new(record::RecordCodeType::new(id)),
             Type::Error(id) => Box::new(error::ErrorCodeType::new(id)),
             Type::CallbackInterface(id) => {

--- a/uniffi_bindgen/src/bindings/swift/templates/Types.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Types.swift
@@ -70,7 +70,7 @@
 {%- when Type::Error(name) %}
 {%- include "ErrorTemplate.swift" %}
 
-{%- when Type::Object(name) %}
+{%- when Type::Object{ name, imp } %}
 {%- include "ObjectTemplate.swift" %}
 
 {%- when Type::Record(name) %}

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -268,7 +268,7 @@ impl APIConverter<Field> for weedle::argument::Argument<'_> {
 impl APIConverter<Field> for weedle::argument::SingleArgument<'_> {
     fn convert(&self, ci: &mut ComponentInterface) -> Result<Field> {
         let type_ = ci.resolve_type_expression(&self.type_)?;
-        if let Type::Object(_) = type_ {
+        if let Type::Object { .. } = type_ {
             bail!("Objects cannot currently be used in enum variant data");
         }
         if self.default.is_some() {

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -39,7 +39,7 @@ use uniffi_meta::Checksum;
 use super::attributes::{ArgumentAttributes, Attribute, FunctionAttributes};
 use super::ffi::{FfiArgument, FfiFunction};
 use super::literal::{convert_default_value, Literal};
-use super::types::{Type, TypeIterator};
+use super::types::{ObjectImpl, Type, TypeIterator};
 use super::{convert_type, APIConverter, ComponentInterface};
 
 /// Represents a standalone function.
@@ -229,6 +229,10 @@ impl Argument {
 
     pub fn by_ref(&self) -> bool {
         self.by_ref
+    }
+
+    pub fn is_trait_ref(&self) -> bool {
+        matches!(&self.type_, Type::Object { imp, .. } if *imp == ObjectImpl::Trait)
     }
 
     pub fn default_value(&self) -> Option<&Literal> {

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -43,7 +43,7 @@ mod filters {
             Type::Timestamp => "std::time::SystemTime".into(),
             Type::Duration => "std::time::Duration".into(),
             Type::Enum(name) | Type::Record(name) | Type::Error(name) => format!("r#{name}"),
-            Type::Object(name) => format!("std::sync::Arc<r#{name}>"),
+            Type::Object { name, imp } => format!("std::sync::Arc<{}>", imp.rust_name_for(name)),
             Type::CallbackInterface(name) => format!("Box<dyn r#{name}>"),
             Type::Optional(t) => format!("std::option::Option<{}>", type_rs(t)?),
             Type::Sequence(t) => format!("std::vec::Vec<{}>", type_rs(t)?),

--- a/uniffi_bindgen/src/scaffolding/templates/macros.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/macros.rs
@@ -10,8 +10,14 @@ r#{{ func.name() }}({% call _arg_list_rs_call(func) -%})
     {%- for arg in func.full_arguments() %}
         match {{- arg.type_().borrow()|ffi_converter }}::try_lift(r#{{ arg.name() }}) {
         {%- if arg.by_ref() %}
+        {#  args passed by reference get special treatment for traits and their Box<> #}
+        {%-     if arg.is_trait_ref() %}
+            Ok(ref val) => &**val,
+        {%-     else %}
             Ok(ref val) => val,
+        {%-     endif %}
         {%- else %}
+        {#  args not passed by reference get passed directly #}
             Ok(val) => val,
         {%- endif %}
 


### PR DESCRIPTION
This PR allows Rust traits to be exposed as interfaces, including when they have associated types. It supersedes #1308 (the memory leaks discussed there were easy to resolve once the other shoe dropped for me)

Instead of repeating what I hope are comprehensive docs and tests, please see the [docs for this](https://github.com/mhammond/uniffi-rs/blob/traits-types/docs/manual/src/udl/interfaces.md#exposing-traits-as-interfaces), see the [new example](https://github.com/mhammond/uniffi-rs/tree/traits-types/examples/traits) (and the coveralls fixture exercises them quite thoroughly).

It has required zero changes to the generated bindings and it all fell out quite cleanly IMO. I've also got a POC in application-services for my specific use-case there, and it works perfectly!
