### PR TITLE
Fixes after the callback interface speedup merge

### DIFF
--- a/fixtures/benchmarks/benches/benchmarks.rs
+++ b/fixtures/benchmarks/benches/benchmarks.rs
@@ -5,7 +5,7 @@
 use clap::Parser;
 use std::env;
 use uniffi_benchmarks::Args;
-use uniffi_bindgen::bindings::{kotlin, python, swift, RunScriptMode};
+use uniffi_bindgen::bindings::{kotlin, python, swift, RunScriptOptions};
 
 fn main() {
     let args = Args::parse();
@@ -13,13 +13,17 @@ fn main() {
         .chain(env::args())
         .collect();
 
+    let options = RunScriptOptions {
+        show_compiler_messages: args.compiler_messages,
+    };
+
     if args.should_run_python() {
         python::run_script(
             std::env!("CARGO_TARGET_TMPDIR"),
             "uniffi-fixture-benchmarks",
             "benches/bindings/run_benchmarks.py",
             script_args.clone(),
-            RunScriptMode::PerformanceTest,
+            &options,
         )
         .unwrap()
     }
@@ -30,7 +34,7 @@ fn main() {
             "uniffi-fixture-benchmarks",
             "benches/bindings/run_benchmarks.kts",
             script_args.clone(),
-            RunScriptMode::PerformanceTest,
+            &options,
         )
         .unwrap()
     }
@@ -41,7 +45,7 @@ fn main() {
             "uniffi-fixture-benchmarks",
             "benches/bindings/run_benchmarks.swift",
             script_args,
-            RunScriptMode::PerformanceTest,
+            &options,
         )
         .unwrap()
     }

--- a/fixtures/benchmarks/src/cli.rs
+++ b/fixtures/benchmarks/src/cli.rs
@@ -19,7 +19,7 @@ pub struct Args {
     pub swift: bool,
 
     /// Dump compiler output to the console.  Good for debugging new benchmarks.
-    #[clap(long, display_order = 1, action)]
+    #[clap(long, display_order = 1)]
     pub compiler_messages: bool,
 
     // Args for running the metrics, these are handled in `lib.rs`

--- a/uniffi_bindgen/src/bindings/mod.rs
+++ b/uniffi_bindgen/src/bindings/mod.rs
@@ -34,10 +34,17 @@ pub enum TargetLanguage {
 }
 
 /// Mode for the `run_script` function defined for each language
-#[derive(Copy, Clone, Debug)]
-pub enum RunScriptMode {
-    Test,
-    PerformanceTest,
+#[derive(Clone, Debug)]
+pub struct RunScriptOptions {
+    pub show_compiler_messages: bool,
+}
+
+impl Default for RunScriptOptions {
+    fn default() -> Self {
+        Self {
+            show_compiler_messages: true,
+        }
+    }
 }
 
 impl TryFrom<&str> for TargetLanguage {

--- a/uniffi_bindgen/src/bindings/python/test.rs
+++ b/uniffi_bindgen/src/bindings/python/test.rs
@@ -2,7 +2,7 @@
 License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bindings::RunScriptMode;
+use crate::bindings::RunScriptOptions;
 use anyhow::{Context, Result};
 use camino::Utf8Path;
 use std::env;
@@ -17,7 +17,7 @@ pub fn run_test(tmp_dir: &str, fixture_name: &str, script_file: &str) -> Result<
         fixture_name,
         script_file,
         vec![],
-        RunScriptMode::Test,
+        &RunScriptOptions::default(),
     )
 }
 
@@ -29,7 +29,7 @@ pub fn run_script(
     crate_name: &str,
     script_file: &str,
     args: Vec<String>,
-    _mode: RunScriptMode,
+    _options: &RunScriptOptions,
 ) -> Result<()> {
     let script_path = Utf8Path::new(".").join(script_file).canonicalize_utf8()?;
     let test_helper = UniFFITestHelper::new(crate_name)?;


### PR DESCRIPTION
After this merged into main the performance tests failed because of a clap issue.  I'm really not sure why this was, I don't think we upgraded clap since I started the branch.  In any case, this fixes the issue.

Also, the `--compiler-messages` flag was not being honored.  Updated the code to use this by replacing `RunScriptMode` enum, with `RunScriptOptions`.  I think this makes more sense since we want the performance test mode to have options.  I also think this will be easier to extend going forward.