### PR TITLE
Add additional functions to uniffi-fixture-time

### DIFF
--- a/fixtures/uniffi-fixture-time/Cargo.toml
+++ b/fixtures/uniffi-fixture-time/Cargo.toml
@@ -13,6 +13,7 @@ name = "uniffi_chronological"
 [dependencies]
 uniffi = {path = "../../uniffi"}
 thiserror = "1.0"
+chrono = { version = "0.4.23", default-features = false, features = ["alloc", "std"] }
 
 [build-dependencies]
 uniffi = {path = "../../uniffi", features = ["build"] }

--- a/fixtures/uniffi-fixture-time/src/chronological.udl
+++ b/fixtures/uniffi-fixture-time/src/chronological.udl
@@ -6,6 +6,16 @@ enum ChronologicalError {
 
 namespace chronological {
   [Throws=ChronologicalError]
+  timestamp return_timestamp(timestamp a);
+
+  [Throws=ChronologicalError]
+  duration return_duration(duration a);
+
+  string to_string_timestamp(timestamp a);
+
+  timestamp get_pre_epoch_timestamp();
+
+  [Throws=ChronologicalError]
   timestamp add(timestamp a, duration b);
 
   [Throws=ChronologicalError]

--- a/fixtures/uniffi-fixture-time/src/lib.rs
+++ b/fixtures/uniffi-fixture-time/src/lib.rs
@@ -4,12 +4,34 @@
 
 use std::time::{Duration, SystemTime};
 
+use chrono::offset::Utc;
+use chrono::DateTime;
+
 #[derive(Debug, thiserror::Error)]
 pub enum ChronologicalError {
     #[error("Time overflow on an operation with {a:?} and {b:?}")]
     TimeOverflow { a: SystemTime, b: Duration },
     #[error("Time difference error {a:?} is before {b:?}")]
     TimeDiffError { a: SystemTime, b: SystemTime },
+}
+
+fn return_timestamp(a: SystemTime) -> Result<SystemTime> {
+    Ok(a)
+}
+
+fn return_duration(a: Duration) -> Result<Duration> {
+    Ok(a)
+}
+
+fn to_string_timestamp(a: SystemTime) -> String {
+    let datetime: DateTime<Utc> = a.into();
+    datetime.format("%Y-%m-%dT%H:%M:%S.%fZ").to_string()
+}
+
+fn get_pre_epoch_timestamp() -> SystemTime {
+    std::time::SystemTime::UNIX_EPOCH
+        .checked_sub(std::time::Duration::new(1, 1_000_000))
+        .unwrap()
 }
 
 fn add(a: SystemTime, b: Duration) -> Result<SystemTime> {


### PR DESCRIPTION
`to_string_timestamp` and `get_pre_epoch_timestamp` separate 2-way back and forth conversion process, making it possible to test 1-way conversion.

`to_string_timestamp` ensures that foreign language bindings lower the timestamp correctly, and that foreign language bindings interpret the timestamp the same way that Rust does.

`get_pre_epoch_timestamp` ensures that foreign language bindings lift the timestamp correctly, and that Rust interprets the timestamp the same way that foreign language bindings do.