### PR TITLE
Add support for external callback interfaces

### DIFF
--- a/fixtures/ext-types/lib/src/ext-types-lib.udl
+++ b/fixtures/ext-types/lib/src/ext-types-lib.udl
@@ -31,7 +31,7 @@ typedef extern UniffiOneEnum;
 [ExternalInterface="uniffi-one"]
 typedef extern UniffiOneInterface;
 
-[ExternalInterface="uniffi-one"]
+[ExternalCallbackInterface="uniffi-one"]
 typedef extern UniffiOneCallbackInterface;
 
 // A "wrapped" type defined in the guid crate (ie, defined in `../../guid/src/lib.rs` and

--- a/fixtures/ext-types/lib/src/ext-types-lib.udl
+++ b/fixtures/ext-types/lib/src/ext-types-lib.udl
@@ -17,7 +17,7 @@ namespace imported_types_lib {
     sequence<UniffiOneEnum?> get_maybe_uniffi_one_enums(sequence<UniffiOneEnum?> es);
 
     UniffiOneInterface get_uniffi_one_interface();
-    void use_uniffi_one_callback_interface(UniffiOneCallbackInterface iface);
+    string use_uniffi_one_callback_interface(UniffiOneCallbackInterface iface);
 };
 
 // A type defined in a .udl file in the `uniffi-one` crate (ie, in

--- a/fixtures/ext-types/lib/src/ext-types-lib.udl
+++ b/fixtures/ext-types/lib/src/ext-types-lib.udl
@@ -17,6 +17,7 @@ namespace imported_types_lib {
     sequence<UniffiOneEnum?> get_maybe_uniffi_one_enums(sequence<UniffiOneEnum?> es);
 
     UniffiOneInterface get_uniffi_one_interface();
+    void use_uniffi_one_callback_interface(UniffiOneCallbackInterface iface);
 };
 
 // A type defined in a .udl file in the `uniffi-one` crate (ie, in
@@ -29,6 +30,9 @@ typedef extern UniffiOneEnum;
 // An interface in the same crate
 [ExternalInterface="uniffi-one"]
 typedef extern UniffiOneInterface;
+
+[ExternalInterface="uniffi-one"]
+typedef extern UniffiOneCallbackInterface;
 
 // A "wrapped" type defined in the guid crate (ie, defined in `../../guid/src/lib.rs` and
 // "declared" in `../../guid/src/guid.udl`). But it's still "external" from our POV,

--- a/fixtures/ext-types/lib/src/lib.rs
+++ b/fixtures/ext-types/lib/src/lib.rs
@@ -108,8 +108,8 @@ fn get_uniffi_one_interface() -> Arc<UniffiOneInterface> {
     Arc::new(UniffiOneInterface::new())
 }
 
-fn use_uniffi_one_callback_interface(iface: Box<dyn UniffiOneCallbackInterface>) {
-    iface.on_done();
+fn use_uniffi_one_callback_interface(iface: Box<dyn UniffiOneCallbackInterface>) -> String {
+    return iface.on_done("fromrust".to_string());
 }
 
 include!(concat!(env!("OUT_DIR"), "/ext-types-lib.uniffi.rs"));

--- a/fixtures/ext-types/lib/src/lib.rs
+++ b/fixtures/ext-types/lib/src/lib.rs
@@ -1,7 +1,7 @@
 use custom_types::Handle;
 use ext_types_guid::Guid;
 use std::sync::Arc;
-use uniffi_one::{UniffiOneEnum, UniffiOneInterface, UniffiOneType};
+use uniffi_one::{UniffiOneCallbackInterface, UniffiOneEnum, UniffiOneInterface, UniffiOneType};
 use url::Url;
 
 pub struct CombinedType {
@@ -106,6 +106,10 @@ fn get_maybe_uniffi_one_enums(es: Vec<Option<UniffiOneEnum>>) -> Vec<Option<Unif
 
 fn get_uniffi_one_interface() -> Arc<UniffiOneInterface> {
     Arc::new(UniffiOneInterface::new())
+}
+
+fn use_uniffi_one_callback_interface(iface: Box<dyn UniffiOneCallbackInterface>) {
+    iface.on_done();
 }
 
 include!(concat!(env!("OUT_DIR"), "/ext-types-lib.uniffi.rs"));

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.kts
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.kts
@@ -5,6 +5,10 @@
 import uniffi.imported_types_lib.*
 import uniffi.uniffi_one.*
 
+class CallbackInterfaceImpl(): UniffiOneCallbackInterface {
+    override fun onDone(doneVal: String): String = doneVal + "-fromkotlin"
+}
+
 val ct = getCombinedType(null)
 assert(ct.uot.sval == "hello")
 assert(ct.guid ==  "a-guid")
@@ -33,3 +37,6 @@ assert(getMaybeUniffiOneEnum(uoe)!! == uoe)
 assert(getMaybeUniffiOneEnum(null) == null)
 assert(getUniffiOneEnums(listOf(uoe)) == listOf(uoe))
 assert(getMaybeUniffiOneEnums(listOf(uoe, null)) == listOf(uoe, null))
+
+val cb = CallbackInterfaceImpl()
+assert(useUniffiOneCallbackInterface(cb) == "fromrust-fromkotlin")

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.py
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.py
@@ -7,6 +7,10 @@ import urllib
 from imported_types_lib import *
 from uniffi_one import *
 
+class CallbackInterfaceImpl(UniffiOneCallbackInterface):
+    def on_done(self, done_val):
+        return f"{done_val}-frompython"
+
 class TestIt(unittest.TestCase):
     def test_it(self):
         ct = get_combined_type(None)
@@ -42,6 +46,15 @@ class TestIt(unittest.TestCase):
         self.assertEqual(None, get_maybe_uniffi_one_enum(None))
         self.assertEqual([e], get_uniffi_one_enums([e]))
         self.assertEqual([e, None], get_maybe_uniffi_one_enums([e, None]))
+
+    def test_get_uniffi_one_interface(self):
+        assert(isinstance(get_uniffi_one_interface(), UniffiOneInterface))
+
+    def test_use_uniffi_one_callback_interface(self):
+        cb_interface = CallbackInterfaceImpl()
+        self.assertEqual(use_uniffi_one_callback_interface(cb_interface), "fromrust-frompython")
+
+
 
 
 if __name__=='__main__':

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.swift
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.swift
@@ -6,6 +6,11 @@ import imported_types_lib
 //import uniffi_one
 import Foundation
 
+class CallbackInterfaceImpl: UniffiOneCallbackInterface {
+    func onDone(doneVal: String) -> String { doneVal + "-fromswift" }
+}
+
+
 let ct = getCombinedType(value: nil)
 assert(ct.uot.sval == "hello")
 assert(ct.guid ==  "a-guid")
@@ -32,3 +37,6 @@ assert(getMaybeUniffiOneEnum(e: UniffiOneEnum.one)! == UniffiOneEnum.one)
 assert(getMaybeUniffiOneEnum(e: nil) == nil)
 assert(getUniffiOneEnums(es: [UniffiOneEnum.one]) == [UniffiOneEnum.one])
 assert(getMaybeUniffiOneEnums(es: [UniffiOneEnum.one, nil]) == [UniffiOneEnum.one, nil])
+
+let cb = CallbackInterfaceImpl()
+assert(useUniffiOneCallbackInterface(iface: cb) == "fromrust-fromkotlin")

--- a/fixtures/ext-types/uniffi-one/src/lib.rs
+++ b/fixtures/ext-types/uniffi-one/src/lib.rs
@@ -25,7 +25,7 @@ impl UniffiOneInterface {
 }
 
 pub trait UniffiOneCallbackInterface: Send + Sync {
-    fn on_done(&self);
+    fn on_done(&self, done_val: String) -> String;
 }
 
 include!(concat!(env!("OUT_DIR"), "/uniffi-one.uniffi.rs"));

--- a/fixtures/ext-types/uniffi-one/src/lib.rs
+++ b/fixtures/ext-types/uniffi-one/src/lib.rs
@@ -24,4 +24,8 @@ impl UniffiOneInterface {
     }
 }
 
+pub trait UniffiOneCallbackInterface: Send + Sync {
+    fn on_done(&self);
+}
+
 include!(concat!(env!("OUT_DIR"), "/uniffi-one.uniffi.rs"));

--- a/fixtures/ext-types/uniffi-one/src/uniffi-one.udl
+++ b/fixtures/ext-types/uniffi-one/src/uniffi-one.udl
@@ -14,3 +14,8 @@ interface UniffiOneInterface {
 
     i32 increment();
 };
+
+
+callback interface UniffiOneCallbackInterface {
+    void on_done();
+};

--- a/fixtures/ext-types/uniffi-one/src/uniffi-one.udl
+++ b/fixtures/ext-types/uniffi-one/src/uniffi-one.udl
@@ -17,5 +17,5 @@ interface UniffiOneInterface {
 
 
 callback interface UniffiOneCallbackInterface {
-    void on_done();
+    string on_done(string done_val);
 };

--- a/uniffi_bindgen/src/bindings/python/gen_python/callback_interface.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/callback_interface.rs
@@ -20,7 +20,7 @@ impl CodeType for CallbackInterfaceCodeType {
     }
 
     fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
-        format!("CallbackInterface{}", self.id)
+        format!("Type{}", self.id)
     }
 
     fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {

--- a/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceTemplate.py
@@ -93,6 +93,9 @@ def py_{{ foreign_callback }}(handle, method, args, buf_ptr):
     # See docs of ForeignCallback in `uniffi/src/ffi/foreigncallbacks.rs`
     return -1
 
+# expose the converter type in case this is called externally by another python component
+FfiConverterType{{ type_name }} = {{ type_name }}
+
 # We need to keep this function reference alive:
 # if they get GC'd while in use then UniFFI internals could attempt to call a function
 # that is in freed memory.

--- a/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceTemplate.py
@@ -93,9 +93,6 @@ def py_{{ foreign_callback }}(handle, method, args, buf_ptr):
     # See docs of ForeignCallback in `uniffi/src/ffi/foreigncallbacks.rs`
     return -1
 
-# expose the converter type in case this is called externally by another python component
-FfiConverterType{{ type_name }} = {{ type_name }}
-
 # We need to keep this function reference alive:
 # if they get GC'd while in use then UniFFI internals could attempt to call a function
 # that is in freed memory.

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/callback_interface.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/callback_interface.rs
@@ -20,6 +20,6 @@ impl CodeType for CallbackInterfaceCodeType {
     }
 
     fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
-        format!("CallbackInterface{}", self.type_label(oracle))
+        format!("Type{}", self.type_label(oracle))
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
@@ -152,3 +152,19 @@ extension {{ ffi_converter_name }} : FfiConverter {
         writeInt(&buf, lower(v))
     }
 }
+
+{#
+We always write these public functions just in case the struct is used as
+an external type by another crate.
+
+Use UInt64 instead of the UniFFICallbackHandle typealias, because the typealias is fileprivate.
+Note: we can't make the typealias public
+#}
+
+public func {{ ffi_converter_name }}_lift(_ handle: UInt64) throws -> {{ type_name }} {
+    return try {{ ffi_converter_name }}.lift(handle)
+}
+
+public func {{ ffi_converter_name }}_lower(_ v: {{ type_name }}) -> UInt64 {
+    return {{ ffi_converter_name }}.lower(v)
+}

--- a/uniffi_bindgen/src/interface/attributes.rs
+++ b/uniffi_bindgen/src/interface/attributes.rs
@@ -755,14 +755,14 @@ mod test {
         assert_eq!(attrs.get_crate_name(), "crate_name");
 
         let (_, node) =
-            weedle::attribute::ExtendedAttributeList::parse("[ExternalInterface=crate_name ]")
+            weedle::attribute::ExtendedAttributeList::parse("[ExternalInterface=crate_name]")
                 .unwrap();
         let attrs = TypedefAttributes::try_from(&node).unwrap();
         assert!(!attrs.is_custom());
         assert_eq!(attrs.get_crate_name(), "crate_name");
 
         let (_, node) = weedle::attribute::ExtendedAttributeList::parse(
-            "[ExternalCallbackInterface=crate_name ]",
+            "[ExternalCallbackInterface=crate_name]",
         )
         .unwrap();
         let attrs = TypedefAttributes::try_from(&node).unwrap();

--- a/uniffi_bindgen/src/interface/attributes.rs
+++ b/uniffi_bindgen/src/interface/attributes.rs
@@ -81,6 +81,10 @@ impl TryFrom<&weedle::attribute::ExtendedAttribute<'_>> for Attribute {
                         crate_name: name_from_id_or_string(&identity.rhs),
                         kind: ExternalKind::Interface,
                     }),
+                    "ExternalCallbackInterface" => Ok(Attribute::External {
+                        crate_name: name_from_id_or_string(&identity.rhs),
+                        kind: ExternalKind::CallbackInterface,
+                    }),
                     _ => anyhow::bail!(
                         "Attribute identity Identifier not supported: {:?}",
                         identity.lhs_identifier.0
@@ -753,6 +757,14 @@ mod test {
         let (_, node) =
             weedle::attribute::ExtendedAttributeList::parse("[ExternalInterface=crate_name ]")
                 .unwrap();
+        let attrs = TypedefAttributes::try_from(&node).unwrap();
+        assert!(!attrs.is_custom());
+        assert_eq!(attrs.get_crate_name(), "crate_name");
+
+        let (_, node) = weedle::attribute::ExtendedAttributeList::parse(
+            "[ExternalCallbackInterface=crate_name ]",
+        )
+        .unwrap();
         let attrs = TypedefAttributes::try_from(&node).unwrap();
         assert!(!attrs.is_custom());
         assert_eq!(attrs.get_crate_name(), "crate_name");

--- a/uniffi_bindgen/src/interface/types/finder.rs
+++ b/uniffi_bindgen/src/interface/types/finder.rs
@@ -216,6 +216,9 @@ mod test {
             [ExternalInterface="crate-name"]
             typedef extern ExternalInterfaceType;
 
+            [ExternalCallbackInterface="crate-name"]
+            typedef extern ExternalCallbackInterfaceType;
+
             [Custom]
             typedef string CustomType;
         "#,
@@ -227,6 +230,10 @@ mod test {
                 assert!(
                     matches!(types.get_type_definition("ExternalInterfaceType").unwrap(), Type::External { name, crate_name, kind: ExternalKind::Interface }
                                                                                  if name == "ExternalInterfaceType" && crate_name == "crate-name")
+                );
+                assert!(
+                    matches!(types.get_type_definition("ExternalCallbackInterfaceType").unwrap(), Type::External { name, crate_name, kind: ExternalKind::CallbackInterface }
+                                                                                 if name == "ExternalCallbackInterfaceType" && crate_name == "crate-name")
                 );
                 assert!(
                     matches!(types.get_type_definition("CustomType").unwrap(), Type::Custom { name, builtin }

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -85,6 +85,7 @@ pub enum Type {
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Checksum, Ord, PartialOrd)]
 pub enum ExternalKind {
     Interface,
+    CallbackInterface,
     // Either a record or enum
     DataClass,
 }
@@ -200,6 +201,10 @@ impl From<&Type> for FfiType {
                 kind: ExternalKind::Interface,
                 ..
             } => FfiType::RustArcPtr(name.clone()),
+            Type::External {
+                kind: ExternalKind::CallbackInterface,
+                ..
+            } => FfiType::UInt64,
             Type::External {
                 name,
                 kind: ExternalKind::DataClass,

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -91,6 +91,13 @@ mod filters {
             } => {
                 format!("<::std::sync::Arc<r#{name}> as uniffi::FfiConverter<crate::UniFfiTag>>")
             }
+            Type::External {
+                name,
+                kind: ExternalKind::CallbackInterface,
+                ..
+            } => {
+                format!("<Box<dyn r#{name}> as uniffi::FfiConverter<crate::UniFfiTag>>")
+            }
             _ => format!(
                 "<{} as uniffi::FfiConverter<crate::UniFfiTag>>",
                 type_rs(type_)?

--- a/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
@@ -8,6 +8,8 @@
 ::uniffi::ffi_converter_forward!(r#{{ name }}, ::{{ crate_name|crate_name_rs }}::UniFfiTag, crate::UniFfiTag);
 {%- when ExternalKind::Interface %}
 ::uniffi::ffi_converter_forward!(::std::sync::Arc<r#{{ name }}>, ::{{ crate_name|crate_name_rs }}::UniFfiTag, crate::UniFfiTag);
+{%- when ExternalKind::CallbackInterface %}
+::uniffi::ffi_converter_forward!(Box<dyn r#{{ name }}>, ::{{ crate_name|crate_name_rs }}::UniFfiTag, crate::UniFfiTag);
 {%- endmatch %}
 {%- endfor %}
 


### PR DESCRIPTION
## Background
- I just tried to ingest the changes from https://github.com/mozilla/uniffi-rs/pull/1456 but my callback interface still failed.
- I originally made this PR to add some fixtures that would reproduce the issue
- I tried to implement the CallbackInterface while I was messing around in here but I cant get all the tests to pass. I think there is a problem with the platform binding generation. 

## Changes
- Add support for `ExternalKind::CallbackInterface`

## Testing
- [x] Added test cases
- [ ] Tests pass
- [x] Added external callback fixture
- [x] Manually built the fixtures lib which happily compiled
