### PR TITLE
Ensure unused `#[derive(uniffi::Object)]`'s don't break things

### DIFF
--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -26,6 +26,19 @@ pub struct Three {
     obj: Arc<Object>,
 }
 
+// An object that's not used anywhere (ie, in records, function signatures, etc)
+// should not break things.
+#[derive(uniffi::Object)]
+pub struct Unused;
+
+#[uniffi::export]
+impl Unused {
+    #[uniffi::constructor]
+    fn new() -> Arc<Self> {
+        Arc::new(Self)
+    }
+}
+
 #[derive(uniffi::Object)]
 pub struct Object;
 

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -636,9 +636,12 @@ impl ComponentInterface {
         Ok(())
     }
 
-    pub(super) fn add_object_free_fn(&mut self, meta: ObjectMetadata) {
+    pub(super) fn add_object_free_fn(&mut self, meta: ObjectMetadata) -> Result<()> {
+        self.types
+            .add_known_type(&Type::Object(meta.name.clone()))?;
         let object = get_or_insert_object(&mut self.objects, &meta.name);
         object.ffi_func_free.name = meta.free_ffi_symbol_name();
+        Ok(())
     }
 
     /// Called by `APIBuilder` impls to add a newly-parsed object definition to the `ComponentInterface`.

--- a/uniffi_bindgen/src/macro_metadata/ci.rs
+++ b/uniffi_bindgen/src/macro_metadata/ci.rs
@@ -88,7 +88,7 @@ pub fn add_to_ci(
                 iface.add_enum_definition(enum_)?;
             }
             Metadata::Object(meta) => {
-                iface.add_object_free_fn(meta);
+                iface.add_object_free_fn(meta)?;
             }
             Metadata::Error(meta) => {
                 let ty = Type::Error(meta.name.clone());


### PR DESCRIPTION
Fixes #1527

The other alternative is to lean into the fact it's unused meaning we optimize the object out entirely, but I'm not sure that's wise.