### PR TITLE
Update module.md

### DIFF
--- a/docs/manual/src/swift/module.md
+++ b/docs/manual/src/swift/module.md
@@ -23,3 +23,7 @@ swiftc
 
 This will produce an `example.swiftmodule` file that can be loaded by
 other Swift code or used from the Swift command-line REPL.
+
+If you are creating an XCFramework with this code, make sure to rename the modulemap file
+to `module.modulemap`, the default value expected by Clang and XCFrameworks for exposing
+the C FFI library to Swift.


### PR DESCRIPTION
I thought about suggesting that the code be changed to always name the module `module.modulemap`, but including some documentation for folks who are attempting to create an XCFramework solves the same issue. (It took me an embarrassingly long time to find out that _not_ having this file named `module.modulemap` was the cause for an otherwise silent failure, reporting the module was unable to be imported in Swift.