### PR TITLE
Check for integer overflows in Python bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ members = [
   "fixtures/swift-omit-labels",
   "fixtures/futures",
   "fixtures/swift-bridging-header-compile",
+  "fixtures/type-limits",
 ]
 
 resolver = "2"

--- a/fixtures/type-limits/Cargo.toml
+++ b/fixtures/type-limits/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "uniffi-fixture-type-limits"
+version = "0.22.0"
+edition = "2018"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+name = "uniffi_type_limits"
+crate-type = ["lib", "cdylib"]
+
+[dependencies]
+uniffi = { path = "../../uniffi" }
+
+[build-dependencies]
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/type-limits/README.md
+++ b/fixtures/type-limits/README.md
@@ -1,0 +1,3 @@
+# A basic test for uniffi components
+
+This test covers basic free-standing functions.

--- a/fixtures/type-limits/build.rs
+++ b/fixtures/type-limits/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::generate_scaffolding("src/type-limits.udl").unwrap();
+}

--- a/fixtures/type-limits/src/lib.rs
+++ b/fixtures/type-limits/src/lib.rs
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn take_i8(v: i8) -> i8 {
+    v
+}
+fn take_i16(v: i16) -> i16 {
+    v
+}
+fn take_i32(v: i32) -> i32 {
+    v
+}
+fn take_i64(v: i64) -> i64 {
+    v
+}
+
+fn take_u8(v: u8) -> u8 {
+    v
+}
+fn take_u16(v: u16) -> u16 {
+    v
+}
+fn take_u32(v: u32) -> u32 {
+    v
+}
+fn take_u64(v: u64) -> u64 {
+    v
+}
+
+uniffi::include_scaffolding!("type-limits");

--- a/fixtures/type-limits/src/type-limits.udl
+++ b/fixtures/type-limits/src/type-limits.udl
@@ -1,0 +1,11 @@
+namespace uniffi_type_limits {
+  i8 take_i8(i8 v);
+  i16 take_i16(i16 v);
+  i32 take_i32(i32 v);
+  i64 take_i64(i64 v);
+
+  u8 take_u8(u8 v);
+  u16 take_u16(u16 v);
+  u32 take_u32(u32 v);
+  u64 take_u64(u64 v);
+};

--- a/fixtures/type-limits/tests/bindings/test_type_limits.py
+++ b/fixtures/type-limits/tests/bindings/test_type_limits.py
@@ -1,0 +1,69 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from uniffi_type_limits import *
+
+def assert_raises(func, exception_cls):
+    try:
+        func()
+    except exception_cls:
+        return
+    raise AssertionError("didn't raise the required exception")
+
+# strict lower bounds
+assert_raises(lambda: take_i8(-2**7 - 1), ValueError)
+assert_raises(lambda: take_i16(-2**15 - 1), ValueError)
+assert_raises(lambda: take_i32(-2**31 - 1), ValueError)
+assert_raises(lambda: take_i64(-2**63 - 1), ValueError)
+assert_raises(lambda: take_u8(-1), ValueError)
+assert_raises(lambda: take_u16(-1), ValueError)
+assert_raises(lambda: take_u32(-1), ValueError)
+assert_raises(lambda: take_u64(-1), ValueError)
+
+assert take_i8(-2**7) == -2**7
+assert take_i16(-2**15) == -2**15
+assert take_i32(-2**31) == -2**31
+assert take_i64(-2**63) == -2**63
+assert take_u8(0) == 0
+assert take_u16(0) == 0
+assert take_u32(0) == 0
+assert take_u64(0) == 0
+
+# strict upper bounds
+assert_raises(lambda: take_i8(2**7), ValueError)
+assert_raises(lambda: take_i16(2**15), ValueError)
+assert_raises(lambda: take_i32(2**31), ValueError)
+assert_raises(lambda: take_i64(2**63), ValueError)
+assert_raises(lambda: take_u8(2**8), ValueError)
+assert_raises(lambda: take_u16(2**16), ValueError)
+assert_raises(lambda: take_u32(2**32), ValueError)
+assert_raises(lambda: take_u64(2**64), ValueError)
+
+assert take_i8(2**7 - 1) == 2**7 - 1
+assert take_i16(2**15 - 1) == 2**15 - 1
+assert take_i32(2**31 - 1) == 2**31 - 1
+assert take_i64(2**63 - 1) == 2**63 - 1
+assert take_u8(2**8 - 1) == 2**8 - 1
+assert take_u16(2**16 - 1) == 2**16 - 1
+assert take_u32(2**32 - 1) == 2**32 - 1
+assert take_u64(2**64 - 1) == 2**64 - 1
+
+# larger numbers
+assert_raises(lambda: take_i8(10**3), ValueError)
+assert_raises(lambda: take_i16(10**5), ValueError)
+assert_raises(lambda: take_i32(10**10), ValueError)
+assert_raises(lambda: take_i64(10**19), ValueError)
+assert_raises(lambda: take_u8(10**3), ValueError)
+assert_raises(lambda: take_u16(10**5), ValueError)
+assert_raises(lambda: take_u32(10**10), ValueError)
+assert_raises(lambda: take_u64(10**20), ValueError)
+
+assert take_i8(10**2) == 10**2
+assert take_i16(10**4) == 10**4
+assert take_i32(10**9) == 10**9
+assert take_i64(10**18) == 10**18
+assert take_u8(10**2) == 10**2
+assert take_u16(10**4) == 10**4
+assert take_u32(10**9) == 10**9
+assert take_u64(10**19) == 10**19

--- a/fixtures/type-limits/tests/test_generated_bindings.rs
+++ b/fixtures/type-limits/tests/test_generated_bindings.rs
@@ -1,0 +1,1 @@
+uniffi::build_foreign_language_testcases!("tests/bindings/test_type_limits.py");

--- a/fixtures/type-limits/uniffi.toml
+++ b/fixtures/type-limits/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.python]
+cdylib_name = "uniffi_type_limits"

--- a/uniffi_bindgen/src/bindings/python/templates/Int16Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int16Helper.py
@@ -1,9 +1,7 @@
-class FfiConverterInt16(FfiConverterPrimitive):
-    @classmethod
-    def lower(cls, value):
-        if not -2**15 <= value < 2**15:
-            raise ValueError("i16 requires {} <= value < {}".format(-2**15, 2**15))
-        return super().lower(value)
+class FfiConverterInt16(FfiConverterPrimitiveInt):
+    CLASS_NAME = "i16"
+    VALUE_MIN = -2**15
+    VALUE_MAX = 2**15
 
     @staticmethod
     def read(buf):

--- a/uniffi_bindgen/src/bindings/python/templates/Int16Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int16Helper.py
@@ -1,4 +1,10 @@
 class FfiConverterInt16(FfiConverterPrimitive):
+    @classmethod
+    def lower(cls, value):
+        if not -2**15 <= value < 2**15:
+            raise ValueError("i16 requires {} <= value < {}".format(-2**15, 2**15))
+        return super().lower(value)
+
     @staticmethod
     def read(buf):
         return buf.readI16()

--- a/uniffi_bindgen/src/bindings/python/templates/Int32Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int32Helper.py
@@ -1,4 +1,10 @@
 class FfiConverterInt32(FfiConverterPrimitive):
+    @classmethod
+    def lower(cls, value):
+        if not -2**31 <= value < 2**31:
+            raise ValueError("i32 requires {} <= value < {}".format(-2**31, 2**31))
+        return super().lower(value)
+
     @staticmethod
     def read(buf):
         return buf.readI32()

--- a/uniffi_bindgen/src/bindings/python/templates/Int32Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int32Helper.py
@@ -1,9 +1,7 @@
-class FfiConverterInt32(FfiConverterPrimitive):
-    @classmethod
-    def lower(cls, value):
-        if not -2**31 <= value < 2**31:
-            raise ValueError("i32 requires {} <= value < {}".format(-2**31, 2**31))
-        return super().lower(value)
+class FfiConverterInt32(FfiConverterPrimitiveInt):
+    CLASS_NAME = "i32"
+    VALUE_MIN = -2**31
+    VALUE_MAX = 2**31
 
     @staticmethod
     def read(buf):

--- a/uniffi_bindgen/src/bindings/python/templates/Int64Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int64Helper.py
@@ -1,9 +1,7 @@
-class FfiConverterInt64(FfiConverterPrimitive):
-    @classmethod
-    def lower(cls, value):
-        if not -2**63 <= value < 2**63:
-            raise ValueError("i64 requires {} <= value < {}".format(-2**63, 2**63))
-        return super().lower(value)
+class FfiConverterInt64(FfiConverterPrimitiveInt):
+    CLASS_NAME = "i64"
+    VALUE_MIN = -2**63
+    VALUE_MAX = 2**63
 
     @staticmethod
     def read(buf):

--- a/uniffi_bindgen/src/bindings/python/templates/Int64Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int64Helper.py
@@ -1,4 +1,10 @@
 class FfiConverterInt64(FfiConverterPrimitive):
+    @classmethod
+    def lower(cls, value):
+        if not -2**63 <= value < 2**63:
+            raise ValueError("i64 requires {} <= value < {}".format(-2**63, 2**63))
+        return super().lower(value)
+
     @staticmethod
     def read(buf):
         return buf.readI64()

--- a/uniffi_bindgen/src/bindings/python/templates/Int8Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int8Helper.py
@@ -1,9 +1,7 @@
-class FfiConverterInt8(FfiConverterPrimitive):
-    @classmethod
-    def lower(cls, value):
-        if not -2**7 <= value < 2**7:
-            raise ValueError("i8 requires {} <= value < {}".format(-2**7, 2**7))
-        return super().lower(value)
+class FfiConverterInt8(FfiConverterPrimitiveInt):
+    CLASS_NAME = "i8"
+    VALUE_MIN = -2**7
+    VALUE_MAX = 2**7
 
     @staticmethod
     def read(buf):

--- a/uniffi_bindgen/src/bindings/python/templates/Int8Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int8Helper.py
@@ -1,4 +1,10 @@
 class FfiConverterInt8(FfiConverterPrimitive):
+    @classmethod
+    def lower(cls, value):
+        if not -2**7 <= value < 2**7:
+            raise ValueError("i8 requires {} <= value < {}".format(-2**7, 2**7))
+        return super().lower(value)
+
     @staticmethod
     def read(buf):
         return buf.readI8()

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferHelper.py
@@ -1,12 +1,24 @@
 # Types conforming to `FfiConverterPrimitive` pass themselves directly over the FFI.
 class FfiConverterPrimitive:
     @classmethod
+    def check(cls, value):
+        pass
+
+    @classmethod
     def lift(cls, value):
         return value
 
     @classmethod
     def lower(cls, value):
+        cls.check(value)
         return value
+
+class FfiConverterPrimitiveInt(FfiConverterPrimitive):
+    @classmethod
+    def check(cls, value):
+        if not cls.VALUE_MIN <= value < cls.VALUE_MAX:
+            raise ValueError("{} requires {} <= value < {}".format(cls.CLASS_NAME, cls.VALUE_MIN, cls.VALUE_MAX))
+        super().check(value)
 
 # Helper class for wrapper types that will always go through a RustBuffer.
 # Classes should inherit from this and implement the `read` and `write` static methods.

--- a/uniffi_bindgen/src/bindings/python/templates/UInt16Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt16Helper.py
@@ -1,4 +1,10 @@
 class FfiConverterUInt16(FfiConverterPrimitive):
+    @classmethod
+    def lower(cls, value):
+        if not 0 <= value < 2**16:
+            raise ValueError("u16 requires {} <= value < {}".format(0, 2**16))
+        return super().lower(value)
+
     @staticmethod
     def read(buf):
         return buf.readU16()

--- a/uniffi_bindgen/src/bindings/python/templates/UInt16Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt16Helper.py
@@ -1,9 +1,7 @@
-class FfiConverterUInt16(FfiConverterPrimitive):
-    @classmethod
-    def lower(cls, value):
-        if not 0 <= value < 2**16:
-            raise ValueError("u16 requires {} <= value < {}".format(0, 2**16))
-        return super().lower(value)
+class FfiConverterUInt16(FfiConverterPrimitiveInt):
+    CLASS_NAME = "u16"
+    VALUE_MIN = 0
+    VALUE_MAX = 2**16
 
     @staticmethod
     def read(buf):

--- a/uniffi_bindgen/src/bindings/python/templates/UInt32Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt32Helper.py
@@ -1,4 +1,10 @@
 class FfiConverterUInt32(FfiConverterPrimitive):
+    @classmethod
+    def lower(cls, value):
+        if not 0 <= value < 2**32:
+            raise ValueError("u32 requires {} <= value < {}".format(0, 2**32))
+        return super().lower(value)
+
     @staticmethod
     def read(buf):
         return buf.readU32()

--- a/uniffi_bindgen/src/bindings/python/templates/UInt32Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt32Helper.py
@@ -1,9 +1,7 @@
-class FfiConverterUInt32(FfiConverterPrimitive):
-    @classmethod
-    def lower(cls, value):
-        if not 0 <= value < 2**32:
-            raise ValueError("u32 requires {} <= value < {}".format(0, 2**32))
-        return super().lower(value)
+class FfiConverterUInt32(FfiConverterPrimitiveInt):
+    CLASS_NAME = "u32"
+    VALUE_MIN = 0
+    VALUE_MAX = 2**32
 
     @staticmethod
     def read(buf):

--- a/uniffi_bindgen/src/bindings/python/templates/UInt64Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt64Helper.py
@@ -1,4 +1,10 @@
 class FfiConverterUInt64(FfiConverterPrimitive):
+    @classmethod
+    def lower(cls, value):
+        if not 0 <= value < 2**64:
+            raise ValueError("u64 requires {} <= value < {}".format(0, 2**64))
+        return super().lower(value)
+
     @staticmethod
     def read(buf):
         return buf.readU64()

--- a/uniffi_bindgen/src/bindings/python/templates/UInt64Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt64Helper.py
@@ -1,9 +1,7 @@
-class FfiConverterUInt64(FfiConverterPrimitive):
-    @classmethod
-    def lower(cls, value):
-        if not 0 <= value < 2**64:
-            raise ValueError("u64 requires {} <= value < {}".format(0, 2**64))
-        return super().lower(value)
+class FfiConverterUInt64(FfiConverterPrimitiveInt):
+    CLASS_NAME = "u64"
+    VALUE_MIN = 0
+    VALUE_MAX = 2**64
 
     @staticmethod
     def read(buf):

--- a/uniffi_bindgen/src/bindings/python/templates/UInt8Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt8Helper.py
@@ -1,4 +1,10 @@
 class FfiConverterUInt8(FfiConverterPrimitive):
+    @classmethod
+    def lower(cls, value):
+        if not 0 <= value < 2**8:
+            raise ValueError("u8 requires {} <= value < {}".format(0, 2**8))
+        return super().lower(value)
+
     @staticmethod
     def read(buf):
         return buf.readU8()

--- a/uniffi_bindgen/src/bindings/python/templates/UInt8Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt8Helper.py
@@ -1,9 +1,7 @@
-class FfiConverterUInt8(FfiConverterPrimitive):
-    @classmethod
-    def lower(cls, value):
-        if not 0 <= value < 2**8:
-            raise ValueError("u8 requires {} <= value < {}".format(0, 2**8))
-        return super().lower(value)
+class FfiConverterUInt8(FfiConverterPrimitiveInt):
+    CLASS_NAME = "u8"
+    VALUE_MIN = 0
+    VALUE_MAX = 2**8
 
     @staticmethod
     def read(buf):


### PR DESCRIPTION
Not spelling out the numbers as numbers is fine, CPython optimizes it out:
```py
>>> import dis
>>> dis.dis("not -2**63 <= value < 2**63")
  0           0 RESUME                   0

  1           2 LOAD_CONST               0 (-9223372036854775808)
              4 LOAD_NAME                0 (value)
              6 SWAP                     2
              8 COPY                     2
             10 COMPARE_OP               1 (<=)
             16 JUMP_IF_FALSE_OR_POP     5 (to 28)
             18 LOAD_CONST               1 (9223372036854775808)
             20 COMPARE_OP               0 (<)
             26 JUMP_FORWARD             2 (to 32)
        >>   28 SWAP                     2
             30 POP_TOP
        >>   32 UNARY_NOT
             34 RETURN_VALUE
```

The exception thrown imitates the one of the `struct` module:
```py
>>> import struct
>>> struct.pack("<I", 2**32)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
struct.error: 'I' format requires 0 <= number <= 4294967295
```

Also add some tests exercising these code paths.

Fixes #1540.