### PR TITLE
Rename the Swift ffi type filter functions (#1106)

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -362,27 +362,27 @@ impl CodeOracle for SwiftCodeOracle {
 
     fn ffi_type_label(&self, ffi_type: &FfiType) -> String {
         match ffi_type {
-            FfiType::Int8 => "int8_t".into(),
-            FfiType::UInt8 => "uint8_t".into(),
-            FfiType::Int16 => "int16_t".into(),
-            FfiType::UInt16 => "uint16_t".into(),
-            FfiType::Int32 => "int32_t".into(),
-            FfiType::UInt32 => "uint32_t".into(),
-            FfiType::Int64 => "int64_t".into(),
-            FfiType::UInt64 => "uint64_t".into(),
-            FfiType::Float32 => "float".into(),
-            FfiType::Float64 => "double".into(),
-            FfiType::RustArcPtr(_) => "void*_Nonnull".into(),
+            FfiType::Int8 => "Int8".into(),
+            FfiType::UInt8 => "UInt8".into(),
+            FfiType::Int16 => "Int16".into(),
+            FfiType::UInt16 => "UInt16".into(),
+            FfiType::Int32 => "Int32".into(),
+            FfiType::UInt32 => "UInt32".into(),
+            FfiType::Int64 => "Int64".into(),
+            FfiType::UInt64 => "UInt64".into(),
+            FfiType::Float32 => "Float".into(),
+            FfiType::Float64 => "Double".into(),
+            FfiType::RustArcPtr(_) => "UnsafeMutableRawPointer".into(),
             FfiType::RustBuffer(_) => "RustBuffer".into(),
             FfiType::ForeignBytes => "ForeignBytes".into(),
             FfiType::ForeignCallback => "ForeignCallback _Nonnull".into(),
-            FfiType::ForeignExecutorCallback => "UniFfiForeignExecutorCallback _Nonnull".into(),
-            FfiType::ForeignExecutorHandle => "size_t".into(),
+            FfiType::ForeignExecutorHandle => "Int".into(),
+            FfiType::ForeignExecutorCallback => "ForeignExecutorCallback _Nonnull".into(),
             FfiType::FutureCallback { return_type } => format!(
                 "UniFfiFutureCallback{} _Nonnull",
                 return_type.canonical_name()
             ),
-            FfiType::FutureCallbackData => "void* _Nonnull".into(),
+            FfiType::FutureCallbackData => "UnsafeMutableRawPointer".into(),
         }
     }
 }
@@ -432,36 +432,36 @@ pub mod filters {
         Ok(codetype.literal(oracle, literal))
     }
 
-    /// Get the Swift syntax for representing a given low-level `FfiType`.
-    pub fn ffi_type_name(type_: &FfiType) -> Result<String, askama::Error> {
-        Ok(oracle().ffi_type_label(type_))
+    /// Get the Swift type for an FFIType
+    pub fn ffi_type_name(ffi_type: &FfiType) -> Result<String, askama::Error> {
+        Ok(oracle().ffi_type_label(ffi_type))
     }
 
-    /// Get the type that a type is lowered into.  This is subtly different than `type_ffi`, see
-    /// #1106 for details
-    pub fn type_ffi_lowered(ffi_type: &FfiType) -> Result<String, askama::Error> {
+    /// Like `ffi_type_name`, but used in `BridgingHeaderTemplate.h` which uses a slightly different
+    /// names.
+    pub fn header_ffi_type_name(ffi_type: &FfiType) -> Result<String, askama::Error> {
         Ok(match ffi_type {
-            FfiType::Int8 => "Int8".into(),
-            FfiType::UInt8 => "UInt8".into(),
-            FfiType::Int16 => "Int16".into(),
-            FfiType::UInt16 => "UInt16".into(),
-            FfiType::Int32 => "Int32".into(),
-            FfiType::UInt32 => "UInt32".into(),
-            FfiType::Int64 => "Int64".into(),
-            FfiType::UInt64 => "UInt64".into(),
-            FfiType::Float32 => "Float".into(),
-            FfiType::Float64 => "Double".into(),
-            FfiType::RustArcPtr(_) => "UnsafeMutableRawPointer".into(),
+            FfiType::Int8 => "int8_t".into(),
+            FfiType::UInt8 => "uint8_t".into(),
+            FfiType::Int16 => "int16_t".into(),
+            FfiType::UInt16 => "uint16_t".into(),
+            FfiType::Int32 => "int32_t".into(),
+            FfiType::UInt32 => "uint32_t".into(),
+            FfiType::Int64 => "int64_t".into(),
+            FfiType::UInt64 => "uint64_t".into(),
+            FfiType::Float32 => "float".into(),
+            FfiType::Float64 => "double".into(),
+            FfiType::RustArcPtr(_) => "void*_Nonnull".into(),
             FfiType::RustBuffer(_) => "RustBuffer".into(),
             FfiType::ForeignBytes => "ForeignBytes".into(),
             FfiType::ForeignCallback => "ForeignCallback _Nonnull".into(),
-            FfiType::ForeignExecutorHandle => "Int".into(),
-            FfiType::ForeignExecutorCallback => "ForeignExecutorCallback _Nonnull".into(),
+            FfiType::ForeignExecutorCallback => "UniFfiForeignExecutorCallback _Nonnull".into(),
+            FfiType::ForeignExecutorHandle => "size_t".into(),
             FfiType::FutureCallback { return_type } => format!(
                 "UniFfiFutureCallback{} _Nonnull",
                 return_type.canonical_name()
             ),
-            FfiType::FutureCallbackData => "UnsafeMutableRawPointer".into(),
+            FfiType::FutureCallbackData => "void* _Nonnull".into(),
         })
     }
 

--- a/uniffi_bindgen/src/bindings/swift/templates/AsyncTypes.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/AsyncTypes.swift
@@ -5,7 +5,7 @@
 {%- for result_type in ci.iter_async_result_types() %}
 fileprivate func {{ result_type|future_callback }}(
     rawContinutation: UnsafeRawPointer,
-    returnValue: {{ result_type.future_callback_param().borrow()|type_ffi_lowered }},
+    returnValue: {{ result_type.future_callback_param().borrow()|ffi_type_name }},
     callStatus: RustCallStatus) {
 
     let continuation = rawContinutation.bindMemory(

--- a/uniffi_bindgen/src/bindings/swift/templates/CustomType.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CustomType.swift
@@ -1,4 +1,4 @@
-{%- let ffi_type_name=builtin.ffi_type().borrow()|type_ffi_lowered %}
+{%- let ffi_type_name=builtin.ffi_type().borrow()|ffi_type_name %}
 {%- match config.custom_types.get(name.as_str())  %}
 {%- when None %}
 {#- No config, just forward all methods to our builtin type #}

--- a/uniffi_bindgen/src/bindings/swift/templates/macros.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/macros.swift
@@ -76,21 +76,6 @@
 {%- endmacro %}
 
 
-{#-
-// Arglist as used in the _UniFFILib function declarations.
-// Note unfiltered name but ffi_type_name filters.
--#}
-{%- macro arg_list_ffi_decl(func) %}
-    {%- if func.arguments().len() > 0 %}
-        {%- for arg in func.arguments() %}
-            {{- arg.type_().borrow()|ffi_type_name }} {{ arg.name() -}}{% if !loop.last || func.has_rust_call_status_arg() %}, {% endif %}
-        {%- endfor %}
-        {%- if func.has_rust_call_status_arg() %}RustCallStatus *_Nonnull out_status{% endif %}
-    {%- else %}
-        {%- if func.has_rust_call_status_arg() %}RustCallStatus *_Nonnull out_status{%- else %}void{% endif %}
-    {% endif %}
-{%- endmacro -%}
-
 {%- macro async(func) %}
 {%- if func.is_async() %}async{% endif %}
 {%- endmacro -%}


### PR DESCRIPTION
The current names are very confusing to me.  The new ones make it clear which to use when.