### PR TITLE
Upgrade to askama v0.12

### DIFF
--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["ffi", "bindgen"]
 
 [dependencies]
 anyhow = "1"
-askama = { version = "0.11", default-features = false, features = ["config"] }
+askama = { version = "0.12", default-features = false, features = ["config"] }
 camino = "1.0.8"
 cargo_metadata = "0.15"
 fs-err = "2.7.0"


### PR DESCRIPTION
This accompanies #1495 in upgrading so we transitively depend less on syn v1, and more on syn v2.
The 2 PRs are independent, but need to be both in the next release to land on m-c.