### PR TITLE
Fix race condition affecting callback interfaces in generated Swift code

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
@@ -102,14 +102,17 @@ fileprivate let {{ foreign_callback }} : ForeignCallback =
 // FfiConverter protocol for callback interfaces
 fileprivate struct {{ ffi_converter_name }} {
     // Initialize our callback method with the scaffolding code
-    private static var callbackInitialized = false
+    private static var callbackInitialized: AtomicBool = false
     private static func initCallback() {
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
                 {{ cbi.ffi_init_callback().name() }}({{ foreign_callback }}, err)
         }
     }
     private static func ensureCallbackinitialized() {
-        if !callbackInitialized {
+        self.callbackInitialized.mutate { callbackInitialized in
+            guard !callbackInitialized else {
+                return
+            }
             initCallback()
             callbackInitialized = true
         }

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
@@ -101,21 +101,15 @@ fileprivate let {{ foreign_callback }} : ForeignCallback =
 
 // FfiConverter protocol for callback interfaces
 fileprivate struct {{ ffi_converter_name }} {
-    // Initialize our callback method with the scaffolding code
-    private static var callbackInitialized: AtomicBool = false
-    private static func initCallback() {
+    private static let initCallbackOnce: () = {
+        // Swift ensures this initializer code will once run once, even when accessed by multiple threads.
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
-                {{ cbi.ffi_init_callback().name() }}({{ foreign_callback }}, err)
+            {{ cbi.ffi_init_callback().name() }}({{ foreign_callback }}, err)
         }
-    }
+    }()
+
     private static func ensureCallbackinitialized() {
-        self.callbackInitialized.mutate { callbackInitialized in
-            guard !callbackInitialized else {
-                return
-            }
-            initCallback()
-            callbackInitialized = true
-        }
+        _ = initCallbackOnce
     }
 
     static func drop(handle: UniFFICallbackHandle) {

--- a/uniffi_bindgen/src/bindings/swift/templates/Helpers.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Helpers.swift
@@ -82,25 +82,3 @@ private func makeRustCall<T>(_ callback: (UnsafeMutablePointer<RustCallStatus>) 
             throw UniffiInternalError.unexpectedRustCallStatusCode
     }
 }
-
-private final class AtomicBool: ExpressibleByBooleanLiteral {
-    private var value: Bool
-    private let lock: UnsafeMutablePointer<os_unfair_lock>
-
-    init(booleanLiteral value: Bool) {
-        self.lock = .allocate(capacity: 1)
-        self.lock.initialize(to: os_unfair_lock())
-        self.value = value
-    }
-
-    deinit {
-        self.lock.deinitialize(count: 1)
-        self.lock.deallocate()
-    }
-
-    func mutate(_ transform: (inout Bool) -> ()) {
-        os_unfair_lock_lock(self.lock)
-        transform(&self.value)
-        os_unfair_lock_unlock(self.lock)
-    }
-}

--- a/uniffi_bindgen/src/bindings/swift/templates/Helpers.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Helpers.swift
@@ -82,3 +82,25 @@ private func makeRustCall<T>(_ callback: (UnsafeMutablePointer<RustCallStatus>) 
             throw UniffiInternalError.unexpectedRustCallStatusCode
     }
 }
+
+private final class AtomicBool: ExpressibleByBooleanLiteral {
+    private var value: Bool
+    private let lock: UnsafeMutablePointer<os_unfair_lock>
+
+    init(booleanLiteral value: Bool) {
+        self.lock = .allocate(capacity: 1)
+        self.lock.initialize(to: os_unfair_lock())
+        self.value = value
+    }
+
+    deinit {
+        self.lock.deinitialize(count: 1)
+        self.lock.deallocate()
+    }
+
+    func mutate(_ transform: (inout Bool) -> ()) {
+        os_unfair_lock_lock(self.lock)
+        transform(&self.value)
+        os_unfair_lock_unlock(self.lock)
+    }
+}


### PR DESCRIPTION
Hello again. I have another one. This time I've encountered an issue that would lead to a Rust panic when interacting with callback interfaces in Swift code in a multi-threaded environment.

The generated output from the panic was
```
Bug: call set_callback multiple times. This is likely a uniffi bug<unnamed>' panicked at 'thread 'Bug: call set_callback multiple times. This is likely a uniffi bug
```
which originates from [here](https://github.com/mozilla/uniffi-rs/blob/e5b99ac2630e7f70e9ae89405ecfd2305e7ab276/uniffi_core/src/ffi/foreigncallbacks.rs#L198).

The issue was in this generated code
```swift
// FfiConverter protocol for callback interfaces
private enum FfiConverterCallbackInterfaceClientDelegate {
    // Initialize our callback method with the scaffolding code
    private static var callbackInitialized = false
    private static func initCallback() {
        try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
            ffi_prose_core_ffi_157f_ClientDelegate_init_callback(foreignCallbackCallbackInterfaceClientDelegate, err)
        }
    }

    private static func ensureCallbackinitialized() {
        if !callbackInitialized {
            initCallback()
            callbackInitialized = true
        }
    }

    static func drop(handle: UniFFICallbackHandle) {
        handleMap.remove(handle: handle)
    }

    private static var handleMap = UniFFICallbackHandleMap<ClientDelegate>()
}
```
which doesn't synchronize access to the `callbackInitialized` property so that `initCallback()` might be called more than once.

I believe that this use-case should work and have introduced an AtomicBool class to allow synchronized access via an UnfairLock.

Unfortunately I wasn't able to reproduce the issue in a unit case on my computer. After modifying the `CallbackInterfaceTemplate.swift` slightly just by adding a print statement however the issue became apparent. You can try yourself [here](https://github.com/nesium/uniffi-rs/commit/cdd304f8e9fe229e0f1ad453e4f12db48661decf).