### PR TITLE
Python: For eq/ne handle types differing from the one we're implementing

### DIFF
--- a/fixtures/trait-methods/tests/bindings/test.py
+++ b/fixtures/trait-methods/tests/bindings/test.py
@@ -19,6 +19,10 @@ class TestTraitMethods(unittest.TestCase):
         self.assertEqual(m, TraitMethods("yo"))
         self.assertNotEqual(m, TraitMethods("yoyo"))
 
+    def test_eq(self):
+        m = TraitMethods("yo")
+        self.assertNotEqual(m, 17)
+
     def test_hash(self):
         d = {}
         m = TraitMethods("m")

--- a/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
@@ -45,8 +45,17 @@ class {{ type_name }}:
 {%-         when UniffiTrait::Display { fmt } %}
             {%- call py::method_decl("__str__", fmt) %}
 {%-         when UniffiTrait::Eq { eq, ne } %}
-            {%- call py::method_decl("__eq__", eq) %}
-            {%- call py::method_decl("__ne__", ne) %}
+    def __eq__(self, other: object):
+        if not isinstance(other, {{ type_name }}):
+            return NotImplemented
+
+        return {{ eq.return_type().unwrap()|lift_fn }}({% call py::to_ffi_call_with_prefix("self._pointer", eq) %})
+
+    def __ne__(self, other: object):
+        if not isinstance(other, {{ type_name }}):
+            return NotImplemented
+
+        return {{ ne.return_type().unwrap()|lift_fn }}({% call py::to_ffi_call_with_prefix("self._pointer", ne) %})
 {%-         when UniffiTrait::Hash { hash } %}
             {%- call py::method_decl("__hash__", hash) %}
 {%      endmatch %}


### PR DESCRIPTION
`NotImplemented` is what these methods should return, see https://docs.python.org/3/library/constants.html#NotImplemented The interpreter is then responsible for doing the right thing.

Unfortunately this means "manually" implementing these methods in the template instead of relying on the convenient macros.