### PR TITLE
Callback interface speedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### What's changed
 
 - The `include_scaffolding!()` macro must now either be called from your crate root or you must have `use the_mod_that_calls_include_scaffolding::*` in your crate root.  This was always the expectation, but wasn't required before.  This will now start failing with errors that say `crate::UniFfiTag` does not exist.
+- Implemented a new callback-interface ABI that signifacantly improves performance on Python and Kotlin.  This will be the default in version `0.24.0`, but can be enabled early using the `new_callback_interface_abi` feature.
 
 ## v0.23.0 (backend crates: v0.23.0) - (_2023-01-27_)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "examples/todolist",
   "examples/custom-types",
 
+  "fixtures/benchmarks",
   "fixtures/coverall",
   "fixtures/callbacks",
 

--- a/fixtures/benchmarks/Cargo.toml
+++ b/fixtures/benchmarks/Cargo.toml
@@ -25,3 +25,6 @@ uniffi_bindgen = {path = "../../uniffi_bindgen"}
 [[bench]]
 name = "benchmarks"
 harness = false
+
+[features]
+new_callback_interface_abi = ["uniffi_bindgen/new_callback_interface_abi", "uniffi/new_callback_interface_abi" ]

--- a/fixtures/benchmarks/Cargo.toml
+++ b/fixtures/benchmarks/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "uniffi-fixture-benchmarks"
+edition = "2021"
+version = "0.22.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "uniffi_benchmarks"
+bench = false
+
+[dependencies]
+uniffi = {path = "../../uniffi"}
+clap = { version = "3.1", features = ["cargo", "std", "derive"] }
+criterion = "0.4.0"
+
+[build-dependencies]
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi_bindgen = {path = "../../uniffi_bindgen"}
+
+[[bench]]
+name = "benchmarks"
+harness = false

--- a/fixtures/benchmarks/README.md
+++ b/fixtures/benchmarks/README.md
@@ -1,0 +1,17 @@
+This fixture runs a set of benchmark tests, using criterion to test the performance.
+
+Benchmarking UniFFI is tricky and involves a bit of ping-pong between Rust and
+the foreign language:
+
+ - `benchmarks.rs` is the top-level Rust executuble where the process starts.
+   It parses the CLI arguments and determines which languages we want to run
+   the benchmarks for.
+ - `benchmarks.rs` executes a script for each foreign language that we want to benchmark.
+ - Those scripts call the `run_benchmarks()` function from `lib.rs`
+ - `run_benchmarks()` parses the CLI arguments again, this time to how to setup
+   the `Criterion` object.
+ - Testing callback interfaces is relatively straightforward, we simply invoke
+   the callback method.
+ - Testing regular functions requires some extra care, since these are called
+   by the foreign bindings.  To test those, `benchmarks.rs` invokes a callback
+   interface method that call the rust function and reports the time taken.

--- a/fixtures/benchmarks/benches/benchmarks.rs
+++ b/fixtures/benchmarks/benches/benchmarks.rs
@@ -40,7 +40,7 @@ fn main() {
             std::env!("CARGO_TARGET_TMPDIR"),
             "uniffi-fixture-benchmarks",
             "benches/bindings/run_benchmarks.swift",
-            script_args.clone(),
+            script_args,
             RunScriptMode::PerformanceTest,
         )
         .unwrap()

--- a/fixtures/benchmarks/benches/benchmarks.rs
+++ b/fixtures/benchmarks/benches/benchmarks.rs
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use clap::Parser;
+use std::env;
+use uniffi_benchmarks::Args;
+use uniffi_bindgen::bindings::{kotlin, python, swift, RunScriptMode};
+
+fn main() {
+    let args = Args::parse();
+    let script_args: Vec<String> = std::iter::once(String::from("--"))
+        .chain(env::args())
+        .collect();
+
+    if args.should_run_python() {
+        python::run_script(
+            std::env!("CARGO_TARGET_TMPDIR"),
+            "uniffi-fixture-benchmarks",
+            "benches/bindings/run_benchmarks.py",
+            script_args.clone(),
+            RunScriptMode::PerformanceTest,
+        )
+        .unwrap()
+    }
+
+    if args.should_run_kotlin() {
+        kotlin::run_script(
+            std::env!("CARGO_TARGET_TMPDIR"),
+            "uniffi-fixture-benchmarks",
+            "benches/bindings/run_benchmarks.kts",
+            script_args.clone(),
+            RunScriptMode::PerformanceTest,
+        )
+        .unwrap()
+    }
+
+    if args.should_run_swift() {
+        swift::run_script(
+            std::env!("CARGO_TARGET_TMPDIR"),
+            "uniffi-fixture-benchmarks",
+            "benches/bindings/run_benchmarks.swift",
+            script_args.clone(),
+            RunScriptMode::PerformanceTest,
+        )
+        .unwrap()
+    }
+}

--- a/fixtures/benchmarks/benches/bindings/run_benchmarks.kts
+++ b/fixtures/benchmarks/benches/bindings/run_benchmarks.kts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import uniffi.benchmarks.*
+import kotlin.system.measureNanoTime
+
+class TestCallbackObj : TestCallbackInterface {
+    override fun testMethod(a: Int, b: Int, data: TestData): String {
+        return data.bar;
+    }
+
+    override fun testVoidReturn(a: Int, b: Int, data: TestData) {
+    }
+
+    override fun testNoArgsVoidReturn() {
+    }
+
+    override fun runTest(testCase: TestCase, count: ULong): ULong {
+        val data = TestData("StringOne", "StringTwo")
+        return when (testCase) {
+            TestCase.FUNCTION -> measureNanoTime {
+                for (i in 0UL..count) {
+                    testFunction(10, 20, data)
+                }
+            }
+            TestCase.VOID_RETURN -> measureNanoTime {
+                for (i in 0UL..count) {
+                    testVoidReturn(10, 20, data)
+                }
+            }
+            TestCase.NO_ARGS_VOID_RETURN -> measureNanoTime {
+                for (i in 0UL..count) {
+                    testNoArgsVoidReturn()
+                }
+            }
+        }.toULong()
+    }
+}
+
+runBenchmarks("kotlin", TestCallbackObj())

--- a/fixtures/benchmarks/benches/bindings/run_benchmarks.py
+++ b/fixtures/benchmarks/benches/bindings/run_benchmarks.py
@@ -1,0 +1,35 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from benchmarks import *
+import time
+
+class TestCallbackObj:
+    def test_method(self, a, b, data):
+        return data.bar
+
+    def test_void_return(self, a, b, data):
+        pass
+
+    def test_no_args_void_return(self):
+        pass
+
+    def run_test(self, test_case, count):
+        data = TestData("StringOne", "StringTwo")
+        if test_case == TestCase.FUNCTION:
+            start = time.perf_counter_ns()
+            for i in range(count):
+                test_function(10, 20, data)
+        elif test_case == TestCase.VOID_RETURN:
+            start = time.perf_counter_ns()
+            for i in range(count):
+                test_void_return(10, 20, data)
+        elif test_case == TestCase.NO_ARGS_VOID_RETURN:
+            start = time.perf_counter_ns()
+            for i in range(count):
+                test_no_args_void_return()
+        end = time.perf_counter_ns()
+        return end - start
+
+run_benchmarks("python", TestCallbackObj())

--- a/fixtures/benchmarks/benches/bindings/run_benchmarks.swift
+++ b/fixtures/benchmarks/benches/bindings/run_benchmarks.swift
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#if canImport(benchmarks)
+    import benchmarks
+#endif
+
+#if os(Linux)
+    import Glibc
+#else
+    import Darwin.C
+#endif
+
+class TestCallbackObj: TestCallbackInterface {
+    func testMethod(a: Int32, b: Int32, data: TestData) -> String {
+        return data.bar
+    }
+
+    func testVoidReturn(a: Int32, b: Int32, data: TestData) {
+    }
+
+    func testNoArgsVoidReturn() {
+    }
+
+    func runTest(testCase: TestCase, count: UInt64) -> UInt64 {
+        let data = TestData(foo: "StringOne", bar: "StringTwo")
+        let start = clock()
+        switch testCase {
+        case TestCase.function:
+            for _ in 0...count {
+                testFunction(a: 10, b: 20, data: data)
+            }
+        case TestCase.voidReturn:
+            for _ in 0...count {
+                testVoidReturn(a: 10, b: 20, data: data)
+            }
+
+        case TestCase.noArgsVoidReturn:
+            for _ in 0...count {
+                testNoArgsVoidReturn()
+            }
+        }
+        let end = clock()
+        return UInt64((end - start) * 1000000000 / CLOCKS_PER_SEC)
+    }
+}
+
+runBenchmarks(languageName: "swift", cb: TestCallbackObj())

--- a/fixtures/benchmarks/build.rs
+++ b/fixtures/benchmarks/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::generate_scaffolding("./src/benchmarks.udl").unwrap();
+}

--- a/fixtures/benchmarks/src/benchmarks.udl
+++ b/fixtures/benchmarks/src/benchmarks.udl
@@ -1,0 +1,40 @@
+namespace benchmarks {
+    // Run all benchmarks and print the results to stdout
+    void run_benchmarks(string language_name, TestCallbackInterface cb);
+
+    // Test functions
+  //
+  // These are intented to test the overhead of Rust function calls including:
+  // popping arguments from the stack, unpacking RustBuffers, pushing return
+  // values back to the stack, etc.
+
+    string test_function(i32 a, i32 b, TestData data); // Should return data.bar
+    void test_void_return(i32 a, i32 b, TestData data);
+    void test_no_args_void_return();
+};
+
+dictionary TestData {
+  string foo;
+  string bar;
+};
+
+enum TestCase {
+  "Function",
+  "VoidReturn",
+  "NoArgsVoidReturn",
+};
+
+callback interface TestCallbackInterface {
+  // Test callback methods.
+  //
+  // These are intented to test the overhead of callback interface calls
+  // including: popping arguments from the stack, unpacking RustBuffers,
+  // pushing return values back to the stack, etc.
+
+  string test_method(i32 a, i32 b, TestData data);  // Should return data.bar
+  void test_void_return(i32 a, i32 b, TestData data);
+  void test_no_args_void_return();
+
+  // Run a performance test N times and return the elapsed time in nanoseconds
+  u64 run_test(TestCase test_case, u64 count);
+};

--- a/fixtures/benchmarks/src/cli.rs
+++ b/fixtures/benchmarks/src/cli.rs
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use clap::Parser;
+use criterion::Criterion;
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    // Args to select which test scripts run.  These are handled in `benchmarks.rs`.
+    /// Run Python tests
+    #[clap(short, long = "py", display_order = 0)]
+    pub python: bool,
+    /// Run Kotlin tests
+    #[clap(short, long = "kt", display_order = 0)]
+    pub kotlin: bool,
+    /// Run Swift tests
+    #[clap(short, long, display_order = 0)]
+    pub swift: bool,
+
+    /// Dump compiler output to the console.  Good for debugging new benchmarks.
+    #[clap(long, display_order = 1, action)]
+    pub compiler_messages: bool,
+
+    // Args for running the metrics, these are handled in `lib.rs`
+    /// Skip benchmarks whose names do not contain FILTER
+    #[clap()]
+    pub filter: Option<String>,
+
+    // It would be great to also support the baseline arguments, but there doesn't seem to be any
+    // way to manually set those.
+
+    // Ignore the `--bench` arg, which Cargo passes to us
+    #[clap(long, hide = true)]
+    bench: bool,
+}
+
+impl Args {
+    /// Should we run the Python tests?
+    pub fn should_run_python(&self) -> bool {
+        self.python || self.no_languages_selected()
+    }
+
+    /// Should we run the Kotlin tests?
+    pub fn should_run_kotlin(&self) -> bool {
+        self.kotlin || self.no_languages_selected()
+    }
+
+    /// Should we run the Swift tests?
+    pub fn should_run_swift(&self) -> bool {
+        self.swift || self.no_languages_selected()
+    }
+
+    pub fn no_languages_selected(&self) -> bool {
+        !(self.python || self.kotlin || self.swift)
+    }
+
+    /// Parse arguments for run_benchmarks()
+    ///
+    /// This is slightly tricky, because run_benchmarks() is called from the foreign bindings side.
+    /// This means that `sys::env::args()` will contain all the arguments needed to run the foreign
+    /// bindings script, and we don't want to parse all of that.
+    pub fn parse_for_run_benchmarks() -> Self {
+        Self::parse_from(
+            std::env::args()
+                .into_iter()
+                // This method finds the first "--" arg, which `benchmarks.rs` inserts to mark the start of
+                // our arguments.
+                .skip_while(|a| a != "--")
+                // Skip over any "--" args.  This is mainly for the "--" arg that we use to separate
+                // our args.  However, it's also needed to workaround some kotlinc behavior.  We need
+                // to pass it the "--" arg to get it to start trying to parse our arguments, but
+                // kotlinc still passes "--" back to us.
+                .skip_while(|a| a == "--")
+                .collect::<Vec<String>>(),
+        )
+    }
+
+    /// Build a Criterion instance from the arguments
+    pub fn build_criterion(&self) -> Criterion {
+        let mut c = Criterion::default();
+        c = match &self.filter {
+            Some(f) => c.with_filter(f),
+            None => c,
+        };
+        c
+    }
+}

--- a/fixtures/benchmarks/src/lib.rs
+++ b/fixtures/benchmarks/src/lib.rs
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::env;
+use std::time::Duration;
+
+mod cli;
+pub use cli::Args;
+
+pub struct TestData {
+    foo: String,
+    bar: String,
+}
+
+pub enum TestCase {
+    Function,
+    VoidReturn,
+    NoArgsVoidReturn,
+}
+
+pub trait TestCallbackInterface {
+    fn test_method(&self, a: i32, b: i32, data: TestData) -> String;
+    fn test_void_return(&self, a: i32, b: i32, data: TestData);
+    fn test_no_args_void_return(&self);
+    fn run_test(&self, test_case: TestCase, count: u64) -> u64;
+}
+
+pub fn test_function(_a: i32, _b: i32, data: TestData) -> String {
+    data.bar
+}
+pub fn test_void_return(_a: i32, _b: i32, _data: TestData) {}
+pub fn test_no_args_void_return() {}
+
+pub fn run_benchmarks(language: String, cb: Box<dyn TestCallbackInterface>) {
+    let args = Args::parse_for_run_benchmarks();
+    let mut c = args.build_criterion();
+
+    c.benchmark_group("calls")
+        // FFI Function call benchmarks
+        //
+        // Note: these are more a proof-of-concept than real benchmarks.  Before using these to
+        // drive changes, make sure to take some time and double check that they're testing the
+        // correct things.
+        .bench_function(format!("{language}-functions-basic"), |b| {
+            b.iter_custom(|count| Duration::from_nanos(cb.run_test(TestCase::Function, count)))
+        })
+        .bench_function(format!("{language}-functions-void-return"), |b| {
+            b.iter_custom(|count| Duration::from_nanos(cb.run_test(TestCase::VoidReturn, count)))
+        })
+        .bench_function(format!("{language}-functions-no-args-void-return"), |b| {
+            b.iter_custom(|count| {
+                Duration::from_nanos(cb.run_test(TestCase::NoArgsVoidReturn, count))
+            })
+        });
+
+    c.benchmark_group("callbacks")
+        // These benchmarks are extra noisy, take extra time to measure them and set a higher noise
+        // threshold
+        .measurement_time(Duration::from_secs(10))
+        .noise_threshold(0.05)
+        .bench_function(format!("{language}-callbacks-basic"), |b| {
+            b.iter(|| {
+                cb.test_method(
+                    10,
+                    100,
+                    TestData {
+                        foo: String::from("SomeStringData"),
+                        bar: String::from("SomeMoreStringData"),
+                    },
+                )
+            })
+        })
+        .bench_function(format!("{language}-callbacks-void-return"), |b| {
+            b.iter(|| {
+                cb.test_void_return(
+                    10,
+                    100,
+                    TestData {
+                        foo: String::from("SomeStringData"),
+                        bar: String::from("SomeMoreStringData"),
+                    },
+                )
+            })
+        })
+        .bench_function(format!("{language}-callbacks-no-args-void-return"), |b| {
+            b.iter(|| cb.test_no_args_void_return())
+        });
+
+    c.final_summary();
+}
+
+include!(concat!(env!("OUT_DIR"), "/benchmarks.uniffi.rs"));

--- a/fixtures/callbacks/Cargo.toml
+++ b/fixtures/callbacks/Cargo.toml
@@ -15,7 +15,10 @@ uniffi = {path = "../../uniffi"}
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", features = ["build"] }
+# Enable the `new_callback_interface_abi` so that we get some test coverage of
+# it.  examples/callbacks doesn't enable this, so we also keep coverage of the
+# older ABI.
+uniffi = {path = "../../uniffi", features = ["build", "new_callback_interface_abi"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }
+uniffi = {path = "../../uniffi", features = ["bindgen-tests", "new_callback_interface_abi"] }

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -42,3 +42,5 @@ bindgen-tests = [ "dep:uniffi_bindgen" ]
 # Enable support for Tokio's futures.
 # This must still be opted into on a per-function basis using `#[uniffi::export(async_runtime = "tokio")]`.
 tokio = ["uniffi_core/tokio"]
+# Make the generated bindings opt-in to the new callback interface ABI
+new_callback_interface_abi = ["dep:uniffi_bindgen", "uniffi_bindgen?/new_callback_interface_abi" ]

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -27,3 +27,7 @@ toml = "0.5"
 weedle2 = { version = "4.0.0", path = "../weedle2" }
 uniffi_meta = { path = "../uniffi_meta", version = "=0.23.0" }
 uniffi_testing = { path = "../uniffi_testing", version = "=0.23.0" }
+
+[features]
+# Make the generated bindings opt-in to the new callback interface ABI
+new_callback_interface_abi = []

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -126,6 +126,7 @@ pub struct TypeRenderer<'a> {
     include_once_names: RefCell<HashSet<String>>,
     // Track imports added with the `add_import()` macro
     imports: RefCell<BTreeSet<ImportRequirement>>,
+    new_callback_interface_abi: bool,
 }
 
 impl<'a> TypeRenderer<'a> {
@@ -135,6 +136,7 @@ impl<'a> TypeRenderer<'a> {
             ci,
             include_once_names: RefCell::new(HashSet::new()),
             imports: RefCell::new(BTreeSet::new()),
+            new_callback_interface_abi: crate::bindings::NEW_CALLBACK_INTERFACE_ABI,
         }
     }
 
@@ -321,7 +323,11 @@ impl CodeOracle for KotlinCodeOracle {
                 None => "RustBuffer.ByValue".to_string(),
             },
             FfiType::ForeignBytes => "ForeignBytes.ByValue".to_string(),
+            // The scaffolding code supports 2 versions of the ForeignCallback function type.
+            // However, the bindings code will use one or the other depending on the
+            // `new_callback_interface_abi` feature.  So map both variants map to the same name.
             FfiType::ForeignCallback => "ForeignCallback".to_string(),
+            FfiType::ForeignCallback2 => "ForeignCallback".to_string(),
         }
     }
 }
@@ -402,7 +408,11 @@ pub mod filters {
                 None => "RustBuffer".into(),
             },
             FfiType::ForeignBytes => "ForeignBytes".into(),
+            // The scaffolding code supports 2 versions of the ForeignCallback function type.
+            // However, the bindings code will use one or the other depending on the
+            // `new_callback_interface_abi` feature.  So map both variants map to the same name.
             FfiType::ForeignCallback => "ForeignCallback".into(),
+            FfiType::ForeignCallback2 => "ForeignCallback".into(),
         })
     }
 

--- a/uniffi_bindgen/src/bindings/kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/mod.rs
@@ -12,7 +12,7 @@ pub use gen_kotlin::{generate_bindings, Config};
 mod test;
 
 use super::super::interface::ComponentInterface;
-pub use test::run_test;
+pub use test::{run_script, run_test};
 
 pub fn write_bindings(
     config: &Config,

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceRuntime.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceRuntime.kt
@@ -36,7 +36,7 @@ internal class ConcurrentHandleMap<T>(
 
 {%- if new_callback_interface_abi %}
 interface ForeignCallback : com.sun.jna.Callback {
-    public fun invoke(handle: Handle, method: Int, args: RustBuffer.ByReference, outBuf: RustBufferByReference): Int
+    public fun invoke(handle: Handle, method: Int, argsData: Pointer, argsLen: Int, outBuf: RustBufferByReference): Int
 }
 {%- else %}
 interface ForeignCallback : com.sun.jna.Callback {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceRuntime.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceRuntime.kt
@@ -34,9 +34,15 @@ internal class ConcurrentHandleMap<T>(
         }
 }
 
+{%- if new_callback_interface_abi %}
+interface ForeignCallback : com.sun.jna.Callback {
+    public fun invoke(handle: Handle, method: Int, args: RustBuffer.ByReference, outBuf: RustBufferByReference): Int
+}
+{%- else %}
 interface ForeignCallback : com.sun.jna.Callback {
     public fun invoke(handle: Handle, method: Int, args: RustBuffer.ByValue, outBuf: RustBufferByReference): Int
 }
+{%- endif %}
 
 // Magic number for the Rust proxy to call using the same mechanism as every other method,
 // to free the callback once it's dropped by Rust.

--- a/uniffi_bindgen/src/bindings/mod.rs
+++ b/uniffi_bindgen/src/bindings/mod.rs
@@ -33,6 +33,13 @@ pub enum TargetLanguage {
     Ruby,
 }
 
+/// Mode for the `run_script` function defined for each language
+#[derive(Copy, Clone, Debug)]
+pub enum RunScriptMode {
+    Test,
+    PerformanceTest,
+}
+
 impl TryFrom<&str> for TargetLanguage {
     type Error = anyhow::Error;
     fn try_from(value: &str) -> Result<Self> {

--- a/uniffi_bindgen/src/bindings/mod.rs
+++ b/uniffi_bindgen/src/bindings/mod.rs
@@ -19,6 +19,13 @@ pub mod python;
 pub mod ruby;
 pub mod swift;
 
+// Express this feature as a static value so that we can use it in the template code
+#[cfg(feature = "new_callback_interface_abi")]
+static NEW_CALLBACK_INTERFACE_ABI: bool = true;
+
+#[cfg(not(feature = "new_callback_interface_abi"))]
+static NEW_CALLBACK_INTERFACE_ABI: bool = false;
+
 /// Enumeration of all foreign language targets currently supported by this crate.
 ///
 /// The functions in this module will delegate to a language-specific backend based

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -170,6 +170,7 @@ pub struct TypeRenderer<'a> {
     include_once_names: RefCell<HashSet<String>>,
     // Track imports added with the `add_import()` macro
     imports: RefCell<BTreeSet<ImportRequirement>>,
+    new_callback_interface_abi: bool,
 }
 
 impl<'a> TypeRenderer<'a> {
@@ -179,6 +180,7 @@ impl<'a> TypeRenderer<'a> {
             ci,
             include_once_names: RefCell::new(HashSet::new()),
             imports: RefCell::new(BTreeSet::new()),
+            new_callback_interface_abi: crate::bindings::NEW_CALLBACK_INTERFACE_ABI,
         }
     }
 
@@ -236,6 +238,7 @@ pub struct PythonWrapper<'a> {
     config: Config,
     type_helper_code: String,
     type_imports: BTreeSet<ImportRequirement>,
+    new_callback_interface_abi: bool,
 }
 impl<'a> PythonWrapper<'a> {
     pub fn new(config: Config, ci: &'a ComponentInterface) -> Self {
@@ -247,6 +250,7 @@ impl<'a> PythonWrapper<'a> {
             ci,
             type_helper_code,
             type_imports,
+            new_callback_interface_abi: crate::bindings::NEW_CALLBACK_INTERFACE_ABI,
         }
     }
 
@@ -365,7 +369,11 @@ impl CodeOracle for PythonCodeOracle {
                 None => "RustBuffer".to_string(),
             },
             FfiType::ForeignBytes => "ForeignBytes".to_string(),
+            // The scaffolding code supports 2 versions of the ForeignCallback function type.
+            // However, the bindings code will use one or the other depending on the
+            // `new_callback_interface_abi` feature.  So map both variants map to the same name.
             FfiType::ForeignCallback => "FOREIGN_CALLBACK_T".to_string(),
+            FfiType::ForeignCallback2 => "FOREIGN_CALLBACK_T".to_string(),
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/mod.rs
@@ -13,7 +13,7 @@ mod test;
 
 use super::super::interface::ComponentInterface;
 pub use gen_python::{generate_python_bindings, Config};
-pub use test::run_test;
+pub use test::{run_script, run_test};
 
 // Generate python bindings for the given ComponentInterface, in the given output directory.
 pub fn write_bindings(

--- a/uniffi_bindgen/src/bindings/python/templates/Helpers.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Helpers.py
@@ -64,4 +64,8 @@ def rust_call_with_error(error_ffi_converter, fn, *args):
 
 # A function pointer for a callback as defined by UniFFI.
 # Rust definition `fn(handle: u64, method: u32, args: RustBuffer, buf_ptr: *mut RustBuffer) -> int`
+{%- if new_callback_interface_abi %}
+FOREIGN_CALLBACK_T = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_ulonglong, ctypes.c_ulong, ctypes.POINTER(RustBuffer), ctypes.POINTER(RustBuffer))
+{%- else %}
 FOREIGN_CALLBACK_T = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_ulonglong, ctypes.c_ulong, RustBuffer, ctypes.POINTER(RustBuffer))
+{%- endif %}

--- a/uniffi_bindgen/src/bindings/python/templates/Helpers.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Helpers.py
@@ -65,7 +65,7 @@ def rust_call_with_error(error_ffi_converter, fn, *args):
 # A function pointer for a callback as defined by UniFFI.
 # Rust definition `fn(handle: u64, method: u32, args: RustBuffer, buf_ptr: *mut RustBuffer) -> int`
 {%- if new_callback_interface_abi %}
-FOREIGN_CALLBACK_T = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_ulonglong, ctypes.c_ulong, ctypes.POINTER(RustBuffer), ctypes.POINTER(RustBuffer))
+FOREIGN_CALLBACK_T = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_ulonglong, ctypes.c_ulong, ctypes.POINTER(ctypes.c_char), ctypes.c_int, ctypes.POINTER(RustBuffer))
 {%- else %}
 FOREIGN_CALLBACK_T = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_ulonglong, ctypes.c_ulong, RustBuffer, ctypes.POINTER(RustBuffer))
 {%- endif %}

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
@@ -49,10 +49,21 @@ class RustBuffer(ctypes.Structure):
             s = RustBufferStream(self)
             yield s
             if s.remaining() != 0:
-                raise RuntimeError("junk data left in buffer after consuming")
+                raise RuntimeError("junk data left in buffer at end of consumeWithStream")
         finally:
             self.free()
 
+    @contextlib.contextmanager
+    def readWithStream(self):
+        """Context-manager to read a buffer using a RustBufferStream.
+
+        This is like consumeWithStream, but doesn't free the buffer afterwards.
+        It should only be used with borrowed `RustBuffer` data.
+        """
+        s = RustBufferStream(self)
+        yield s
+        if s.remaining() != 0:
+            raise RuntimeError("junk data left in buffer at end of readWithStream")
 
 class ForeignBytes(ctypes.Structure):
     _fields_ = [

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
@@ -46,7 +46,7 @@ class RustBuffer(ctypes.Structure):
         leak it even if an error occurs.
         """
         try:
-            s = RustBufferStream(self)
+            s = RustBufferStream.from_rust_buffer(self)
             yield s
             if s.remaining() != 0:
                 raise RuntimeError("junk data left in buffer at end of consumeWithStream")
@@ -60,7 +60,7 @@ class RustBuffer(ctypes.Structure):
         This is like consumeWithStream, but doesn't free the buffer afterwards.
         It should only be used with borrowed `RustBuffer` data.
         """
-        s = RustBufferStream(self)
+        s = RustBufferStream.from_rust_buffer(self)
         yield s
         if s.remaining() != 0:
             raise RuntimeError("junk data left in buffer at end of readWithStream")
@@ -80,24 +80,29 @@ class RustBufferStream(object):
     Helper for structured reading of bytes from a RustBuffer
     """
 
-    def __init__(self, rbuf):
-        self.rbuf = rbuf
+    def __init__(self, data, len):
+        self.data = data
+        self.len = len
         self.offset = 0
 
+    @classmethod
+    def from_rust_buffer(cls, buf):
+        return cls(buf.data, buf.len)
+
     def remaining(self):
-        return self.rbuf.len - self.offset
+        return self.len - self.offset
 
     def _unpack_from(self, size, format):
-        if self.offset + size > self.rbuf.len:
+        if self.offset + size > self.len:
             raise InternalError("read past end of rust buffer")
-        value = struct.unpack(format, self.rbuf.data[self.offset:self.offset+size])[0]
+        value = struct.unpack(format, self.data[self.offset:self.offset+size])[0]
         self.offset += size
         return value
 
     def read(self, size):
-        if self.offset + size > self.rbuf.len:
+        if self.offset + size > self.len:
             raise InternalError("read past end of rust buffer")
-        data = self.rbuf.data[self.offset:self.offset+size]
+        data = self.data[self.offset:self.offset+size]
         self.offset += size
         return data
 

--- a/uniffi_bindgen/src/bindings/python/test.rs
+++ b/uniffi_bindgen/src/bindings/python/test.rs
@@ -2,37 +2,53 @@
 License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::bindings::RunScriptMode;
 use anyhow::{Context, Result};
 use camino::Utf8Path;
 use std::env;
 use std::ffi::OsString;
-use std::process::{Command, Stdio};
+use std::process::Command;
 use uniffi_testing::UniFFITestHelper;
 
 /// Run Python tests for a UniFFI test fixture
 pub fn run_test(tmp_dir: &str, fixture_name: &str, script_file: &str) -> Result<()> {
+    run_script(
+        tmp_dir,
+        fixture_name,
+        script_file,
+        vec![],
+        RunScriptMode::Test,
+    )
+}
+
+/// Run a Python script
+///
+/// This function will set things up so that the script can import the UniFFI bindings for a crate
+pub fn run_script(
+    tmp_dir: &str,
+    crate_name: &str,
+    script_file: &str,
+    args: Vec<String>,
+    _mode: RunScriptMode,
+) -> Result<()> {
     let script_path = Utf8Path::new(".").join(script_file).canonicalize_utf8()?;
-    let test_helper = UniFFITestHelper::new(fixture_name).context("UniFFITestHelper::new")?;
-    let out_dir = test_helper
-        .create_out_dir(tmp_dir, &script_path)
-        .context("create_out_dir")?;
-    test_helper
-        .copy_cdylibs_to_out_dir(&out_dir)
-        .context("copy_cdylibs_to_out_dir")?;
-    generate_sources(&test_helper.cdylib_path()?, &out_dir, &test_helper)
-        .context("generate_sources")?;
+    let test_helper = UniFFITestHelper::new(crate_name)?;
+    let out_dir = test_helper.create_out_dir(tmp_dir, &script_path)?;
+    test_helper.copy_cdylibs_to_out_dir(&out_dir)?;
+    generate_sources(&test_helper.cdylib_path()?, &out_dir, &test_helper)?;
 
     let pythonpath = env::var_os("PYTHONPATH").unwrap_or_else(|| OsString::from(""));
     let pythonpath = env::join_paths(
         env::split_paths(&pythonpath).chain(vec![out_dir.to_path_buf().into_std_path_buf()]),
     )?;
 
-    let status = Command::new("python3")
+    let mut command = Command::new("python3");
+    command
         .current_dir(out_dir)
         .env("PYTHONPATH", pythonpath)
         .arg(script_path)
-        .stderr(Stdio::inherit())
-        .stdout(Stdio::inherit())
+        .args(args);
+    let status = command
         .spawn()
         .context("Failed to spawn `python3` when running script")?
         .wait()

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -96,6 +96,7 @@ mod filters {
             FfiType::RustBuffer(_) => "RustBuffer.by_value".to_string(),
             FfiType::ForeignBytes => "ForeignBytes".to_string(),
             FfiType::ForeignCallback => unimplemented!("Callback interfaces are not implemented"),
+            FfiType::ForeignCallback2 => unimplemented!("Callback interfaces are not implemented"),
         })
     }
 

--- a/uniffi_bindgen/src/bindings/ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/mod.rs
@@ -11,7 +11,7 @@ use fs_err::File;
 pub mod gen_ruby;
 mod test;
 pub use gen_ruby::{Config, RubyWrapper};
-pub use test::run_test;
+pub use test::{run_test, test_script_command};
 
 use super::super::interface::ComponentInterface;
 

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -174,6 +174,7 @@ pub struct TypeRenderer<'a> {
     include_once_names: RefCell<HashSet<String>>,
     // Track imports added with the `add_import()` macro
     imports: RefCell<BTreeSet<String>>,
+    new_callback_interface_abi: bool,
 }
 
 impl<'a> TypeRenderer<'a> {
@@ -183,6 +184,7 @@ impl<'a> TypeRenderer<'a> {
             ci,
             include_once_names: RefCell::new(HashSet::new()),
             imports: RefCell::new(BTreeSet::new()),
+            new_callback_interface_abi: crate::bindings::NEW_CALLBACK_INTERFACE_ABI,
         }
     }
 
@@ -220,6 +222,7 @@ impl<'a> TypeRenderer<'a> {
 pub struct BridgingHeader<'config, 'ci> {
     _config: &'config Config,
     ci: &'ci ComponentInterface,
+    new_callback_interface_abi: bool,
 }
 
 impl<'config, 'ci> BridgingHeader<'config, 'ci> {
@@ -227,6 +230,7 @@ impl<'config, 'ci> BridgingHeader<'config, 'ci> {
         Self {
             _config: config,
             ci,
+            new_callback_interface_abi: crate::bindings::NEW_CALLBACK_INTERFACE_ABI,
         }
     }
 }
@@ -378,7 +382,11 @@ impl CodeOracle for SwiftCodeOracle {
             FfiType::RustArcPtr(_) => "void*_Nonnull".into(),
             FfiType::RustBuffer(_) => "RustBuffer".into(),
             FfiType::ForeignBytes => "ForeignBytes".into(),
+            // The scaffolding code supports 2 versions of the ForeignCallback function type.
+            // However, the bindings code will use one or the other depending on the
+            // `new_callback_interface_abi` feature.  So map both variants map to the same name.
             FfiType::ForeignCallback => "ForeignCallback _Nonnull".to_string(),
+            FfiType::ForeignCallback2 => "ForeignCallback _Nonnull".to_string(),
         }
     }
 }
@@ -450,7 +458,11 @@ pub mod filters {
             FfiType::RustArcPtr(_) => "void*_Nonnull".into(),
             FfiType::RustBuffer(_) => "RustBuffer".into(),
             FfiType::ForeignBytes => "ForeignBytes".into(),
+            // The scaffolding code supports 2 versions of the ForeignCallback function type.
+            // However, the bindings code will use one or the other depending on the
+            // `new_callback_interface_abi` feature.  So map both variants map to the same name.
             FfiType::ForeignCallback => "ForeignCallback  _Nonnull".to_string(),
+            FfiType::ForeignCallback2 => "ForeignCallback  _Nonnull".to_string(),
         })
     }
 

--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -40,7 +40,7 @@ pub use gen_swift::{generate_bindings, Config};
 mod test;
 
 use super::super::interface::ComponentInterface;
-pub use test::run_test;
+pub use test::{run_script, run_test};
 
 /// The Swift bindings generated from a [`ComponentInterface`].
 ///

--- a/uniffi_bindgen/src/bindings/swift/templates/BridgingHeaderTemplate.h
+++ b/uniffi_bindgen/src/bindings/swift/templates/BridgingHeaderTemplate.h
@@ -28,7 +28,11 @@ typedef struct RustBuffer
     uint8_t *_Nullable data;
 } RustBuffer;
 
+{%- if new_callback_interface_abi %}
+typedef int32_t (*ForeignCallback)(uint64_t, int32_t, const RustBuffer *_Nonnull, RustBuffer *_Nonnull);
+{%- else %}
 typedef int32_t (*ForeignCallback)(uint64_t, int32_t, RustBuffer, RustBuffer *_Nonnull);
+{%- endif %}
 
 typedef struct ForeignBytes
 {

--- a/uniffi_bindgen/src/bindings/swift/templates/BridgingHeaderTemplate.h
+++ b/uniffi_bindgen/src/bindings/swift/templates/BridgingHeaderTemplate.h
@@ -29,7 +29,7 @@ typedef struct RustBuffer
 } RustBuffer;
 
 {%- if new_callback_interface_abi %}
-typedef int32_t (*ForeignCallback)(uint64_t, int32_t, const RustBuffer *_Nonnull, RustBuffer *_Nonnull);
+typedef int32_t (*ForeignCallback)(uint64_t, int32_t, const uint8_t *_Nonnull, int32_t, RustBuffer *_Nonnull);
 {%- else %}
 typedef int32_t (*ForeignCallback)(uint64_t, int32_t, RustBuffer, RustBuffer *_Nonnull);
 {%- endif %}

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
@@ -17,7 +17,7 @@ public protocol {{ type_name }} : AnyObject {
 // The ForeignCallback that is passed to Rust.
 {%- if new_callback_interface_abi %}
 fileprivate let {{ foreign_callback }} : ForeignCallback =
-    { (handle: UniFFICallbackHandle, method: Int32, args: UnsafePointer<RustBuffer>, out_buf: UnsafeMutablePointer<RustBuffer>) -> Int32 in
+    { (handle: UniFFICallbackHandle, method: Int32, argsData: UnsafePointer<UInt8>, argsLen: Int32, out_buf: UnsafeMutablePointer<RustBuffer>) -> Int32 in
 {%- else %}
 fileprivate let {{ foreign_callback }} : ForeignCallback =
     { (handle: UniFFICallbackHandle, method: Int32, args: RustBuffer, out_buf: UnsafeMutablePointer<RustBuffer>) -> Int32 in
@@ -26,7 +26,7 @@ fileprivate let {{ foreign_callback }} : ForeignCallback =
     {%- let method_name = format!("invoke_{}", meth.name())|fn_name -%}
 
     {%- if new_callback_interface_abi %}
-    func {{ method_name }}(_ swiftCallbackInterface: {{ type_name }}, _ args: UnsafePointer<RustBuffer>, _ out_buf: UnsafeMutablePointer<RustBuffer>) throws -> Int32 {
+    func {{ method_name }}(_ swiftCallbackInterface: {{ type_name }}, _ argsData: UnsafePointer<UInt8>, _ argsLen: Int32, _ out_buf: UnsafeMutablePointer<RustBuffer>) throws -> Int32 {
     {%- else %}
     func {{ method_name }}(_ swiftCallbackInterface: {{ type_name }}, _ args: RustBuffer, _ out_buf: UnsafeMutablePointer<RustBuffer>) throws -> Int32 {
     {%- endif %}
@@ -36,7 +36,7 @@ fileprivate let {{ foreign_callback }} : ForeignCallback =
 
         {%- if meth.arguments().len() > 0 %}
         {%- if new_callback_interface_abi %}
-        var reader = createReader(data: Data(rustBuffer: args.pointee))
+        var reader = createReader(data: Data(bytes: argsData, count: Int(argsLen)))
         {%- else %}
         var reader = createReader(data: Data(rustBuffer: args))
         {%- endif %}
@@ -100,7 +100,11 @@ fileprivate let {{ foreign_callback }} : ForeignCallback =
                 return -1
             }
             do {
+                {%- if new_callback_interface_abi %}
+                return try {{ method_name }}(cb, argsData, argsLen, out_buf)
+                {%- else %}
                 return try {{ method_name }}(cb, args, out_buf)
+                {%- endif %}
             } catch let error {
                 out_buf.pointee = {{ Type::String.borrow()|lower_fn }}(String(describing: error))
                 return -1

--- a/uniffi_bindgen/src/bindings/swift/test.rs
+++ b/uniffi_bindgen/src/bindings/swift/test.rs
@@ -2,6 +2,7 @@
 License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::bindings::RunScriptMode;
 use anyhow::{bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use heck::ToSnakeCase;
@@ -9,22 +10,36 @@ use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
 use std::ffi::OsStr;
 use std::fs::{read_to_string, File};
 use std::io::Write;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use uniffi_testing::{CompileSource, UniFFITestHelper};
 
 /// Run Swift tests for a UniFFI test fixture
 pub fn run_test(tmp_dir: &str, fixture_name: &str, script_file: &str) -> Result<()> {
+    run_script(
+        tmp_dir,
+        fixture_name,
+        script_file,
+        vec![],
+        RunScriptMode::Test,
+    )
+}
+
+/// Run a Swift script
+///
+/// This function will set things up so that the script can import the UniFFI bindings for a crate
+pub fn run_script(
+    tmp_dir: &str,
+    crate_name: &str,
+    script_file: &str,
+    args: Vec<String>,
+    mode: RunScriptMode,
+) -> Result<()> {
     let script_path = Utf8Path::new(".").join(script_file).canonicalize_utf8()?;
-    let test_helper = UniFFITestHelper::new(fixture_name).context("UniFFITestHelper::new")?;
-    let out_dir = test_helper
-        .create_out_dir(tmp_dir, &script_path)
-        .context("create_out_dir()")?;
-    test_helper
-        .copy_cdylibs_to_out_dir(&out_dir)
-        .context("copy_fixture_library_to_out_dir()")?;
+    let test_helper = UniFFITestHelper::new(crate_name)?;
+    let out_dir = test_helper.create_out_dir(tmp_dir, &script_path)?;
+    test_helper.copy_cdylibs_to_out_dir(&out_dir)?;
     let generated_sources =
-        GeneratedSources::new(&test_helper.cdylib_path()?, &out_dir, &test_helper)
-            .context("generate_sources()")?;
+        GeneratedSources::new(&test_helper.cdylib_path()?, &out_dir, &test_helper)?;
 
     // Compile the generated sources together to create a single swift module
     compile_swift_module(
@@ -32,11 +47,11 @@ pub fn run_test(tmp_dir: &str, fixture_name: &str, script_file: &str) -> Result<
         &calc_module_name(&generated_sources.main_source_filename),
         &generated_sources.generated_swift_files,
         &generated_sources.module_map,
+        mode,
     )?;
 
     // Run the test script against compiled bindings
-
-    let mut command = Command::new("swift");
+    let mut command = create_command("swift", mode);
     command
         .current_dir(&out_dir)
         .arg("-I")
@@ -49,7 +64,8 @@ pub fn run_test(tmp_dir: &str, fixture_name: &str, script_file: &str) -> Result<
             "-fmodule-map-file={}",
             generated_sources.module_map
         ))
-        .arg(&script_path);
+        .arg(&script_path)
+        .args(args);
     let status = command
         .spawn()
         .context("Failed to spawn `swiftc` when running test script")?
@@ -70,9 +86,10 @@ fn compile_swift_module<T: AsRef<OsStr>>(
     module_name: &str,
     sources: impl IntoIterator<Item = T>,
     module_map: &Utf8Path,
+    mode: RunScriptMode,
 ) -> Result<()> {
     let output_filename = format!("{DLL_PREFIX}testmod_{module_name}{DLL_SUFFIX}");
-    let mut command = Command::new("swiftc");
+    let mut command = create_command("swiftc", mode);
     command
         .current_dir(out_dir)
         .arg("-emit-module")
@@ -193,6 +210,18 @@ impl GeneratedSources {
             false,
         )
     }
+}
+
+fn create_command(program: &str, mode: RunScriptMode) -> Command {
+    let mut command = Command::new(program);
+    if let RunScriptMode::PerformanceTest = mode {
+        // This prevents most compiler messages, but not remarks
+        command.arg("-suppress-warnings");
+        // This gets the remorks.  Note: swift will eventually get a `-supress-remarks` argument,
+        // maybe we can eventually move to that
+        command.stderr(Stdio::null());
+    }
+    command
 }
 
 // Wraps glob to use Utf8Paths and flattens errors

--- a/uniffi_bindgen/src/interface/callbacks.rs
+++ b/uniffi_bindgen/src/interface/callbacks.rs
@@ -53,6 +53,9 @@ pub struct CallbackInterface {
     //    avoids a weird circular dependency in the calculation.
     #[checksum_ignore]
     pub(super) ffi_init_callback: FfiFunction,
+
+    #[checksum_ignore]
+    pub(super) ffi_init_callback2: FfiFunction,
 }
 
 impl CallbackInterface {
@@ -61,6 +64,7 @@ impl CallbackInterface {
             name,
             methods: Default::default(),
             ffi_init_callback: Default::default(),
+            ffi_init_callback2: Default::default(),
         }
     }
 
@@ -80,13 +84,28 @@ impl CallbackInterface {
         &self.ffi_init_callback
     }
 
+    pub fn ffi_init_callback2(&self) -> &FfiFunction {
+        &self.ffi_init_callback2
+    }
+
     pub(super) fn derive_ffi_funcs(&mut self, ci_prefix: &str) {
+        // Default callback registration function
         self.ffi_init_callback.name = format!("ffi_{ci_prefix}_{}_init_callback", self.name);
         self.ffi_init_callback.arguments = vec![FfiArgument {
             name: "callback_stub".to_string(),
             type_: FfiType::ForeignCallback,
         }];
         self.ffi_init_callback.return_type = None;
+
+        // New-style callback registration function, bindings will use this when the
+        // `new_callback_interface_abi` feature is enabled and it will become the default in
+        // version `0.24.0`.
+        self.ffi_init_callback2.name = format!("ffi_{ci_prefix}_{}_init_callback2", self.name);
+        self.ffi_init_callback2.arguments = vec![FfiArgument {
+            name: "callback_stub".to_string(),
+            type_: FfiType::ForeignCallback2,
+        }];
+        self.ffi_init_callback2.return_type = None;
     }
 
     pub fn iter_types(&self) -> TypeIterator<'_> {

--- a/uniffi_bindgen/src/interface/ffi.rs
+++ b/uniffi_bindgen/src/interface/ffi.rs
@@ -48,6 +48,8 @@ pub enum FfiType {
     /// A pointer to a single function in to the foreign language.
     /// This function contains all the machinery to make callbacks work on the foreign language side.
     ForeignCallback,
+    // New-style version of ForeignCallback
+    ForeignCallback2,
     // TODO: you can imagine a richer structural typesystem here, e.g. `Ref<String>` or something.
     // We don't need that yet and it's possible we never will, so it isn't here for now.
 }

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -452,6 +452,11 @@ impl ComponentInterface {
                     .iter()
                     .map(|cb| cb.ffi_init_callback()),
             )
+            .chain(
+                self.callback_interfaces
+                    .iter()
+                    .map(|cb| cb.ffi_init_callback2()),
+            )
             .chain(self.functions.iter().map(|f| &f.ffi_func))
     }
 

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -76,6 +76,7 @@ mod filters {
             FfiType::RustBuffer(_) => "uniffi::RustBuffer".into(),
             FfiType::ForeignBytes => "uniffi::ForeignBytes".into(),
             FfiType::ForeignCallback => "uniffi::ForeignCallback".into(),
+            FfiType::ForeignCallback2 => "uniffi::ForeignCallback2".into(),
         })
     }
 

--- a/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
@@ -25,6 +25,13 @@ pub extern "C" fn {{ cbi.ffi_init_callback().name() }}(callback: uniffi::Foreign
     // The call status should be initialized to CALL_SUCCESS, so no need to modify it.
 }
 
+#[doc(hidden)]
+#[no_mangle]
+pub extern "C" fn {{ cbi.ffi_init_callback2().name() }}(callback: uniffi::ForeignCallback2, _: &mut uniffi::RustCallStatus) {
+    {{ foreign_callback_internals }}.set_callback2(callback);
+    // The call status should be initialized to CALL_SUCCESS, so no need to modify it.
+}
+
 // Make an implementation which will shell out to the foreign language.
 #[doc(hidden)]
 #[derive(Debug)]

--- a/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
@@ -34,9 +34,9 @@ struct {{ trait_impl }} {
 
 impl Drop for {{ trait_impl }} {
     fn drop(&mut self) {
-        let callback = {{ foreign_callback_internals }}.get_callback().unwrap();
-        let mut rbuf = uniffi::RustBuffer::new();
-        unsafe { callback(self.handle, uniffi::IDX_CALLBACK_FREE, Default::default(), &mut rbuf) };
+        {{ foreign_callback_internals }}.invoke_callback_void_return(
+            self.handle, uniffi::IDX_CALLBACK_FREE, Default::default()
+        )
     }
 }
 
@@ -68,97 +68,20 @@ impl r#{{ trait_name }} for {{ trait_impl }} {
         let args_rbuf = uniffi::RustBuffer::from_vec(args_buf);
 
     {#- Calling into foreign code. #}
-        let callback = {{ foreign_callback_internals }}.get_callback().unwrap();
+        {%- match (meth.return_type(), meth.throws_type()) %}
+        {%- when (Some(return_type), None) %}
+        {{ foreign_callback_internals }}.invoke_callback::<{{ return_type|type_rs }}, crate::UniFfiTag>(self.handle, {{ loop.index }}, args_rbuf)
 
-        unsafe {
-            // SAFETY:
-            // * We're passing in a pointer to an empty buffer.
-            //   * Nothing allocated, so nothing to drop.
-            // * We expect the callback to write into that a valid allocated instance of a
-            //   RustBuffer.
-            let mut ret_rbuf = uniffi::RustBuffer::new();
-            let ret = callback(self.handle, {{ loop.index }}, args_rbuf, &mut ret_rbuf);
-            #[allow(clippy::let_and_return, clippy::let_unit_value)]
-            match ret {
-                1 => {
-                    // 1 indicates success with the return value written to the RustBuffer for
-                    //   non-void calls.
-                    let result = {
-                        {% match meth.return_type() -%}
-                        {%- when Some(return_type) -%}
-                        let vec = ret_rbuf.destroy_into_vec();
-                        let mut ret_buf = vec.as_slice();
-                        {{ return_type|ffi_converter }}::try_read(&mut ret_buf).unwrap()
-                        {%- else %}
-                        uniffi::RustBuffer::destroy(ret_rbuf);
-                        {%- endmatch %}
-                    };
-                    {%- if meth.throws() %}
-                    Ok(result)
-                    {%- else %}
-                    result
-                    {%- endif %}
-                }
-                -2 => {
-                    // -2 indicates an error written to the RustBuffer
-                    {% match meth.throws_type() -%}
-                    {% when Some(error_type) -%}
-                    let vec = ret_rbuf.destroy_into_vec();
-                    let mut ret_buf = vec.as_slice();
-                    Err({{ error_type|ffi_converter }}::try_read(&mut ret_buf).unwrap())
-                    {%- else -%}
-                    panic!("Callback return -2, but throws_type() is None");
-                    {%- endmatch %}
-                }
-                // 0 is a deprecated method to indicates success for void returns
-                0 => {
-                    uniffi::deps::log::error!("UniFFI: Callback interface returned 0. Please update the bindings code to return 1 for all successful calls");
-                    {% match (meth.return_type(), meth.throws()) %}
-                    {% when (Some(_), _) %}
-                    panic!("Callback returned 0 when we were expecting a return value");
-                    {% when (None, false) %}
-                    {% when (None, true) %}
-                    Ok(())
-                    {%- endmatch %}
-                }
-                // -1 indicates an unexpected error
-                {% match meth.throws_type() %}
-                {%- when Some(error_type) -%}
-                -1 => {
-                    let reason = if !ret_rbuf.is_empty() {
-                        match {{ Type::String.borrow()|ffi_converter }}::try_lift(ret_rbuf) {
-                            Ok(s) => s,
-                            Err(e) => {
-                                uniffi::deps::log::error!("{{ trait_name }} Error reading ret_buf: {e}");
-                                String::from("[Error reading reason]")
-                            }
-                        }
-                    } else {
-                        uniffi::RustBuffer::destroy(ret_rbuf);
-                        String::from("[Unknown Reason]")
-                    };
-                    let e: {{ error_type|type_rs }} = uniffi::UnexpectedUniFFICallbackError::from_reason(reason).into();
-                    Err(e)
-                }
-                {%- else %}
-                -1 => {
-                    if !ret_rbuf.is_empty() {
-                        let reason = match {{ Type::String.borrow()|ffi_converter }}::try_lift(ret_rbuf) {
-                            Ok(s) => s,
-                            Err(_) => {
-                                String::from("[Error reading reason]")
-                            }
-                        };
-                        panic!("callback failed. Reason: {reason}");
-                    } else {
-                        panic!("Callback failed")
-                    }
-                },
-                {%- endmatch %}
-                // Other values should never be returned
-                _ => panic!("Callback failed with unexpected return code"),
-            }
-        }
+        {%- when (Some(return_type), Some(error_type)) %}
+        {{ foreign_callback_internals }}.invoke_callback_with_error::<{{ return_type|type_rs }}, {{ error_type|type_rs }}, crate::UniFfiTag>(self.handle, {{ loop.index }}, args_rbuf)
+
+        {%- when (None, Some(error_type)) %}
+        {{ foreign_callback_internals }}.invoke_callback_with_error::<(), {{ error_type|type_rs }}, crate::UniFfiTag>(self.handle, {{ loop.index }}, args_rbuf)
+
+        {%- when (None, None) %}
+        {{ foreign_callback_internals }}.invoke_callback_void_return(self.handle, {{ loop.index }}, args_rbuf)
+
+        {%- endmatch %}
     }
     {%- endfor %}
 }

--- a/uniffi_core/src/ffi/foreigncallbacks.rs
+++ b/uniffi_core/src/ffi/foreigncallbacks.rs
@@ -157,7 +157,8 @@ pub type ForeignCallback = unsafe extern "C" fn(
 pub type ForeignCallback2 = unsafe extern "C" fn(
     handle: u64,
     method: u32,
-    args: &RustBuffer,
+    args_data: *const u8,
+    args_len: i32,
     buf_ptr: *mut RustBuffer,
 ) -> c_int;
 
@@ -253,7 +254,13 @@ impl ForeignCallbackInternals {
             unsafe {
                 let callback = std::mem::transmute::<usize, Option<ForeignCallback2>>(ptr_value)
                     .expect("Callback not set");
-                callback(handle, method, &args, ret_rbuf)
+                callback(
+                    handle,
+                    method,
+                    args.data_pointer(),
+                    args.len() as i32,
+                    ret_rbuf,
+                )
             }
         }
     }

--- a/uniffi_core/src/ffi/foreigncallbacks.rs
+++ b/uniffi_core/src/ffi/foreigncallbacks.rs
@@ -370,17 +370,14 @@ impl ForeignCallbackInternals {
         let mut ret_rbuf = RustBuffer::new();
         let callback_result = self.call_callback(handle, method, args, &mut ret_rbuf);
         match callback_result {
-            1 => {
-                // 1 indicates success
-                ()
-            }
+            // 1 indicates success
+            1 => {}
             -2 => {
                 panic!("Callback return -2, but no Error was expected")
             }
             // 0 is a deprecated method to indicates success for void returns
             0 => {
                 log::error!("UniFFI: Callback interface returned 0. Please update the bindings code to return 1 for all successful calls");
-                ()
             }
             // -1 indicates an unexpected error
             -1 => {

--- a/uniffi_core/src/ffi/rustbuffer.rs
+++ b/uniffi_core/src/ffi/rustbuffer.rs
@@ -101,6 +101,11 @@ impl RustBuffer {
             .expect("buffer length negative or overflowed")
     }
 
+    /// Get a pointer to the data
+    pub fn data_pointer(&self) -> *const u8 {
+        self.data
+    }
+
     /// Returns true if the length of the buffer is 0.
     pub fn is_empty(&self) -> bool {
         self.len == 0

--- a/uniffi_testing/src/lib.rs
+++ b/uniffi_testing/src/lib.rs
@@ -258,7 +258,6 @@ fn get_cargo_build_messages() -> Vec<Message> {
     let mut child = Command::new(env!("CARGO"))
         .arg("build")
         .arg("--message-format=json")
-        .arg("--tests")
         .stdout(Stdio::piped())
         .spawn()
         .expect("Error running cargo build");


### PR DESCRIPTION
This branch improves callback interface performance, which we realized could be an issue when using callbacks for logging.  The performance is okay for small numbers of calls, but it starts to matter once you start making 1000s of calls per second -- which we thought could maybe happen with logging.

This PR adds some very basic benchmarking that I used to test the performance improvements.  The benchmarks are quite noisy but any kind of numbers are nice when working on this.  I also started benchmarks for regular calls, but that's more of a proof-of-concept than anything, that code should definitely be double-checked before making code changes based on it.

The other thing I'm trying is to update the ABI, without creating a breaking change.  https://github.com/mozilla/uniffi-rs/commit/05115dfd7c6585c759471c30082836b94151785b describes how I think we can do that.  Please double check that my assumptions are correct here though.