### PR TITLE
Callback interface returns

### DIFF
--- a/fixtures/callbacks/src/callbacks.udl
+++ b/fixtures/callbacks/src/callbacks.udl
@@ -26,6 +26,8 @@ callback interface ForeignGetters {
   string? get_option(string? v, boolean arg2);
   [Throws=SimpleError]
   sequence<i32> get_list(sequence<i32> v, boolean arg2);
+  [Throws=SimpleError]
+  void get_nothing(string v);
 };
 
 /// These objects are implemented in Rust, and call out to `ForeignGetters`
@@ -42,6 +44,8 @@ interface RustGetters {
   sequence<i32> get_list(ForeignGetters callback, sequence<i32> v, boolean arg2);
   [Throws=SimpleError]
   string? get_string_optional_callback(ForeignGetters? callback, string v, boolean arg2);
+  [Throws=SimpleError]
+  void get_nothing(ForeignGetters callback, string v);
 };
 
 /// These objects are implemented by the foreign language and passed

--- a/fixtures/callbacks/src/lib.rs
+++ b/fixtures/callbacks/src/lib.rs
@@ -7,6 +7,7 @@ trait ForeignGetters {
     fn get_string(&self, v: String, arg2: bool) -> Result<String, SimpleError>;
     fn get_option(&self, v: Option<String>, arg2: bool) -> Result<Option<String>, ComplexError>;
     fn get_list(&self, v: Vec<i32>, arg2: bool) -> Result<Vec<i32>, SimpleError>;
+    fn get_nothing(&self, v: String) -> Result<(), SimpleError>;
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -84,6 +85,10 @@ impl RustGetters {
         arg2: bool,
     ) -> Result<Option<String>, SimpleError> {
         callback.map(|c| c.get_string(v, arg2)).transpose()
+    }
+
+    fn get_nothing(&self, callback: Box<dyn ForeignGetters>, v: String) -> Result<(), SimpleError> {
+        callback.get_nothing(v)
     }
 }
 

--- a/fixtures/callbacks/tests/bindings/test_callbacks.kts
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.kts
@@ -31,6 +31,14 @@ class KotlinGetters(): ForeignGetters {
         return if (arg2) v?.uppercase() else v
     }
     override fun getList(v: List<Int>, arg2: Boolean): List<Int> = if (arg2) v else listOf()
+    override fun getNothing(v: String): Unit {
+         if (v == "bad-argument") {
+            throw SimpleException.BadArgument("bad argument")
+        }
+        if (v == "unexpected-error") {
+            throw RuntimeException("something failed")
+        }
+    }
 }
 
 val callback = KotlinGetters()
@@ -65,6 +73,8 @@ listOf("Some", null).forEach { v ->
 assert(rustGetters.getStringOptionalCallback(callback, "TestString", false) == "TestString")
 assert(rustGetters.getStringOptionalCallback(null, "TestString", false) == null)
 
+// Should not throw
+rustGetters.getNothing(callback, "TestString")
 
 try {
     rustGetters.getString(callback, "bad-argument", true)
@@ -93,6 +103,20 @@ try {
 } catch (e: ComplexException.UnexpectedErrorWithReason) {
     // Expected error
     assert(e.reason == RuntimeException("something failed").toString())
+}
+
+
+try {
+    rustGetters.getNothing(callback, "bad-argument")
+    throw RuntimeException("Expected SimpleException.BadArgument")
+} catch (e: SimpleException.BadArgument){
+    // Expected error
+}
+try {
+    rustGetters.getNothing(callback, "unexpected-error")
+    throw RuntimeException("Expected SimpleException.UnexpectedException")
+} catch (e: SimpleException.UnexpectedException) {
+    // Expected error
 }
 
 rustGetters.destroy()

--- a/fixtures/callbacks/tests/bindings/test_callbacks.py
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.py
@@ -45,6 +45,12 @@ class PythonGetters(ForeignGetters):
         else:
             return []
 
+    def get_nothing(self, v):
+        if v == "bad-argument":
+            raise SimpleError.BadArgument()
+        elif v == "unexpected-error":
+            raise ValueError("unexpected value")
+
 class ForeignGettersTest(unittest.TestCase):
     def test_get_bool(self):
         callback = PythonGetters()
@@ -82,6 +88,9 @@ class ForeignGettersTest(unittest.TestCase):
         self.assertEqual(rust_getters.get_string_optional_callback(PythonGetters(), "TestString", False), "TestString")
         self.assertEqual(rust_getters.get_string_optional_callback(None, "TestString", False), None)
 
+    def test_get_nothing(self):
+        rust_getters.get_nothing(PythonGetters(), "TestString")
+
 # 2. Pass the callback in as a constructor argument, to be stored on the Object struct.
 # This is crucial if we want to configure a system at startup,
 # then use it without passing callbacks all the time.
@@ -106,6 +115,11 @@ class TestCallbackErrors(unittest.TestCase):
             rust_getters.get_string(callback, "bad-argument", True)
         with self.assertRaises(SimpleError.UnexpectedError):
             rust_getters.get_string(callback, "unexpected-error", True)
+
+        with self.assertRaises(SimpleError.BadArgument):
+            rust_getters.get_nothing(callback, "bad-argument")
+        with self.assertRaises(SimpleError.UnexpectedError):
+            rust_getters.get_nothing(callback, "unexpected-error")
 
     def test_complex_errors(self):
         callback = PythonGetters()

--- a/fixtures/callbacks/tests/bindings/test_callbacks.swift
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.swift
@@ -35,6 +35,14 @@ class SwiftGetters: ForeignGetters {
         return arg2 ? v?.uppercased() : v
     }
     func getList(v: [Int32], arg2: Bool) throws -> [Int32] { arg2 ? v : [] }
+    func getNothing(v: String) throws -> () {
+        if v == "bad-argument" {
+            throw SimpleError.BadArgument(message: "Bad argument")
+        }
+        if v == "unexpected-error" {
+            throw SomeOtherError()
+        }
+    }
 }
 
 do {
@@ -69,6 +77,9 @@ do {
 
     assert(try! rustGetters.getStringOptionalCallback(callback: callback, v: "TestString", arg2: false) == "TestString")
     assert(try! rustGetters.getStringOptionalCallback(callback: nil, v: "TestString", arg2: false) == nil)
+
+    // Should not throw
+    try! rustGetters.getNothing(callback: callback, v: "TestString")
 
     // rustGetters.destroy()
 
@@ -123,4 +134,19 @@ do {
         // Expected exception
         assert(reason == String(describing: SomeOtherError()))
     }
+
+    do {
+        _ = try rustGetters.getNothing(callback: callback, v: "bad-argument")
+        assertionFailure("getNothing() should have thrown an exception")
+    } catch SimpleError.BadArgument {
+        // Expected exception
+    }
+
+    do {
+        _ = try rustGetters.getNothing(callback: callback, v: "unexpected-error")
+        assertionFailure("getNothing() should have thrown an exception")
+    } catch SimpleError.UnexpectedError {
+        // Expected exception
+    }
+
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
@@ -59,7 +59,6 @@ public struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
         {% for variant in e.variants() %}
         case let .{{ variant.name()|class_name }}(message):
             writeInt(&buf, Int32({{ loop.index }}))
-            {{ Type::String.borrow()|write_fn }}(message, into: &buf)
         {%- endfor %}
 
         {% else %}

--- a/uniffi_core/src/ffi/rustfuture.rs
+++ b/uniffi_core/src/ffi/rustfuture.rs
@@ -355,7 +355,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::MockExecutor;
+    use crate::{try_lift_from_rust_buffer, MockExecutor};
     use std::sync::Weak;
 
     // Mock future that we can manually control using an Option<>
@@ -489,7 +489,7 @@ mod tests {
         assert_eq!(result.status.code, 1);
         unsafe {
             assert_eq!(
-                <String as FfiConverter<crate::UniFfiTag>>::try_lift(
+                try_lift_from_rust_buffer::<String, crate::UniFfiTag>(
                     result.status.error_buf.assume_init()
                 )
                 .unwrap(),


### PR DESCRIPTION
Refactoring the callback interface return code
    
Added a `FfiConverter` method to handle returning values from callback interface methods.  This removes the need for multiple `invoke_callback_*` methods and fixes #1547.

Removed the swift code that wrote an string to the RustBuffer for flat errors.  No other bindings do that and we just ignored it on the Rust side.

Implemented the lift/lower/read/write for the unit struct.  We now call these methods in the callback interface code.
