### PR TITLE
[CLIPPY] Update templates to allow generated scaffolding to pass pedantic clippy

### DIFF
--- a/uniffi_bindgen/src/scaffolding/templates/ReexportUniFFIScaffolding.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ReexportUniFFIScaffolding.rs
@@ -11,10 +11,11 @@
 // megazord).  The combined library has a cargo dependency for each component and calls
 // uniffi_reexport_scaffolding!() for each one.
 
+#[allow(clippy::missing_docs_in_private_items)]
 #[doc(hidden)]
-pub fn uniffi_reexport_hack() {
-}
+pub const fn uniffi_reexport_hack() {}
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! uniffi_reexport_scaffolding {
     () => {

--- a/uniffi_bindgen/src/scaffolding/templates/ReexportUniFFIScaffolding.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ReexportUniFFIScaffolding.rs
@@ -11,7 +11,7 @@
 // megazord).  The combined library has a cargo dependency for each component and calls
 // uniffi_reexport_scaffolding!() for each one.
 
-#[allow(clippy::missing_docs_in_private_items)]
+#[allow(missing_docs)]
 #[doc(hidden)]
 pub const fn uniffi_reexport_hack() {}
 

--- a/uniffi_bindgen/src/scaffolding/templates/RustBuffer.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/RustBuffer.rs
@@ -2,25 +2,29 @@
 //
 // See `uniffi/src/ffi/rustbuffer.rs` for documentation on these functions
 
-#[allow(clippy::missing_safety_doc)]
+#[allow(clippy::missing_safety_doc, clippy::missing_docs_in_private_items)]
+#[doc(hidden)]
 #[no_mangle]
 pub extern "C" fn {{ ci.ffi_rustbuffer_alloc().name() }}(size: i32, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
     uniffi::ffi::uniffi_rustbuffer_alloc(size, call_status)
 }
 
-#[allow(clippy::missing_safety_doc)]
+#[allow(clippy::missing_safety_doc, clippy::missing_docs_in_private_items)]
+#[doc(hidden)]
 #[no_mangle]
 pub unsafe extern "C" fn {{ ci.ffi_rustbuffer_from_bytes().name() }}(bytes: uniffi::ForeignBytes, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
     uniffi::ffi::uniffi_rustbuffer_from_bytes(bytes, call_status)
 }
 
-#[allow(clippy::missing_safety_doc)]
+#[allow(clippy::missing_safety_doc, clippy::missing_docs_in_private_items)]
+#[doc(hidden)]
 #[no_mangle]
 pub unsafe extern "C" fn {{ ci.ffi_rustbuffer_free().name() }}(buf: uniffi::RustBuffer, call_status: &mut uniffi::RustCallStatus) {
-    uniffi::ffi::uniffi_rustbuffer_free(buf, call_status)
+    uniffi::ffi::uniffi_rustbuffer_free(buf, call_status);
 }
 
-#[allow(clippy::missing_safety_doc)]
+#[allow(clippy::missing_safety_doc, clippy::missing_docs_in_private_items)]
+#[doc(hidden)]
 #[no_mangle]
 pub unsafe extern "C" fn {{ ci.ffi_rustbuffer_reserve().name() }}(buf: uniffi::RustBuffer, additional: i32, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
     uniffi::ffi::uniffi_rustbuffer_reserve(buf, additional, call_status)

--- a/uniffi_bindgen/src/scaffolding/templates/RustBuffer.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/RustBuffer.rs
@@ -2,28 +2,28 @@
 //
 // See `uniffi/src/ffi/rustbuffer.rs` for documentation on these functions
 
-#[allow(clippy::missing_safety_doc, clippy::missing_docs_in_private_items)]
+#[allow(clippy::missing_safety_doc, missing_docs)]
 #[doc(hidden)]
 #[no_mangle]
 pub extern "C" fn {{ ci.ffi_rustbuffer_alloc().name() }}(size: i32, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
     uniffi::ffi::uniffi_rustbuffer_alloc(size, call_status)
 }
 
-#[allow(clippy::missing_safety_doc, clippy::missing_docs_in_private_items)]
+#[allow(clippy::missing_safety_doc, missing_docs)]
 #[doc(hidden)]
 #[no_mangle]
 pub unsafe extern "C" fn {{ ci.ffi_rustbuffer_from_bytes().name() }}(bytes: uniffi::ForeignBytes, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
     uniffi::ffi::uniffi_rustbuffer_from_bytes(bytes, call_status)
 }
 
-#[allow(clippy::missing_safety_doc, clippy::missing_docs_in_private_items)]
+#[allow(clippy::missing_safety_doc, missing_docs)]
 #[doc(hidden)]
 #[no_mangle]
 pub unsafe extern "C" fn {{ ci.ffi_rustbuffer_free().name() }}(buf: uniffi::RustBuffer, call_status: &mut uniffi::RustCallStatus) {
     uniffi::ffi::uniffi_rustbuffer_free(buf, call_status);
 }
 
-#[allow(clippy::missing_safety_doc, clippy::missing_docs_in_private_items)]
+#[allow(clippy::missing_safety_doc, missing_docs)]
 #[doc(hidden)]
 #[no_mangle]
 pub unsafe extern "C" fn {{ ci.ffi_rustbuffer_reserve().name() }}(buf: uniffi::RustBuffer, additional: i32, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {

--- a/uniffi_bindgen/src/scaffolding/templates/macros.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/macros.rs
@@ -112,7 +112,8 @@ uniffi::call_with_output(call_status, || {
     {% else -%}
     {% if func.full_arguments().is_empty() %}#[allow(clippy::redundant_closure)]{% endif %}
     {% call to_rs_call(func) %}
+    {%- if func.return_type().is_none() %};{% endif %}
     {% endmatch -%}
-})
+}){%- if func.return_type().is_none() -%};{% endif %}
 {% endmatch %}
 {% endmacro %}


### PR DESCRIPTION
## Background
- https://github.com/mozilla/uniffi-rs/issues/1476
- The problem here is that rust scaffolding has to be directly included into the module where the implementation is defined or else is it wont compile. This means that a consumer's code cant have stricter clippy rules than the generated scaffolding.
- Theres not really a way to deal with this except to make the generated scaffolding pass all possible clippy rules
- I think this is fair because consumers of uniffi - I dont have control over the generated code so it should have no impact over their code formatting

## Changes
- Add exceptions of fix all clippy errors that fired with 
```
cargo clippy -- --all-targets --all-features -- \
	-D warnings \
	-D clippy::all \
	-D missing_docs \
	-D clippy::missing_docs_in_private_items \
	-D clippy::pedantic \
	-W clippy::nursery \
	-W clippy::cargo
```
- Add some exceptions so that uniffi scaffolding isnt included in generated cargo docs for consumers

## Tests
- [x] Ingested into my own project and verified by hand
- [x] All uniffi tests pass  