### PR TITLE
Adding some documentation for external types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   - External bindings authors will need to update their bindings code.  See PR #1494 for details.
 - ABI: Changed API checksum handling.  This affects external bindings authors who will need to update their code to work with the new system.  See PR #1469 for details.
 - Removed the long deprecated `ThreadSafe` attribute.
+- `External` types now require a valid crate name.  Before the docs said it must be a crate name,
+  but any string could be used as long as it was consistent with the external type map in
+  `uniffi.toml`.
+- `External` types must be available in the Rust crate root.
 
 ### What's changed
 

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -212,6 +212,26 @@ mod kw {
 
 #[derive(Default)]
 pub(crate) struct CommonAttr {
+    /// Specifies the `UniFfiTag` used when implementing `FfiConverter`
+    ///   - When things are defined with proc-macros, this is `None` which means create a blanket
+    ///     impl for all types.
+    ///   - When things are defined with UDL files this is `Some(crate::UniFfiTag)`, which means only
+    ///     implement it for the local tag in the crate
+    ///
+    /// The reason for this split is remote types, i.e. types defined in remote crates that we
+    /// don't control and therefore can't define a blanket impl on because of the orphan rules.
+    ///
+    /// With UDL, we handle this by only implementing `FfiConverter<crate::UniFfiTag>` for the
+    /// type.  This gets around the orphan rules since a local type is in the trait, but requires
+    /// a `uniffi::ffi_converter_forward!` call if the type is used in a second local crate (an
+    /// External typedef).  This is natural for UDL-based generation, since you always need to
+    /// define the external type in the UDL file.
+    ///
+    /// With proc-macros this system isn't so natural.  Instead, we plan to use this system:
+    ///   - Most of the time, types aren't remote and we use the blanket impl.
+    ///   - When types are remote, we'll need a special syntax to define an `FfiConverter` for them
+    ///     and also a special declaration to use the types in other crates.  This requires some
+    ///     extra work for the consumer, but it should be rare.
     pub tag: Option<Path>,
 }
 


### PR DESCRIPTION
These are some small changes related to a couple PRs:

 I was hoping to implement the system described in  https://github.com/mozilla/uniffi-rs/issues/1531, but I realized that
 wouldn't be easy for UDL files.  Currently, any `record` or `enum`  defined in a UDL file can be a remote type and there's no distiction  made between the two.  I don't want to put in the work to change that, so I just tried to document things and explain the differences.

 I realized that we introduced a couple breaking changes in corner cases with external types and documented them:
   - We discussed this some in https://github.com/mozilla/uniffi-rs/pull/1516#discussion_r1198960326, but I realize that the `ExternalTypes.rs` template also uses the external type crate name.  So I decided that it does deserve a line in the changelog and that line can be worded a bit simpler since it applies to current usage, not only to users that switch to library mode.
   - I realized we added the requirement for exteranl types type in the crate root when I tried using the new UniFFI code with app-services.