### PR TITLE
Update `docker/cargo-docker.sh` to new image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -4,9 +4,9 @@ in CI. To build a new version of this docker image, run
 the following from the root of the repository:
 
 ```
-docker build -t rfkelly/uniffi-ci -f docker/Dockerfile-build .
-docker push rfkelly/uniffi-ci
+docker build -t janerik/uniffi-ci -f docker/Dockerfile-build .
+docker push janerik/uniffi-ci
 ```
 
-That only works if you're `rfkelly`; we need to figure out
+That only works if you're `janerik`; we need to figure out
 a better strategy for maintainership of said docker image.

--- a/docker/cargo-docker.sh
+++ b/docker/cargo-docker.sh
@@ -10,4 +10,4 @@ docker run \
     -v $HOME/.cargo/registry:/usr/local/cargo/registry \
     -v $PWD:/mounted_workdir \
     -w /mounted_workdir \
-    rfkelly/uniffi-ci:latest bash -i -c "cargo $*"
+    janerik/uniffi-ci:latest bash -i -c "cargo $*"

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,7 +43,7 @@ If you want to try them out, you will need:
 * The [Ruby FFI](https://github.com/ffi/ffi#installation)
   * `gem install ffi test-unit rubocop`
 
-We publish a [docker image](https://hub.docker.com/r/rfkelly/uniffi-ci) that has all of this dependencies
+We publish a [docker image](https://hub.docker.com/r/janerik/uniffi-ci) that has all of this dependencies
 pre-installed, if you want to get up and running quickly.
 
 With that in place, try the following:


### PR DESCRIPTION
Following b18505488dc2 ("Switch to updated container image").

The changes to the README are a bit silly/pointless but I figured they ought to be in sync.

/cc @badboy.