### PR TITLE
Don't explicitly derive from `object` in Python

### DIFF
--- a/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
@@ -19,7 +19,7 @@ class {{ type_name }}:
 
     # Each enum variant is a nested class of the enum itself.
     {% for variant in e.variants() -%}
-    class {{ variant.name()|enum_variant_py }}(object):
+    class {{ variant.name()|enum_variant_py }}:
         def __init__(self,{% for field in variant.fields() %}{{ field.name()|var_name }}{% if loop.last %}{% else %}, {% endif %}{% endfor %}):
             {% if variant.has_fields() %}
             {%- for field in variant.fields() %}

--- a/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
@@ -1,6 +1,6 @@
 {%- let obj = ci.get_object_definition(name).unwrap() %}
 
-class {{ type_name }}(object):
+class {{ type_name }}:
     {%- match obj.primary_constructor() %}
     {%- when Some with (cons) %}
     def __init__(self, {% call py::arg_list_decl(cons) -%}):

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
@@ -75,7 +75,7 @@ class ForeignBytes(ctypes.Structure):
         return "ForeignBytes(len={}, data={})".format(self.len, self.data[0:self.len])
 
 
-class RustBufferStream(object):
+class RustBufferStream:
     """
     Helper for structured reading of bytes from a RustBuffer
     """
@@ -140,7 +140,7 @@ class RustBufferStream(object):
     def readCSizeT(self):
         return self._unpack_from(ctypes.sizeof(ctypes.c_size_t) , "@N")
 
-class RustBufferBuilder(object):
+class RustBufferBuilder:
     """
     Helper for structured writing of bytes into a RustBuffer.
     """


### PR DESCRIPTION
That's an artifact from Python 2, Python 3 does that automatically.