### PR TITLE
Spike/Experiment: Add JSON helper methods for Python `dictionary` types

### DIFF
--- a/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
@@ -17,10 +17,31 @@ class {{ type_name }}:
     def __init__(self):
         raise RuntimeError("{{ type_name }} cannot be instantiated directly")
 
+    {%- if python_config.json_support %}
+    @staticmethod
+    def from_json(str):
+        {%- for variant in e.variants() %}
+        try:
+            return {{ type_name }}.{{ variant.name()|enum_variant_py }}.from_json(str)
+        except TypeError or ValueError as e:
+            print('Unable to parse dict as type {{ type_name }}.{{ variant.name()|enum_variant_py }}', e)
+        {%- endfor %}
+
+
+    @staticmethod
+    def from_dict(dict_value):
+        {%- for variant in e.variants() %}
+        try:
+            return {{ type_name }}.{{ variant.name()|enum_variant_py }}.from_dict(dict_value)
+        except TypeError or ValueError as e:
+            print('Unable to parse dict as type {{ type_name }}.{{ variant.name()|enum_variant_py }}', e)
+        {%- endfor %}
+    {%- endif %}
+
     # Each enum variant is a nested class of the enum itself.
     {% for variant in e.variants() -%}
     class {{ variant.name()|enum_variant_py }}(object):
-        def __init__(self,{% for field in variant.fields() %}{{ field.name()|var_name }}{% if loop.last %}{% else %}, {% endif %}{% endfor %}):
+        def __init__(self,*,{% for field in variant.fields() %}{{ field.name()|var_name }}{% if loop.last %}{% else %}, {% endif %}{% endfor %}):
             {% if variant.has_fields() %}
             {%- for field in variant.fields() %}
             self.{{ field.name()|var_name }} = {{ field.name()|var_name }}
@@ -40,6 +61,48 @@ class {{ type_name }}:
                 return False
             {%- endfor %}
             return True
+
+        {%- if python_config.json_support %}
+
+        def to_dict(self):
+            return dict({
+                {%- for field in variant.fields() %}
+                {%- let field_name = field.name()|var_name %}
+                {%- let field_from_type = field_name|from_type("self", field.type_().borrow(), ci, python_config) %}
+                "{{ field_name }}": {{ field_from_type }}
+                {%- if !loop.last %},{% endif %}
+                {%- endfor %}
+            })
+
+
+        def to_json(self):
+            return json.dumps(self.to_dict())
+
+
+        @staticmethod
+        def from_json(str):
+            value = json.loads(str)
+            return {{ type_name }}.{{ variant.name()|enum_variant_py }}.from_dict(value)
+
+
+        @staticmethod
+        def from_dict(dict_value):
+            {%- for field in variant.fields() %}
+            {%- let field_name = field.name()|var_name %}
+            {%- match field_name|into_type("dict_value", field.type_().borrow(), ci, python_config) %}
+            {%- when None %}
+            {%- when Some with(value) %}
+            dict_value["{{ field_name }}"] = {{ value }}
+            {%- endmatch %}
+            {%- endfor %}
+
+            # {%- for field in variant.fields() %}
+            # {%- let field_name = field.name()|var_name %}
+            # {{ field_name }} = dict_value.pop("{{ field_name }}", None)
+            # {%- endfor %}
+
+            return {{ type_name }}.{{ variant.name()|enum_variant_py }}(**dict_value)#{% for field in variant.fields() %}{% let field_name = field.name()|var_name %}{{ field_name }}{% if !loop.last %}, {% endif %}{% endfor %})
+        {%- endif %}
     {% endfor %}
 
     # For each variant, we have an `is_NAME` method for easily checking
@@ -70,7 +133,7 @@ class {{ ffi_converter_name }}(FfiConverterRustBuffer):
             {%- else %}
             return {{ type_name }}.{{variant.name()|enum_variant_py}}(
                 {%- for field in variant.fields() %}
-                {{ field|read_fn }}(buf),
+                {{ field.name()|var_name }}={{ field|read_fn }}(buf),
                 {%- endfor %}
             )
             {%- endif %}

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -205,6 +205,10 @@ impl Variant {
         !self.fields.is_empty()
     }
 
+    pub fn has_field_with_default(&self) -> bool {
+        self.fields.iter().any(|f| f.default.is_some())
+    }
+
     pub fn iter_types(&self) -> TypeIterator<'_> {
         Box::new(self.fields.iter().flat_map(Field::iter_types))
     }

--- a/uniffi_bindgen/src/interface/record.rs
+++ b/uniffi_bindgen/src/interface/record.rs
@@ -80,6 +80,10 @@ impl Record {
         &self.fields
     }
 
+    pub fn has_field_with_default(&self) -> bool {
+        self.fields.iter().any(|f| f.default.is_some())
+    }
+
     pub fn iter_types(&self) -> TypeIterator<'_> {
         Box::new(self.fields.iter().flat_map(Field::iter_types))
     }

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -148,6 +148,26 @@ impl Type {
         };
         Box::new(std::iter::once(self).chain(nested_types))
     }
+
+    pub fn is_primitive(&self) -> bool {
+        return match self {
+            Type::UInt8 |
+            Type::Int8 |
+            Type::UInt16 |
+            Type::Int16 |
+            Type::UInt32 |
+            Type::Int32 |
+            Type::UInt64 |
+            Type::Int64 |
+            Type::Float32 |
+            Type::Float64 |
+            Type::Boolean |
+            Type::String |
+            Type::Timestamp |
+            Type::Duration => true,
+            _ => false
+        }
+    }
 }
 
 /// When passing data across the FFI, each `Type` value will be lowered into a corresponding


### PR DESCRIPTION
Okay so this is very much the definition of a draft, I figure we can use it as a point for discussion if there's interest or a reference for posterity if we decide to just close it.

### Explanation
Long story short, I was [setting up a library's UDL file](https://github.com/jeddai/application-services/blob/OLD-udl-full/components/nimbus/src/cirrus.udl) in such a way that it was going to be _very_ strongly typed across the FFI boundary. This library is going to sit behind a REST API, so converting JSON to Python types and vice-versa would be somewhat important. 

UDL `dictionary` and `enum` types are converted to Python `class`es, and **(in my limited experience with Python)** I could not for the life of me get `json.<loads|dumps>` to work with the typed classes. I tried a few things before going the route I went with this set of changes:
* Having the classes be generated as `dataclass`es
* Having the classes inherit from Pydantic's `BaseModel` (used by FastAPI)

_Author's note: to say I am inexperienced with Python would be an understatement, so there may be some simple solution to this with which I'm not familiar._

### Still needs work
* Some of the UDL types are not implemented yet, I focused on the ones I'd need to function for the library I was working on first
* Tests (there's no testing around these changes atm)
* Refactoring the processing of enums that are not flat
    * At the time I wasn't aware of how `serde_json` mapped non-flat enums with the enum name in the object-def, so the try/except setup I used in this changeset should be replaced in favor of that.
