### PR TITLE
Don't pass non-UTF-8 bytes as string from Ruby to Rust

### DIFF
--- a/fixtures/type-limits/src/lib.rs
+++ b/fixtures/type-limits/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::str;
+
 fn take_i8(v: i8) -> i8 {
     v
 }
@@ -32,6 +34,11 @@ fn take_f32(v: f32) -> f32 {
     v
 }
 fn take_f64(v: f64) -> f64 {
+    v
+}
+
+fn take_string(v: String) -> String {
+    assert!(str::from_utf8(v.as_bytes()).is_ok());
     v
 }
 

--- a/fixtures/type-limits/src/type-limits.udl
+++ b/fixtures/type-limits/src/type-limits.udl
@@ -11,4 +11,6 @@ namespace uniffi_type_limits {
 
   f32 take_f32(f32 v);
   f64 take_f64(f64 v);
+
+  string take_string(string v);
 };

--- a/fixtures/type-limits/tests/bindings/test_type_limits.py
+++ b/fixtures/type-limits/tests/bindings/test_type_limits.py
@@ -174,5 +174,11 @@ class TestTypeLimits(unittest.TestCase):
         self.assertTrue(math.isnan(take_f32(math.nan)))
         self.assertTrue(math.isnan(take_f64(math.nan)))
 
+    def test_strings(self):
+        self.assertRaises(ValueError, lambda: take_string("\ud800")) # surrogate
+        self.assertEqual(take_string(""), "")
+        self.assertEqual(take_string("愛"), "愛")
+        self.assertEqual(take_string("💖"), "💖")
+
 if __name__ == "__main__":
     unittest.main()

--- a/fixtures/type-limits/tests/bindings/test_type_limits.rb
+++ b/fixtures/type-limits/tests/bindings/test_type_limits.rb
@@ -65,4 +65,11 @@ class TestTypeLimits < Test::Unit::TestCase
     assert_equal(UniffiTypeLimits.take_u32(10**9), 10**9)
     assert_equal(UniffiTypeLimits.take_u64(10**19), 10**19)
   end
+  def test_strings
+    assert_raise Encoding::InvalidByteSequenceError do UniffiTypeLimits.take_string("\xff") end # invalid byte
+    assert_raise Encoding::InvalidByteSequenceError do UniffiTypeLimits.take_string("\xed\xa0\x80") end # surrogate
+    assert_equal(UniffiTypeLimits.take_string(""), "")
+    assert_equal(UniffiTypeLimits.take_string("愛"), "愛")
+    assert_equal(UniffiTypeLimits.take_string("💖"), "💖")
+  end
 end

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -226,7 +226,7 @@ mod filters {
             Type::Float32 | Type::Float64 => format!("{nm}.to_f"),
             Type::Boolean => format!("{nm} ? true : false"),
             Type::Object { .. } | Type::Enum(_) | Type::Record(_) => nm.to_string(),
-            Type::String | Type::Bytes => format!("{nm}.to_s"),
+            Type::String | Type::Bytes => format!("{ns}::uniffi_utf8({nm})"),
             Type::Timestamp | Type::Duration => nm.to_string(),
             Type::CallbackInterface(_) => panic!("No support for coercing callback interfaces yet"),
             Type::Optional(t) => format!("({nm} ? {} : nil)", coerce_rb(nm, ns, t)?),

--- a/uniffi_bindgen/src/bindings/ruby/templates/Helpers.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/Helpers.rb
@@ -3,3 +3,9 @@ def self.uniffi_in_range(i, type_name, min, max)
   raise RangeError, "#{type_name} requires #{min} <= value < #{max}" unless (min <= i && i < max)
   i
 end
+
+def self.uniffi_utf8(v)
+  v = v.to_s.encode(Encoding::UTF_8)
+  raise Encoding::InvalidByteSequenceError, "not a valid UTF-8 encoded string" unless v.valid_encoding?
+  v
+end

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -108,7 +108,7 @@ class RustBufferBuilder
   {% when Type::String -%}
 
   def write_String(v)
-    v = v.to_s
+    v = {{ ci.namespace()|class_name_rb }}::uniffi_utf8(v)
     pack_into 4, 'l>', v.bytes.size
     write v
   end


### PR DESCRIPTION
This would be UB on the Rust side. Add some tests verifying that this is caught in both Ruby and Python.