### PR TITLE
Add "return_type()" to Constructor

### DIFF
--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -249,6 +249,42 @@ impl APIConverter<Argument> for weedle::argument::SingleArgument<'_> {
     }
 }
 
+/// Implemented by function-like types (Function, Method, Constructor)
+pub trait Callable {
+    fn arguments(&self) -> Vec<&Argument>;
+    fn return_type(&self) -> Option<Type>;
+    fn throws_type(&self) -> Option<Type>;
+}
+
+impl Callable for Function {
+    fn arguments(&self) -> Vec<&Argument> {
+        self.arguments()
+    }
+
+    fn return_type(&self) -> Option<Type> {
+        self.return_type().cloned()
+    }
+
+    fn throws_type(&self) -> Option<Type> {
+        self.throws_type()
+    }
+}
+
+// Needed because Askama likes to add extra refs to variables
+impl<T: Callable> Callable for &T {
+    fn arguments(&self) -> Vec<&Argument> {
+        (*self).arguments()
+    }
+
+    fn return_type(&self) -> Option<Type> {
+        (*self).return_type()
+    }
+
+    fn throws_type(&self) -> Option<Type> {
+        (*self).throws_type()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -64,7 +64,7 @@ pub use enum_::Enum;
 mod error;
 pub use error::Error;
 mod function;
-pub use function::{Argument, Function};
+pub use function::{Argument, Callable, Function};
 mod literal;
 pub use literal::{Literal, Radix};
 mod namespace;

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -65,7 +65,7 @@ use uniffi_meta::Checksum;
 
 use super::attributes::{Attribute, ConstructorAttributes, InterfaceAttributes, MethodAttributes};
 use super::ffi::{FfiArgument, FfiFunction, FfiType};
-use super::function::Argument;
+use super::function::{Argument, Callable};
 use super::types::{Type, TypeIterator};
 use super::{convert_type, APIConverter, ComponentInterface};
 
@@ -333,6 +333,20 @@ impl APIConverter<Constructor> for weedle::interface::ConstructorInterfaceMember
     }
 }
 
+impl Callable for Constructor {
+    fn arguments(&self) -> Vec<&Argument> {
+        self.arguments()
+    }
+
+    fn return_type(&self) -> Option<Type> {
+        self.return_type().cloned()
+    }
+
+    fn throws_type(&self) -> Option<Type> {
+        self.throws_type()
+    }
+}
+
 // Represents an instance method for an object type.
 //
 // The FFI will represent this as a function whose first/self argument is a
@@ -486,6 +500,20 @@ impl APIConverter<Method> for weedle::interface::OperationInterfaceMember<'_> {
             ffi_func: Default::default(),
             attributes: MethodAttributes::try_from(self.attributes.as_ref())?,
         })
+    }
+}
+
+impl Callable for Method {
+    fn arguments(&self) -> Vec<&Argument> {
+        self.arguments()
+    }
+
+    fn return_type(&self) -> Option<Type> {
+        self.return_type().cloned()
+    }
+
+    fn throws_type(&self) -> Option<Type> {
+        self.throws_type()
     }
 }
 


### PR DESCRIPTION
This makes Constructor more nominal with Function, i.e. the constructor can be used as a function in macros:
```
{% macro(func) %}
    {{ func.return_type() }}
{% endmacro %}

{% call macro(constructor) %}
```

This is very useful for generating Go bindings, because in Go errors are handled via multiple return values, instead of exceptions. That means that codegen for function return signatures get quite complicated, and being able to re-use the same code for constructors as for regular functions makes it much easier to generate code.