### PR TITLE
Clarify the semantics of Enums and Errors

### DIFF
--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -6,9 +6,17 @@ namespace coverall {
 
     sequence<TestTrait> get_traits();
 
+    MaybeSimpleDict get_maybe_simple_dict(i8 index);
+
     // void returning error throwing namespace function to catch clippy warnings (eg, #1330)
     [Throws=CoverallError]
     void println(string text);
+
+    [Throws=CoverallFlatError]
+    void throw_flat_error();
+
+    [Throws=CoverallRichErrorNoVariantData]
+    void throw_rich_error_no_variant_data();
 };
 
 dictionary SimpleDict {
@@ -48,9 +56,31 @@ interface MaybeSimpleDict {
     Nah();
 };
 
+// Note that UDL *can not* express flat enums (ie, those with variants that carry data which
+// should be ignored for the ffi), only flat errors?
+//enum SimpleFlatEnum {
+//    "First",
+//    "Second",
+//};
+
 [Error]
 enum CoverallError {
     "TooManyHoles"
+};
+
+// This error is described in Rust with variants, but because it's declared
+// here via an `enum` it's considered "flat"
+[Error]
+enum CoverallFlatError {
+    "TooManyVariants"
+};
+
+// This error is for an enum that's still "flat" on the Rust side (ie, no
+// variants have associated data), but it behaves differently on the bindings
+// side than had it been described via `enum`
+[Error]
+interface CoverallRichErrorNoVariantData {
+    TooManyPlainVariants();
 };
 
 [Error]

--- a/uniffi_macros/src/error.rs
+++ b/uniffi_macros/src/error.rs
@@ -79,7 +79,8 @@ fn error_ffi_converter_impl(ident: &Ident, enum_: &DataEnum, attr: &ErrorAttr) -
 
 // FfiConverters for "flat errors"
 //
-// These are errors where we only expose the variants, not the data.
+// These are errors where we only lower the to_string() value, rather than any assocated data.
+// We lower the to_string() value unconditionally, whether the enum has associated data or not.
 fn flat_error_ffi_converter_impl(
     ident: &Ident,
     enum_: &DataEnum,


### PR DESCRIPTION
The `is_flat` semantics for enums and errors was confusing me (mainly because that's entirely the wrong term which should be used), so I tried to capture the semantics and expand some comments on it.

It mainly adds additional coverall tests for enums and error, and adds matching enum and error definitions via proc_macros, and ensures the semantics are the same.
