### PR TITLE
Fix custom type demo usage of deprecated URL constructor in kotlin

### DIFF
--- a/examples/custom-types/uniffi.toml
+++ b/examples/custom-types/uniffi.toml
@@ -41,9 +41,9 @@ package_name = "customtypes"
 # Name of the type in the Kotlin code
 type_name = "URL"
 # Classes that need to be imported
-imports = [ "java.net.URL" ]
+imports = [ "java.net.URI", "java.net.URL" ]
 # Functions to convert between strings and URLs
-into_custom = "URL({})"
+into_custom = "URI({}).toURL()"
 from_custom = "{}.toString()"
 
 [bindings.python.custom_types.Url]


### PR DESCRIPTION
Somehow I've ended up with java 20 or something, and this example is failing due to deprecated use of the url constructor. Hopefully this new way works with the older versions.