### PR TITLE
Implement magic "trait methods"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@
 - The `bytes` primitive type was added, it represents an array of bytes. It maps to `ByteArray` in Kotlin, `bytes` in Python, `String` with `Encoding::BINARY` in Ruby and `Data` in Swift.
 - Shortened `str()` representations of errors in Python to align with other exceptions in Python. Use `repr()` or the `{!r}` format to get the old representation back.
 
+- Methods implemented by standard Rust traits, such as `Debug`, `Display`, `Eq` and `Hash` can now be exposed over the FFI and bindings may implement special methods for them.
+  See [the documentation](https://mozilla.github.io/uniffi-rs/udl/interfaces.html#exposing-methods-from-standard-rust-traits).
+
 ## v0.23.0 (backend crates: v0.23.0) - (_2023-01-27_)
 
 [All changes in v0.23.0](https://github.com/mozilla/uniffi-rs/compare/v0.22.0...v0.23.0).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
   "fixtures/regressions/swift-callbacks-omit-labels",
   "fixtures/regressions/swift-dictionary-nesting",
   "fixtures/regressions/unary-result-alias",
+  "fixtures/trait-methods",
   "fixtures/uitests",
   "fixtures/uniffi-fixture-time",
   "fixtures/version-mismatch",

--- a/docs/manual/src/udl/interfaces.md
+++ b/docs/manual/src/udl/interfaces.md
@@ -148,6 +148,35 @@ For each alternate constructor, UniFFI will expose an appropriate static-method,
 in the foreign language binding, and will connect it to the Rust method of the same name on the underlying
 Rust struct.
 
+## Exposing methods from standard Rust traits
+
+Rust has a number of general purpose traits which add functionality to objects, such
+as `Debug`, `Display`, etc. It's possible to tell UniFFI that your object implements these
+traits and to generate FFI functions to expose them to consumers. Bindings may then optionally
+generate special methods on the object.
+
+For example, consider the following example:
+```
+[Traits=Debug]
+interface TodoList {
+    ...
+}
+```
+and the following Rust code:
+```rust
+#[derive(Debug)]
+struct TodoList {
+   ...
+}
+```
+
+This will cause the Python bindings to generate a `__repr__` method that returns the value implemented by the `Debug` trait.
+Not all bindings support generating special methods, so they may be ignored.
+It is your responsibility to implement the trait on your objects; UniFFI will attempt to generate a meaningful error if you do not.
+
+The list of supported traits is hard-coded in UniFFI's internals, and at time of writing
+is `Debug`, `Display`, `Eq` and `Hash`.
+
 ## Managing Shared References
 
 To the foreign-language consumer, UniFFI object instances are designed to behave as much like

--- a/fixtures/trait-methods/Cargo.toml
+++ b/fixtures/trait-methods/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "uniffi-fixture-trait-methods"
+version = "0.22.0"
+edition = "2021"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "uniffi_trait_methods"
+
+[dependencies]
+uniffi = {path = "../../uniffi"}
+once_cell = "1.12"
+thiserror = "1.0"
+
+[build-dependencies]
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }
+

--- a/fixtures/trait-methods/build.rs
+++ b/fixtures/trait-methods/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::generate_scaffolding("./src/trait_methods.udl").unwrap();
+}

--- a/fixtures/trait-methods/src/lib.rs
+++ b/fixtures/trait-methods/src/lib.rs
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct TraitMethods {
+    val: String,
+}
+
+impl TraitMethods {
+    fn new(val: String) -> Self {
+        Self { val }
+    }
+}
+
+impl std::fmt::Display for TraitMethods {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TraitMethods({})", self.val)
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/trait_methods.uniffi.rs"));

--- a/fixtures/trait-methods/src/trait_methods.udl
+++ b/fixtures/trait-methods/src/trait_methods.udl
@@ -1,0 +1,6 @@
+namespace trait_methods {};
+
+[Traits=(Display, Debug, Eq, Hash)]
+interface TraitMethods {
+    constructor(string name);
+};

--- a/fixtures/trait-methods/tests/bindings/test.py
+++ b/fixtures/trait-methods/tests/bindings/test.py
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import unittest
+from trait_methods import *
+
+class TestTraitMethods(unittest.TestCase):
+    def test_str(self):
+        m = TraitMethods("yo")
+        self.assertEqual(str(m), "TraitMethods(yo)")
+
+    def test_repr(self):
+        m = TraitMethods("yo")
+        self.assertEqual(repr(m), 'TraitMethods { val: "yo" }')
+
+    def test_eq(self):
+        m = TraitMethods("yo")
+        self.assertEqual(m, TraitMethods("yo"))
+        self.assertNotEqual(m, TraitMethods("yoyo"))
+
+    def test_hash(self):
+        d = {}
+        m = TraitMethods("m")
+        d[m] = "m"
+        self.assertTrue(m in d)
+
+if __name__=='__main__':
+    unittest.main()

--- a/fixtures/trait-methods/tests/test_generated_bindings.rs
+++ b/fixtures/trait-methods/tests/test_generated_bindings.rs
@@ -1,0 +1,1 @@
+uniffi::build_foreign_language_testcases!("tests/bindings/test.py",);

--- a/fixtures/uitests/src/trait_methods_unknown_trait.udl
+++ b/fixtures/uitests/src/trait_methods_unknown_trait.udl
@@ -1,0 +1,6 @@
+namespace trait_methods {};
+
+// We don't directly support `PartialEq` - this test checks what happens if you specify an unknown trait.
+[Traits=(Display, Debug, PartialEq, Hash, Eq)]
+interface TraitMethods {
+};

--- a/fixtures/uitests/tests/ui/trait_methods_no_trait.rs
+++ b/fixtures/uitests/tests/ui/trait_methods_no_trait.rs
@@ -1,0 +1,14 @@
+// Unfortunately, path is relative to a temporary build directory :-/
+uniffi_macros::generate_and_include_scaffolding!("../../../../fixtures/trait-methods/src/trait_methods.udl");
+
+fn main() { /* empty main required by `trybuild` */}
+
+// We derive most required traits, just not `Display`, to keep the output smaller.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct TraitMethods {}
+
+impl TraitMethods {
+    fn new(name: String) -> Self {
+        unreachable!();
+    }
+}

--- a/fixtures/uitests/tests/ui/trait_methods_no_trait.stderr
+++ b/fixtures/uitests/tests/ui/trait_methods_no_trait.stderr
@@ -1,0 +1,28 @@
+error[E0277]: `TraitMethods` doesn't implement `std::fmt::Display`
+ --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
+  |
+  | ...   uniffi::deps::static_assertions::assert_impl_all!(r#TraitMethods: std::fmt::Display); // This object has a trait method which requi...
+  |                                                         ^^^^^^^^^^^^^^ `TraitMethods` cannot be formatted with the default formatter
+  |
+  = help: the trait `std::fmt::Display` is not implemented for `TraitMethods`
+  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `uniffi_trait_methods_fn_method_traitmethods_uniffi_trait_display::{closure#0}::_::{closure#0}::assert_impl_all`
+ --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
+  |
+  |             uniffi::deps::static_assertions::assert_impl_all!(r#TraitMethods: std::fmt::Display); // This object has a trait method which...
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `uniffi_trait_methods_fn_method_traitmethods_uniffi_trait_display::{closure#0}::_::{closure#0}::assert_impl_all`
+  = note: this error originates in the macro `uniffi::deps::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `TraitMethods` doesn't implement `std::fmt::Display`
+ --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
+  |
+  | /                 match<std::sync::Arc<r#TraitMethods> as ::uniffi::FfiConverter<crate::UniFfiTag>>::try_lift(r#ptr) {
+  | |                     Ok(ref val) => val,
+  | |                     Err(err) => panic!("Failed to convert arg '{}': {}", "ptr", err),
+  | |                 }
+  | |_________________^ `TraitMethods` cannot be formatted with the default formatter
+  |
+  = help: the trait `std::fmt::Display` is not implemented for `TraitMethods`
+  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+  = help: the trait `std::fmt::Display` is implemented for `Arc<T>`
+  = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/fixtures/uitests/tests/ui/trait_methods_unknown_trait.rs
+++ b/fixtures/uitests/tests/ui/trait_methods_unknown_trait.rs
@@ -1,0 +1,14 @@
+// Unfortunately, path is relative to a temporary build directory :-/
+uniffi_macros::generate_and_include_scaffolding!("../../../../fixtures/uitests/src/trait_methods_unknown_trait.udl");
+
+fn main() { /* empty main required by `trybuild` */}
+
+// We derive all required traits, plus one we don't know about.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct TraitMethods {}
+
+impl std::fmt::Display for TraitMethods {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TraitMethods()")
+    }
+}

--- a/fixtures/uitests/tests/ui/trait_methods_unknown_trait.stderr
+++ b/fixtures/uitests/tests/ui/trait_methods_unknown_trait.stderr
@@ -1,0 +1,7 @@
+error: Failed to generate scaffolding from UDL file at ../../../../fixtures/uitests/src/trait_methods_unknown_trait.udl: Failed to parse UDL: Invalid trait name: PartialEq
+ --> tests/ui/trait_methods_unknown_trait.rs:2:1
+  |
+2 | uniffi_macros::generate_and_include_scaffolding!("../../../../fixtures/uitests/src/trait_methods_unknown_trait.udl");
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `uniffi_macros::generate_and_include_scaffolding` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -70,7 +70,7 @@ pub use literal::{Literal, Radix};
 mod namespace;
 pub use namespace::Namespace;
 mod object;
-pub use object::{Constructor, Method, Object};
+pub use object::{Constructor, Method, Object, UniffiTrait};
 mod record;
 pub use record::{Field, Record};
 

--- a/uniffi_bindgen/src/scaffolding/templates/macros.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/macros.rs
@@ -62,3 +62,22 @@ r#{{ func.name() }}({% call _arg_list_rs_call(func) -%})
 {%- else -%}
 {%- endmatch -%}
 {%- endmacro -%}
+
+{%- macro method_decl_prelude(meth) %}
+#[doc(hidden)]
+#[no_mangle]
+#[allow(clippy::let_unit_value,clippy::unit_arg)] // The generated code uses the unit type like other types to keep things uniform
+pub extern "C" fn r#{{ meth.ffi_func().name() }}(
+    {%- call arg_list_ffi_decl(meth.ffi_func()) %}
+) {% call return_signature(meth) %} {
+    uniffi::deps::log::debug!("{{ meth.ffi_func().name() }}");
+    uniffi::rust_call(call_status, || {
+        {{ meth|return_ffi_converter }}::lower_return(
+{%- endmacro %}
+
+{%- macro method_decl_postscript(meth) %}
+            {% if meth.throws() %}.map_err(Into::into){% endif %}
+        )
+    })
+}
+{% endmacro %}

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -201,9 +201,10 @@ pub fn generate_and_include_scaffolding(udl_file: TokenStream) -> TokenStream {
         quote! {
             compile_error!("This macro assumes the crate has a build.rs script, but $OUT_DIR is not present");
         }
-    } else if uniffi_build::generate_scaffolding(udl_file_path).is_err() {
+    } else if let Err(e) = uniffi_build::generate_scaffolding(udl_file_path) {
+        let err = format!("{e:#}");
         quote! {
-            compile_error!(concat!("Failed to generate scaffolding from UDL file at ", #udl_file));
+            compile_error!(concat!("Failed to generate scaffolding from UDL file at ", #udl_file, ": ", #err));
         }
     } else {
         // We know the filename is good because `generate_scaffolding` succeeded,


### PR DESCRIPTION
This is a POC for supporting "magic" methods in foreign bindings. In the included test, we show Python generating `__repr__`, `__str__`, `__eq__` and `__hash__` for a uniffi exposed object, each with the correct semantics. I haven't implemented any languages other than Python, but hopefully it's clear how Kotlin might work as requested in #1286.

It's a bit hacky, bit it turned out better than I was expecting.
* The "trait names" are just strings, which we assume are among a "well known" set and currently match Rust trait names (eg, `Display`, `PartialEq`, etc). 
* In all cases, we generate "custom" ffi signatures in the rust crate, and these signatures are assumed to be known by the bindings - ie, there's no way to communicate that the ffi hash function has a signature of `fn(&self)->u64`, but the foreign side is expected to just know that.
* No support for macros yet, but that should be relatively modest.

@jplatte @bendk @badboy WDTY?