### PR TITLE
Stricter type checking for Python integers and floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `External` types must be available in the Rust crate root.
 - External bindings: The `ExternalBindingsConfig` trait was replaced with `BindingsConfig`. External bindings implementations will need to make minor changes to implement the new trait instead.
 - Removed support for the `--config` flag when running the `scaffolding` command.  This flag has never an effect, because there was no scaffolding configuration options.
+- Python bindings are now more strict with their types. You can no longer pass strings to methods taking integers or floats, or floats to methods taking integers.
 
 ### What's changed
 

--- a/fixtures/type-limits/src/lib.rs
+++ b/fixtures/type-limits/src/lib.rs
@@ -28,4 +28,11 @@ fn take_u64(v: u64) -> u64 {
     v
 }
 
+fn take_f32(v: f32) -> f32 {
+    v
+}
+fn take_f64(v: f64) -> f64 {
+    v
+}
+
 uniffi::include_scaffolding!("type-limits");

--- a/fixtures/type-limits/src/type-limits.udl
+++ b/fixtures/type-limits/src/type-limits.udl
@@ -8,4 +8,7 @@ namespace uniffi_type_limits {
   u16 take_u16(u16 v);
   u32 take_u32(u32 v);
   u64 take_u64(u64 v);
+
+  f32 take_f32(f32 v);
+  f64 take_f64(f64 v);
 };

--- a/fixtures/type-limits/tests/bindings/test_type_limits.py
+++ b/fixtures/type-limits/tests/bindings/test_type_limits.py
@@ -4,66 +4,65 @@
 
 from uniffi_type_limits import *
 
-def assert_raises(func, exception_cls):
-    try:
-        func()
-    except exception_cls:
-        return
-    raise AssertionError("didn't raise the required exception")
+import unittest
 
-# strict lower bounds
-assert_raises(lambda: take_i8(-2**7 - 1), ValueError)
-assert_raises(lambda: take_i16(-2**15 - 1), ValueError)
-assert_raises(lambda: take_i32(-2**31 - 1), ValueError)
-assert_raises(lambda: take_i64(-2**63 - 1), ValueError)
-assert_raises(lambda: take_u8(-1), ValueError)
-assert_raises(lambda: take_u16(-1), ValueError)
-assert_raises(lambda: take_u32(-1), ValueError)
-assert_raises(lambda: take_u64(-1), ValueError)
+class TestTypeLimits(unittest.TestCase):
+    def test_strict_lower_bounds(self):
+        self.assertRaises(ValueError, lambda: take_i8(-2**7 - 1))
+        self.assertRaises(ValueError, lambda: take_i16(-2**15 - 1))
+        self.assertRaises(ValueError, lambda: take_i32(-2**31 - 1))
+        self.assertRaises(ValueError, lambda: take_i64(-2**63 - 1))
+        self.assertRaises(ValueError, lambda: take_u8(-1))
+        self.assertRaises(ValueError, lambda: take_u16(-1))
+        self.assertRaises(ValueError, lambda: take_u32(-1))
+        self.assertRaises(ValueError, lambda: take_u64(-1))
 
-assert take_i8(-2**7) == -2**7
-assert take_i16(-2**15) == -2**15
-assert take_i32(-2**31) == -2**31
-assert take_i64(-2**63) == -2**63
-assert take_u8(0) == 0
-assert take_u16(0) == 0
-assert take_u32(0) == 0
-assert take_u64(0) == 0
+        self.assertEqual(take_i8(-2**7), -2**7)
+        self.assertEqual(take_i16(-2**15), -2**15)
+        self.assertEqual(take_i32(-2**31), -2**31)
+        self.assertEqual(take_i64(-2**63), -2**63)
+        self.assertEqual(take_u8(0), 0)
+        self.assertEqual(take_u16(0), 0)
+        self.assertEqual(take_u32(0), 0)
+        self.assertEqual(take_u64(0), 0)
 
-# strict upper bounds
-assert_raises(lambda: take_i8(2**7), ValueError)
-assert_raises(lambda: take_i16(2**15), ValueError)
-assert_raises(lambda: take_i32(2**31), ValueError)
-assert_raises(lambda: take_i64(2**63), ValueError)
-assert_raises(lambda: take_u8(2**8), ValueError)
-assert_raises(lambda: take_u16(2**16), ValueError)
-assert_raises(lambda: take_u32(2**32), ValueError)
-assert_raises(lambda: take_u64(2**64), ValueError)
+    def test_strict_upper_bounds(self):
+        self.assertRaises(ValueError, lambda: take_i8(2**7))
+        self.assertRaises(ValueError, lambda: take_i16(2**15))
+        self.assertRaises(ValueError, lambda: take_i32(2**31))
+        self.assertRaises(ValueError, lambda: take_i64(2**63))
+        self.assertRaises(ValueError, lambda: take_u8(2**8))
+        self.assertRaises(ValueError, lambda: take_u16(2**16))
+        self.assertRaises(ValueError, lambda: take_u32(2**32))
+        self.assertRaises(ValueError, lambda: take_u64(2**64))
 
-assert take_i8(2**7 - 1) == 2**7 - 1
-assert take_i16(2**15 - 1) == 2**15 - 1
-assert take_i32(2**31 - 1) == 2**31 - 1
-assert take_i64(2**63 - 1) == 2**63 - 1
-assert take_u8(2**8 - 1) == 2**8 - 1
-assert take_u16(2**16 - 1) == 2**16 - 1
-assert take_u32(2**32 - 1) == 2**32 - 1
-assert take_u64(2**64 - 1) == 2**64 - 1
+        self.assertEqual(take_i8(2**7 - 1), 2**7 - 1)
+        self.assertEqual(take_i16(2**15 - 1), 2**15 - 1)
+        self.assertEqual(take_i32(2**31 - 1), 2**31 - 1)
+        self.assertEqual(take_i64(2**63 - 1), 2**63 - 1)
+        self.assertEqual(take_u8(2**8 - 1), 2**8 - 1)
+        self.assertEqual(take_u16(2**16 - 1), 2**16 - 1)
+        self.assertEqual(take_u32(2**32 - 1), 2**32 - 1)
+        self.assertEqual(take_u64(2**64 - 1), 2**64 - 1)
 
-# larger numbers
-assert_raises(lambda: take_i8(10**3), ValueError)
-assert_raises(lambda: take_i16(10**5), ValueError)
-assert_raises(lambda: take_i32(10**10), ValueError)
-assert_raises(lambda: take_i64(10**19), ValueError)
-assert_raises(lambda: take_u8(10**3), ValueError)
-assert_raises(lambda: take_u16(10**5), ValueError)
-assert_raises(lambda: take_u32(10**10), ValueError)
-assert_raises(lambda: take_u64(10**20), ValueError)
+    def test_larger_numbers(self):
+        self.assertRaises(ValueError, lambda: take_i8(10**3))
+        self.assertRaises(ValueError, lambda: take_i16(10**5))
+        self.assertRaises(ValueError, lambda: take_i32(10**10))
+        self.assertRaises(ValueError, lambda: take_i64(10**19))
+        self.assertRaises(ValueError, lambda: take_u8(10**3))
+        self.assertRaises(ValueError, lambda: take_u16(10**5))
+        self.assertRaises(ValueError, lambda: take_u32(10**10))
+        self.assertRaises(ValueError, lambda: take_u64(10**20))
 
-assert take_i8(10**2) == 10**2
-assert take_i16(10**4) == 10**4
-assert take_i32(10**9) == 10**9
-assert take_i64(10**18) == 10**18
-assert take_u8(10**2) == 10**2
-assert take_u16(10**4) == 10**4
-assert take_u32(10**9) == 10**9
-assert take_u64(10**19) == 10**19
+        self.assertEqual(take_i8(10**2), 10**2)
+        self.assertEqual(take_i16(10**4), 10**4)
+        self.assertEqual(take_i32(10**9), 10**9)
+        self.assertEqual(take_i64(10**18), 10**18)
+        self.assertEqual(take_u8(10**2), 10**2)
+        self.assertEqual(take_u16(10**4), 10**4)
+        self.assertEqual(take_u32(10**9), 10**9)
+        self.assertEqual(take_u64(10**19), 10**19)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/fixtures/type-limits/tests/bindings/test_type_limits.py
+++ b/fixtures/type-limits/tests/bindings/test_type_limits.py
@@ -4,6 +4,7 @@
 
 from uniffi_type_limits import *
 
+import math
 import unittest
 
 class TestTypeLimits(unittest.TestCase):
@@ -63,6 +64,115 @@ class TestTypeLimits(unittest.TestCase):
         self.assertEqual(take_u16(10**4), 10**4)
         self.assertEqual(take_u32(10**9), 10**9)
         self.assertEqual(take_u64(10**19), 10**19)
+
+    def test_non_integer(self):
+        self.assertRaises(TypeError, lambda: take_i8("0"))
+        self.assertRaises(TypeError, lambda: take_i16("0"))
+        self.assertRaises(TypeError, lambda: take_i32("0"))
+        self.assertRaises(TypeError, lambda: take_i64("0"))
+        self.assertRaises(TypeError, lambda: take_u8("0"))
+        self.assertRaises(TypeError, lambda: take_u16("0"))
+        self.assertRaises(TypeError, lambda: take_u32("0"))
+        self.assertRaises(TypeError, lambda: take_u64("0"))
+
+        self.assertRaises(TypeError, lambda: take_i8(0.0))
+        self.assertRaises(TypeError, lambda: take_i16(0.0))
+        self.assertRaises(TypeError, lambda: take_i32(0.0))
+        self.assertRaises(TypeError, lambda: take_i64(0.0))
+        self.assertRaises(TypeError, lambda: take_u8(0.0))
+        self.assertRaises(TypeError, lambda: take_u16(0.0))
+        self.assertRaises(TypeError, lambda: take_u32(0.0))
+        self.assertRaises(TypeError, lambda: take_u64(0.0))
+
+        class A:
+            pass
+
+        self.assertRaises(TypeError, lambda: take_i8(A()))
+        self.assertRaises(TypeError, lambda: take_i16(A()))
+        self.assertRaises(TypeError, lambda: take_i32(A()))
+        self.assertRaises(TypeError, lambda: take_i64(A()))
+        self.assertRaises(TypeError, lambda: take_u8(A()))
+        self.assertRaises(TypeError, lambda: take_u16(A()))
+        self.assertRaises(TypeError, lambda: take_u32(A()))
+        self.assertRaises(TypeError, lambda: take_u64(A()))
+
+    def test_integer_like(self):
+        self.assertEqual(take_i8(False), 0)
+        self.assertEqual(take_i16(False), 0)
+        self.assertEqual(take_i32(False), 0)
+        self.assertEqual(take_i64(False), 0)
+        self.assertEqual(take_u8(False), 0)
+        self.assertEqual(take_u16(False), 0)
+        self.assertEqual(take_u32(False), 0)
+        self.assertEqual(take_u64(False), 0)
+
+        self.assertEqual(take_i8(True), 1)
+        self.assertEqual(take_i16(True), 1)
+        self.assertEqual(take_i32(True), 1)
+        self.assertEqual(take_i64(True), 1)
+        self.assertEqual(take_u8(True), 1)
+        self.assertEqual(take_u16(True), 1)
+        self.assertEqual(take_u32(True), 1)
+        self.assertEqual(take_u64(True), 1)
+
+        class A:
+            def __index__(self):
+                return 123
+
+        self.assertEqual(take_i8(A()), 123)
+        self.assertEqual(take_i16(A()), 123)
+        self.assertEqual(take_i32(A()), 123)
+        self.assertEqual(take_i64(A()), 123)
+        self.assertEqual(take_u8(A()), 123)
+        self.assertEqual(take_u16(A()), 123)
+        self.assertEqual(take_u32(A()), 123)
+        self.assertEqual(take_u64(A()), 123)
+
+    def test_non_float(self):
+        self.assertRaises(TypeError, lambda: take_f32("0"))
+        self.assertRaises(TypeError, lambda: take_f64("0"))
+
+        self.assertRaises(TypeError, lambda: take_f32(1j))
+        self.assertRaises(TypeError, lambda: take_f64(1j))
+
+        class A:
+            pass
+
+        self.assertRaises(TypeError, lambda: take_f32(A()))
+        self.assertRaises(TypeError, lambda: take_f64(A()))
+
+    def test_float_like(self):
+        self.assertEqual(take_f32(False), 0.0)
+        self.assertEqual(take_f64(False), 0.0)
+
+        self.assertEqual(take_f32(True), 1.0)
+        self.assertEqual(take_f64(True), 1.0)
+
+        self.assertEqual(take_f32(123), 123.0)
+        self.assertEqual(take_f64(123), 123.0)
+
+        class A:
+            def __float__(self):
+                return 456.0
+
+        self.assertEqual(take_f32(A()), 456.0)
+        self.assertEqual(take_f64(A()), 456.0)
+
+    def test_special_floats(self):
+        self.assertEqual(take_f32(math.inf), math.inf)
+        self.assertEqual(take_f64(math.inf), math.inf)
+
+        self.assertEqual(take_f32(-math.inf), -math.inf)
+        self.assertEqual(take_f64(-math.inf), -math.inf)
+
+        self.assertEqual(math.copysign(1.0, take_f32(0.0)), 1.0)
+        self.assertEqual(math.copysign(1.0, take_f64(0.0)), 1.0)
+
+        self.assertEqual(math.copysign(1.0, take_f32(-0.0)), -1.0)
+        self.assertEqual(math.copysign(1.0, take_f64(-0.0)), -1.0)
+
+        self.assertTrue(math.isnan(take_f32(math.nan)))
+        self.assertTrue(math.isnan(take_f64(math.nan)))
 
 if __name__ == "__main__":
     unittest.main()

--- a/uniffi_bindgen/src/backend/types.rs
+++ b/uniffi_bindgen/src/backend/types.rs
@@ -99,11 +99,6 @@ pub trait CodeType {
     fn initialization_fn(&self, _oracle: &dyn CodeOracle) -> Option<String> {
         None
     }
-
-    /// An expression to coerce the given variable to the expected type.
-    fn coerce(&self, oracle: &dyn CodeOracle, _nm: &str) -> String {
-        panic!("Unimplemented for {}", self.type_label(oracle));
-    }
 }
 
 /// This trait is used to implement `CodeType` for `Type` and type-like structs (`Record`, `Enum`, `Field`,
@@ -210,9 +205,5 @@ impl<T: CodeTypeDispatch> CodeType for T {
 
     fn initialization_fn(&self, oracle: &dyn CodeOracle) -> Option<String> {
         self.code_type_impl(oracle).initialization_fn(oracle)
-    }
-
-    fn coerce(&self, oracle: &dyn CodeOracle, nm: &str) -> String {
-        self.code_type_impl(oracle).coerce(oracle, nm)
     }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/callback_interface.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/callback_interface.rs
@@ -26,8 +26,4 @@ impl CodeType for CallbackInterfaceCodeType {
     fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
         unreachable!();
     }
-
-    fn coerce(&self, _oracle: &dyn CodeOracle, nm: &str) -> String {
-        nm.to_string()
-    }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/compounds.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/compounds.rs
@@ -32,14 +32,6 @@ impl CodeType for OptionalCodeType {
             _ => oracle.find(&self.inner).literal(oracle, literal),
         }
     }
-
-    fn coerce(&self, oracle: &dyn CodeOracle, nm: &str) -> String {
-        format!(
-            "(None if {} is None else {})",
-            nm,
-            oracle.find(&self.inner).coerce(oracle, nm)
-        )
-    }
 }
 
 pub struct SequenceCodeType {
@@ -69,14 +61,6 @@ impl CodeType for SequenceCodeType {
             Literal::EmptySequence => "[]".into(),
             _ => unimplemented!(),
         }
-    }
-
-    fn coerce(&self, oracle: &dyn CodeOracle, nm: &str) -> String {
-        format!(
-            "list({} for x in {})",
-            oracle.find(&self.inner).coerce(oracle, "x"),
-            nm
-        )
     }
 }
 
@@ -109,14 +93,5 @@ impl CodeType for MapCodeType {
             Literal::EmptyMap => "{}".into(),
             _ => unimplemented!(),
         }
-    }
-
-    fn coerce(&self, oracle: &dyn CodeOracle, nm: &str) -> String {
-        format!(
-            "dict(({}, {}) for (k, v) in {}.items())",
-            self.key.coerce(oracle, "k"),
-            self.value.coerce(oracle, "v"),
-            nm
-        )
     }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/custom.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/custom.rs
@@ -22,8 +22,4 @@ impl CodeType for CustomCodeType {
     fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
         format!("Type{}", self.name)
     }
-
-    fn coerce(&self, _oracle: &dyn CodeOracle, nm: &str) -> String {
-        nm.to_string()
-    }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/enum_.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/enum_.rs
@@ -34,8 +34,4 @@ impl CodeType for EnumCodeType {
             unreachable!();
         }
     }
-
-    fn coerce(&self, _oracle: &dyn CodeOracle, nm: &str) -> String {
-        nm.to_string()
-    }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/error.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/error.rs
@@ -26,8 +26,4 @@ impl CodeType for ErrorCodeType {
     fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
         unreachable!();
     }
-
-    fn coerce(&self, _oracle: &dyn CodeOracle, nm: &str) -> String {
-        nm.to_string()
-    }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/executor.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/executor.rs
@@ -14,8 +14,4 @@ impl CodeType for ForeignExecutorCodeType {
     fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
         "ForeignExecutor".into()
     }
-
-    fn coerce(&self, _oracle: &dyn CodeOracle, nm: &str) -> String {
-        nm.to_string()
-    }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/external.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/external.rs
@@ -22,8 +22,4 @@ impl CodeType for ExternalCodeType {
     fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
         format!("Type{}", self.name)
     }
-
-    fn coerce(&self, _oracle: &dyn CodeOracle, nm: &str) -> String {
-        nm.into()
-    }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/miscellany.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/miscellany.rs
@@ -22,10 +22,6 @@ macro_rules! impl_code_type_for_miscellany {
                 fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
                     unreachable!()
                 }
-
-                fn coerce(&self, _oracle: &dyn CodeOracle, nm: &str) -> String {
-                    nm.to_string()
-                }
             }
         }
     };

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -462,9 +462,4 @@ pub mod filters {
     pub fn enum_variant_py(nm: &str) -> Result<String, askama::Error> {
         Ok(oracle().enum_variant_name(nm))
     }
-
-    pub fn coerce_py(nm: &str, type_: &Type) -> Result<String, askama::Error> {
-        let oracle = oracle();
-        Ok(oracle.find(type_).coerce(oracle, nm))
-    }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/object.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/object.rs
@@ -26,8 +26,4 @@ impl CodeType for ObjectCodeType {
     fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
         unreachable!();
     }
-
-    fn coerce(&self, _oracle: &dyn CodeOracle, nm: &str) -> String {
-        nm.to_string()
-    }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/primitives.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/primitives.rs
@@ -34,7 +34,7 @@ fn render_literal(_oracle: &dyn CodeOracle, literal: &Literal) -> String {
 }
 
 macro_rules! impl_code_type_for_primitive {
-    ($T:ty, $class_name:literal, $coerce_code:expr) => {
+    ($T:ty, $class_name:literal) => {
         paste! {
             pub struct $T;
 
@@ -46,25 +46,21 @@ macro_rules! impl_code_type_for_primitive {
                 fn literal(&self, oracle: &dyn CodeOracle, literal: &Literal) -> String {
                     render_literal(oracle, &literal)
                 }
-
-                fn coerce(&self, _oracle: &dyn CodeOracle, nm: &str) -> String {
-                    format!($coerce_code, nm)
-                }
             }
         }
     };
 }
 
-impl_code_type_for_primitive!(BooleanCodeType, "Bool", "bool({})");
-impl_code_type_for_primitive!(StringCodeType, "String", "{}");
-impl_code_type_for_primitive!(BytesCodeType, "Bytes", "{}");
-impl_code_type_for_primitive!(Int8CodeType, "Int8", "int({})");
-impl_code_type_for_primitive!(Int16CodeType, "Int16", "int({})");
-impl_code_type_for_primitive!(Int32CodeType, "Int32", "int({})");
-impl_code_type_for_primitive!(Int64CodeType, "Int64", "int({})");
-impl_code_type_for_primitive!(UInt8CodeType, "UInt8", "int({})");
-impl_code_type_for_primitive!(UInt16CodeType, "UInt16", "int({})");
-impl_code_type_for_primitive!(UInt32CodeType, "UInt32", "int({})");
-impl_code_type_for_primitive!(UInt64CodeType, "UInt64", "int({})");
-impl_code_type_for_primitive!(Float32CodeType, "Float", "float({})");
-impl_code_type_for_primitive!(Float64CodeType, "Double", "float({})");
+impl_code_type_for_primitive!(BooleanCodeType, "Bool");
+impl_code_type_for_primitive!(StringCodeType, "String");
+impl_code_type_for_primitive!(BytesCodeType, "Bytes");
+impl_code_type_for_primitive!(Int8CodeType, "Int8");
+impl_code_type_for_primitive!(Int16CodeType, "Int16");
+impl_code_type_for_primitive!(Int32CodeType, "Int32");
+impl_code_type_for_primitive!(Int64CodeType, "Int64");
+impl_code_type_for_primitive!(UInt8CodeType, "UInt8");
+impl_code_type_for_primitive!(UInt16CodeType, "UInt16");
+impl_code_type_for_primitive!(UInt32CodeType, "UInt32");
+impl_code_type_for_primitive!(UInt64CodeType, "UInt64");
+impl_code_type_for_primitive!(Float32CodeType, "Float");
+impl_code_type_for_primitive!(Float64CodeType, "Double");

--- a/uniffi_bindgen/src/bindings/python/gen_python/record.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/record.rs
@@ -26,8 +26,4 @@ impl CodeType for RecordCodeType {
     fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
         unreachable!();
     }
-
-    fn coerce(&self, _oracle: &dyn CodeOracle, nm: &str) -> String {
-        nm.to_string()
-    }
 }

--- a/uniffi_bindgen/src/bindings/python/templates/BooleanHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/BooleanHelper.py
@@ -1,16 +1,16 @@
-class FfiConverterBool:
+class FfiConverterBool(FfiConverterPrimitive):
+    @classmethod
+    def check(cls, value):
+        return not not value
+
     @classmethod
     def read(cls, buf):
         return cls.lift(buf.readU8())
 
     @classmethod
-    def write(cls, value, buf):
-        buf.writeU8(cls.lower(value))
+    def writeUnchecked(cls, value, buf):
+        buf.writeU8(value)
 
     @staticmethod
     def lift(value):
         return value != 0
-
-    @staticmethod
-    def lower(value):
-        return 1 if value else 0

--- a/uniffi_bindgen/src/bindings/python/templates/Float32Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Float32Helper.py
@@ -1,8 +1,8 @@
-class FfiConverterFloat(FfiConverterPrimitive):
+class FfiConverterFloat(FfiConverterPrimitiveFloat):
     @staticmethod
     def read(buf):
         return buf.readFloat()
 
     @staticmethod
-    def write(value, buf):
+    def writeUnchecked(value, buf):
         buf.writeFloat(value)

--- a/uniffi_bindgen/src/bindings/python/templates/Float64Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Float64Helper.py
@@ -1,8 +1,8 @@
-class FfiConverterDouble(FfiConverterPrimitive):
+class FfiConverterDouble(FfiConverterPrimitiveFloat):
     @staticmethod
     def read(buf):
         return buf.readDouble()
 
     @staticmethod
-    def write(value, buf):
+    def writeUnchecked(value, buf):
         buf.writeDouble(value)

--- a/uniffi_bindgen/src/bindings/python/templates/Int16Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int16Helper.py
@@ -8,5 +8,5 @@ class FfiConverterInt16(FfiConverterPrimitiveInt):
         return buf.readI16()
 
     @staticmethod
-    def write(value, buf):
+    def writeUnchecked(value, buf):
         buf.writeI16(value)

--- a/uniffi_bindgen/src/bindings/python/templates/Int32Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int32Helper.py
@@ -8,5 +8,5 @@ class FfiConverterInt32(FfiConverterPrimitiveInt):
         return buf.readI32()
 
     @staticmethod
-    def write(value, buf):
+    def writeUnchecked(value, buf):
         buf.writeI32(value)

--- a/uniffi_bindgen/src/bindings/python/templates/Int64Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int64Helper.py
@@ -8,5 +8,5 @@ class FfiConverterInt64(FfiConverterPrimitiveInt):
         return buf.readI64()
 
     @staticmethod
-    def write(value, buf):
+    def writeUnchecked(value, buf):
         buf.writeI64(value)

--- a/uniffi_bindgen/src/bindings/python/templates/Int8Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int8Helper.py
@@ -8,5 +8,5 @@ class FfiConverterInt8(FfiConverterPrimitiveInt):
         return buf.readI8()
 
     @staticmethod
-    def write(value, buf):
+    def writeUnchecked(value, buf):
         buf.writeI8(value)

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferHelper.py
@@ -23,7 +23,12 @@ class FfiConverterPrimitive:
 class FfiConverterPrimitiveInt(FfiConverterPrimitive):
     @classmethod
     def check(cls, value):
-        value = int(value)
+        try:
+            value = value.__index__()
+        except Exception:
+            raise TypeError("'{}' object cannot be interpreted as an integer".format(type(value).__name__))
+        if not isinstance(value, int):
+            raise TypeError("__index__ returned non-int (type {})".format(type(value).__name__))
         if not cls.VALUE_MIN <= value < cls.VALUE_MAX:
             raise ValueError("{} requires {} <= value < {}".format(cls.CLASS_NAME, cls.VALUE_MIN, cls.VALUE_MAX))
         return super().check(value)
@@ -31,7 +36,13 @@ class FfiConverterPrimitiveInt(FfiConverterPrimitive):
 class FfiConverterPrimitiveFloat(FfiConverterPrimitive):
     @classmethod
     def check(cls, value):
-        return super().check(float(value))
+        try:
+            value = value.__float__()
+        except Exception:
+            raise TypeError("must be real number, not {}".format(type(value).__name__))
+        if not isinstance(value, float):
+            raise TypeError("__float__ returned non-float (type {})".format(type(value).__name__))
+        return super().check(value)
 
 # Helper class for wrapper types that will always go through a RustBuffer.
 # Classes should inherit from this and implement the `read` and `write` static methods.

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferHelper.py
@@ -2,7 +2,7 @@
 class FfiConverterPrimitive:
     @classmethod
     def check(cls, value):
-        pass
+        return value
 
     @classmethod
     def lift(cls, value):
@@ -10,15 +10,28 @@ class FfiConverterPrimitive:
 
     @classmethod
     def lower(cls, value):
-        cls.check(value)
+        return cls.lowerUnchecked(cls.check(value))
+
+    @classmethod
+    def lowerUnchecked(cls, value):
         return value
+
+    @classmethod
+    def write(cls, value, buf):
+        cls.writeUnchecked(cls.check(value), buf)
 
 class FfiConverterPrimitiveInt(FfiConverterPrimitive):
     @classmethod
     def check(cls, value):
+        value = int(value)
         if not cls.VALUE_MIN <= value < cls.VALUE_MAX:
             raise ValueError("{} requires {} <= value < {}".format(cls.CLASS_NAME, cls.VALUE_MIN, cls.VALUE_MAX))
-        super().check(value)
+        return super().check(value)
+
+class FfiConverterPrimitiveFloat(FfiConverterPrimitive):
+    @classmethod
+    def check(cls, value):
+        return super().check(float(value))
 
 # Helper class for wrapper types that will always go through a RustBuffer.
 # Classes should inherit from this and implement the `read` and `write` static methods.

--- a/uniffi_bindgen/src/bindings/python/templates/UInt16Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt16Helper.py
@@ -8,5 +8,5 @@ class FfiConverterUInt16(FfiConverterPrimitiveInt):
         return buf.readU16()
 
     @staticmethod
-    def write(value, buf):
+    def writeUnchecked(value, buf):
         buf.writeU16(value)

--- a/uniffi_bindgen/src/bindings/python/templates/UInt32Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt32Helper.py
@@ -8,5 +8,5 @@ class FfiConverterUInt32(FfiConverterPrimitiveInt):
         return buf.readU32()
 
     @staticmethod
-    def write(value, buf):
+    def writeUnchecked(value, buf):
         buf.writeU32(value)

--- a/uniffi_bindgen/src/bindings/python/templates/UInt64Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt64Helper.py
@@ -8,5 +8,5 @@ class FfiConverterUInt64(FfiConverterPrimitiveInt):
         return buf.readU64()
 
     @staticmethod
-    def write(value, buf):
+    def writeUnchecked(value, buf):
         buf.writeU64(value)

--- a/uniffi_bindgen/src/bindings/python/templates/UInt8Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt8Helper.py
@@ -8,5 +8,5 @@ class FfiConverterUInt8(FfiConverterPrimitiveInt):
         return buf.readU8()
 
     @staticmethod
-    def write(value, buf):
+    def writeUnchecked(value, buf):
         buf.writeU8(value)

--- a/uniffi_bindgen/src/bindings/python/templates/macros.py
+++ b/uniffi_bindgen/src/bindings/python/templates/macros.py
@@ -66,19 +66,15 @@ rust_call(
 {% endmacro -%}
 
 {#
- # Setup function arguments by initializing default values and passing other
- # values through coerce.
+ # Setup function arguments by initializing default values.
  #}
 {%- macro setup_args(func) %}
     {%- for arg in func.arguments() %}
     {%- match arg.default_value() %}
     {%- when None %}
-    {{ arg.name()|var_name }} = {{ arg.name()|var_name|coerce_py(arg.type_().borrow()) -}}
     {%- when Some with(literal) %}
     if {{ arg.name()|var_name }} is DEFAULT:
         {{ arg.name()|var_name }} = {{ literal|literal_py(arg.type_().borrow()) }}
-    else:
-        {{ arg.name()|var_name }} = {{ arg.name()|var_name|coerce_py(arg.type_().borrow()) -}}
     {%- endmatch %}
     {% endfor -%}
 {%- endmacro -%}
@@ -91,12 +87,9 @@ rust_call(
         {%- for arg in func.arguments() %}
         {%- match arg.default_value() %}
         {%- when None %}
-        {{ arg.name()|var_name }} = {{ arg.name()|var_name|coerce_py(arg.type_().borrow()) -}}
         {%- when Some with(literal) %}
         if {{ arg.name()|var_name }} is DEFAULT:
             {{ arg.name()|var_name }} = {{ literal|literal_py(arg.type_().borrow()) }}
-        else:
-            {{ arg.name()|var_name }} = {{ arg.name()|var_name|coerce_py(arg.type_().borrow()) -}}
         {%- endmatch %}
         {% endfor -%}
 {%- endmacro -%}


### PR DESCRIPTION
The error messages mirror the ones used in Python itself. E.g.:

```python
>>> chr(1.0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'float' object cannot be interpreted as an integer
>>> class A:
...     def __index__(self):
...             return 1.0
...
>>> chr(A())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __index__ returned non-int (type float)
```
and
```python
>>> math.sqrt("1")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: must be real number, not str
>>> class A:
...     def __float__(self):
...             return "1"
...
>>> math.sqrt(A())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: A.__float__ returned non-float (type str)
```

Fixes #1544.

Also add some tests checking the stricter type checking plus a few floating point roundtrip tests.