### PR TITLE
Support returning an `Option<Object>` from an async function

### DIFF
--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -130,6 +130,16 @@ pub async fn async_new_megaphone() -> Arc<Megaphone> {
     new_megaphone()
 }
 
+/// Async function that possibly generates a new `Megaphone`.
+#[uniffi::export]
+pub async fn async_maybe_new_megaphone(y: bool) -> Option<Arc<Megaphone>> {
+    if y {
+        Some(new_megaphone())
+    } else {
+        None
+    }
+}
+
 /// A megaphone. Be careful with the neighbours.
 #[derive(uniffi::Object)]
 pub struct Megaphone;

--- a/fixtures/futures/tests/bindings/test_futures.kts
+++ b/fixtures/futures/tests/bindings/test_futures.kts
@@ -92,6 +92,15 @@ runBlocking {
     println(" ... ok")
 }
 
+// Test async method returning optional object
+runBlocking {
+    val megaphone = asyncMaybeNewMegaphone(true)
+    assert(megaphone != null)
+
+    val not_megaphone = asyncMaybeNewMegaphone(false)
+    assert(not_megaphone == null)
+}
+
 // Test with the Tokio runtime.
 runBlocking {
     val time = measureTimeMillis {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
@@ -30,7 +30,7 @@ internal interface _UniFFILib : Library {
         }
 
         {%- if ci.has_async_fns() %}
-        internal val FUTURE_WAKER_ENVIRONMENTS: ConcurrentHashMap<Int, RustFutureWakerEnvironment<out Any>> by lazy {
+        internal val FUTURE_WAKER_ENVIRONMENTS: ConcurrentHashMap<Int, RustFutureWakerEnvironment<out Any?>> by lazy {
             ConcurrentHashMap(8)
         }
         {%- endif %}


### PR DESCRIPTION
The newly added test case previously failed with:

```
target/tmp/uniffi-fixture-futures-a3d73500fcde9679/uniffi/fixture/futures/uniffi_futures.kt:1638:63: error: type mismatch: inferred type is RustFutureWakerEnvironment<Megaphone?> but RustFutureWakerEnvironment<out Any> was expected
            _UniFFILib.FUTURE_WAKER_ENVIRONMENTS.put(envHash, env)
                                                              ^
test uniffi_foreign_language_testcase_test_futures_kts ... FAILED
```