### PR TITLE
Support Into::into for function results to be consistent with errors

### DIFF
--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -6,6 +6,11 @@ namespace coverall {
 
     sequence<TestTrait> get_traits();
 
+    MaybeSimpleDict get_maybe_simple_dict(i8 index);
+    MaybeSimpleDict get_maybe_simple_internal_dict(string? text);
+    [Throws=CoverallError]
+    MaybeSimpleDict fallible_get_maybe_simple_internal_dict(string? text);
+
     // void returning error throwing namespace function to catch clippy warnings (eg, #1330)
     [Throws=CoverallError]
     void println(string text);
@@ -88,6 +93,10 @@ interface Coveralls {
 
     [Throws=CoverallError]
     void fallible_panic(string message);
+
+    MaybeSimpleDict get_maybe_simple_internal_dict(string? text);
+    [Throws=CoverallError]
+    MaybeSimpleDict fallible_get_maybe_simple_internal_dict(string? text);
 
     // *** Test functions which take either `self` or other params as `Arc<Self>` ***
 

--- a/fixtures/coverall/tests/bindings/test_coverall.py
+++ b/fixtures/coverall/tests/bindings/test_coverall.py
@@ -193,6 +193,21 @@ class TestCoverall(unittest.TestCase):
         coveralls = None
         self.assertEqual(get_num_alive(), 0)
 
+    def test_into(self):
+        # Test errors and results being into'd - in reality the fact things compile is the real test,
+        # but we should check things actually do what we think.
+        self.assertEqual(get_maybe_simple_internal_dict(None), MaybeSimpleDict.NAH())
+        self.assertTrue(get_maybe_simple_internal_dict("foo").d.text, "foo")
+        with self.assertRaises(CoverallError):
+            fallible_get_maybe_simple_internal_dict(None)
+
+        # Same tests on an instance.
+        coveralls = Coveralls("test_return_objects")
+        self.assertEqual(coveralls.get_maybe_simple_internal_dict(None), MaybeSimpleDict.NAH())
+        self.assertTrue(coveralls.get_maybe_simple_internal_dict("foo").d.text, "foo")
+        with self.assertRaises(CoverallError):
+            coveralls.fallible_get_maybe_simple_internal_dict(None)
+
     def test_bad_objects(self):
         coveralls = Coveralls("test_bad_objects")
         patch = Patch(Color.RED)

--- a/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
+++ b/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
@@ -49,5 +49,5 @@ error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
 error[E0425]: cannot find function `get_dict` in this scope
  --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
   |
-  |             r#get_dict())
-  |             ^^^^^^^^^^ not found in this scope
+  |         r#get_dict().into()
+  |         ^^^^^^^^^^ not found in this scope

--- a/uniffi_bindgen/src/scaffolding/templates/TopLevelFunctionTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/TopLevelFunctionTemplate.rs
@@ -2,18 +2,20 @@
 // For each top-level function declared in the UDL, we assume the caller has provided a corresponding
 // rust function of the same name. We provide a `pub extern "C"` wrapper that does type conversions to
 // send data across the FFI, which will fail to compile if the provided function does not match what's
-// specified in the UDL.    
+// specified in the UDL.   
 #}
 #[doc(hidden)]
 #[no_mangle]
-#[allow(clippy::let_unit_value,clippy::unit_arg)] // The generated code uses the unit type like other types to keep things uniform
+#[allow(clippy::let_unit_value,clippy::unit_arg,clippy::useless_conversion)] // The generated code uses the unit type like other types to keep things uniform
 pub extern "C" fn r#{{ func.ffi_func().name() }}(
-    {% call rs::arg_list_ffi_decl(func.ffi_func()) %}
+{% call rs::arg_list_ffi_decl(func.ffi_func()) %}
 ) {% call rs::return_signature(func) %} {
     // If the provided function does not match the signature specified in the UDL
     // then this attempt to call it will not compile, and will give guidance as to why.
     uniffi::deps::log::debug!("{{ func.ffi_func().name() }}");
     uniffi::rust_call(call_status, || {{ func|return_ffi_converter }}::lower_return(
-            {% call rs::to_rs_call(func) %}){% if func.throws() %}.map_err(Into::into){% endif %}
+        {% call rs::to_rs_call(func) -%}
+            {% if func.throws() %}.map(Into::into).map_err(Into::into){% else %}.into(){% endif %}
+        )
     )
 }

--- a/uniffi_bindgen/src/scaffolding/templates/macros.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/macros.rs
@@ -66,7 +66,7 @@ r#{{ func.name() }}({% call _arg_list_rs_call(func) -%})
 {%- macro method_decl_prelude(meth) %}
 #[doc(hidden)]
 #[no_mangle]
-#[allow(clippy::let_unit_value,clippy::unit_arg)] // The generated code uses the unit type like other types to keep things uniform
+#[allow(clippy::let_unit_value,clippy::unit_arg,clippy::useless_conversion)] // The generated code uses the unit type like other types to keep things uniform
 pub extern "C" fn r#{{ meth.ffi_func().name() }}(
     {%- call arg_list_ffi_decl(meth.ffi_func()) %}
 ) {% call return_signature(meth) %} {
@@ -76,7 +76,7 @@ pub extern "C" fn r#{{ meth.ffi_func().name() }}(
 {%- endmacro %}
 
 {%- macro method_decl_postscript(meth) %}
-            {% if meth.throws() %}.map_err(Into::into){% endif %}
+            {% if meth.throws() %}.map(Into::into).map_err(Into::into){% else %}.into(){% endif %}
         )
     })
 }


### PR DESCRIPTION
Uniffi [already supports mapping "internal" errors to public ones](https://github.com/mozilla/uniffi-rs/blob/755049ebaa967fdfbb192d5b9c111353a7fee99f/fixtures/coverall/src/lib.rs#L23-L37). This PR does the same thing for function results.