### PR TITLE
Re-introduce distinction between CodeType and CodeTypeDispatch

### DIFF
--- a/uniffi_bindgen/src/backend/mod.rs
+++ b/uniffi_bindgen/src/backend/mod.rs
@@ -10,7 +10,7 @@ mod types;
 pub use config::TemplateExpression;
 pub use declarations::CodeDeclaration;
 pub use oracle::CodeOracle;
-pub use types::CodeType;
+pub use types::{CodeType, CodeTypeDispatch};
 
 pub type TypeIdentifier = crate::interface::Type;
 pub type Literal = crate::interface::Literal;

--- a/uniffi_bindgen/src/backend/oracle.rs
+++ b/uniffi_bindgen/src/backend/oracle.rs
@@ -5,14 +5,8 @@
 use super::{CodeType, TypeIdentifier};
 use crate::interface::FfiType;
 
-/// An object to look up a foreign language code specific renderer for a given type used.
-/// Every `Type` referred to in the `ComponentInterface` should map to a corresponding
-/// `CodeType`.
-///
-/// The mapping may be opaque, but the oracle always knows the answer.
-///
-/// In adddition, the oracle knows how to render identifiers (function names,
-/// class names, variable names etc).
+/// An object to supply a foreign language specific CodeType for a given type. It also
+/// supplys the specific rendering of a given identifier when used in a specific context.
 pub trait CodeOracle {
     fn find(&self, type_: &TypeIdentifier) -> Box<dyn CodeType>;
 

--- a/uniffi_bindgen/src/backend/types.rs
+++ b/uniffi_bindgen/src/backend/types.rs
@@ -11,50 +11,40 @@
 //! (the FfiType), and foreign language expressions that call into the machinery. This helper code
 //! can be provided by a template file.
 //!
-//! A `CodeDeclaration` is needed for each type that is declared in the UDL file. This has access to
-//! the [crate::interface::ComponentInterface], which is the closest thing to an Intermediate Representation.
-//!
-//! `CodeDeclaration`s provide the target language's version of the UDL type, including forwarding method calls
-//! into Rust. It is likely if you're implementing a `CodeDeclaration` for this purpose, it will also need to cross
-//! the FFI, and you'll also need a `CodeType`.
-//!
-//! `CodeDeclaration`s can also be used to conditionally include code: e.g. only include the CallbackInterfaceRuntime
-//! if the user has used at least one callback interface.
-//!
-//! Each backend has a wrapper template for each file it needs to generate. This should collect the `CodeDeclaration`s that
-//! the backend and `ComponentInterface` between them specify and use them to stitch together a file in the target language.
-//!
 //! The `CodeOracle` provides methods to map the `Type` values found in the `ComponentInterface` to the `CodeType`s specified
 //! by the backend. It also provides methods for transforming identifiers into the coding standard for the target language.
+//!
+//! There's also a CodeTypeDispatch trait, implemented for every type, which allows a CodeType to be created
+//! by the specified `CodeOracle`. This means backends are able to provide a custom CodeType for each type
+//! via that backend's CodeOracle.
 //!
 //! Each backend will have its own `filter` module, which is used by the askama templates used in all `CodeType`s and `CodeDeclaration`s.
 //! This filter provides methods to generate expressions and identifiers in the target language. These are all forwarded to the oracle.
 
+use std::fmt::Debug;
+
 use super::{CodeOracle, Literal};
 use crate::interface::*;
 
-/// A Trait to emit foreign language code to handle referenced types.
-/// A type which is specified in the UDL (i.e. a member of the component interface)
-/// will have a `CodeDeclaration` as well, but for types used e.g. primitive types, Strings, etc
-/// only a `CodeType` is needed.
-pub trait CodeType {
+/// A Trait to help render types in a language specific format.
+pub trait CodeType: Debug {
     /// The language specific label used to reference this type. This will be used in
     /// method signatures and property declarations.
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String;
+    fn type_label(&self) -> String;
 
     /// A representation of this type label that can be used as part of another
     /// identifier. e.g. `read_foo()`, or `FooInternals`.
     ///
     /// This is especially useful when creating specialized objects or methods to deal
     /// with this type only.
-    fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
-        self.type_label(oracle)
+    fn canonical_name(&self) -> String {
+        self.type_label()
     }
 
     /// A representation of the given literal for this type.
     /// N.B. `Literal` is aliased from `interface::Literal`, so may not be whole suited to this task.
-    fn literal(&self, oracle: &dyn CodeOracle, _literal: &Literal) -> String {
-        unimplemented!("Unimplemented for {}", self.type_label(oracle))
+    fn literal(&self, _literal: &Literal) -> String {
+        unimplemented!("Unimplemented for {}", self.type_label())
     }
 
     /// Name of the FfiConverter
@@ -65,38 +55,38 @@ pub trait CodeType {
     /// This is the newer way of handling these methods and replaces the lower, write, lift, and
     /// read CodeType methods.  Currently only used by Kotlin, but the plan is to move other
     /// backends to using this.
-    fn ffi_converter_name(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.class_name(&format!("FfiConverter{}", self.canonical_name(oracle)))
+    fn ffi_converter_name(&self) -> String {
+        format!("FfiConverter{}", self.canonical_name())
     }
 
     /// An expression for lowering a value into something we can pass over the FFI.
-    fn lower(&self, oracle: &dyn CodeOracle) -> String {
-        format!("{}.lower", self.ffi_converter_name(oracle))
+    fn lower(&self) -> String {
+        format!("{}.lower", self.ffi_converter_name())
     }
 
     /// An expression for writing a value into a byte buffer.
-    fn write(&self, oracle: &dyn CodeOracle) -> String {
-        format!("{}.write", self.ffi_converter_name(oracle))
+    fn write(&self) -> String {
+        format!("{}.write", self.ffi_converter_name())
     }
 
     /// An expression for lifting a value from something we received over the FFI.
-    fn lift(&self, oracle: &dyn CodeOracle) -> String {
-        format!("{}.lift", self.ffi_converter_name(oracle))
+    fn lift(&self) -> String {
+        format!("{}.lift", self.ffi_converter_name())
     }
 
     /// An expression for reading a value from a byte buffer.
-    fn read(&self, oracle: &dyn CodeOracle) -> String {
-        format!("{}.read", self.ffi_converter_name(oracle))
+    fn read(&self) -> String {
+        format!("{}.read", self.ffi_converter_name())
     }
 
     /// A list of imports that are needed if this type is in use.
     /// Classes are imported exactly once.
-    fn imports(&self, _oracle: &dyn CodeOracle) -> Option<Vec<String>> {
+    fn imports(&self) -> Option<Vec<String>> {
         None
     }
 
     /// Function to run at startup
-    fn initialization_fn(&self, _oracle: &dyn CodeOracle) -> Option<String> {
+    fn initialization_fn(&self) -> Option<String> {
         None
     }
 }
@@ -104,7 +94,7 @@ pub trait CodeType {
 /// This trait is used to implement `CodeType` for `Type` and type-like structs (`Record`, `Enum`, `Field`,
 /// etc).  We forward all method calls to a `Box<dyn CodeType>`, which we get by calling
 /// `CodeOracle.find()`.
-pub trait CodeTypeDispatch {
+pub trait CodeTypeDispatch: Debug {
     fn code_type_impl(&self, oracle: &dyn CodeOracle) -> Box<dyn CodeType>;
 }
 
@@ -159,51 +149,10 @@ impl CodeTypeDispatch for Argument {
 // Needed to handle &&Type and &&&Type values, which we sometimes end up with in the template code
 impl<T, C> CodeTypeDispatch for T
 where
-    T: std::ops::Deref<Target = C>,
+    T: std::ops::Deref<Target = C> + Debug,
     C: CodeTypeDispatch,
 {
     fn code_type_impl(&self, oracle: &dyn CodeOracle) -> Box<dyn CodeType> {
         self.deref().code_type_impl(oracle)
-    }
-}
-
-impl<T: CodeTypeDispatch> CodeType for T {
-    // The above code implements `CodeTypeDispatch` for `Type` and type-like structs (`Record`,
-    // `Enum`, `Field`, etc).  Now we can leverage that to implement `CodeType` for all of them.
-    // This allows for simpler template code (`field|lower` instead of `field.type_()|lower`)
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        self.code_type_impl(oracle).type_label(oracle)
-    }
-
-    fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
-        self.code_type_impl(oracle).canonical_name(oracle)
-    }
-
-    fn literal(&self, oracle: &dyn CodeOracle, literal: &Literal) -> String {
-        self.code_type_impl(oracle).literal(oracle, literal)
-    }
-
-    fn lower(&self, oracle: &dyn CodeOracle) -> String {
-        self.code_type_impl(oracle).lower(oracle)
-    }
-
-    fn write(&self, oracle: &dyn CodeOracle) -> String {
-        self.code_type_impl(oracle).write(oracle)
-    }
-
-    fn lift(&self, oracle: &dyn CodeOracle) -> String {
-        self.code_type_impl(oracle).lift(oracle)
-    }
-
-    fn read(&self, oracle: &dyn CodeOracle) -> String {
-        self.code_type_impl(oracle).read(oracle)
-    }
-
-    fn imports(&self, oracle: &dyn CodeOracle) -> Option<Vec<String>> {
-        self.code_type_impl(oracle).imports(oracle)
-    }
-
-    fn initialization_fn(&self, oracle: &dyn CodeOracle) -> Option<String> {
-        self.code_type_impl(oracle).initialization_fn(oracle)
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/callback_interface.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/callback_interface.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::{CodeOracle, CodeType, Literal};
 
+#[derive(Debug)]
 pub struct CallbackInterfaceCodeType {
     id: String,
 }
@@ -15,19 +16,19 @@ impl CallbackInterfaceCodeType {
 }
 
 impl CodeType for CallbackInterfaceCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.class_name(&self.id)
+    fn type_label(&self) -> String {
+        super::KotlinCodeOracle.class_name(&self.id)
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.id)
     }
 
-    fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+    fn literal(&self, _literal: &Literal) -> String {
         unreachable!();
     }
 
-    fn initialization_fn(&self, oracle: &dyn CodeOracle) -> Option<String> {
-        Some(format!("{}.register", self.ffi_converter_name(oracle)))
+    fn initialization_fn(&self) -> Option<String> {
+        Some(format!("{}.register", self.ffi_converter_name()))
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/custom.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/custom.rs
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::backend::{CodeOracle, CodeType, Literal};
+use crate::backend::{CodeType, Literal};
 
+#[derive(Debug)]
 pub struct CustomCodeType {
     name: String,
 }
@@ -15,15 +16,15 @@ impl CustomCodeType {
 }
 
 impl CodeType for CustomCodeType {
-    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+    fn type_label(&self) -> String {
         self.name.clone()
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.name)
     }
 
-    fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+    fn literal(&self, _literal: &Literal) -> String {
         unreachable!("Can't have a literal of a custom type");
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/enum_.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/enum_.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::{CodeOracle, CodeType, Literal};
 
+#[derive(Debug)]
 pub struct EnumCodeType {
     id: String,
 }
@@ -15,20 +16,20 @@ impl EnumCodeType {
 }
 
 impl CodeType for EnumCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.class_name(&self.id)
+    fn type_label(&self) -> String {
+        super::KotlinCodeOracle.class_name(&self.id)
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.id)
     }
 
-    fn literal(&self, oracle: &dyn CodeOracle, literal: &Literal) -> String {
+    fn literal(&self, literal: &Literal) -> String {
         if let Literal::Enum(v, _) = literal {
             format!(
                 "{}.{}",
-                self.type_label(oracle),
-                oracle.enum_variant_name(v)
+                self.type_label(),
+                super::KotlinCodeOracle.enum_variant_name(v)
             )
         } else {
             unreachable!();

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/error.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/error.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::{CodeOracle, CodeType, Literal};
 
+#[derive(Debug)]
 pub struct ErrorCodeType {
     id: String,
 }
@@ -15,15 +16,15 @@ impl ErrorCodeType {
 }
 
 impl CodeType for ErrorCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.error_name(&self.id)
+    fn type_label(&self) -> String {
+        super::KotlinCodeOracle.error_name(&self.id)
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.id)
     }
 
-    fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+    fn literal(&self, _literal: &Literal) -> String {
         unreachable!();
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/executor.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/executor.rs
@@ -2,21 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::backend::{CodeOracle, CodeType};
+use crate::backend::CodeType;
 
+#[derive(Debug)]
 pub struct ForeignExecutorCodeType;
 
 impl CodeType for ForeignExecutorCodeType {
-    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+    fn type_label(&self) -> String {
         // Kotlin uses a CoroutineScope for ForeignExecutor
         "CoroutineScope".into()
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         "ForeignExecutor".into()
     }
 
-    fn initialization_fn(&self, _oracle: &dyn CodeOracle) -> Option<String> {
+    fn initialization_fn(&self) -> Option<String> {
         Some("FfiConverterForeignExecutor.register".into())
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/external.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/external.rs
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::backend::{CodeOracle, CodeType, Literal};
+use crate::backend::{CodeType, Literal};
 
+#[derive(Debug)]
 pub struct ExternalCodeType {
     name: String,
 }
@@ -15,15 +16,15 @@ impl ExternalCodeType {
 }
 
 impl CodeType for ExternalCodeType {
-    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+    fn type_label(&self) -> String {
         self.name.clone()
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.name)
     }
 
-    fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+    fn literal(&self, _literal: &Literal) -> String {
         unreachable!("Can't have a literal of an external type");
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/miscellany.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/miscellany.rs
@@ -2,24 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::backend::{CodeOracle, CodeType, Literal};
+use crate::backend::{CodeType, Literal};
 use paste::paste;
 
 macro_rules! impl_code_type_for_miscellany {
     ($T:ty, $class_name:literal, $canonical_name:literal) => {
         paste! {
+            #[derive(Debug)]
             pub struct $T;
 
             impl CodeType for $T  {
-                fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+                fn type_label(&self) -> String {
                     $class_name.into()
                 }
 
-                fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+                fn canonical_name(&self) -> String {
                    $canonical_name.into()
                }
 
-                fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+                fn literal(&self, _literal: &Literal) -> String {
                     unreachable!()
                 }
             }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/object.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/object.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::{CodeOracle, CodeType, Literal};
 
+#[derive(Debug)]
 pub struct ObjectCodeType {
     id: String,
 }
@@ -15,15 +16,15 @@ impl ObjectCodeType {
 }
 
 impl CodeType for ObjectCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.class_name(&self.id)
+    fn type_label(&self) -> String {
+        super::KotlinCodeOracle.class_name(&self.id)
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.id)
     }
 
-    fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+    fn literal(&self, _literal: &Literal) -> String {
         unreachable!();
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/primitives.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/primitives.rs
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::backend::{CodeOracle, CodeType, Literal};
+use crate::backend::{CodeType, Literal};
 use crate::interface::{types::Type, Radix};
 use paste::paste;
 
-fn render_literal(_oracle: &dyn CodeOracle, literal: &Literal) -> String {
+fn render_literal(literal: &Literal) -> String {
     fn typed_number(type_: &Type, num_str: String) -> String {
         match type_ {
             // Bytes, Shorts and Ints can all be inferred from the type.
@@ -50,15 +50,16 @@ fn render_literal(_oracle: &dyn CodeOracle, literal: &Literal) -> String {
 macro_rules! impl_code_type_for_primitive {
     ($T:ty, $class_name:literal) => {
         paste! {
+            #[derive(Debug)]
             pub struct $T;
 
             impl CodeType for $T  {
-                fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+                fn type_label(&self) -> String {
                     $class_name.into()
                 }
 
-                fn literal(&self, oracle: &dyn CodeOracle, literal: &Literal) -> String {
-                    render_literal(oracle, &literal)
+                fn literal(&self, literal: &Literal) -> String {
+                    render_literal(&literal)
                 }
             }
         }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/record.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/record.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::{CodeOracle, CodeType, Literal};
 
+#[derive(Debug)]
 pub struct RecordCodeType {
     id: String,
 }
@@ -15,15 +16,15 @@ impl RecordCodeType {
 }
 
 impl CodeType for RecordCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.class_name(&self.id)
+    fn type_label(&self) -> String {
+        super::KotlinCodeOracle.class_name(&self.id)
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.id)
     }
 
-    fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+    fn literal(&self, _literal: &Literal) -> String {
         unreachable!();
     }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/callback_interface.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/callback_interface.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::{CodeOracle, CodeType, Literal};
 
+#[derive(Debug)]
 pub struct CallbackInterfaceCodeType {
     id: String,
 }
@@ -15,15 +16,15 @@ impl CallbackInterfaceCodeType {
 }
 
 impl CodeType for CallbackInterfaceCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.class_name(&self.id)
+    fn type_label(&self) -> String {
+        super::PythonCodeOracle.class_name(&self.id)
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("CallbackInterface{}", self.id)
     }
 
-    fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+    fn literal(&self, _literal: &Literal) -> String {
         unreachable!();
     }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/compounds.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/compounds.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::{CodeOracle, CodeType, Literal, TypeIdentifier};
 
+#[derive(Debug)]
 pub struct OptionalCodeType {
     inner: TypeIdentifier,
 }
@@ -15,25 +16,26 @@ impl OptionalCodeType {
 }
 
 impl CodeType for OptionalCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.find(&self.inner).type_label(oracle)
+    fn type_label(&self) -> String {
+        super::PythonCodeOracle.find(&self.inner).type_label()
     }
 
-    fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!(
             "Optional{}",
-            oracle.find(&self.inner).canonical_name(oracle),
+            super::PythonCodeOracle.find(&self.inner).canonical_name(),
         )
     }
 
-    fn literal(&self, oracle: &dyn CodeOracle, literal: &Literal) -> String {
+    fn literal(&self, literal: &Literal) -> String {
         match literal {
             Literal::Null => "None".into(),
-            _ => oracle.find(&self.inner).literal(oracle, literal),
+            _ => super::PythonCodeOracle.find(&self.inner).literal(literal),
         }
     }
 }
 
+#[derive(Debug)]
 pub struct SequenceCodeType {
     inner: TypeIdentifier,
 }
@@ -45,18 +47,18 @@ impl SequenceCodeType {
 }
 
 impl CodeType for SequenceCodeType {
-    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+    fn type_label(&self) -> String {
         "list".to_string()
     }
 
-    fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!(
             "Sequence{}",
-            oracle.find(&self.inner).canonical_name(oracle),
+            super::PythonCodeOracle.find(&self.inner).canonical_name(),
         )
     }
 
-    fn literal(&self, _oracle: &dyn CodeOracle, literal: &Literal) -> String {
+    fn literal(&self, literal: &Literal) -> String {
         match literal {
             Literal::EmptySequence => "[]".into(),
             _ => unimplemented!(),
@@ -64,6 +66,7 @@ impl CodeType for SequenceCodeType {
     }
 }
 
+#[derive(Debug)]
 pub struct MapCodeType {
     key: TypeIdentifier,
     value: TypeIdentifier,
@@ -76,19 +79,19 @@ impl MapCodeType {
 }
 
 impl CodeType for MapCodeType {
-    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+    fn type_label(&self) -> String {
         "dict".to_string()
     }
 
-    fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!(
             "Map{}{}",
-            oracle.find(&self.key).canonical_name(oracle),
-            oracle.find(&self.value).canonical_name(oracle),
+            super::PythonCodeOracle.find(&self.key).canonical_name(),
+            super::PythonCodeOracle.find(&self.value).canonical_name(),
         )
     }
 
-    fn literal(&self, _oracle: &dyn CodeOracle, literal: &Literal) -> String {
+    fn literal(&self, literal: &Literal) -> String {
         match literal {
             Literal::EmptyMap => "{}".into(),
             _ => unimplemented!(),

--- a/uniffi_bindgen/src/bindings/python/gen_python/custom.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/custom.rs
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::backend::{CodeOracle, CodeType};
+use crate::backend::CodeType;
 
+#[derive(Debug)]
 pub struct CustomCodeType {
     name: String,
 }
@@ -15,11 +16,11 @@ impl CustomCodeType {
 }
 
 impl CodeType for CustomCodeType {
-    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+    fn type_label(&self) -> String {
         self.name.clone()
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.name)
     }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/enum_.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/enum_.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::{CodeOracle, CodeType, Literal};
 
+#[derive(Debug)]
 pub struct EnumCodeType {
     id: String,
 }
@@ -15,20 +16,20 @@ impl EnumCodeType {
 }
 
 impl CodeType for EnumCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.class_name(&self.id)
+    fn type_label(&self) -> String {
+        super::PythonCodeOracle.class_name(&self.id)
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.id)
     }
 
-    fn literal(&self, oracle: &dyn CodeOracle, literal: &Literal) -> String {
+    fn literal(&self, literal: &Literal) -> String {
         if let Literal::Enum(v, _) = literal {
             format!(
                 "{}.{}",
-                self.type_label(oracle),
-                oracle.enum_variant_name(v)
+                self.type_label(),
+                super::PythonCodeOracle.enum_variant_name(v)
             )
         } else {
             unreachable!();

--- a/uniffi_bindgen/src/bindings/python/gen_python/error.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/error.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::{CodeOracle, CodeType, Literal};
 
+#[derive(Debug)]
 pub struct ErrorCodeType {
     id: String,
 }
@@ -15,15 +16,15 @@ impl ErrorCodeType {
 }
 
 impl CodeType for ErrorCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.class_name(&self.id)
+    fn type_label(&self) -> String {
+        super::PythonCodeOracle.class_name(&self.id)
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.id)
     }
 
-    fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+    fn literal(&self, _literal: &Literal) -> String {
         unreachable!();
     }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/executor.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/executor.rs
@@ -2,16 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::backend::{CodeOracle, CodeType};
+use crate::backend::CodeType;
 
+#[derive(Debug)]
 pub struct ForeignExecutorCodeType;
 
 impl CodeType for ForeignExecutorCodeType {
-    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+    fn type_label(&self) -> String {
         "asyncio.BaseEventLoop".into()
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         "ForeignExecutor".into()
     }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/external.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/external.rs
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::backend::{CodeOracle, CodeType};
+use crate::backend::CodeType;
 
+#[derive(Debug)]
 pub struct ExternalCodeType {
     name: String,
 }
@@ -15,11 +16,11 @@ impl ExternalCodeType {
 }
 
 impl CodeType for ExternalCodeType {
-    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+    fn type_label(&self) -> String {
         self.name.clone()
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.name)
     }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/miscellany.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/miscellany.rs
@@ -2,24 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::backend::{CodeOracle, CodeType, Literal};
+use crate::backend::{CodeType, Literal};
 use paste::paste;
 
 macro_rules! impl_code_type_for_miscellany {
     ($T:ty, $canonical_name:literal) => {
         paste! {
+            #[derive(Debug)]
             pub struct $T;
 
             impl CodeType for $T  {
-                fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+                fn type_label(&self) -> String {
                     format!("{}", $canonical_name)
                 }
 
-                fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+                fn canonical_name(&self) -> String {
                     format!("{}", $canonical_name)
                 }
 
-                fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+                fn literal(&self, _literal: &Literal) -> String {
                     unreachable!()
                 }
             }

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -11,7 +11,7 @@ use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::collections::{BTreeSet, HashMap, HashSet};
 
-use crate::backend::{CodeOracle, CodeType, TemplateExpression, TypeIdentifier};
+use crate::backend::{CodeOracle, CodeType, CodeTypeDispatch, TemplateExpression, TypeIdentifier};
 use crate::interface::*;
 use crate::BindingsConfig;
 
@@ -384,34 +384,31 @@ pub mod filters {
         &PythonCodeOracle
     }
 
-    pub fn type_name(codetype: &impl CodeType) -> Result<String, askama::Error> {
-        let oracle = oracle();
-        Ok(codetype.type_label(oracle))
+    pub fn type_name(codetype: &impl CodeTypeDispatch) -> Result<String, askama::Error> {
+        Ok(codetype.code_type_impl(oracle()).type_label())
     }
 
-    pub fn ffi_converter_name(codetype: &impl CodeType) -> Result<String, askama::Error> {
-        let oracle = oracle();
-        Ok(codetype.ffi_converter_name(oracle))
+    pub fn ffi_converter_name(codetype: &impl CodeTypeDispatch) -> Result<String, askama::Error> {
+        Ok(codetype.code_type_impl(oracle()).ffi_converter_name())
     }
 
-    pub fn canonical_name(codetype: &impl CodeType) -> Result<String, askama::Error> {
-        let oracle = oracle();
-        Ok(codetype.canonical_name(oracle))
+    pub fn canonical_name(codetype: &impl CodeTypeDispatch) -> Result<String, askama::Error> {
+        Ok(codetype.code_type_impl(oracle()).canonical_name())
     }
 
-    pub fn lift_fn(codetype: &impl CodeType) -> Result<String, askama::Error> {
+    pub fn lift_fn(codetype: &impl CodeTypeDispatch) -> Result<String, askama::Error> {
         Ok(format!("{}.lift", ffi_converter_name(codetype)?))
     }
 
-    pub fn lower_fn(codetype: &impl CodeType) -> Result<String, askama::Error> {
+    pub fn lower_fn(codetype: &impl CodeTypeDispatch) -> Result<String, askama::Error> {
         Ok(format!("{}.lower", ffi_converter_name(codetype)?))
     }
 
-    pub fn read_fn(codetype: &impl CodeType) -> Result<String, askama::Error> {
+    pub fn read_fn(codetype: &impl CodeTypeDispatch) -> Result<String, askama::Error> {
         Ok(format!("{}.read", ffi_converter_name(codetype)?))
     }
 
-    pub fn write_fn(codetype: &impl CodeType) -> Result<String, askama::Error> {
+    pub fn write_fn(codetype: &impl CodeTypeDispatch) -> Result<String, askama::Error> {
         Ok(format!("{}.write", ffi_converter_name(codetype)?))
     }
 
@@ -432,10 +429,9 @@ pub mod filters {
 
     pub fn literal_py(
         literal: &Literal,
-        codetype: &impl CodeType,
+        codetype: &impl CodeTypeDispatch,
     ) -> Result<String, askama::Error> {
-        let oracle = oracle();
-        Ok(codetype.literal(oracle, literal))
+        Ok(codetype.code_type_impl(oracle()).literal(literal))
     }
 
     /// Get the Python syntax for representing a given low-level `FfiType`.

--- a/uniffi_bindgen/src/bindings/python/gen_python/object.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/object.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::{CodeOracle, CodeType, Literal};
 
+#[derive(Debug)]
 pub struct ObjectCodeType {
     id: String,
 }
@@ -15,15 +16,15 @@ impl ObjectCodeType {
 }
 
 impl CodeType for ObjectCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.class_name(&self.id)
+    fn type_label(&self) -> String {
+        super::PythonCodeOracle.class_name(&self.id)
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.id)
     }
 
-    fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+    fn literal(&self, _literal: &Literal) -> String {
         unreachable!();
     }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/primitives.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/primitives.rs
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::backend::{CodeOracle, CodeType, Literal};
+use crate::backend::{CodeType, Literal};
 use crate::interface::Radix;
 use paste::paste;
 
-fn render_literal(_oracle: &dyn CodeOracle, literal: &Literal) -> String {
+fn render_literal(literal: &Literal) -> String {
     match literal {
         Literal::Boolean(v) => {
             if *v {
@@ -36,15 +36,15 @@ fn render_literal(_oracle: &dyn CodeOracle, literal: &Literal) -> String {
 macro_rules! impl_code_type_for_primitive {
     ($T:ty, $class_name:literal) => {
         paste! {
+            #[derive(Debug)]
             pub struct $T;
-
             impl CodeType for $T  {
-                fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+                fn type_label(&self) -> String {
                     $class_name.into()
                 }
 
-                fn literal(&self, oracle: &dyn CodeOracle, literal: &Literal) -> String {
-                    render_literal(oracle, &literal)
+                fn literal(&self, literal: &Literal) -> String {
+                    render_literal(&literal)
                 }
             }
         }

--- a/uniffi_bindgen/src/bindings/python/gen_python/record.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/record.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::{CodeOracle, CodeType, Literal};
 
+#[derive(Debug)]
 pub struct RecordCodeType {
     id: String,
 }
@@ -15,15 +16,15 @@ impl RecordCodeType {
 }
 
 impl CodeType for RecordCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.class_name(&self.id)
+    fn type_label(&self) -> String {
+        super::PythonCodeOracle.class_name(&self.id)
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.id)
     }
 
-    fn literal(&self, _oracle: &dyn CodeOracle, _literal: &Literal) -> String {
+    fn literal(&self, _literal: &Literal) -> String {
         unreachable!();
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/callback_interface.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/callback_interface.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::{CodeOracle, CodeType};
 
+#[derive(Debug)]
 pub struct CallbackInterfaceCodeType {
     id: String,
 }
@@ -15,11 +16,11 @@ impl CallbackInterfaceCodeType {
 }
 
 impl CodeType for CallbackInterfaceCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.class_name(&self.id)
+    fn type_label(&self) -> String {
+        super::SwiftCodeOracle.class_name(&self.id)
     }
 
-    fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
-        format!("CallbackInterface{}", self.type_label(oracle))
+    fn canonical_name(&self) -> String {
+        format!("CallbackInterface{}", self.type_label())
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/compounds.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/compounds.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::{CodeOracle, CodeType, Literal, TypeIdentifier};
 
+#[derive(Debug)]
 pub struct OptionalCodeType {
     inner: TypeIdentifier,
 }
@@ -15,22 +16,26 @@ impl OptionalCodeType {
 }
 
 impl CodeType for OptionalCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        format!("{}?", oracle.find(&self.inner).type_label(oracle))
+    fn type_label(&self) -> String {
+        format!("{}?", super::SwiftCodeOracle.find(&self.inner).type_label())
     }
 
-    fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
-        format!("Option{}", oracle.find(&self.inner).canonical_name(oracle))
+    fn canonical_name(&self) -> String {
+        format!(
+            "Option{}",
+            super::SwiftCodeOracle.find(&self.inner).canonical_name()
+        )
     }
 
-    fn literal(&self, oracle: &dyn CodeOracle, literal: &Literal) -> String {
+    fn literal(&self, literal: &Literal) -> String {
         match literal {
             Literal::Null => "nil".into(),
-            _ => oracle.find(&self.inner).literal(oracle, literal),
+            _ => super::SwiftCodeOracle.find(&self.inner).literal(literal),
         }
     }
 }
 
+#[derive(Debug)]
 pub struct SequenceCodeType {
     inner: TypeIdentifier,
 }
@@ -42,18 +47,21 @@ impl SequenceCodeType {
 }
 
 impl CodeType for SequenceCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        format!("[{}]", oracle.find(&self.inner).type_label(oracle))
-    }
-
-    fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
+    fn type_label(&self) -> String {
         format!(
-            "Sequence{}",
-            oracle.find(&self.inner).canonical_name(oracle)
+            "[{}]",
+            super::SwiftCodeOracle.find(&self.inner).type_label()
         )
     }
 
-    fn literal(&self, _oracle: &dyn CodeOracle, literal: &Literal) -> String {
+    fn canonical_name(&self) -> String {
+        format!(
+            "Sequence{}",
+            super::SwiftCodeOracle.find(&self.inner).canonical_name()
+        )
+    }
+
+    fn literal(&self, literal: &Literal) -> String {
         match literal {
             Literal::EmptySequence => "[]".into(),
             _ => unreachable!(),
@@ -61,6 +69,7 @@ impl CodeType for SequenceCodeType {
     }
 }
 
+#[derive(Debug)]
 pub struct MapCodeType {
     key: TypeIdentifier,
     value: TypeIdentifier,
@@ -73,23 +82,23 @@ impl MapCodeType {
 }
 
 impl CodeType for MapCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
+    fn type_label(&self) -> String {
         format!(
             "[{}: {}]",
-            oracle.find(&self.key).type_label(oracle),
-            oracle.find(&self.value).type_label(oracle)
+            super::SwiftCodeOracle.find(&self.key).type_label(),
+            super::SwiftCodeOracle.find(&self.value).type_label()
         )
     }
 
-    fn canonical_name(&self, oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!(
             "Dictionary{}{}",
-            oracle.find(&self.key).canonical_name(oracle),
-            oracle.find(&self.value).canonical_name(oracle)
+            super::SwiftCodeOracle.find(&self.key).canonical_name(),
+            super::SwiftCodeOracle.find(&self.value).canonical_name()
         )
     }
 
-    fn literal(&self, _oracle: &dyn CodeOracle, literal: &Literal) -> String {
+    fn literal(&self, literal: &Literal) -> String {
         match literal {
             Literal::EmptyMap => "[:]".into(),
             _ => unreachable!(),

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/custom.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/custom.rs
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::backend::{CodeOracle, CodeType};
+use crate::backend::CodeType;
 
+#[derive(Debug)]
 pub struct CustomCodeType {
     name: String,
 }
@@ -15,11 +16,11 @@ impl CustomCodeType {
 }
 
 impl CodeType for CustomCodeType {
-    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+    fn type_label(&self) -> String {
         self.name.clone()
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.name)
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/enum_.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/enum_.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::{CodeOracle, CodeType, Literal};
 
+#[derive(Debug)]
 pub struct EnumCodeType {
     id: String,
 }
@@ -15,17 +16,17 @@ impl EnumCodeType {
 }
 
 impl CodeType for EnumCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.class_name(&self.id)
+    fn type_label(&self) -> String {
+        super::SwiftCodeOracle.class_name(&self.id)
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.id)
     }
 
-    fn literal(&self, oracle: &dyn CodeOracle, literal: &Literal) -> String {
+    fn literal(&self, literal: &Literal) -> String {
         if let Literal::Enum(v, _) = literal {
-            format!(".{}", oracle.enum_variant_name(v))
+            format!(".{}", super::SwiftCodeOracle.enum_variant_name(v))
         } else {
             unreachable!();
         }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/error.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/error.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::{CodeOracle, CodeType};
 
+#[derive(Debug)]
 pub struct ErrorCodeType {
     id: String,
 }
@@ -15,11 +16,11 @@ impl ErrorCodeType {
 }
 
 impl CodeType for ErrorCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.class_name(&self.id)
+    fn type_label(&self) -> String {
+        super::SwiftCodeOracle.class_name(&self.id)
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.id)
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/executor.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/executor.rs
@@ -2,21 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::backend::{CodeOracle, CodeType};
+use crate::backend::CodeType;
 
+#[derive(Debug)]
 pub struct ForeignExecutorCodeType;
 
 impl CodeType for ForeignExecutorCodeType {
-    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+    fn type_label(&self) -> String {
         // On Swift, we define a struct to represent a ForeignExecutor
         "UniFfiForeignExecutor".into()
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         "ForeignExecutor".into()
     }
 
-    fn initialization_fn(&self, _oracle: &dyn CodeOracle) -> Option<String> {
+    fn initialization_fn(&self) -> Option<String> {
         Some("uniffiInitForeignExecutor".into())
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/external.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/external.rs
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::backend::{CodeOracle, CodeType};
+use crate::backend::CodeType;
 
+#[derive(Debug)]
 pub struct ExternalCodeType {
     name: String,
 }
@@ -15,21 +16,21 @@ impl ExternalCodeType {
 }
 
 impl CodeType for ExternalCodeType {
-    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+    fn type_label(&self) -> String {
         self.name.clone()
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.name)
     }
 
     // lower and lift need to call public function which were generated for
     // the original types.
-    fn lower(&self, oracle: &dyn CodeOracle) -> String {
-        format!("{}_lower", self.ffi_converter_name(oracle))
+    fn lower(&self) -> String {
+        format!("{}_lower", self.ffi_converter_name())
     }
 
-    fn lift(&self, oracle: &dyn CodeOracle) -> String {
-        format!("{}_lift", self.ffi_converter_name(oracle))
+    fn lift(&self) -> String {
+        format!("{}_lift", self.ffi_converter_name())
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/miscellany.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/miscellany.rs
@@ -2,28 +2,30 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::backend::{CodeOracle, CodeType};
+use crate::backend::CodeType;
 
+#[derive(Debug)]
 pub struct TimestampCodeType;
 
 impl CodeType for TimestampCodeType {
-    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+    fn type_label(&self) -> String {
         "Date".into()
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         "Timestamp".into()
     }
 }
 
+#[derive(Debug)]
 pub struct DurationCodeType;
 
 impl CodeType for DurationCodeType {
-    fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+    fn type_label(&self) -> String {
         "TimeInterval".into()
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         "Duration".into()
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/object.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/object.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::{CodeOracle, CodeType};
 
+#[derive(Debug)]
 pub struct ObjectCodeType {
     id: String,
 }
@@ -15,11 +16,11 @@ impl ObjectCodeType {
 }
 
 impl CodeType for ObjectCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.class_name(&self.id)
+    fn type_label(&self) -> String {
+        super::SwiftCodeOracle.class_name(&self.id)
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.id)
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/record.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/record.rs
@@ -4,6 +4,7 @@
 
 use crate::backend::{CodeOracle, CodeType};
 
+#[derive(Debug)]
 pub struct RecordCodeType {
     id: String,
 }
@@ -15,11 +16,11 @@ impl RecordCodeType {
 }
 
 impl CodeType for RecordCodeType {
-    fn type_label(&self, oracle: &dyn CodeOracle) -> String {
-        oracle.class_name(&self.id)
+    fn type_label(&self) -> String {
+        super::SwiftCodeOracle.class_name(&self.id)
     }
 
-    fn canonical_name(&self, _oracle: &dyn CodeOracle) -> String {
+    fn canonical_name(&self) -> String {
         format!("Type{}", self.id)
     }
 }


### PR DESCRIPTION
This fixes a source of significant confusion in the code-oracle support.

On one hand, it has the concept of a `CodeType` which you get back from an Oracle via a `CodeDispatch` - so a code-type is closely tied to the oracle that supplied it. But:

* Every `CodeType` method takes a `CodeOracle` param - which is odd because the `CodeType` came from the oracle - it doesn't need the oracle to work.

* There's a blanket implementation of `CodeType` made available for `Type` - so not only do we now have a `CodeType` that didn't come from an Oracle, so clearly can't know the language semantics the Oracle abstracts away, there's now *two* implementations of `CodeType` for each type, with each behaving differently.

This cleans all that up:

* CodeType is only supplied by Oracles - there's no blanket implementation for Type.

* Therefore `CodeType` no longer takes Oracle's as args.

* Filters now take a `CodeTypeDispatch` - which *are* implemented for type, and explicitly use the oracle to get a `CodeType`