### PR TITLE
Check for integer overflows in Ruby bindings

### DIFF
--- a/fixtures/type-limits/tests/bindings/test_type_limits.rb
+++ b/fixtures/type-limits/tests/bindings/test_type_limits.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require 'test/unit'
+require 'uniffi_type_limits'
+
+class TestTypeLimits < Test::Unit::TestCase
+  def test_strict_lower_bounds
+    assert_raise RangeError do UniffiTypeLimits.take_i8(-2**7 - 1) end
+    assert_raise RangeError do UniffiTypeLimits.take_i16(-2**15 - 1) end
+    assert_raise RangeError do UniffiTypeLimits.take_i32(-2**31 - 1) end
+    assert_raise RangeError do UniffiTypeLimits.take_i64(-2**63 - 1) end
+    assert_raise RangeError do UniffiTypeLimits.take_u8(-1) end
+    assert_raise RangeError do UniffiTypeLimits.take_u16(-1) end
+    assert_raise RangeError do UniffiTypeLimits.take_u32(-1) end
+    assert_raise RangeError do UniffiTypeLimits.take_u64(-1) end
+
+    assert_equal(UniffiTypeLimits.take_i8(-2**7), -2**7)
+    assert_equal(UniffiTypeLimits.take_i16(-2**15), -2**15)
+    assert_equal(UniffiTypeLimits.take_i32(-2**31), -2**31)
+    assert_equal(UniffiTypeLimits.take_i64(-2**63), -2**63)
+    assert_equal(UniffiTypeLimits.take_u8(0), 0)
+    assert_equal(UniffiTypeLimits.take_u16(0), 0)
+    assert_equal(UniffiTypeLimits.take_u32(0), 0)
+    assert_equal(UniffiTypeLimits.take_u64(0), 0)
+  end
+  def test_strict_upper_bounds
+    assert_raise RangeError do UniffiTypeLimits.take_i8(2**7) end
+    assert_raise RangeError do UniffiTypeLimits.take_i16(2**15) end
+    assert_raise RangeError do UniffiTypeLimits.take_i32(2**31) end
+    assert_raise RangeError do UniffiTypeLimits.take_i64(2**63) end
+    assert_raise RangeError do UniffiTypeLimits.take_u8(2**8) end
+    assert_raise RangeError do UniffiTypeLimits.take_u16(2**16) end
+    assert_raise RangeError do UniffiTypeLimits.take_u32(2**32) end
+    assert_raise RangeError do UniffiTypeLimits.take_u64(2**64) end
+
+    assert_equal(UniffiTypeLimits.take_i8(2**7 - 1), 2**7 - 1)
+    assert_equal(UniffiTypeLimits.take_i16(2**15 - 1), 2**15 - 1)
+    assert_equal(UniffiTypeLimits.take_i32(2**31 - 1), 2**31 - 1)
+    assert_equal(UniffiTypeLimits.take_i64(2**63 - 1), 2**63 - 1)
+    assert_equal(UniffiTypeLimits.take_u8(2**8 - 1), 2**8 - 1)
+    assert_equal(UniffiTypeLimits.take_u16(2**16 - 1), 2**16 - 1)
+    assert_equal(UniffiTypeLimits.take_u32(2**32 - 1), 2**32 - 1)
+    assert_equal(UniffiTypeLimits.take_u64(2**64 - 1), 2**64 - 1)
+  end
+  def test_larger_numbers
+    assert_raise RangeError do UniffiTypeLimits.take_i8(10**3) end
+    assert_raise RangeError do UniffiTypeLimits.take_i16(10**5) end
+    assert_raise RangeError do UniffiTypeLimits.take_i32(10**10) end
+    assert_raise RangeError do UniffiTypeLimits.take_i64(10**19) end
+    assert_raise RangeError do UniffiTypeLimits.take_u8(10**3) end
+    assert_raise RangeError do UniffiTypeLimits.take_u16(10**5) end
+    assert_raise RangeError do UniffiTypeLimits.take_u32(10**10) end
+    assert_raise RangeError do UniffiTypeLimits.take_u64(10**20) end
+
+    assert_equal(UniffiTypeLimits.take_i8(10**2), 10**2)
+    assert_equal(UniffiTypeLimits.take_i16(10**4), 10**4)
+    assert_equal(UniffiTypeLimits.take_i32(10**9), 10**9)
+    assert_equal(UniffiTypeLimits.take_i64(10**18), 10**18)
+    assert_equal(UniffiTypeLimits.take_u8(10**2), 10**2)
+    assert_equal(UniffiTypeLimits.take_u16(10**4), 10**4)
+    assert_equal(UniffiTypeLimits.take_u32(10**9), 10**9)
+    assert_equal(UniffiTypeLimits.take_u64(10**19), 10**19)
+  end
+end

--- a/fixtures/type-limits/tests/test_generated_bindings.rs
+++ b/fixtures/type-limits/tests/test_generated_bindings.rs
@@ -1,1 +1,4 @@
-uniffi::build_foreign_language_testcases!("tests/bindings/test_type_limits.py");
+uniffi::build_foreign_language_testcases!(
+    "tests/bindings/test_type_limits.py",
+    "tests/bindings/test_type_limits.rb",
+);

--- a/fixtures/type-limits/uniffi.toml
+++ b/fixtures/type-limits/uniffi.toml
@@ -1,2 +1,5 @@
 [bindings.python]
 cdylib_name = "uniffi_type_limits"
+
+[bindings.ruby]
+cdylib_name = "uniffi_type_limits"

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -161,14 +161,14 @@ mod filters {
 
     pub fn coerce_rb(nm: &str, type_: &Type) -> Result<String, askama::Error> {
         Ok(match type_ {
-            Type::Int8
-            | Type::UInt8
-            | Type::Int16
-            | Type::UInt16
-            | Type::Int32
-            | Type::UInt32
-            | Type::Int64
-            | Type::UInt64 => format!("{nm}.to_i"), // TODO: check max/min value
+            Type::Int8 => format!("uniffi_in_range({nm}, \"i8\", -2**7, 2**7)"),
+            Type::Int16 => format!("uniffi_in_range({nm}, \"i16\", -2**15, 2**15)"),
+            Type::Int32 => format!("uniffi_in_range({nm}, \"i32\", -2**31, 2**31)"),
+            Type::Int64 => format!("uniffi_in_range({nm}, \"i64\", -2**63, 2**63)"),
+            Type::UInt8 => format!("uniffi_in_range({nm}, \"u8\", 0, 2**8)"),
+            Type::UInt16 => format!("uniffi_in_range({nm}, \"u16\", 0, 2**16)"),
+            Type::UInt32 => format!("uniffi_in_range({nm}, \"u32\", 0, 2**32)"),
+            Type::UInt64 => format!("uniffi_in_range({nm}, \"u64\", 0, 2**64)"),
             Type::Float32 | Type::Float64 => format!("{nm}.to_f"),
             Type::Boolean => format!("{nm} ? true : false"),
             Type::Object { .. } | Type::Enum(_) | Type::Error(_) | Type::Record(_) => {

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -159,16 +159,16 @@ mod filters {
         Ok(nm.to_string().to_shouty_snake_case())
     }
 
-    pub fn coerce_rb(nm: &str, type_: &Type) -> Result<String, askama::Error> {
+    pub fn coerce_rb(nm: &str, ns: &str, type_: &Type) -> Result<String, askama::Error> {
         Ok(match type_ {
-            Type::Int8 => format!("uniffi_in_range({nm}, \"i8\", -2**7, 2**7)"),
-            Type::Int16 => format!("uniffi_in_range({nm}, \"i16\", -2**15, 2**15)"),
-            Type::Int32 => format!("uniffi_in_range({nm}, \"i32\", -2**31, 2**31)"),
-            Type::Int64 => format!("uniffi_in_range({nm}, \"i64\", -2**63, 2**63)"),
-            Type::UInt8 => format!("uniffi_in_range({nm}, \"u8\", 0, 2**8)"),
-            Type::UInt16 => format!("uniffi_in_range({nm}, \"u16\", 0, 2**16)"),
-            Type::UInt32 => format!("uniffi_in_range({nm}, \"u32\", 0, 2**32)"),
-            Type::UInt64 => format!("uniffi_in_range({nm}, \"u64\", 0, 2**64)"),
+            Type::Int8 => format!("{ns}::uniffi_in_range({nm}, \"i8\", -2**7, 2**7)"),
+            Type::Int16 => format!("{ns}::uniffi_in_range({nm}, \"i16\", -2**15, 2**15)"),
+            Type::Int32 => format!("{ns}::uniffi_in_range({nm}, \"i32\", -2**31, 2**31)"),
+            Type::Int64 => format!("{ns}::uniffi_in_range({nm}, \"i64\", -2**63, 2**63)"),
+            Type::UInt8 => format!("{ns}::uniffi_in_range({nm}, \"u8\", 0, 2**8)"),
+            Type::UInt16 => format!("{ns}::uniffi_in_range({nm}, \"u16\", 0, 2**16)"),
+            Type::UInt32 => format!("{ns}::uniffi_in_range({nm}, \"u32\", 0, 2**32)"),
+            Type::UInt64 => format!("{ns}::uniffi_in_range({nm}, \"u64\", 0, 2**64)"),
             Type::Float32 | Type::Float64 => format!("{nm}.to_f"),
             Type::Boolean => format!("{nm} ? true : false"),
             Type::Object { .. } | Type::Enum(_) | Type::Error(_) | Type::Record(_) => {
@@ -177,9 +177,9 @@ mod filters {
             Type::String | Type::Bytes => format!("{nm}.to_s"),
             Type::Timestamp | Type::Duration => nm.to_string(),
             Type::CallbackInterface(_) => panic!("No support for coercing callback interfaces yet"),
-            Type::Optional(t) => format!("({nm} ? {} : nil)", coerce_rb(nm, t)?),
+            Type::Optional(t) => format!("({nm} ? {} : nil)", coerce_rb(nm, ns, t)?),
             Type::Sequence(t) => {
-                let coerce_code = coerce_rb("v", t)?;
+                let coerce_code = coerce_rb("v", ns, t)?;
                 if coerce_code == "v" {
                     nm.to_string()
                 } else {
@@ -187,8 +187,8 @@ mod filters {
                 }
             }
             Type::Map(_k, t) => {
-                let k_coerce_code = coerce_rb("k", &Type::String)?;
-                let v_coerce_code = coerce_rb("v", t)?;
+                let k_coerce_code = coerce_rb("k", ns, &Type::String)?;
+                let v_coerce_code = coerce_rb("v", ns, t)?;
 
                 if k_coerce_code == "k" && v_coerce_code == "v" {
                     nm.to_string()

--- a/uniffi_bindgen/src/bindings/ruby/templates/Helpers.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/Helpers.rb
@@ -1,0 +1,5 @@
+def uniffi_in_range(i, type_name, min, max)
+  i = i.to_i
+  raise RangeError, "#{type_name} requires #{min} <= value < #{max}" unless (min <= i && i < max)
+  i
+end

--- a/uniffi_bindgen/src/bindings/ruby/templates/Helpers.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/Helpers.rb
@@ -1,4 +1,4 @@
-def uniffi_in_range(i, type_name, min, max)
+def self.uniffi_in_range(i, type_name, min, max)
   i = i.to_i
   raise RangeError, "#{type_name} requires #{min} <= value < #{max}" unless (min <= i && i < max)
   i

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -34,48 +34,56 @@ class RustBufferBuilder
   {% when Type::Int8 -%}
 
   def write_I8(v)
+    v = uniffi_in_range(v, "i8", -2**7, 2**7)
     pack_into(1, 'c', v)
   end
 
   {% when Type::UInt8 -%}
 
   def write_U8(v)
+    v = uniffi_in_range(v, "u8", 0, 2**8)
     pack_into(1, 'c', v)
   end
 
   {% when Type::Int16 -%}
 
   def write_I16(v)
+    v = uniffi_in_range(v, "i16", -2**15, 2**15)
     pack_into(2, 's>', v)
   end
 
   {% when Type::UInt16 -%}
 
   def write_U16(v)
+    v = uniffi_in_range(v, "u16", 0, 2**16)
     pack_into(2, 'S>', v)
   end
 
   {% when Type::Int32 -%}
 
   def write_I32(v)
+    v = uniffi_in_range(v, "i32", -2**31, 2**31)
     pack_into(4, 'l>', v)
   end
 
   {% when Type::UInt32 -%}
 
   def write_U32(v)
+    v = uniffi_in_range(v, "u32", 0, 2**32)
     pack_into(4, 'L>', v)
   end
 
   {% when Type::Int64 -%}
 
   def write_I64(v)
+    v = uniffi_in_range(v, "i64", -2**63, 2**63)
     pack_into(8, 'q>', v)
   end
 
   {% when Type::UInt64 -%}
 
   def write_U64(v)
+    v = uniffi_in_range(v, "u64", 0, 2**64)
     pack_into(8, 'Q>', v)
   end
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -34,56 +34,56 @@ class RustBufferBuilder
   {% when Type::Int8 -%}
 
   def write_I8(v)
-    v = uniffi_in_range(v, "i8", -2**7, 2**7)
+    v = {{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i8", -2**7, 2**7)
     pack_into(1, 'c', v)
   end
 
   {% when Type::UInt8 -%}
 
   def write_U8(v)
-    v = uniffi_in_range(v, "u8", 0, 2**8)
+    v = {{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u8", 0, 2**8)
     pack_into(1, 'c', v)
   end
 
   {% when Type::Int16 -%}
 
   def write_I16(v)
-    v = uniffi_in_range(v, "i16", -2**15, 2**15)
+    v = {{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i16", -2**15, 2**15)
     pack_into(2, 's>', v)
   end
 
   {% when Type::UInt16 -%}
 
   def write_U16(v)
-    v = uniffi_in_range(v, "u16", 0, 2**16)
+    v = {{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u16", 0, 2**16)
     pack_into(2, 'S>', v)
   end
 
   {% when Type::Int32 -%}
 
   def write_I32(v)
-    v = uniffi_in_range(v, "i32", -2**31, 2**31)
+    v = {{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i32", -2**31, 2**31)
     pack_into(4, 'l>', v)
   end
 
   {% when Type::UInt32 -%}
 
   def write_U32(v)
-    v = uniffi_in_range(v, "u32", 0, 2**32)
+    v = {{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u32", 0, 2**32)
     pack_into(4, 'L>', v)
   end
 
   {% when Type::Int64 -%}
 
   def write_I64(v)
-    v = uniffi_in_range(v, "i64", -2**63, 2**63)
+    v = {{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i64", -2**63, 2**63)
     pack_into(8, 'q>', v)
   end
 
   {% when Type::UInt64 -%}
 
   def write_U64(v)
-    v = uniffi_in_range(v, "u64", 0, 2**64)
+    v = {{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u64", 0, 2**64)
     pack_into(8, 'Q>', v)
   end
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
@@ -62,12 +62,12 @@
 
 {%- macro coerce_args(func) %}
     {%- for arg in func.arguments() %}
-    {{ arg.name() }} = {{ arg.name()|coerce_rb(arg.as_type().borrow()) -}}
+    {{ arg.name() }} = {{ arg.name()|coerce_rb(ci.namespace()|class_name_rb, arg.as_type().borrow()) -}}
     {% endfor -%}
 {%- endmacro -%}
 
 {%- macro coerce_args_extra_indent(func) %}
         {%- for arg in func.arguments() %}
-        {{ arg.name() }} = {{ arg.name()|coerce_rb(arg.as_type().borrow()) }}
+        {{ arg.name() }} = {{ arg.name()|coerce_rb(ci.namespace()|class_name_rb, arg.as_type().borrow()) }}
         {%- endfor %}
 {%- endmacro -%}

--- a/uniffi_bindgen/src/bindings/ruby/templates/wrapper.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/wrapper.rb
@@ -15,9 +15,10 @@
 
 require 'ffi'
 
-{% include "Helpers.rb" %}
 
 module {{ ci.namespace()|class_name_rb }}
+  {% include "Helpers.rb" %}
+
   {% include "RustBufferTemplate.rb" %}
   {% include "RustBufferStream.rb" %}
   {% include "RustBufferBuilder.rb" %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/wrapper.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/wrapper.rb
@@ -15,6 +15,8 @@
 
 require 'ffi'
 
+{% include "Helpers.rb" %}
+
 module {{ ci.namespace()|class_name_rb }}
   {% include "RustBufferTemplate.rb" %}
   {% include "RustBufferStream.rb" %}


### PR DESCRIPTION
The exception thrown is [`RangeError`](https://docs.ruby-lang.org/en/master/RangeError.html), like e.g. when doing `256.chr`.

```
> 256.chr
(irb):1:in `chr': 256 out of char range (RangeError)
        from (irb):1:in `<main>'
        from /usr/lib/ruby/gems/3.0.0/gems/irb-1.4.2/exe/irb:11:in `<top (required)>'
        from /usr/bin/irb:25:in `load'
        from /usr/bin/irb:25:in `<main>'
```