### PR TITLE
Improve UniFFI tag handling in macros

### DIFF
--- a/fixtures/uitests/tests/ui/fieldless_errors_used_in_callbacks_cant_have_fields.stderr
+++ b/fixtures/uitests/tests/ui/fieldless_errors_used_in_callbacks_cant_have_fields.stderr
@@ -1,7 +1,11 @@
 error[E0533]: expected unit struct, unit variant or constant, found struct variant `Self::DivisionByZero`
  --> $OUT_DIR[uniffi_uitests]/errors.uniffi.rs
   |
-  | #[::uniffi::ffi_converter_error(crate::UniFfiTag)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | / #[::uniffi::ffi_converter_error(
+  | |     tag = crate::UniFfiTag,
+  | |     flat_error,
+  | |     with_try_read,
+  | | )]
+  | |__^
   |
   = note: this error originates in the attribute macro `::uniffi::ffi_converter_error` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/fixtures/uitests/tests/ui/interface_cannot_use_mut_self.stderr
+++ b/fixtures/uitests/tests/ui/interface_cannot_use_mut_self.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
-   --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
-    |
-    |             Ok(ref val) => val,
-    |                            ^^^ types differ in mutability
-    |
-    = note: expected mutable reference `&mut Counter`
-                       found reference `&Arc<Counter>`
+ --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
+  |
+  |             Ok(ref val) => val,
+  |                            ^^^ types differ in mutability
+  |
+  = note: expected mutable reference `&mut Counter`
+                     found reference `&Arc<Counter>`

--- a/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
+++ b/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `Cell<u32>` cannot be shared between threads safely
  --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
   |
-  | #[::uniffi::ffi_converter_interface(crate::UniFfiTag)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
+  | #[::uniffi::ffi_converter_interface(tag = crate::UniFfiTag)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
   |
   = help: within `Counter`, the trait `Sync` is not implemented for `Cell<u32>`
 note: required because it appears within the type `Counter`

--- a/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
@@ -7,7 +7,7 @@
 // public so other crates can refer to it via an `[External='crate'] typedef`
 #}
 
-#[::uniffi::ffi_converter_enum(crate::UniFfiTag)]
+#[::uniffi::ffi_converter_enum(tag = crate::UniFfiTag)]
 enum r#{{ e.name() }} {
     {%- for variant in e.variants() %}
     r#{{ variant.name() }} {

--- a/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
@@ -7,10 +7,15 @@
 // public so other crates can refer to it via an `[External='crate'] typedef`
 #}
 
-#[::uniffi::ffi_converter_error(crate::UniFfiTag)]
-{%- if e.is_flat() %}
-#[uniffi(flat_error{% if ci.should_generate_error_read(e) %},with_try_read{% endif %})]
-{%- endif %}
+#[::uniffi::ffi_converter_error(
+    tag = crate::UniFfiTag,
+    {% if e.is_flat() -%}
+    flat_error,
+    {% if ci.should_generate_error_read(e) -%}
+    with_try_read,
+    {%- endif %}
+    {%- endif %}
+)]
 enum r#{{ e.name() }} {
     {%- for variant in e.variants() %}
     r#{{ variant.name() }} {

--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -24,7 +24,7 @@
 fn uniffi_note_threadsafe_deprecation_{{ obj.name() }}() {}
 {% endif %}
 
-#[::uniffi::ffi_converter_interface(crate::UniFfiTag)]
+#[::uniffi::ffi_converter_interface(tag = crate::UniFfiTag)]
 struct r#{{ obj.name() }} { }
 
 // All Object structs must be `Sync + Send`. The generated scaffolding will fail to compile

--- a/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
@@ -8,7 +8,7 @@
 // public so other crates can refer to it via an `[External='crate'] typedef`
 #}
 
-#[::uniffi::ffi_converter_record(crate::UniFfiTag)]
+#[::uniffi::ffi_converter_record(tag = crate::UniFfiTag)]
 struct r#{{ rec.name() }} {
     {%- for field in rec.fields() %}
     r#{{ field.name() }}: {{ field.type_()|type_rs }},

--- a/uniffi_macros/src/error.rs
+++ b/uniffi_macros/src/error.rs
@@ -107,7 +107,7 @@ pub(crate) fn flat_error_ffi_converter_impl(
     tag_handler: FfiConverterTagHandler,
     implement_try_read: bool,
 ) -> TokenStream {
-    let (impl_spec, tag) = tag_handler.into_impl_and_tag_path("FfiConverter", ident);
+    let impl_spec = tag_handler.into_impl("FfiConverter", ident);
 
     let write_impl = {
         let match_arms = enum_.variants.iter().enumerate().map(|(i, v)| {
@@ -117,7 +117,7 @@ pub(crate) fn flat_error_ffi_converter_impl(
             quote! {
                 Self::#v_ident { .. } => {
                     ::uniffi::deps::bytes::BufMut::put_i32(buf, #idx);
-                    <::std::string::String as ::uniffi::FfiConverter<#tag>>::write(error_msg, buf);
+                    <::std::string::String as ::uniffi::FfiConverter<()>>::write(error_msg, buf);
                 }
             }
         });
@@ -150,7 +150,7 @@ pub(crate) fn flat_error_ffi_converter_impl(
     quote! {
         #[automatically_derived]
         unsafe #impl_spec {
-            ::uniffi::ffi_converter_rust_buffer_lift_and_lower!(#tag);
+            ::uniffi::ffi_converter_rust_buffer_lift_and_lower!(crate::UniFfiTag);
 
             fn write(obj: Self, buf: &mut ::std::vec::Vec<u8>) {
                 #write_impl

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -81,7 +81,9 @@ pub fn derive_record(input: TokenStream) -> TokenStream {
     };
     let input = parse_macro_input!(input);
 
-    expand_record(input, mod_path).into()
+    expand_record(input, mod_path)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
 }
 
 #[proc_macro_derive(Enum)]
@@ -92,7 +94,9 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
     };
     let input = parse_macro_input!(input);
 
-    expand_enum(input, mod_path).into()
+    expand_enum(input, mod_path)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
 }
 
 #[proc_macro_derive(Object)]
@@ -103,7 +107,9 @@ pub fn derive_object(input: TokenStream) -> TokenStream {
     };
     let input = parse_macro_input!(input);
 
-    expand_object(input, mod_path).into()
+    expand_object(input, mod_path)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
 }
 
 #[proc_macro_derive(Error, attributes(uniffi))]
@@ -114,7 +120,9 @@ pub fn derive_error(input: TokenStream) -> TokenStream {
     };
     let input = parse_macro_input!(input);
 
-    expand_error(input, mod_path).into()
+    expand_error(input, mod_path)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
 }
 
 /// Generate the FfiConverter implementation for a Record

--- a/uniffi_macros/src/object.rs
+++ b/uniffi_macros/src/object.rs
@@ -45,7 +45,7 @@ pub fn expand_ffi_converter_interface(attrs: AttributeArgs, input: DeriveInput) 
 }
 
 pub(crate) fn interface_impl(ident: &Ident, tag_handler: FfiConverterTagHandler) -> TokenStream {
-    let (impl_spec, _) = tag_handler.into_impl_and_tag_path("Interface", ident);
+    let impl_spec = tag_handler.into_impl("Interface", ident);
     quote! {
         #[doc(hidden)]
         #[automatically_derived]

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -127,12 +127,12 @@ pub fn rewrite_self_type(item: &mut Item) {
     }
 }
 
-pub fn try_read_field(f: &syn::Field, tag: &Path) -> TokenStream {
+pub fn try_read_field(f: &syn::Field) -> TokenStream {
     let ident = &f.ident;
     let ty = &f.ty;
 
     quote! {
-        #ident: <#ty as ::uniffi::FfiConverter<#tag>>::try_read(buf)?,
+        #ident: <#ty as ::uniffi::FfiConverter<crate::UniFfiTag>>::try_read(buf)?,
     }
 }
 
@@ -232,18 +232,11 @@ impl FfiConverterTagHandler {
         Self { tag: None }
     }
 
-    pub(crate) fn into_impl_and_tag_path(
-        self,
-        trait_name: &str,
-        ident: &Ident,
-    ) -> (TokenStream, Path) {
+    pub(crate) fn into_impl(self, trait_name: &str, ident: &Ident) -> TokenStream {
         let trait_name = Ident::new(trait_name, Span::call_site());
         match self.tag {
-            Some(tag) => (quote! { impl ::uniffi::#trait_name<#tag> for #ident }, tag),
-            None => (
-                quote! { impl<T> ::uniffi::#trait_name<T> for #ident },
-                Ident::new("T", Span::call_site()).into(),
-            ),
+            Some(tag) => quote! { impl ::uniffi::#trait_name<#tag> for #ident },
+            None => quote! { impl<T> ::uniffi::#trait_name<T> for #ident },
         }
     }
 }


### PR DESCRIPTION
About the first commit: I think down the line it makes sense to support `#[uniffi(tag = Tag)]` on fields to support pulling in an `FfiConverter` impl from another crate, but I don't think this is currently required anywhere, right?