### PR TITLE
[Discuss] New docs/examples in preparation for async callbacks

### DIFF
--- a/docs/manual/src/udl/builtin_types.md
+++ b/docs/manual/src/udl/builtin_types.md
@@ -17,5 +17,6 @@ The following built-in types can be passed as arguments/returned by Rust methods
 | `HashMap<String, T>` | `record<DOMString, T>` | Only string keys are supported                                  |
 | `()`                 | `void`                 | Empty return                                                    |
 | `Result<T, E>`       | N/A                    | See [Errors](./errors.md) section                               |
+| `uniffi::TaskQueue`  | `TaskQueue`            | Task queue in the foreign language: Kotlin CoroutineScope, Python Executor, Swift DispatchQueue, etc. |
 
 And of course you can use your own types, which is covered in the following sections.

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,8 @@ Newcomers are recommended to explore them in the following order:
   code, through rust and back again.
 * [`./fxa-client`](./fxa-client/) doesn't work yet, but it contains aspirational example of what the UDL
   might look like for an actual real-world component.
+* [`./user-data-store`](./user-data-store/) shows how async Rust code can be driven by an executor
+  running in the foreign language.
 
 Each example has the following structure:
 

--- a/examples/callbacks/README.md
+++ b/examples/callbacks/README.md
@@ -1,0 +1,3 @@
+This example is actually several mini-examples that should how callbacks can be used.  The
+emphasis on how they can be used as a port/adapter style system with the embedding application
+providing the Rust library with a set of capabilities from outside.

--- a/examples/user-data-store/Cargo.toml
+++ b/examples/user-data-store/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "uniffi-example-user-data-store"
+edition = "2021"
+version = "0.23.0"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "uniffi_user_data_store"
+
+[dependencies]
+uniffi = {path = "../../uniffi"}
+futures = "0.3"
+async_once_cell = "0.4"
+async-lock = "2.7.0"
+thiserror = "1.0"
+
+[build-dependencies]
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }

--- a/examples/user-data-store/build.rs
+++ b/examples/user-data-store/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::generate_scaffolding("./src/user_data_store.udl").unwrap();
+}

--- a/examples/user-data-store/src/lib.rs
+++ b/examples/user-data-store/src/lib.rs
@@ -1,0 +1,132 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! An example of a user data store that with an async interface that's driven by the executor on
+//! the foreign side of the FFI.  This is achieved by awaiting async callback interface methods.
+//! See the callbacks section of the manual for the technical details.
+
+use async_once_cell::OnceCell;
+use async_mutex::{Mutex, MutexGuard};
+use futures::{join, FutureExt};
+use std::sync::Arc;
+use uniffi::{CallbackResult, ThreadQueue, ForeignFuture};
+
+#[derive(uniffi::Error)]
+pub enum Error {
+    DatabaseError(String),
+    UnexpectedError(String),
+}
+
+impl From<uniffi::UnexpectedCallbackError> for Error {
+    fn from(_: uniffi::UnexpectedCallbackError) -> Self {
+        Self::UnexpectedError("Error invoking callback interface")
+    }
+}
+
+pub type Result<T> = Result<T, Error>;
+
+#[uniffi::callback_interface]
+pub trait Logger {
+    /// Log a message
+    async fn log(&self, message: String) -> CallbackResult<()>;
+}
+
+#[uniffi::callback_interface]
+pub trait CryptoKeyStore {
+    /// Get a key for cryptography operations.  Depending on the application, this may load the key
+    /// from a file or from an OS key store and may require the user to take some action to unloke
+    /// the key.
+    async fn get(&self) -> CallbackResult<String>;
+}
+
+/// Event notification system.
+#[uniffi::callback_interface]
+pub trait EventListener {
+    async fn db_operation_complete(&self, store: Arc<UserStore>, success: bool) -> CallbackResult<()>;
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UserStore {
+    logger: Box<dyn Logger>,
+    key_store: Box<dyn KeyStore>,
+    listener: Box<dyn EventListener>,
+    queue: ThreadQueue,
+    // Use OnceCell lazily initialize the DB/crypto key.
+    // async_once_cell also has a `Lazy` type, which is closer to what we really want, but it seems
+    // to require spelling out the concrete type that implement Future, which would be awkward.
+    db_cell: OnceCell<CallbackResult<Mutex<UserDatabase>>>,
+    crypto_key_cell: OnceCell<CallbackResult<String>>,
+}
+
+
+#[uniffi::export]
+impl UserStore {
+    // Constructors are not yet implemented with proc-macros, but let's pretend they are
+    #[constructor]
+    pub fn new(logger: Box<dyn Logger>, key_store: Box<dyn Logger>, listener: Box<dyn EventListener>, queue: ThreadQueue) -> Self {
+        Self {
+            logger,
+            key_store,
+            listener,
+            queue,
+            db_cell: OnceCell::new(),
+            crypto_key_cell: OnceCell::new()
+        }
+    }
+
+    async fn get_db(&self) -> Result<&Mutex<UserDatabase>> {
+        Ok(db_cell.get_or_init(self.queue.schedule(|| Mutex::new(UserDatabase::new()))).await?)
+    }
+
+    async fn get_crypto_key(&self) -> Result<&str> {
+        Ok(db_cell.get_or_init(self.key_store.get()).await?)
+    }
+
+    /// Warmup by loading the database
+    ///
+    /// TODO: use this method as an example to show how the plumbing works and how execution flows.
+    /// I tried writing it up, but it was hard to do without actual code to use as a reference.
+    pub async fn warmup(&self) {
+        self.get_db().await;
+    }
+
+    // Wrapper for a database operation that awaits on DB initialization and loading the crypto
+    // key.  f should be a synchronous function.
+    //
+    // This is the main point of this example.  This wrapper uses async callback interfaces to:
+    //   - Initialize the database and load the crypto key asynchronously
+    //   - Schedule the database operation in a background thread
+    //   - Log any errors
+    //   - Notify the application that the operation completed
+    fn db_operation<T, F: FnOnce(MutexGuard<'_, Database>, &str) -> Result<T>>(self: &Arc<Self>, f: F) -> Result<T> {
+        let db = self.get_db().await?;
+        let crypto_key = self.get_crypto_key().await?;
+        let result = self.queue.schedule(|| f(db, crypto_key)).await?;
+        if let Err(e) = &result {
+            self.logger.log(format!("Database error: {e}")).fire();
+        }
+        self.events.db_operation_complete(self.clone(), result.is_ok()).fire();
+        result
+    }
+
+    pub async fn add_user(self: Arc<Self>, username: String, password: String) -> Result<()> {
+        &self.db_operation(|db, key| {
+            db.insert(username, encrypt(password, key))
+        })
+    }
+
+    pub async fn lookup_password(self: Arc<Self>, username: String, password: String) -> Result<String> {
+        &self.db_operation(|db, key| {
+            Ok(decrypt(db.lookup(username)?, key))
+        })
+    }
+
+    pub async fn delete_user(self: Arc<Self>, username: String, password: String) -> Result<()> {
+        &self.db_operation(|db, _| {
+            db.delete(username)
+        })
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/user_store.uniffi.rs"));

--- a/examples/user-data-store/src/user_data_store.udl
+++ b/examples/user-data-store/src/user_data_store.udl
@@ -1,0 +1,1 @@
+namespace user_data_store {};


### PR DESCRIPTION
This PR is how I think async callbacks could work and why they would be useful.  Any feedback would be greatly appreciated.

The main point is that if we have async callbacks, then foreign application that uses the UniFFIed library can drive things.  We don't need to start up new threads or run a tokio event loop.   This opens up some very interesting possibilities.  Check out the `user-store` example for details here.

I also want to suggest a couple ergonomics changes for callbacks, check out `callback_interfaces.md` for details.