### PR TITLE
Ensure bridging header function prototypes are valid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ members = [
   "fixtures/simple-iface",
   "fixtures/swift-omit-labels",
   "fixtures/futures",
+  "fixtures/swift-bridging-header-compile",
 ]
 
 resolver = "2"

--- a/fixtures/swift-bridging-header-compile/Cargo.toml
+++ b/fixtures/swift-bridging-header-compile/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "swift-bridging-header-compile"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+name = "uniffi_swift_bridging_header_compiler"
+crate-type = ["lib", "cdylib"]
+
+[dependencies]
+uniffi = { path = "../../uniffi" }
+
+[build-dependencies]
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests", "cli"] }
+uniffi_testing = { path = "../../uniffi_testing" }
+anyhow = "1"

--- a/fixtures/swift-bridging-header-compile/README.md
+++ b/fixtures/swift-bridging-header-compile/README.md
@@ -1,0 +1,2 @@
+Test that the `nameFFI.h` bridging header can be compiler with a
+reasonably strict set of compiler warnings enabled.

--- a/fixtures/swift-bridging-header-compile/build.rs
+++ b/fixtures/swift-bridging-header-compile/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::generate_scaffolding("./src/swift-bridging-header-compile.udl").unwrap();
+}

--- a/fixtures/swift-bridging-header-compile/src/lib.rs
+++ b/fixtures/swift-bridging-header-compile/src/lib.rs
@@ -1,0 +1,6 @@
+pub fn no_arguments() {}
+
+include!(concat!(
+    env!("OUT_DIR"),
+    "/swift-bridging-header-compile.uniffi.rs"
+));

--- a/fixtures/swift-bridging-header-compile/src/swift-bridging-header-compile.udl
+++ b/fixtures/swift-bridging-header-compile/src/swift-bridging-header-compile.udl
@@ -1,0 +1,3 @@
+namespace swift_bridging_header_compile {
+    void no_arguments();
+};

--- a/fixtures/swift-bridging-header-compile/tests/clang.rs
+++ b/fixtures/swift-bridging-header-compile/tests/clang.rs
@@ -1,0 +1,55 @@
+use std::process::Command;
+use uniffi_testing::UniFFITestHelper;
+
+#[test]
+fn clang() -> Result<(), anyhow::Error> {
+    let tmp_dir = std::env!("CARGO_TARGET_TMPDIR");
+    let crate_name = std::env!("CARGO_PKG_NAME");
+
+    let test_helper = UniFFITestHelper::new(crate_name)?;
+    let out_dir = test_helper.create_out_dir(tmp_dir, "clang.rs")?;
+    let main_compile_source = test_helper.get_main_compile_source()?;
+
+    uniffi::generate_bindings(
+        &main_compile_source.udl_path,
+        main_compile_source.config_path.as_deref(),
+        vec!["swift"],
+        Some(&out_dir),
+        None,
+        false,
+    )?;
+
+    let bridging_h = out_dir.join("swift_bridging_header_compileFFI.h");
+
+    // Compile the header as objective-c with a pendantic set of warnings.
+    let o = Command::new("clang")
+        .args([
+            "-c",
+            "-x",
+            "objective-c",
+            "-Wpedantic",
+            "-Werror",
+            "-Wstrict-prototypes",
+            "-Wno-pragma-once-outside-header", // We are compiling a header directly, so this is fine.
+            "-Wno-newline-eof",                // If `swiftformat` were used this would be ok.
+            "-o",
+            "/dev/null",
+            bridging_h.as_str(),
+        ])
+        .output()?;
+
+    assert!(
+        o.status.success(),
+        r#"Failed to compile bridging header {}:
+stdout:
+{}
+
+stderr:
+{}
+"#,
+        o.status,
+        String::from_utf8_lossy(&o.stdout),
+        String::from_utf8_lossy(&o.stderr)
+    );
+    Ok(())
+}

--- a/uniffi_bindgen/src/bindings/swift/templates/macros.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/macros.swift
@@ -82,10 +82,14 @@
 // Note unfiltered name but ffi_type_name filters.
 -#}
 {%- macro arg_list_ffi_decl(func) %}
-    {%- for arg in func.arguments() %}
-        {{- arg.type_().borrow()|ffi_type_name }} {{ arg.name() -}}{% if !loop.last || func.has_rust_call_status_arg() %}, {% endif %}
-    {%- endfor %}
-    {%- if func.has_rust_call_status_arg() %}RustCallStatus *_Nonnull out_status{% endif %}
+    {%- if func.arguments().len() > 0 %}
+        {%- for arg in func.arguments() %}
+            {{- arg.type_().borrow()|ffi_type_name }} {{ arg.name() -}}{% if !loop.last || func.has_rust_call_status_arg() %}, {% endif %}
+        {%- endfor %}
+        {%- if func.has_rust_call_status_arg() %}RustCallStatus *_Nonnull out_status{% endif %}
+    {%- else %}
+        {%- if func.has_rust_call_status_arg() %}RustCallStatus *_Nonnull out_status{%- else %}void{% endif %}
+    {% endif %}
 {%- endmacro -%}
 
 {%- macro async(func) %}


### PR DESCRIPTION
Compiling my swift project I am seeing:

```
Generated/mycrateFFI.h:75:45: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
```

for the `ffi_mycrate_uniffi_contract_version` and
`uniffi_mycrate_checksum_func_myfun` declarations.

This is because they take no arguments which is emitted as `()`, for C `(void)` is required, C++ is happy with either.

Add a specific case to `swift::arg_list_ffi_decl` to handle this. The resulting diff is:

```
--- mycrateFFI.h	2023-04-06 10:38:25.645130502 +0100
+++ mycrateFFI.h	2023-04-06 11:01:12.415958817 +0100
@@ -73,9 +73,11 @@ RustBuffer ffi_mycrate_rustbuffer_reserv
 );

 uint32_t ffi_mycrate_uniffi_contract_version(
+    void

 );

 uint16_t uniffi_mycrate_checksum_func_myfun(
+    void

 );
```

---