### PR TITLE
Split out bindgen feature from full CLI

### DIFF
--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -30,9 +30,12 @@ default = []
 # Support for features needed by the `build.rs` script. Enable this in your
 # `build-dependencies`.
 build = [ "dep:uniffi_build" ]
+# Support for `uniffi_bindgen::{generate_bindings, generate_component_scaffolding}`.
+# Enable this feature for your `uniffi-bindgen` binaries if you don't need the full CLI.
+bindgen = ["dep:uniffi_bindgen"]
 # Support for `uniffi_bindgen_run_main()`. Enable this feature for your
 # `uniffi-bindgen` binaries.
-cli = [ "dep:uniffi_bindgen", "dep:clap", "dep:camino" ]
+cli = [ "bindgen", "dep:clap", "dep:camino" ]
 # Support for running example/fixture tests for `uniffi-bindgen`.  You probably
 # don't need to enable this.
 bindgen-tests = [ "dep:uniffi_bindgen" ]

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -15,7 +15,7 @@ pub use uniffi_bindgen::bindings::python::run_test as python_run_test;
 pub use uniffi_bindgen::bindings::ruby::run_test as ruby_run_test;
 #[cfg(feature = "bindgen-tests")]
 pub use uniffi_bindgen::bindings::swift::run_test as swift_run_test;
-#[cfg(feature = "cli")]
+#[cfg(feature = "bindgen")]
 pub use uniffi_bindgen::{generate_bindings, generate_component_scaffolding, print_json};
 #[cfg(feature = "build")]
 pub use uniffi_build::generate_scaffolding;


### PR DESCRIPTION
This allows consumers to avoid the clap dependency if they don't require the full CLI (with argument parsing).

Fixes #1416 