### PR TITLE
Format Python names according to PEP8

### DIFF
--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -303,17 +303,17 @@ impl PythonCodeOracle {
             FfiType::Float64 => "ctypes.c_double".to_string(),
             FfiType::RustArcPtr(_) => "ctypes.c_void_p".to_string(),
             FfiType::RustBuffer(maybe_suffix) => match maybe_suffix {
-                Some(suffix) => format!("RustBuffer{suffix}"),
-                None => "RustBuffer".to_string(),
+                Some(suffix) => format!("_UniffiRustBuffer{suffix}"),
+                None => "_UniffiRustBuffer".to_string(),
             },
-            FfiType::ForeignBytes => "ForeignBytes".to_string(),
-            FfiType::ForeignCallback => "FOREIGN_CALLBACK_T".to_string(),
+            FfiType::ForeignBytes => "_UniffiForeignBytes".to_string(),
+            FfiType::ForeignCallback => "_UNIFFI_FOREIGN_CALLBACK_T".to_string(),
             // Pointer to an `asyncio.EventLoop` instance
             FfiType::ForeignExecutorHandle => "ctypes.c_size_t".to_string(),
-            FfiType::ForeignExecutorCallback => "UNIFFI_FOREIGN_EXECUTOR_CALLBACK_T".to_string(),
+            FfiType::ForeignExecutorCallback => "_UNIFFI_FOREIGN_EXECUTOR_CALLBACK_T".to_string(),
             FfiType::FutureCallback { return_type } => {
                 format!(
-                    "uniffi_future_callback_t({})",
+                    "_uniffi_future_callback_t({})",
                     Self::ffi_type_label(return_type),
                 )
             }
@@ -385,7 +385,7 @@ pub mod filters {
     }
 
     pub fn ffi_converter_name(as_ct: &impl AsCodeType) -> Result<String, askama::Error> {
-        Ok(as_ct.as_codetype().ffi_converter_name())
+        Ok(String::from("_Uniffi") + &as_ct.as_codetype().ffi_converter_name()[3..])
     }
 
     pub fn canonical_name(as_ct: &impl AsCodeType) -> Result<String, askama::Error> {
@@ -419,7 +419,7 @@ pub mod filters {
             None => "void".into(),
         };
         Ok(format!(
-            "uniffi_async_callback_{return_string}__{throws_string}"
+            "_uniffi_async_callback_{return_string}__{throws_string}"
         ))
     }
 

--- a/uniffi_bindgen/src/bindings/python/templates/AsyncTypes.py
+++ b/uniffi_bindgen/src/bindings/python/templates/AsyncTypes.py
@@ -1,11 +1,11 @@
 # Callback handlers for async returns
 
-UniFfiPyFuturePointerManager = UniFfiPointerManager()
+_UniffiPyFuturePointerManager = _UniffiPointerManager()
 
 # Callback handlers for an async calls.  These are invoked by Rust when the future is ready.  They
 # lift the return value or error and resolve the future, causing the async function to resume.
 {%- for result_type in ci.iter_async_result_types() %}
-@uniffi_future_callback_t(
+@_uniffi_future_callback_t(
         {%- match result_type.return_type -%}
         {%- when Some(return_type) -%}
         {{ return_type|ffi_type|ffi_type_name }}
@@ -14,15 +14,15 @@ UniFfiPyFuturePointerManager = UniFfiPointerManager()
         {%- endmatch -%}
 )
 def {{ result_type|async_callback_fn }}(future_ptr, result, call_status):
-    future = UniFfiPyFuturePointerManager.release_pointer(future_ptr)
+    future = _UniffiPyFuturePointerManager.release_pointer(future_ptr)
     if future.cancelled():
         return
     try:
         {%- match result_type.throws_type %}
         {%- when Some(throws_type) %}
-        uniffi_check_call_status({{ throws_type|ffi_converter_name }}, call_status)
+        _uniffi_check_call_status({{ throws_type|ffi_converter_name }}, call_status)
         {%- when None %}
-        uniffi_check_call_status(None, call_status)
+        _uniffi_check_call_status(None, call_status)
         {%- endmatch %}
 
         {%- match result_type.return_type %}

--- a/uniffi_bindgen/src/bindings/python/templates/BooleanHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/BooleanHelper.py
@@ -1,15 +1,15 @@
-class FfiConverterBool(FfiConverterPrimitive):
+class _UniffiConverterBool(_UniffiConverterPrimitive):
     @classmethod
     def check(cls, value):
         return not not value
 
     @classmethod
     def read(cls, buf):
-        return cls.lift(buf.readU8())
+        return cls.lift(buf.read_u8())
 
     @classmethod
-    def writeUnchecked(cls, value, buf):
-        buf.writeU8(value)
+    def write_unchecked(cls, value, buf):
+        buf.write_u8(value)
 
     @staticmethod
     def lift(value):

--- a/uniffi_bindgen/src/bindings/python/templates/BytesHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/BytesHelper.py
@@ -1,7 +1,7 @@
-class FfiConverterBytes(FfiConverterRustBuffer):
+class _UniffiConverterBytes(_UniffiConverterRustBuffer):
     @staticmethod
     def read(buf):
-        size = buf.readI32()
+        size = buf.read_i32()
         if size < 0:
             raise InternalError("Unexpected negative byte string length")
         return buf.read(size)
@@ -12,5 +12,5 @@ class FfiConverterBytes(FfiConverterRustBuffer):
             memoryview(value)
         except TypeError:
             raise TypeError("a bytes-like object is required, not {!r}".format(type(value).__name__))
-        buf.writeI32(len(value))
+        buf.write_i32(len(value))
         buf.write(value)

--- a/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceRuntime.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceRuntime.py
@@ -41,11 +41,11 @@ class ConcurrentHandleMap:
 # to free the callback once it's dropped by Rust.
 IDX_CALLBACK_FREE = 0
 # Return codes for callback calls
-UNIFFI_CALLBACK_SUCCESS = 0
-UNIFFI_CALLBACK_ERROR = 1
-UNIFFI_CALLBACK_UNEXPECTED_ERROR = 2
+_UNIFFI_CALLBACK_SUCCESS = 0
+_UNIFFI_CALLBACK_ERROR = 1
+_UNIFFI_CALLBACK_UNEXPECTED_ERROR = 2
 
-class FfiConverterCallbackInterface:
+class _UniffiConverterCallbackInterface:
     _handle_map = ConcurrentHandleMap()
 
     def __init__(self, cb):
@@ -64,7 +64,7 @@ class FfiConverterCallbackInterface:
 
     @classmethod
     def read(cls, buf):
-        handle = buf.readU64()
+        handle = buf.read_u64()
         cls.lift(handle)
 
     @classmethod
@@ -74,4 +74,4 @@ class FfiConverterCallbackInterface:
 
     @classmethod
     def write(cls, cb, buf):
-        buf.writeU64(cls.lower(cb))
+        buf.write_u64(cls.lower(cb))

--- a/uniffi_bindgen/src/bindings/python/templates/CustomType.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CustomType.py
@@ -4,7 +4,7 @@
 # Type alias
 {{ name }} = {{ builtin|type_name }}
 
-class FfiConverterType{{ name }}:
+class _UniffiConverterType{{ name }}:
     @staticmethod
     def write(value, buf):
         {{ builtin|ffi_converter_name }}.write(value, buf)
@@ -35,7 +35,7 @@ class FfiConverterType{{ name }}:
 {{ name }} = {{ builtin|type_name }}
 
 {#- Custom type config supplied, use it to convert the builtin type #}
-class FfiConverterType{{ name }}:
+class _UniffiConverterType{{ name }}:
     @staticmethod
     def write(value, buf):
         builtin_value = {{ config.from_custom.render("value") }}

--- a/uniffi_bindgen/src/bindings/python/templates/DurationHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/DurationHelper.py
@@ -4,11 +4,11 @@ Duration = datetime.timedelta
 # There is a loss of precision when converting from Rust durations,
 # which are accurate to the nanosecond,
 # to Python durations, which are only accurate to the microsecond.
-class FfiConverterDuration(FfiConverterRustBuffer):
+class _UniffiConverterDuration(_UniffiConverterRustBuffer):
     @staticmethod
     def read(buf):
-        seconds = buf.readU64()
-        microseconds = buf.readU32() / 1.0e3
+        seconds = buf.read_u64()
+        microseconds = buf.read_u32() / 1.0e3
         return datetime.timedelta(seconds=seconds, microseconds=microseconds)
 
     @staticmethod
@@ -17,5 +17,5 @@ class FfiConverterDuration(FfiConverterRustBuffer):
         nanoseconds = value.microseconds * 1000
         if seconds < 0:
             raise ValueError("Invalid duration, must be non-negative")
-        buf.writeI64(seconds)
-        buf.writeU32(nanoseconds)
+        buf.write_i64(seconds)
+        buf.write_u32(nanoseconds)

--- a/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
@@ -57,10 +57,10 @@ class {{ type_name }}:
 
 {% endif %}
 
-class {{ ffi_converter_name }}(FfiConverterRustBuffer):
+class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
     @staticmethod
     def read(buf):
-        variant = buf.readI32()
+        variant = buf.read_i32()
 
         {%- for variant in e.variants() %}
         if variant == {{ loop.index }}:
@@ -80,10 +80,10 @@ class {{ ffi_converter_name }}(FfiConverterRustBuffer):
         {%- for variant in e.variants() %}
         {%- if e.is_flat() %}
         if value == {{ type_name }}.{{ variant.name()|enum_variant_py }}:
-            buf.writeI32({{ loop.index }})
+            buf.write_i32({{ loop.index }})
         {%- else %}
         if value.is_{{ variant.name()|var_name }}():
-            buf.writeI32({{ loop.index }})
+            buf.write_i32({{ loop.index }})
             {%- for field in variant.fields() %}
             {{ field|write_fn }}(value.{{ field.name()|var_name }}, buf)
             {%- endfor %}

--- a/uniffi_bindgen/src/bindings/python/templates/ExternalTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ExternalTemplate.py
@@ -1,8 +1,8 @@
 {%- let mod_name = module_path|fn_name %}
 
-{%- let ffi_converter_name = "FfiConverterType{}"|format(name) %}
+{%- let ffi_converter_name = "_UniffiConverterType{}"|format(name) %}
 {{ self.add_import_of(mod_name, ffi_converter_name) }}
 {{ self.add_import_of(mod_name, name) }} {#- import the type alias itself -#}
 
-{%- let rustbuffer_local_name = "RustBuffer{}"|format(name) %}
-{{ self.add_import_of_as(mod_name, "RustBuffer", rustbuffer_local_name) }}
+{%- let rustbuffer_local_name = "_UniffiRustBuffer{}"|format(name) %}
+{{ self.add_import_of_as(mod_name, "_UniffiRustBuffer", rustbuffer_local_name) }}

--- a/uniffi_bindgen/src/bindings/python/templates/Float32Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Float32Helper.py
@@ -1,8 +1,8 @@
-class FfiConverterFloat(FfiConverterPrimitiveFloat):
+class _UniffiConverterFloat(_UniffiConverterPrimitiveFloat):
     @staticmethod
     def read(buf):
-        return buf.readFloat()
+        return buf.read_float()
 
     @staticmethod
-    def writeUnchecked(value, buf):
-        buf.writeFloat(value)
+    def write_unchecked(value, buf):
+        buf.write_float(value)

--- a/uniffi_bindgen/src/bindings/python/templates/Float64Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Float64Helper.py
@@ -1,8 +1,8 @@
-class FfiConverterDouble(FfiConverterPrimitiveFloat):
+class _UniffiConverterDouble(_UniffiConverterPrimitiveFloat):
     @staticmethod
     def read(buf):
-        return buf.readDouble()
+        return buf.read_double()
 
     @staticmethod
-    def writeUnchecked(value, buf):
-        buf.writeDouble(value)
+    def write_unchecked(value, buf):
+        buf.write_double(value)

--- a/uniffi_bindgen/src/bindings/python/templates/ForeignExecutorTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ForeignExecutorTemplate.py
@@ -3,33 +3,33 @@
 {{ self.add_import("asyncio") }}
 
 class {{ ffi_converter_name }}:
-    _pointer_manager = UniFfiPointerManager()
+    _pointer_manager = _UniffiPointerManager()
 
     @classmethod
     def lower(cls, eventloop):
         if not isinstance(eventloop, asyncio.BaseEventLoop):
-            raise TypeError("uniffi_executor_callback: Expected EventLoop instance")
+            raise TypeError("_uniffi_executor_callback: Expected EventLoop instance")
         return cls._pointer_manager.new_pointer(eventloop)
 
     @classmethod
     def write(cls, eventloop, buf):
-        buf.writeCSizeT(cls.lower(eventloop))
+        buf.write_c_size_t(cls.lower(eventloop))
 
     @classmethod
     def read(cls, buf):
-        return cls.lift(buf.readCSizeT())
+        return cls.lift(buf.read_c_size_t())
 
     @classmethod
     def lift(cls, value):
         return cls._pointer_manager.lookup(value)
 
-@UNIFFI_FOREIGN_EXECUTOR_CALLBACK_T
-def uniffi_executor_callback(eventloop_address, delay, task_ptr, task_data):
+@_UNIFFI_FOREIGN_EXECUTOR_CALLBACK_T
+def _uniffi_executor_callback(eventloop_address, delay, task_ptr, task_data):
     if task_ptr is None:
         {{ ffi_converter_name }}._pointer_manager.release_pointer(eventloop_address)
     else:
         eventloop = {{ ffi_converter_name }}._pointer_manager.lookup(eventloop_address)
-        callback = UNIFFI_RUST_TASK(task_ptr)
+        callback = _UNIFFI_RUST_TASK(task_ptr)
         if delay == 0:
             # This can be called from any thread, so make sure to use `call_soon_threadsafe'
             eventloop.call_soon_threadsafe(callback, task_data)
@@ -39,4 +39,4 @@ def uniffi_executor_callback(eventloop_address, delay, task_ptr, task_data):
             eventloop.call_soon_threadsafe(eventloop.call_later, delay / 1000.0, callback, task_data)
 
 # Register the callback with the scaffolding
-_UniFFILib.uniffi_foreign_executor_callback_set(uniffi_executor_callback)
+_UniffiLib.uniffi_foreign_executor_callback_set(_uniffi_executor_callback)

--- a/uniffi_bindgen/src/bindings/python/templates/Helpers.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Helpers.py
@@ -4,13 +4,13 @@
 class InternalError(Exception):
     pass
 
-class RustCallStatus(ctypes.Structure):
+class _UniffiRustCallStatus(ctypes.Structure):
     """
     Error runtime.
     """
     _fields_ = [
         ("code", ctypes.c_int8),
-        ("error_buf", RustBuffer),
+        ("error_buf", _UniffiRustBuffer),
     ]
 
     # These match the values from the uniffi::rustcalls module
@@ -19,72 +19,72 @@ class RustCallStatus(ctypes.Structure):
     CALL_PANIC = 2
 
     def __str__(self):
-        if self.code == RustCallStatus.CALL_SUCCESS:
-            return "RustCallStatus(CALL_SUCCESS)"
-        elif self.code == RustCallStatus.CALL_ERROR:
-            return "RustCallStatus(CALL_ERROR)"
-        elif self.code == RustCallStatus.CALL_PANIC:
-            return "RustCallStatus(CALL_PANIC)"
+        if self.code == _UniffiRustCallStatus.CALL_SUCCESS:
+            return "_UniffiRustCallStatus(CALL_SUCCESS)"
+        elif self.code == _UniffiRustCallStatus.CALL_ERROR:
+            return "_UniffiRustCallStatus(CALL_ERROR)"
+        elif self.code == _UniffiRustCallStatus.CALL_PANIC:
+            return "_UniffiRustCallStatus(CALL_PANIC)"
         else:
-            return "RustCallStatus(<invalid code>)"
+            return "_UniffiRustCallStatus(<invalid code>)"
 
-def rust_call(fn, *args):
+def _rust_call(fn, *args):
     # Call a rust function
-    return rust_call_with_error(None, fn, *args)
+    return _rust_call_with_error(None, fn, *args)
 
-def rust_call_with_error(error_ffi_converter, fn, *args):
+def _rust_call_with_error(error_ffi_converter, fn, *args):
     # Call a rust function and handle any errors
     #
     # This function is used for rust calls that return Result<> and therefore can set the CALL_ERROR status code.
-    # error_ffi_converter must be set to the FfiConverter for the error class that corresponds to the result.
-    call_status = RustCallStatus(code=RustCallStatus.CALL_SUCCESS, error_buf=RustBuffer(0, 0, None))
+    # error_ffi_converter must be set to the _UniffiConverter for the error class that corresponds to the result.
+    call_status = _UniffiRustCallStatus(code=_UniffiRustCallStatus.CALL_SUCCESS, error_buf=_UniffiRustBuffer(0, 0, None))
 
     args_with_error = args + (ctypes.byref(call_status),)
     result = fn(*args_with_error)
-    uniffi_check_call_status(error_ffi_converter, call_status)
+    _uniffi_check_call_status(error_ffi_converter, call_status)
     return result
 
-def rust_call_async(scaffolding_fn, callback_fn, *args):
+def _rust_call_async(scaffolding_fn, callback_fn, *args):
     # Call the scaffolding function, passing it a callback handler for `AsyncTypes.py` and a pointer
     # to a python Future object.  The async function then awaits the Future.
     uniffi_eventloop = asyncio.get_running_loop()
     uniffi_py_future = uniffi_eventloop.create_future()
-    uniffi_call_status = RustCallStatus(code=RustCallStatus.CALL_SUCCESS, error_buf=RustBuffer(0, 0, None))
+    uniffi_call_status = _UniffiRustCallStatus(code=_UniffiRustCallStatus.CALL_SUCCESS, error_buf=_UniffiRustBuffer(0, 0, None))
     scaffolding_fn(*args,
-       FfiConverterForeignExecutor._pointer_manager.new_pointer(uniffi_eventloop),
+       _UniffiConverterForeignExecutor._pointer_manager.new_pointer(uniffi_eventloop),
        callback_fn,
        # Note: It's tempting to skip the pointer manager and just use a `py_object` pointing to a
        # local variable like we do in Swift.  However, Python doesn't use cooperative cancellation
        # -- asyncio can cancel a task at anytime.  This means if we use a local variable, the Rust
        # callback could fire with a dangling pointer.
-       UniFfiPyFuturePointerManager.new_pointer(uniffi_py_future),
+       _UniffiPyFuturePointerManager.new_pointer(uniffi_py_future),
        ctypes.byref(uniffi_call_status),
     )
-    uniffi_check_call_status(None, uniffi_call_status)
+    _uniffi_check_call_status(None, uniffi_call_status)
     return uniffi_py_future
 
-def uniffi_check_call_status(error_ffi_converter, call_status):
-    if call_status.code == RustCallStatus.CALL_SUCCESS:
+def _uniffi_check_call_status(error_ffi_converter, call_status):
+    if call_status.code == _UniffiRustCallStatus.CALL_SUCCESS:
         pass
-    elif call_status.code == RustCallStatus.CALL_ERROR:
+    elif call_status.code == _UniffiRustCallStatus.CALL_ERROR:
         if error_ffi_converter is None:
             call_status.error_buf.free()
-            raise InternalError("rust_call_with_error: CALL_ERROR, but error_ffi_converter is None")
+            raise InternalError("_rust_call_with_error: CALL_ERROR, but error_ffi_converter is None")
         else:
             raise error_ffi_converter.lift(call_status.error_buf)
-    elif call_status.code == RustCallStatus.CALL_PANIC:
-        # When the rust code sees a panic, it tries to construct a RustBuffer
+    elif call_status.code == _UniffiRustCallStatus.CALL_PANIC:
+        # When the rust code sees a panic, it tries to construct a _UniffiRustBuffer
         # with the message.  But if that code panics, then it just sends back
         # an empty buffer.
         if call_status.error_buf.len > 0:
-            msg = FfiConverterString.lift(call_status.error_buf)
+            msg = _UniffiConverterString.lift(call_status.error_buf)
         else:
             msg = "Unknown rust panic"
         raise InternalError(msg)
     else:
-        raise InternalError("Invalid RustCallStatus code: {}".format(
+        raise InternalError("Invalid _UniffiRustCallStatus code: {}".format(
             call_status.code))
 
 # A function pointer for a callback as defined by UniFFI.
-# Rust definition `fn(handle: u64, method: u32, args: RustBuffer, buf_ptr: *mut RustBuffer) -> int`
-FOREIGN_CALLBACK_T = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_ulonglong, ctypes.c_ulong, ctypes.POINTER(ctypes.c_char), ctypes.c_int, ctypes.POINTER(RustBuffer))
+# Rust definition `fn(handle: u64, method: u32, args: _UniffiRustBuffer, buf_ptr: *mut _UniffiRustBuffer) -> int`
+_UNIFFI_FOREIGN_CALLBACK_T = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_ulonglong, ctypes.c_ulong, ctypes.POINTER(ctypes.c_char), ctypes.c_int, ctypes.POINTER(_UniffiRustBuffer))

--- a/uniffi_bindgen/src/bindings/python/templates/Int16Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int16Helper.py
@@ -1,12 +1,12 @@
-class FfiConverterInt16(FfiConverterPrimitiveInt):
+class _UniffiConverterInt16(_UniffiConverterPrimitiveInt):
     CLASS_NAME = "i16"
     VALUE_MIN = -2**15
     VALUE_MAX = 2**15
 
     @staticmethod
     def read(buf):
-        return buf.readI16()
+        return buf.read_i16()
 
     @staticmethod
-    def writeUnchecked(value, buf):
-        buf.writeI16(value)
+    def write_unchecked(value, buf):
+        buf.write_i16(value)

--- a/uniffi_bindgen/src/bindings/python/templates/Int32Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int32Helper.py
@@ -1,12 +1,12 @@
-class FfiConverterInt32(FfiConverterPrimitiveInt):
+class _UniffiConverterInt32(_UniffiConverterPrimitiveInt):
     CLASS_NAME = "i32"
     VALUE_MIN = -2**31
     VALUE_MAX = 2**31
 
     @staticmethod
     def read(buf):
-        return buf.readI32()
+        return buf.read_i32()
 
     @staticmethod
-    def writeUnchecked(value, buf):
-        buf.writeI32(value)
+    def write_unchecked(value, buf):
+        buf.write_i32(value)

--- a/uniffi_bindgen/src/bindings/python/templates/Int64Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int64Helper.py
@@ -1,12 +1,12 @@
-class FfiConverterInt64(FfiConverterPrimitiveInt):
+class _UniffiConverterInt64(_UniffiConverterPrimitiveInt):
     CLASS_NAME = "i64"
     VALUE_MIN = -2**63
     VALUE_MAX = 2**63
 
     @staticmethod
     def read(buf):
-        return buf.readI64()
+        return buf.read_i64()
 
     @staticmethod
-    def writeUnchecked(value, buf):
-        buf.writeI64(value)
+    def write_unchecked(value, buf):
+        buf.write_i64(value)

--- a/uniffi_bindgen/src/bindings/python/templates/Int8Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int8Helper.py
@@ -1,12 +1,12 @@
-class FfiConverterInt8(FfiConverterPrimitiveInt):
+class _UniffiConverterInt8(_UniffiConverterPrimitiveInt):
     CLASS_NAME = "i8"
     VALUE_MIN = -2**7
     VALUE_MAX = 2**7
 
     @staticmethod
     def read(buf):
-        return buf.readI8()
+        return buf.read_i8()
 
     @staticmethod
-    def writeUnchecked(value, buf):
-        buf.writeI8(value)
+    def write_unchecked(value, buf):
+        buf.write_i8(value)

--- a/uniffi_bindgen/src/bindings/python/templates/MapTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/MapTemplate.py
@@ -1,17 +1,17 @@
 {%- let key_ffi_converter = key_type|ffi_converter_name %}
 {%- let value_ffi_converter = value_type|ffi_converter_name %}
 
-class {{ ffi_converter_name }}(FfiConverterRustBuffer):
+class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
     @classmethod
     def write(cls, items, buf):
-        buf.writeI32(len(items))
+        buf.write_i32(len(items))
         for (key, value) in items.items():
             {{ key_ffi_converter }}.write(key, buf)
             {{ value_ffi_converter }}.write(value, buf)
 
     @classmethod
     def read(cls, buf):
-        count = buf.readI32()
+        count = buf.read_i32()
         if count < 0:
             raise InternalError("Unexpected negative map size")
 

--- a/uniffi_bindgen/src/bindings/python/templates/NamespaceLibraryTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/NamespaceLibraryTemplate.py
@@ -14,22 +14,20 @@ Normally we should call task(task_data) after the detail.
 However, when task is NULL this indicates that Rust has dropped the ForeignExecutor and we should
 decrease the EventLoop refcount.
 """
-UNIFFI_FOREIGN_EXECUTOR_CALLBACK_T = ctypes.CFUNCTYPE(None, ctypes.c_size_t, ctypes.c_uint32, ctypes.c_void_p, ctypes.c_void_p)
+_UNIFFI_FOREIGN_EXECUTOR_CALLBACK_T = ctypes.CFUNCTYPE(None, ctypes.c_size_t, ctypes.c_uint32, ctypes.c_void_p, ctypes.c_void_p)
 
 """
 Function pointer for a Rust task, which a callback function that takes a opaque pointer
 """
-UNIFFI_RUST_TASK = ctypes.CFUNCTYPE(None, ctypes.c_void_p)
+_UNIFFI_RUST_TASK = ctypes.CFUNCTYPE(None, ctypes.c_void_p)
 
-def uniffi_future_callback_t(return_type):
+def _uniffi_future_callback_t(return_type):
     """
     Factory function to create callback function types for async functions
     """
-    return ctypes.CFUNCTYPE(None, ctypes.c_size_t, return_type, RustCallStatus)
+    return ctypes.CFUNCTYPE(None, ctypes.c_size_t, return_type, _UniffiRustCallStatus)
 
-from pathlib import Path
-
-def loadIndirect():
+def _uniffi_load_indirect():
     """
     This is how we find and load the dynamic library provided by the component.
     For now we just look it up by name.
@@ -50,11 +48,11 @@ def loadIndirect():
         libname = "lib{}.so"
 
     libname = libname.format("{{ config.cdylib_name() }}")
-    path = str(Path(__file__).parent / libname)
+    path = os.path.join(os.path.dirname(__file__), libname)
     lib = ctypes.cdll.LoadLibrary(path)
     return lib
 
-def uniffi_check_contract_api_version(lib):
+def _uniffi_check_contract_api_version(lib):
     # Get the bindings contract version from our ComponentInterface
     bindings_contract_version = {{ ci.uniffi_contract_version() }}
     # Get the scaffolding contract version by calling the into the dylib
@@ -62,7 +60,7 @@ def uniffi_check_contract_api_version(lib):
     if bindings_contract_version != scaffolding_contract_version:
         raise InternalError("UniFFI contract version mismatch: try cleaning and rebuilding your project")
 
-def uniffi_check_api_checksums(lib):
+def _uniffi_check_api_checksums(lib):
     {%- for (name, expected_checksum) in ci.iter_checksums() %}
     if lib.{{ name }}() != {{ expected_checksum }}:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -73,13 +71,13 @@ def uniffi_check_api_checksums(lib):
 # A ctypes library to expose the extern-C FFI definitions.
 # This is an implementation detail which will be called internally by the public API.
 
-_UniFFILib = loadIndirect()
+_UniffiLib = _uniffi_load_indirect()
 {%- for func in ci.iter_ffi_function_definitions() %}
-_UniFFILib.{{ func.name() }}.argtypes = (
+_UniffiLib.{{ func.name() }}.argtypes = (
     {%- call py::arg_list_ffi_decl(func) -%}
 )
-_UniFFILib.{{ func.name() }}.restype = {% match func.return_type() %}{% when Some with (type_) %}{{ type_|ffi_type_name }}{% when None %}None{% endmatch %}
+_UniffiLib.{{ func.name() }}.restype = {% match func.return_type() %}{% when Some with (type_) %}{{ type_|ffi_type_name }}{% when None %}None{% endmatch %}
 {%- endfor %}
 {# Ensure to call the contract verification only after we defined all functions. -#}
-uniffi_check_contract_api_version(_UniFFILib)
-uniffi_check_api_checksums(_UniFFILib)
+_uniffi_check_contract_api_version(_UniffiLib)
+_uniffi_check_api_checksums(_UniffiLib)

--- a/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
@@ -15,7 +15,7 @@ class {{ type_name }}:
         # In case of partial initialization of instances.
         pointer = getattr(self, "_pointer", None)
         if pointer is not None:
-            rust_call(_UniFFILib.{{ obj.ffi_object_free().name() }}, pointer)
+            _rust_call(_UniffiLib.{{ obj.ffi_object_free().name() }}, pointer)
 
     # Used by alternative constructors or any methods which return this type.
     @classmethod
@@ -67,7 +67,7 @@ class {{ type_name }}:
 class {{ ffi_converter_name }}:
     @classmethod
     def read(cls, buf):
-        ptr = buf.readU64()
+        ptr = buf.read_u64()
         if ptr == 0:
             raise InternalError("Raw pointer value was null")
         return cls.lift(ptr)
@@ -75,8 +75,8 @@ class {{ ffi_converter_name }}:
     @classmethod
     def write(cls, value, buf):
         if not isinstance(value, {{ type_name }}):
-            raise TypeError("Expected {{ type_name }} instance, {} found".format(value.__class__.__name__))
-        buf.writeU64(cls.lower(value))
+            raise TypeError("Expected {{ type_name }} instance, {} found".format(type(value).__name__))
+        buf.write_u64(cls.lower(value))
 
     @staticmethod
     def lift(value):

--- a/uniffi_bindgen/src/bindings/python/templates/OptionalTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/OptionalTemplate.py
@@ -1,18 +1,18 @@
 {%- let inner_ffi_converter = inner_type|ffi_converter_name %}
 
-class {{ ffi_converter_name }}(FfiConverterRustBuffer):
+class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
     @classmethod
     def write(cls, value, buf):
         if value is None:
-            buf.writeU8(0)
+            buf.write_u8(0)
             return
 
-        buf.writeU8(1)
+        buf.write_u8(1)
         {{ inner_ffi_converter }}.write(value, buf)
 
     @classmethod
     def read(cls, buf):
-        flag = buf.readU8()
+        flag = buf.read_u8()
         if flag == 0:
             return None
         elif flag == 1:

--- a/uniffi_bindgen/src/bindings/python/templates/PointerManager.py
+++ b/uniffi_bindgen/src/bindings/python/templates/PointerManager.py
@@ -1,9 +1,9 @@
-class UniFfiPointerManagerCPython:
+class _UniffiPointerManagerCPython:
     """
     Manage giving out pointers to Python objects on CPython
 
     This class is used to generate opaque pointers that reference Python objects to pass to Rust.
-    It assumes a CPython platform.  See UniFfiPointerManagerGeneral for the alternative.
+    It assumes a CPython platform.  See _UniffiPointerManagerGeneral for the alternative.
     """
 
     def new_pointer(self, obj):
@@ -30,11 +30,11 @@ class UniFfiPointerManagerCPython:
     def lookup(self, address):
         return ctypes.cast(address, ctypes.py_object).value
 
-class UniFfiPointerManagerGeneral:
+class _UniffiPointerManagerGeneral:
     """
     Manage giving out pointers to Python objects on non-CPython platforms
 
-    This has the same API as UniFfiPointerManagerCPython, but doesn't assume we're running on
+    This has the same API as _UniffiPointerManagerCPython, but doesn't assume we're running on
     CPython and is slightly slower.
 
     Instead of using real pointers, it maps integer values to objects and returns the keys as
@@ -63,6 +63,6 @@ class UniFfiPointerManagerGeneral:
 
 # Pick an pointer manager implementation based on the platform
 if platform.python_implementation() == 'CPython':
-    UniFfiPointerManager = UniFfiPointerManagerCPython  # type: ignore
+    _UniffiPointerManager = _UniffiPointerManagerCPython # type: ignore
 else:
-    UniFfiPointerManager = UniFfiPointerManagerGeneral  # type: ignore
+    _UniffiPointerManager = _UniffiPointerManagerGeneral # type: ignore

--- a/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
@@ -3,7 +3,7 @@ class {{ type_name }}:
 
     def __init__(self, {% for field in rec.fields() %}
     {{- field.name()|var_name }}
-    {%- if field.default_value().is_some() %} = DEFAULT{% endif %}
+    {%- if field.default_value().is_some() %} = _DEFAULT{% endif %}
     {%- if !loop.last %}, {% endif %}
     {%- endfor %}):
         {%- for field in rec.fields() %}
@@ -12,7 +12,7 @@ class {{ type_name }}:
         {%- when None %}
         self.{{ field_name }} = {{ field_name }}
         {%- when Some with(literal) %}
-        if {{ field_name }} is DEFAULT:
+        if {{ field_name }} is _DEFAULT:
             self.{{ field_name }} = {{ literal|literal_py(field) }}
         else:
             self.{{ field_name }} = {{ field_name }}
@@ -29,7 +29,7 @@ class {{ type_name }}:
         {%- endfor %}
         return True
 
-class {{ ffi_converter_name }}(FfiConverterRustBuffer):
+class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
     @staticmethod
     def read(buf):
         return {{ type_name }}(

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferHelper.py
@@ -1,5 +1,5 @@
-# Types conforming to `FfiConverterPrimitive` pass themselves directly over the FFI.
-class FfiConverterPrimitive:
+# Types conforming to `_UniffiConverterPrimitive` pass themselves directly over the FFI.
+class _UniffiConverterPrimitive:
     @classmethod
     def check(cls, value):
         return value
@@ -18,9 +18,9 @@ class FfiConverterPrimitive:
 
     @classmethod
     def write(cls, value, buf):
-        cls.writeUnchecked(cls.check(value), buf)
+        cls.write_unchecked(cls.check(value), buf)
 
-class FfiConverterPrimitiveInt(FfiConverterPrimitive):
+class _UniffiConverterPrimitiveInt(_UniffiConverterPrimitive):
     @classmethod
     def check(cls, value):
         try:
@@ -33,7 +33,7 @@ class FfiConverterPrimitiveInt(FfiConverterPrimitive):
             raise ValueError("{} requires {} <= value < {}".format(cls.CLASS_NAME, cls.VALUE_MIN, cls.VALUE_MAX))
         return super().check(value)
 
-class FfiConverterPrimitiveFloat(FfiConverterPrimitive):
+class _UniffiConverterPrimitiveFloat(_UniffiConverterPrimitive):
     @classmethod
     def check(cls, value):
         try:
@@ -44,16 +44,16 @@ class FfiConverterPrimitiveFloat(FfiConverterPrimitive):
             raise TypeError("__float__ returned non-float (type {})".format(type(value).__name__))
         return super().check(value)
 
-# Helper class for wrapper types that will always go through a RustBuffer.
+# Helper class for wrapper types that will always go through a _UniffiRustBuffer.
 # Classes should inherit from this and implement the `read` and `write` static methods.
-class FfiConverterRustBuffer:
+class _UniffiConverterRustBuffer:
     @classmethod
     def lift(cls, rbuf):
-        with rbuf.consumeWithStream() as stream:
+        with rbuf.consume_with_stream() as stream:
             return cls.read(stream)
 
     @classmethod
     def lower(cls, value):
-        with RustBuffer.allocWithBuilder() as builder:
+        with _UniffiRustBuffer.alloc_with_builder() as builder:
             cls.write(value, builder)
             return builder.finalize()

--- a/uniffi_bindgen/src/bindings/python/templates/SequenceTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/SequenceTemplate.py
@@ -1,16 +1,16 @@
 {%- let inner_ffi_converter = inner_type|ffi_converter_name %}
 
-class {{ ffi_converter_name}}(FfiConverterRustBuffer):
+class {{ ffi_converter_name}}(_UniffiConverterRustBuffer):
     @classmethod
     def write(cls, value, buf):
         items = len(value)
-        buf.writeI32(items)
+        buf.write_i32(items)
         for item in value:
             {{ inner_ffi_converter }}.write(item, buf)
 
     @classmethod
     def read(cls, buf):
-        count = buf.readI32()
+        count = buf.read_i32()
         if count < 0:
             raise InternalError("Unexpected negative sequence length")
 

--- a/uniffi_bindgen/src/bindings/python/templates/StringHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/StringHelper.py
@@ -1,4 +1,4 @@
-class FfiConverterString:
+class _UniffiConverterString:
     @staticmethod
     def check(value):
         if not isinstance(value, str):
@@ -7,27 +7,27 @@ class FfiConverterString:
 
     @staticmethod
     def read(buf):
-        size = buf.readI32()
+        size = buf.read_i32()
         if size < 0:
             raise InternalError("Unexpected negative string length")
-        utf8Bytes = buf.read(size)
-        return utf8Bytes.decode("utf-8")
+        utf8_bytes = buf.read(size)
+        return utf8_bytes.decode("utf-8")
 
     @staticmethod
     def write(value, buf):
-        value = FfiConverterString.check(value)
-        utf8Bytes = value.encode("utf-8")
-        buf.writeI32(len(utf8Bytes))
-        buf.write(utf8Bytes)
+        value = _UniffiConverterString.check(value)
+        utf8_bytes = value.encode("utf-8")
+        buf.write_i32(len(utf8_bytes))
+        buf.write(utf8_bytes)
 
     @staticmethod
     def lift(buf):
-        with buf.consumeWithStream() as stream:
+        with buf.consume_with_stream() as stream:
             return stream.read(stream.remaining()).decode("utf-8")
 
     @staticmethod
     def lower(value):
-        value = FfiConverterString.check(value)
-        with RustBuffer.allocWithBuilder() as builder:
+        value = _UniffiConverterString.check(value)
+        with _UniffiRustBuffer.alloc_with_builder() as builder:
             builder.write(value.encode("utf-8"))
             return builder.finalize()

--- a/uniffi_bindgen/src/bindings/python/templates/TimestampHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/TimestampHelper.py
@@ -4,11 +4,11 @@ Timestamp = datetime.datetime
 # There is a loss of precision when converting from Rust timestamps,
 # which are accurate to the nanosecond,
 # to Python datetimes, which have a variable precision due to the use of float as representation.
-class FfiConverterTimestamp(FfiConverterRustBuffer):
+class _UniffiConverterTimestamp(_UniffiConverterRustBuffer):
     @staticmethod
     def read(buf):
-        seconds = buf.readI64()
-        microseconds = buf.readU32() / 1000
+        seconds = buf.read_i64()
+        microseconds = buf.read_u32() / 1000
         # Use fromtimestamp(0) then add the seconds using a timedelta.  This
         # ensures that we get OverflowError rather than ValueError when
         # seconds is too large.
@@ -28,5 +28,5 @@ class FfiConverterTimestamp(FfiConverterRustBuffer):
 
         seconds = delta.seconds + delta.days * 24 * 3600
         nanoseconds = delta.microseconds * 1000
-        buf.writeI64(sign * seconds)
-        buf.writeU32(nanoseconds)
+        buf.write_i64(sign * seconds)
+        buf.write_u32(nanoseconds)

--- a/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
@@ -2,8 +2,8 @@
 
 async def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}):
     {%- call py::setup_args(func) %}
-    return await rust_call_async(
-        _UniFFILib.{{ func.ffi_func().name() }},
+    return await _rust_call_async(
+        _UniffiLib.{{ func.ffi_func().name() }},
         {{ func.result_type().borrow()|async_callback_fn }},
         {% call py::arg_list_lowered(func) %}
     )

--- a/uniffi_bindgen/src/bindings/python/templates/UInt16Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt16Helper.py
@@ -1,12 +1,12 @@
-class FfiConverterUInt16(FfiConverterPrimitiveInt):
+class _UniffiConverterUInt16(_UniffiConverterPrimitiveInt):
     CLASS_NAME = "u16"
     VALUE_MIN = 0
     VALUE_MAX = 2**16
 
     @staticmethod
     def read(buf):
-        return buf.readU16()
+        return buf.read_u16()
 
     @staticmethod
-    def writeUnchecked(value, buf):
-        buf.writeU16(value)
+    def write_unchecked(value, buf):
+        buf.write_u16(value)

--- a/uniffi_bindgen/src/bindings/python/templates/UInt32Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt32Helper.py
@@ -1,12 +1,12 @@
-class FfiConverterUInt32(FfiConverterPrimitiveInt):
+class _UniffiConverterUInt32(_UniffiConverterPrimitiveInt):
     CLASS_NAME = "u32"
     VALUE_MIN = 0
     VALUE_MAX = 2**32
 
     @staticmethod
     def read(buf):
-        return buf.readU32()
+        return buf.read_u32()
 
     @staticmethod
-    def writeUnchecked(value, buf):
-        buf.writeU32(value)
+    def write_unchecked(value, buf):
+        buf.write_u32(value)

--- a/uniffi_bindgen/src/bindings/python/templates/UInt64Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt64Helper.py
@@ -1,12 +1,12 @@
-class FfiConverterUInt64(FfiConverterPrimitiveInt):
+class _UniffiConverterUInt64(_UniffiConverterPrimitiveInt):
     CLASS_NAME = "u64"
     VALUE_MIN = 0
     VALUE_MAX = 2**64
 
     @staticmethod
     def read(buf):
-        return buf.readU64()
+        return buf.read_u64()
 
     @staticmethod
-    def writeUnchecked(value, buf):
-        buf.writeU64(value)
+    def write_unchecked(value, buf):
+        buf.write_u64(value)

--- a/uniffi_bindgen/src/bindings/python/templates/UInt8Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt8Helper.py
@@ -1,12 +1,12 @@
-class FfiConverterUInt8(FfiConverterPrimitiveInt):
+class _UniffiConverterUInt8(_UniffiConverterPrimitiveInt):
     CLASS_NAME = "u8"
     VALUE_MIN = 0
     VALUE_MAX = 2**8
 
     @staticmethod
     def read(buf):
-        return buf.readU8()
+        return buf.read_u8()
 
     @staticmethod
-    def writeUnchecked(value, buf):
-        buf.writeU8(value)
+    def write_unchecked(value, buf):
+        buf.write_u8(value)

--- a/uniffi_bindgen/src/bindings/python/templates/macros.py
+++ b/uniffi_bindgen/src/bindings/python/templates/macros.py
@@ -7,11 +7,11 @@
 {%- macro to_ffi_call(func) -%}
     {%- match func.throws_type() -%}
     {%- when Some with (e) -%}
-rust_call_with_error({{ e|ffi_converter_name }},
+_rust_call_with_error({{ e|ffi_converter_name }},
     {%- else -%}
-rust_call(
+_rust_call(
     {%- endmatch -%}
-    _UniFFILib.{{ func.ffi_func().name() }},
+    _UniffiLib.{{ func.ffi_func().name() }},
     {%- call arg_list_lowered(func) -%}
 )
 {%- endmacro -%}
@@ -19,12 +19,12 @@ rust_call(
 {%- macro to_ffi_call_with_prefix(prefix, func) -%}
     {%- match func.throws_type() -%}
     {%- when Some with (e) -%}
-rust_call_with_error(
+_rust_call_with_error(
     {{ e|ffi_converter_name }},
     {%- else -%}
-rust_call(
+_rust_call(
     {%- endmatch -%}
-    _UniFFILib.{{ func.ffi_func().name() }},
+    _UniffiLib.{{ func.ffi_func().name() }},
     {{- prefix }},
     {%- call arg_list_lowered(func) -%}
 )
@@ -46,7 +46,7 @@ rust_call(
     {%- for arg in func.arguments() -%}
         {{ arg.name()|var_name }}
         {%- match arg.default_value() %}
-        {%- when Some with(literal) %}: "typing.Union[object, {{ arg|type_name -}}]" = DEFAULT
+        {%- when Some with(literal) %}: "typing.Union[object, {{ arg|type_name -}}]" = _DEFAULT
         {%- else %}: "{{ arg|type_name -}}"
         {%- endmatch %}
         {%- if !loop.last %},{% endif -%}
@@ -54,7 +54,7 @@ rust_call(
 {%- endmacro %}
 
 {#-
-// Arglist as used in the _UniFFILib function declarations.
+// Arglist as used in the _UniffiLib function declarations.
 // Note unfiltered name but ffi_type_name filters.
 -#}
 {%- macro arg_list_ffi_decl(func) %}
@@ -62,7 +62,7 @@ rust_call(
     {{ arg.type_().borrow()|ffi_type_name }},
     {%- endfor %}
     {%- if func.has_rust_call_status_arg() %}
-    ctypes.POINTER(RustCallStatus),{% endif %}
+    ctypes.POINTER(_UniffiRustCallStatus),{% endif %}
 {% endmacro -%}
 
 {#
@@ -73,7 +73,7 @@ rust_call(
     {%- match arg.default_value() %}
     {%- when None %}
     {%- when Some with(literal) %}
-    if {{ arg.name()|var_name }} is DEFAULT:
+    if {{ arg.name()|var_name }} is _DEFAULT:
         {{ arg.name()|var_name }} = {{ literal|literal_py(arg.as_type().borrow()) }}
     {%- endmatch %}
     {% endfor -%}
@@ -88,7 +88,7 @@ rust_call(
         {%- match arg.default_value() %}
         {%- when None %}
         {%- when Some with(literal) %}
-        if {{ arg.name()|var_name }} is DEFAULT:
+        if {{ arg.name()|var_name }} is _DEFAULT:
             {{ arg.name()|var_name }} = {{ literal|literal_py(arg.as_type().borrow()) }}
         {%- endmatch %}
         {% endfor -%}
@@ -102,8 +102,8 @@ rust_call(
 
     async def {{ py_method_name }}(self, {% call arg_list_decl(meth) %}):
         {%- call setup_args_extra_indent(meth) %}
-        return await rust_call_async(
-            _UniFFILib.{{ func.ffi_func().name() }},
+        return await _rust_call_async(
+            _UniffiLib.{{ func.ffi_func().name() }},
             {{ func.result_type().borrow()|async_callback_fn }},
             self._pointer,
             {% call arg_list_lowered(func) %}

--- a/uniffi_bindgen/src/bindings/python/templates/wrapper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/wrapper.py
@@ -30,7 +30,7 @@ import platform
 {%- endfor %}
 
 # Used for default argument values
-DEFAULT = object()
+_DEFAULT = object()
 
 {% include "RustBufferTemplate.py" %}
 {% include "Helpers.py" %}


### PR DESCRIPTION
All internal symbols now start with `_Uniffi` or `_uniffi` so that name clashes are unlikely. Additionally, this means that they are no longer included in typical autocompletion. This is quite a heavy-handed approach because it requires all changes to the Python bindings to be aware that names have to start with an underscore.

Fixes #1557.