### PR TITLE
macros: Disallow specifying tag type for derives

### DIFF
--- a/uniffi_macros/src/enum_.rs
+++ b/uniffi_macros/src/enum_.rs
@@ -4,31 +4,35 @@ use syn::{Data, DataEnum, DeriveInput, Field, Index, Path};
 
 use crate::util::{
     create_metadata_items, ident_to_string, mod_path, tagged_impl_header,
-    try_metadata_value_from_usize, try_read_field, AttributeSliceExt, CommonAttr,
+    try_metadata_value_from_usize, try_read_field, ArgumentNotAllowedHere, AttributeSliceExt,
+    CommonAttr,
 };
 
-pub fn expand_enum(input: DeriveInput) -> syn::Result<TokenStream> {
+pub fn expand_enum(input: DeriveInput) -> TokenStream {
     let enum_ = match input.data {
         Data::Enum(e) => e,
         _ => {
-            return Err(syn::Error::new(
-                Span::call_site(),
-                "This derive must only be used on enums",
-            ));
+            return syn::Error::new(Span::call_site(), "This derive must only be used on enums")
+                .into_compile_error();
         }
     };
 
     let ident = &input.ident;
-    let attr = input.attrs.parse_uniffi_attr_args::<CommonAttr>()?;
-    let ffi_converter_impl = enum_ffi_converter_impl(ident, &enum_, attr.tag.as_ref());
+    let attr_error = input
+        .attrs
+        .parse_uniffi_attr_args::<ArgumentNotAllowedHere>()
+        .err()
+        .map(syn::Error::into_compile_error);
+    let ffi_converter_impl = enum_ffi_converter_impl(ident, &enum_, None);
 
     let meta_static_var =
         enum_meta_static_var(ident, &enum_).unwrap_or_else(syn::Error::into_compile_error);
 
-    Ok(quote! {
+    quote! {
+        #attr_error
         #ffi_converter_impl
         #meta_static_var
-    })
+    }
 }
 
 pub(crate) fn expand_enum_ffi_converter(attr: CommonAttr, input: DeriveInput) -> TokenStream {

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -67,16 +67,12 @@ pub fn export(attr_args: TokenStream, input: TokenStream) -> TokenStream {
 
 #[proc_macro_derive(Record)]
 pub fn derive_record(input: TokenStream) -> TokenStream {
-    expand_record(parse_macro_input!(input))
-        .unwrap_or_else(syn::Error::into_compile_error)
-        .into()
+    expand_record(parse_macro_input!(input)).into()
 }
 
 #[proc_macro_derive(Enum)]
 pub fn derive_enum(input: TokenStream) -> TokenStream {
-    expand_enum(parse_macro_input!(input))
-        .unwrap_or_else(syn::Error::into_compile_error)
-        .into()
+    expand_enum(parse_macro_input!(input)).into()
 }
 
 #[proc_macro_derive(Object)]
@@ -87,9 +83,7 @@ pub fn derive_object(input: TokenStream) -> TokenStream {
     };
     let input = parse_macro_input!(input);
 
-    expand_object(input, mod_path)
-        .unwrap_or_else(syn::Error::into_compile_error)
-        .into()
+    expand_object(input, mod_path).into()
 }
 
 #[proc_macro_derive(Error, attributes(uniffi))]


### PR DESCRIPTION
As [requested](https://github.com/mozilla/uniffi-rs/pull/1561#discussion_r1205719813).

Should we also enforce that the tag *is* specified for the `ffi_converter_*` attribute macros?