### PR TITLE
swift: Correct lowered type for returning an `Arc<_>`.

### DIFF
--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -124,6 +124,12 @@ pub fn new_megaphone() -> Arc<Megaphone> {
     Arc::new(Megaphone)
 }
 
+/// Async function that generates a new `Megaphone`.
+#[uniffi::export]
+pub async fn async_new_megaphone() -> Arc<Megaphone> {
+    new_megaphone()
+}
+
 /// A megaphone. Be careful with the neighbours.
 #[derive(uniffi::Object)]
 pub struct Megaphone;

--- a/fixtures/futures/tests/bindings/test_futures.swift
+++ b/fixtures/futures/tests/bindings/test_futures.swift
@@ -112,6 +112,18 @@ Task {
 	counter.leave()
 }
 
+// Test async function returning an object
+counter.enter()
+
+Task {
+	let megaphone = await asyncNewMegaphone()
+
+	let result = try await megaphone.fallibleMe(doFail: false)
+	assert(result == 42)
+
+	counter.leave()
+}
+
 // Test with the Tokio runtime.
 counter.enter()
 

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -443,7 +443,7 @@ pub mod filters {
             FfiType::UInt64 => "UInt64".into(),
             FfiType::Float32 => "Float".into(),
             FfiType::Float64 => "Double".into(),
-            FfiType::RustArcPtr(_) => "void*_Nonnull".into(),
+            FfiType::RustArcPtr(_) => "UnsafeMutableRawPointer".into(),
             FfiType::RustBuffer(_) => "RustBuffer".into(),
             FfiType::ForeignBytes => "ForeignBytes".into(),
             FfiType::ForeignCallback => "ForeignCallback  _Nonnull".to_string(),


### PR DESCRIPTION
The newly added test previously failed with:

```
/mounted_workdir/target/tmp/uniffi-fixture-futures-33456a6570cdb80a/uniffi_futures.swift:1024:62: error: '>' is not a postfix unary operator
        let polledResult = UnsafeMutablePointer<void*_Nonnull>.allocate(capacity: 1)
                                                             ^
/mounted_workdir/target/tmp/uniffi-fixture-futures-33456a6570cdb80a/uniffi_futures.swift:1024:54: error: cannot find '_Nonnull' in scope
        let polledResult = UnsafeMutablePointer<void*_Nonnull>.allocate(capacity: 1)
                                                     ^~~~~~~~
test uniffi_foreign_language_testcase_test_futures_swift ... FAILED
```

Fixes: #1505 /cc @Hywan @conanoc.