### PR TITLE
CI: Use fully-qualified image name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
 
   Deploy Docker:
     docker:
-      - image: cimg/python
+      - image: cimg/python:3.11
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
There's no latest, only version-tagged ones