### PR TITLE
Add proc-macro external type support (#1531)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 - No more implicit conversion to integers/floats in Ruby ([#1596](https://github.com/mozilla/uniffi-rs/pull/1596))
 - Updated Rust dependencies ([#1495](https://github.com/mozilla/uniffi-rs/pull/1495), [#1583](https://github.com/mozilla/uniffi-rs/pull/1583), [#1569](https://github.com/mozilla/uniffi-rs/pull/1569))
 - Added type checking to strings/bytes for Python/Ruby ([#1597](https://github.com/mozilla/uniffi-rs/pull/1597#))
+- Implemented proc-macro external type support.  This allows proc-macros to use types defined in UDL files from other crates, [#1600](https://github.com/mozilla/uniffi-rs/pull/1600)
 
 ### Guidance for external bindings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   "fixtures/ext-types/guid",
   "fixtures/ext-types/uniffi-one",
   "fixtures/ext-types/lib",
+  "fixtures/ext-types/proc-macro-lib",
 
   # we should roll the above and below up somehow that makes sense...
   "fixtures/external-types/crate-one",

--- a/docs/manual/src/proc_macro/index.md
+++ b/docs/manual/src/proc_macro/index.md
@@ -276,6 +276,29 @@ impl From<UnexpectedUniFFICallbackError> for MyApiError {
 }
 ```
 
+## Types from dependent crates
+
+When using proc-macros, you can use types from dependent crates in your exported library, as long as
+the dependent crate annotates the type with one of the UniFFI derives.  However, there are a couple
+exceptions:
+
+### Types from UDL-based dependent crates
+
+If the dependent crate uses a UDL file to define their types, then you must invoke one of the
+`uniffi::use_udl_*!` macros, for example:
+
+```rust
+uniffi::use_udl_record!(dependent_crate, RecordType);
+uniffi::use_udl_enum!(dependent_crate, EnumType);
+uniffi::use_udl_error!(dependent_crate, ErrorType);
+uniffi::use_udl_object!(dependent_crate, ObjectType);
+```
+
+### Non-UniFFI types from dependent crates
+
+If the dependent crate doesn't define the type in a UDL file or use one of the UniFFI derive macros,
+then it's currently not possible to use them in an proc-macro exported interface.  However, we hope
+to fix this limitation soon.
 
 ## Other limitations
 

--- a/fixtures/ext-types/README.md
+++ b/fixtures/ext-types/README.md
@@ -1,0 +1,6 @@
+This directory contains the tests for external types -- types defined in one crate and used in a
+different one.
+
+- `guid` and `uniffi-one` are dependent crates that define types exported by UniFFI
+- `lib` is a library crate that depends on `guid` and `uniffi-one`
+- `proc-macro-lib` is another library crate, but this one uses proc-macros rather than UDL files

--- a/fixtures/ext-types/proc-macro-lib/Cargo.toml
+++ b/fixtures/ext-types/proc-macro-lib/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "uniffi-fixture-ext-types-proc-macro"
+edition = "2021"
+version = "0.22.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+license = "MPL-2.0"
+publish = false
+
+[package.metadata.uniffi.testing]
+external-crates = [
+    "uniffi-fixture-ext-types-guid",
+    "uniffi-fixture-ext-types-lib-one",
+    "uniffi-example-custom-types",
+]
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "uniffi_ext_types_proc_macro_lib"
+
+[dependencies]
+anyhow = "1"
+bytes = "1.3"
+uniffi = {path = "../../../uniffi"}
+
+uniffi-fixture-ext-types-lib-one = {path = "../uniffi-one"}
+uniffi-fixture-ext-types-guid = {path = "../guid"}
+
+# Reuse one of our examples.
+uniffi-example-custom-types = {path = "../../../examples/custom-types"}
+
+url = "2.2"
+
+[build-dependencies]
+uniffi = {path = "../../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../../uniffi", features = ["bindgen-tests"] }

--- a/fixtures/ext-types/proc-macro-lib/build.rs
+++ b/fixtures/ext-types/proc-macro-lib/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::generate_scaffolding("src/ext-types-lib.udl").unwrap();
+}

--- a/fixtures/ext-types/proc-macro-lib/src/ext-types-lib.udl
+++ b/fixtures/ext-types/proc-macro-lib/src/ext-types-lib.udl
@@ -1,0 +1,1 @@
+namespace imported_types_lib { };

--- a/fixtures/ext-types/proc-macro-lib/src/lib.rs
+++ b/fixtures/ext-types/proc-macro-lib/src/lib.rs
@@ -1,0 +1,139 @@
+use custom_types::Handle;
+use ext_types_guid::Guid;
+use std::sync::Arc;
+use uniffi_one::{UniffiOneEnum, UniffiOneInterface, UniffiOneProcMacroType, UniffiOneType};
+use url::Url;
+
+uniffi::use_udl_record!(uniffi_one, UniffiOneType);
+uniffi::use_udl_enum!(uniffi_one, UniffiOneEnum);
+uniffi::use_udl_object!(uniffi_one, UniffiOneInterface);
+uniffi::use_udl_record!(ext_types_guid, Guid);
+uniffi::use_udl_record!(custom_types, Url);
+uniffi::use_udl_record!(custom_types, Handle);
+
+#[derive(uniffi::Record)]
+pub struct CombinedType {
+    pub uoe: UniffiOneEnum,
+    pub uot: UniffiOneType,
+    pub uots: Vec<UniffiOneType>,
+    pub maybe_uot: Option<UniffiOneType>,
+
+    pub guid: Guid,
+    pub guids: Vec<Guid>,
+    pub maybe_guid: Option<Guid>,
+
+    pub url: Url,
+    pub urls: Vec<Url>,
+    pub maybe_url: Option<Url>,
+
+    pub handle: Handle,
+    pub handles: Vec<Handle>,
+    pub maybe_handle: Option<Handle>,
+}
+
+#[uniffi::export]
+fn get_combined_type(value: Option<CombinedType>) -> CombinedType {
+    value.unwrap_or_else(|| CombinedType {
+        uoe: UniffiOneEnum::One,
+        uot: UniffiOneType {
+            sval: "hello".to_string(),
+        },
+        uots: vec![
+            UniffiOneType {
+                sval: "first of many".to_string(),
+            },
+            UniffiOneType {
+                sval: "second of many".to_string(),
+            },
+        ],
+        maybe_uot: None,
+
+        guid: Guid("a-guid".into()),
+        guids: vec![Guid("b-guid".into()), Guid("c-guid".into())],
+        maybe_guid: None,
+
+        url: Url::parse("http://example.com/").unwrap(),
+        urls: vec![],
+        maybe_url: None,
+
+        handle: Handle(123),
+        handles: vec![Handle(1), Handle(2), Handle(3)],
+        maybe_handle: Some(Handle(4)),
+    })
+}
+
+// A Custom type
+#[uniffi::export]
+fn get_url(url: Url) -> Url {
+    url
+}
+
+#[uniffi::export]
+fn get_urls(urls: Vec<Url>) -> Vec<Url> {
+    urls
+}
+
+#[uniffi::export]
+fn get_maybe_url(url: Option<Url>) -> Option<Url> {
+    url
+}
+
+#[uniffi::export]
+fn get_maybe_urls(urls: Vec<Option<Url>>) -> Vec<Option<Url>> {
+    urls
+}
+
+// A struct
+#[uniffi::export]
+fn get_uniffi_one_type(t: UniffiOneType) -> UniffiOneType {
+    t
+}
+
+// Test using a type defined in a proc-macro in another crate
+#[uniffi::export]
+fn get_uniffi_one_proc_macro_type(t: UniffiOneProcMacroType) -> UniffiOneProcMacroType {
+    t
+}
+
+#[uniffi::export]
+fn get_uniffi_one_types(ts: Vec<UniffiOneType>) -> Vec<UniffiOneType> {
+    ts
+}
+
+#[uniffi::export]
+fn get_maybe_uniffi_one_type(t: Option<UniffiOneType>) -> Option<UniffiOneType> {
+    t
+}
+
+#[uniffi::export]
+fn get_maybe_uniffi_one_types(ts: Vec<Option<UniffiOneType>>) -> Vec<Option<UniffiOneType>> {
+    ts
+}
+
+// An enum
+#[uniffi::export]
+fn get_uniffi_one_enum(e: UniffiOneEnum) -> UniffiOneEnum {
+    e
+}
+
+#[uniffi::export]
+fn get_uniffi_one_enums(es: Vec<UniffiOneEnum>) -> Vec<UniffiOneEnum> {
+    es
+}
+
+#[uniffi::export]
+fn get_maybe_uniffi_one_enum(e: Option<UniffiOneEnum>) -> Option<UniffiOneEnum> {
+    e
+}
+
+#[uniffi::export]
+fn get_maybe_uniffi_one_enums(es: Vec<Option<UniffiOneEnum>>) -> Vec<Option<UniffiOneEnum>> {
+    es
+}
+
+#[uniffi::export]
+fn get_uniffi_one_interface() -> Arc<UniffiOneInterface> {
+    Arc::new(UniffiOneInterface::new())
+}
+
+uniffi::include_scaffolding!("ext-types-lib");

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.kts
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.kts
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import uniffi.imported_types_lib.*
+import uniffi.uniffi_one.*
+
+val ct = getCombinedType(null)
+assert(ct.uot.sval == "hello")
+assert(ct.guid ==  "a-guid")
+assert(ct.url ==  java.net.URL("http://example.com/"))
+
+val ct2 = getCombinedType(ct)
+assert(ct == ct2)
+
+val url = java.net.URL("http://example.com/")
+assert(getUrl(url) ==  url)
+assert(getMaybeUrl(url)!! ==  url)
+assert(getMaybeUrl(null) ==  null)
+assert(getUrls(listOf(url)) ==  listOf(url))
+assert(getMaybeUrls(listOf(url, null)) == listOf(url, null))
+
+val uot = UniffiOneType("hello")
+assert(getUniffiOneType(uot) == uot)
+assert(getMaybeUniffiOneType(uot)!! == uot)
+assert(getMaybeUniffiOneType(null) == null)
+assert(getUniffiOneTypes(listOf(uot)) == listOf(uot))
+assert(getMaybeUniffiOneTypes(listOf(uot, null)) == listOf(uot, null))
+
+val uopmt = UniffiOneProcMacroType("hello from proc-macro world")
+assert(getUniffiOneProcMacroType(uopmt) == uopmt)
+
+val uoe = UniffiOneEnum.ONE
+assert(getUniffiOneEnum(uoe) == uoe)
+assert(getMaybeUniffiOneEnum(uoe)!! == uoe)
+assert(getMaybeUniffiOneEnum(null) == null)
+assert(getUniffiOneEnums(listOf(uoe)) == listOf(uoe))
+assert(getMaybeUniffiOneEnums(listOf(uoe, null)) == listOf(uoe, null))

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.py
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.py
@@ -1,0 +1,52 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import unittest
+import urllib
+from imported_types_lib import *
+from uniffi_one import *
+
+class TestIt(unittest.TestCase):
+    def test_it(self):
+        ct = get_combined_type(None)
+        self.assertEqual(ct.uot.sval, "hello")
+        self.assertEqual(ct.guid, "a-guid")
+        self.assertEqual(ct.url.scheme, 'http')
+        self.assertEqual(ct.url.netloc, 'example.com')
+        self.assertEqual(ct.url.path, '/')
+
+        ct2 = get_combined_type(ct)
+        self.assertEqual(ct, ct2)
+
+    def test_get_url(self):
+        url = urllib.parse.urlparse("http://example.com/")
+        self.assertEqual(get_url(url), url)
+        self.assertEqual(get_urls([url]), [url])
+        self.assertEqual(get_maybe_url(url), url)
+        self.assertEqual(get_maybe_url(None), None)
+        self.assertEqual(get_maybe_urls([url, None]), [url, None])
+
+    def test_get_uniffi_one_type(self):
+        t1 = UniffiOneType("hello")
+        self.assertEqual(t1, get_uniffi_one_type(t1))
+        self.assertEqual(t1, get_maybe_uniffi_one_type(t1))
+        self.assertEqual(None, get_maybe_uniffi_one_type(None))
+        self.assertEqual([t1], get_uniffi_one_types([t1]))
+        self.assertEqual([t1, None], get_maybe_uniffi_one_types([t1, None]))
+
+    def test_get_uniffi_one_proc_macro_type(self):
+        t1 = UniffiOneProcMacroType("hello")
+        self.assertEqual(t1, get_uniffi_one_proc_macro_type(t1))
+
+    def test_get_uniffi_one_enum(self):
+        e = UniffiOneEnum.ONE
+        self.assertEqual(e, get_uniffi_one_enum(e))
+        self.assertEqual(e, get_maybe_uniffi_one_enum(e))
+        self.assertEqual(None, get_maybe_uniffi_one_enum(None))
+        self.assertEqual([e], get_uniffi_one_enums([e]))
+        self.assertEqual([e, None], get_maybe_uniffi_one_enums([e, None]))
+
+
+if __name__=='__main__':
+    unittest.main()

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.swift
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.swift
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import imported_types_lib
+//import uniffi_one
+import Foundation
+
+let ct = getCombinedType(value: nil)
+assert(ct.uot.sval == "hello")
+assert(ct.guid ==  "a-guid")
+assert(ct.url ==  URL(string: "http://example.com/"))
+
+let ct2 = getCombinedType(value: ct)
+assert(ct == ct2)
+
+let url = URL(string: "http://example.com/")!;
+assert(getUrl(url: url) ==  url)
+assert(getMaybeUrl(url: url)! == url)
+assert(getMaybeUrl(url: nil) == nil)
+assert(getUrls(urls: [url]) == [url])
+assert(getMaybeUrls(urls: [url, nil]) == [url, nil])
+
+assert(getUniffiOneType(t: UniffiOneType(sval: "hello")).sval == "hello")
+assert(getMaybeUniffiOneType(t: UniffiOneType(sval: "hello"))!.sval == "hello")
+assert(getMaybeUniffiOneType(t: nil) == nil)
+assert(getUniffiOneTypes(ts: [UniffiOneType(sval: "hello")]) == [UniffiOneType(sval: "hello")])
+assert(getMaybeUniffiOneTypes(ts: [UniffiOneType(sval: "hello"), nil]) == [UniffiOneType(sval: "hello"), nil])
+
+assert(getUniffiOneProcMacroType(t: UniffiOneProcMacroType(sval: "hello from proc-macro world")).sval == "hello from proc-macro world")
+
+assert(getUniffiOneEnum(e: UniffiOneEnum.one) == UniffiOneEnum.one)
+assert(getMaybeUniffiOneEnum(e: UniffiOneEnum.one)! == UniffiOneEnum.one)
+assert(getMaybeUniffiOneEnum(e: nil) == nil)
+assert(getUniffiOneEnums(es: [UniffiOneEnum.one]) == [UniffiOneEnum.one])
+assert(getMaybeUniffiOneEnums(es: [UniffiOneEnum.one, nil]) == [UniffiOneEnum.one, nil])

--- a/fixtures/ext-types/proc-macro-lib/tests/test_generated_bindings.rs
+++ b/fixtures/ext-types/proc-macro-lib/tests/test_generated_bindings.rs
@@ -1,0 +1,5 @@
+uniffi::build_foreign_language_testcases!(
+    "tests/bindings/test_imported_types.kts",
+    "tests/bindings/test_imported_types.py",
+    "tests/bindings/test_imported_types.swift",
+);

--- a/fixtures/ext-types/uniffi-one/src/lib.rs
+++ b/fixtures/ext-types/uniffi-one/src/lib.rs
@@ -9,6 +9,11 @@ pub enum UniffiOneEnum {
     Two,
 }
 
+#[derive(uniffi::Record)]
+pub struct UniffiOneProcMacroType {
+    pub sval: String,
+}
+
 #[derive(Default)]
 pub struct UniffiOneInterface {
     current: AtomicI32,

--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -132,12 +132,15 @@ mod test_type_ids {
     #[test]
     fn test_user_types() {
         check_type_id::<Person>(Type::Record {
+            module_path: "uniffi_fixture_metadata".into(),
             name: "Person".into(),
         });
         check_type_id::<Weapon>(Type::Enum {
+            module_path: "uniffi_fixture_metadata".into(),
             name: "Weapon".into(),
         });
         check_type_id::<Arc<Calculator>>(Type::ArcObject {
+            module_path: "uniffi_fixture_metadata".into(),
             object_name: "Calculator".into(),
             is_trait: false,
         });
@@ -243,6 +246,7 @@ mod test_metadata {
                         fields: vec![FieldMetadata {
                             name: "result".into(),
                             ty: Type::Record {
+                                module_path: "uniffi_fixture_metadata".into(),
                                 name: "Person".into(),
                             },
                             default: None,
@@ -303,6 +307,7 @@ mod test_metadata {
                             fields: vec![FieldMetadata {
                                 name: "weapon".into(),
                                 ty: Type::Enum {
+                                    module_path: "uniffi_fixture_metadata".into(),
                                     name: "Weapon".into(),
                                 },
                                 default: None,
@@ -399,12 +404,14 @@ mod test_function_metadata {
                     FnParamMetadata {
                         name: "person".into(),
                         ty: Type::Record {
+                            module_path: "uniffi_fixture_metadata".into(),
                             name: "Person".into(),
                         },
                     },
                     FnParamMetadata {
                         name: "weapon".into(),
                         ty: Type::Enum {
+                            module_path: "uniffi_fixture_metadata".into(),
                             name: "Weapon".into(),
                         },
                     },
@@ -443,9 +450,11 @@ mod test_function_metadata {
                 is_async: false,
                 inputs: vec![],
                 return_type: Some(Type::Enum {
+                    module_path: "uniffi_fixture_metadata".into(),
                     name: "State".into(),
                 }),
                 throws: Some(Type::Enum {
+                    module_path: "uniffi_fixture_metadata".into(),
                     name: "FlatError".into(),
                 }),
                 checksum: UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_FUNC_TEST_FUNC_THAT_THROWS
@@ -465,6 +474,7 @@ mod test_function_metadata {
                 inputs: vec![],
                 return_type: None,
                 throws: Some(Type::Enum {
+                    module_path: "uniffi_fixture_metadata".into(),
                     name: "FlatError".into(),
                 }),
                 checksum:
@@ -513,12 +523,14 @@ mod test_function_metadata {
                     FnParamMetadata {
                         name: "person".into(),
                         ty: Type::Record {
+                            module_path: "uniffi_fixture_metadata".into(),
                             name: "Person".into(),
                         },
                     },
                     FnParamMetadata {
                         name: "weapon".into(),
                         ty: Type::Enum {
+                            module_path: "uniffi_fixture_metadata".into(),
                             name: "Weapon".into(),
                         },
                     },
@@ -540,9 +552,11 @@ mod test_function_metadata {
                 is_async: true,
                 inputs: vec![],
                 return_type: Some(Type::Enum {
+                    module_path: "uniffi_fixture_metadata".into(),
                     name: "State".into(),
                 }),
                 throws: Some(Type::Enum {
+                    module_path: "uniffi_fixture_metadata".into(),
                     name: "FlatError".into(),
                 }),
                 checksum:
@@ -590,6 +604,7 @@ mod test_function_metadata {
                 is_async: false,
                 inputs: vec![],
                 return_type: Some(Type::ArcObject {
+                    module_path: "uniffi_fixture_metadata".into(),
                     object_name: "CalculatorDisplay".into(),
                     is_trait: true,
                 }),

--- a/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
+++ b/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `Cell<u32>` cannot be shared between threads safely
  --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
   |
-  | struct r#Counter { }
-  |        ^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
+  | uniffi::deps::static_assertions::assert_impl_all!(r#Counter: Sync, Send);
+  |                                                   ^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
   |
   = help: within `Counter`, the trait `Sync` is not implemented for `Cell<u32>`
   = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicU32` instead
@@ -11,8 +11,9 @@ note: required because it appears within the type `Counter`
   |
 9 | pub struct Counter {
   |            ^^^^^^^
-note: required by a bound in `Interface`
- --> $WORKSPACE/uniffi_core/src/lib.rs
+note: required by a bound in `assert_impl_all`
+ --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
   |
-  | pub trait Interface<UT>: Send + Sync + Sized {
-  |                                 ^^^^ required by this bound in `Interface`
+  | uniffi::deps::static_assertions::assert_impl_all!(r#Counter: Sync, Send);
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+  = note: this error originates in the macro `uniffi::deps::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/uniffi/tests/ui/proc_macro_arc.stderr
+++ b/uniffi/tests/ui/proc_macro_arc.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `Foo: Interface<UniFfiTag>` is not satisfied
+error[E0277]: the trait bound `Foo: FfiConverterArc<UniFfiTag>` is not satisfied
   --> tests/ui/proc_macro_arc.rs:10:1
    |
 10 | #[uniffi::export]
-   | ^^^^^^^^^^^^^^^^^ the trait `Interface<UniFfiTag>` is not implemented for `Foo`
+   | ^^^^^^^^^^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `Foo`
    |
    = help: the trait `FfiConverter<UT>` is implemented for `Arc<T>`
    = note: required for `Arc<Foo>` to implement `FfiConverter<UniFfiTag>`
@@ -16,11 +16,11 @@ note: erroneous constant used
    |
    = note: this note originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `child::Foo: Interface<UniFfiTag>` is not satisfied
+error[E0277]: the trait bound `child::Foo: FfiConverterArc<UniFfiTag>` is not satisfied
   --> tests/ui/proc_macro_arc.rs:20:5
    |
 20 |     #[uniffi::export]
-   |     ^^^^^^^^^^^^^^^^^ the trait `Interface<UniFfiTag>` is not implemented for `child::Foo`
+   |     ^^^^^^^^^^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `child::Foo`
    |
    = help: the trait `FfiConverter<UT>` is implemented for `Arc<T>`
    = note: required for `Arc<child::Foo>` to implement `FfiConverter<UniFfiTag>`

--- a/uniffi_bindgen/src/bindings/swift/templates/ForeignExecutorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ForeignExecutorTemplate.swift
@@ -19,17 +19,17 @@ fileprivate struct FfiConverterForeignExecutor: FfiConverter {
     // let's use `Int`, which is equivalent to `size_t`
     typealias FfiType = Int
 
-    static func lift(_ value: FfiType) throws -> SwiftType {
+    public static func lift(_ value: FfiType) throws -> SwiftType {
         UniFfiForeignExecutor(priority: TaskPriority(rawValue: numericCast(value)))
     }
-    static func lower(_ value: SwiftType) -> FfiType {
+    public static func lower(_ value: SwiftType) -> FfiType {
         numericCast(value.priority.rawValue)
     }
 
-    static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
         fatalError("FfiConverterForeignExecutor.read not implemented yet")
     }
-    static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
         fatalError("FfiConverterForeignExecutor.read not implemented yet")
     }
 }

--- a/uniffi_bindgen/src/interface/types/mod.rs
+++ b/uniffi_bindgen/src/interface/types/mod.rs
@@ -238,17 +238,18 @@ impl From<uniffi_meta::Type> for Type {
             Ty::SystemTime => Type::Timestamp,
             Ty::Duration => Type::Duration,
             Ty::ForeignExecutor => Type::ForeignExecutor,
-            Ty::Record { name } => Type::Record(name),
+            Ty::Record { name, .. } => Type::Record(name),
             Ty::Enum { name, .. } => Type::Enum(name),
             Ty::ArcObject {
                 object_name,
                 is_trait,
+                ..
             } => Type::Object {
                 name: object_name,
                 imp: ObjectImpl::from_is_trait(is_trait),
             },
-            Ty::CallbackInterface { name } => Type::CallbackInterface(name),
-            Ty::Custom { name, builtin } => Type::Custom {
+            Ty::CallbackInterface { name, .. } => Type::CallbackInterface(name),
+            Ty::Custom { name, builtin, .. } => Type::Custom {
                 name,
                 builtin: builtin.into(),
             },
@@ -258,6 +259,15 @@ impl From<uniffi_meta::Type> for Type {
                 key_type,
                 value_type,
             } => Type::Map(key_type.into(), value_type.into()),
+            Ty::External {
+                module_path,
+                name,
+                kind,
+            } => Type::External {
+                crate_name: module_path.split(':').next().unwrap().to_string(),
+                name,
+                kind: kind.into(),
+            },
         }
     }
 }
@@ -271,6 +281,15 @@ impl From<uniffi_meta::Type> for Box<Type> {
 impl From<Box<uniffi_meta::Type>> for Box<Type> {
     fn from(ty: Box<uniffi_meta::Type>) -> Self {
         Box::new((*ty).into())
+    }
+}
+
+impl From<uniffi_meta::ExternalKind> for ExternalKind {
+    fn from(kind: uniffi_meta::ExternalKind) -> Self {
+        match kind {
+            uniffi_meta::ExternalKind::DataClass => Self::DataClass,
+            uniffi_meta::ExternalKind::Interface => Self::Interface,
+        }
     }
 }
 

--- a/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
@@ -79,4 +79,4 @@ impl r#{{ trait_name }} for {{ trait_impl }} {
     {%- endfor %}
 }
 
-::uniffi::ffi_converter_callback_interface!(r#{{ trait_name }}, {{ trait_impl }}, "{{ cbi.name() }}", crate::UniFfiTag);
+::uniffi::scaffolding_ffi_converter_callback_interface!(r#{{ trait_name }}, {{ trait_impl }});

--- a/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
@@ -50,6 +50,7 @@ unsafe impl uniffi::FfiConverter<crate::UniFfiTag> for r#{{ name }} {
     ::uniffi::ffi_converter_default_return!(crate::UniFfiTag);
 
     const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_CUSTOM)
+        .concat_str("{{ ci.namespace() }}")
         .concat_str("{{ name }}")
         .concat({{ builtin|ffi_converter }}::TYPE_ID_META);
 }

--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -12,7 +12,7 @@
 
 {%- match obj.imp() -%}
 {%- when ObjectImpl::Trait %}
-::uniffi::ffi_converter_trait_decl!({{ obj.rust_name() }}, "{{ obj.name() }}", crate::UniFfiTag);
+::uniffi::scaffolding_ffi_converter_trait_interface!(r#{{ obj.name() }});
 {% else %}
 #[::uniffi::ffi_converter_interface(tag = crate::UniFfiTag)]
 struct {{ obj.rust_name() }} { }

--- a/uniffi_core/src/ffi_converter_traits.rs
+++ b/uniffi_core/src/ffi_converter_traits.rs
@@ -1,0 +1,255 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::sync::Arc;
+
+use crate::{
+    try_lift_from_rust_buffer, FfiDefault, MetadataBuffer, Result, RustBuffer, RustCallStatus,
+    UnexpectedUniFFICallbackError,
+};
+
+/// Trait defining how to transfer values via the FFI layer.
+///
+/// The `FfiConverter` trait defines how to pass values of a particular type back-and-forth over
+/// the uniffi generated FFI layer, both as standalone argument or return values, and as
+/// part of serialized compound data structures. `FfiConverter` is mainly used in generated code.
+/// The goal is to make it easy for the code generator to name the correct FFI-related function for
+/// a given type.
+///
+/// FfiConverter has a generic parameter, that's filled in with a type local to the UniFFI consumer crate.
+/// This allows us to work around the Rust orphan rules for remote types. See
+/// `https://mozilla.github.io/uniffi-rs/internals/lifting_and_lowering.html#code-generation-and-the-fficonverter-trait`
+/// for details.
+///
+/// ## Scope
+///
+/// It could be argued that FfiConverter handles too many concerns and should be split into
+/// separate traits (like `FfiLiftAndLower`, `FfiSerialize`, `FfiReturn`).  However, there are good
+/// reasons to keep all the functionality in one trait.
+///
+/// The main reason is that splitting the traits requires fairly complex blanket implementations,
+/// for example `impl<UT, T> FfiReturn<UT> for T: FfiLiftAndLower<UT>`.  Writing these impls often
+/// means fighting with `rustc` over what counts as a conflicting implementation.  In fact, as of
+/// Rust 1.66, that previous example conflicts with `impl<UT> FfiReturn<UT> for ()`, since other
+/// crates can implement `impl FfiReturn<MyLocalType> for ()`. In general, this path gets
+/// complicated very quickly and that distracts from the logic that we want to define, which is
+/// fairly simple.
+///
+/// The main downside of having a single `FfiConverter` trait is that we need to implement it for
+/// types that only support some of the functionality.  For example, `Result<>` supports returning
+/// values, but not lifting/lowering/serializing them.  This is a bit weird, but works okay --
+/// especially since `FfiConverter` is rarely used outside of generated code.
+///
+/// ## Safety
+///
+/// This is an unsafe trait (implementing it requires `unsafe impl`) because we can't guarantee
+/// that it's safe to pass your type out to foreign-language code and back again. Buggy
+/// implementations of this trait might violate some assumptions made by the generated code,
+/// or might not match with the corresponding code in the generated foreign-language bindings.
+///
+/// In general, you should not need to implement this trait by hand, and should instead rely on
+/// implementations generated from your component UDL via the `uniffi-bindgen scaffolding` command.
+pub unsafe trait FfiConverter<UT>: Sized {
+    /// The low-level type used for passing values of this type over the FFI.
+    ///
+    /// This must be a C-compatible type (e.g. a numeric primitive, a `#[repr(C)]` struct) into
+    /// which values of the target rust type can be converted.
+    ///
+    /// For complex data types, we currently recommend using `RustBuffer` and serializing
+    /// the data for transfer. In theory it could be possible to build a matching
+    /// `#[repr(C)]` struct for a complex data type and pass that instead, but explicit
+    /// serialization is simpler and safer as a starting point.
+    type FfiType;
+
+    /// The type that should be returned by scaffolding functions for this type.
+    ///
+    /// This is usually the same as `FfiType`, but `Result<>` has specialized handling.
+    type ReturnType: FfiDefault;
+
+    /// The `FutureCallback<T>` type used for async functions
+    ///
+    /// This is almost always `FutureCallback<Self::ReturnType>`.  The one exception is the
+    /// unit type, see that `FfiConverter` impl for details.
+    type FutureCallback: Copy;
+
+    /// Lower a rust value of the target type, into an FFI value of type Self::FfiType.
+    ///
+    /// This trait method is used for sending data from rust to the foreign language code,
+    /// by (hopefully cheaply!) converting it into something that can be passed over the FFI
+    /// and reconstructed on the other side.
+    ///
+    /// Note that this method takes an owned value; this allows it to transfer ownership in turn to
+    /// the foreign language code, e.g. by boxing the value and passing a pointer.
+    fn lower(obj: Self) -> Self::FfiType;
+
+    /// Lower this value for scaffolding function return
+    ///
+    /// This method converts values into the `Result<>` type that [rust_call] expects. For
+    /// successful calls, return `Ok(lower_return)`.  For errors that should be translated into
+    /// thrown exceptions on the foreign code, serialize the error into a RustBuffer and return
+    /// `Err(buf)`
+    fn lower_return(obj: Self) -> Result<Self::ReturnType, RustBuffer>;
+
+    /// Lift a rust value of the target type, from an FFI value of type Self::FfiType.
+    ///
+    /// This trait method is used for receiving data from the foreign language code in rust,
+    /// by (hopefully cheaply!) converting it from a low-level FFI value of type Self::FfiType
+    /// into a high-level rust value of the target type.
+    ///
+    /// Since we cannot statically guarantee that the foreign-language code will send valid
+    /// values of type Self::FfiType, this method is fallible.
+    fn try_lift(v: Self::FfiType) -> Result<Self>;
+
+    /// Lift a Rust value for a callback interface method result
+    fn lift_callback_return(buf: RustBuffer) -> Self {
+        try_lift_from_rust_buffer(buf).expect("Error reading callback interface result")
+    }
+
+    /// Lift a Rust value for a callback interface method error result
+    ///
+    /// This is called for "expected errors" -- the callback method returns a Result<> type and the
+    /// foreign code throws an exception that corresponds to the error type.
+    fn lift_callback_error(_buf: RustBuffer) -> Self {
+        panic!("Callback interface method returned unexpected error")
+    }
+
+    /// Lift a Rust value for an unexpected callback interface error
+    ///
+    /// The main reason this is called is when the callback interface throws an error type that
+    /// doesn't match the Rust trait definition.  It's also called for corner cases, like when the
+    /// foreign code doesn't follow the FFI contract.
+    ///
+    /// The default implementation panics unconditionally.  Errors used in callback interfaces
+    /// handle this using the `From<UnexpectedUniFFICallbackError>` impl that the library author
+    /// must provide.
+    fn handle_callback_unexpected_error(_e: UnexpectedUniFFICallbackError) -> Self {
+        panic!("Callback interface method returned unexpected error")
+    }
+
+    /// Write a rust value into a buffer, to send over the FFI in serialized form.
+    ///
+    /// This trait method can be used for sending data from rust to the foreign language code,
+    /// in cases where we're not able to use a special-purpose FFI type and must fall back to
+    /// sending serialized bytes.
+    ///
+    /// Note that this method takes an owned value because it's transferring ownership
+    /// to the foreign language code via the RustBuffer.
+    fn write(obj: Self, buf: &mut Vec<u8>);
+
+    /// Read a rust value from a buffer, received over the FFI in serialized form.
+    ///
+    /// This trait method can be used for receiving data from the foreign language code in rust,
+    /// in cases where we're not able to use a special-purpose FFI type and must fall back to
+    /// receiving serialized bytes.
+    ///
+    /// Since we cannot statically guarantee that the foreign-language code will send valid
+    /// serialized bytes for the target type, this method is fallible.
+    ///
+    /// Note the slightly unusual type here - we want a mutable reference to a slice of bytes,
+    /// because we want to be able to advance the start of the slice after reading an item
+    /// from it (but will not mutate the actual contents of the slice).
+    fn try_read(buf: &mut &[u8]) -> Result<Self>;
+
+    /// Invoke a `FutureCallback` to complete a async call
+    fn invoke_future_callback(
+        callback: Self::FutureCallback,
+        callback_data: *const (),
+        return_value: Self::ReturnType,
+        call_status: RustCallStatus,
+    );
+
+    /// Type ID metadata, serialized into a [MetadataBuffer]
+    const TYPE_ID_META: MetadataBuffer;
+}
+
+/// FfiConverter for Arc-types
+///
+/// This trait gets around the orphan rule limitations, which prevent library crates from
+/// implementing `FfiConverter` on an Arc. When this is implemented for T, we generate an
+/// `FfiConverter` impl for Arc<T>.
+///
+/// Note: There's no need for `FfiConverterBox`, since Box is a fundamental type.
+///
+/// ## Safety
+///
+/// This has the same safety considerations as FfiConverter
+pub unsafe trait FfiConverterArc<UT> {
+    type FfiType;
+    type ReturnType: FfiDefault;
+    type FutureCallback: Copy;
+
+    fn lower(obj: Arc<Self>) -> Self::FfiType;
+    fn lower_return(obj: Arc<Self>) -> Result<Self::ReturnType, RustBuffer>;
+    fn try_lift(v: Self::FfiType) -> Result<Arc<Self>>;
+    fn lift_callback_return(buf: RustBuffer) -> Arc<Self> {
+        try_lift_from_rust_buffer(buf).expect("Error reading callback interface result")
+    }
+    fn lift_callback_error(_buf: RustBuffer) -> Arc<Self> {
+        panic!("Callback interface method returned unexpected error")
+    }
+    fn handle_callback_unexpected_error(_e: UnexpectedUniFFICallbackError) -> Arc<Self> {
+        panic!("Callback interface method returned unexpected error")
+    }
+    fn write(obj: Arc<Self>, buf: &mut Vec<u8>);
+    fn try_read(buf: &mut &[u8]) -> Result<Arc<Self>>;
+    fn invoke_future_callback(
+        callback: Self::FutureCallback,
+        callback_data: *const (),
+        return_value: Self::ReturnType,
+        call_status: RustCallStatus,
+    );
+    const TYPE_ID_META: MetadataBuffer;
+}
+
+unsafe impl<T, UT> FfiConverter<UT> for Arc<T>
+where
+    T: FfiConverterArc<UT> + ?Sized,
+{
+    type FfiType = T::FfiType;
+    type ReturnType = T::ReturnType;
+    type FutureCallback = T::FutureCallback;
+
+    fn lower(obj: Self) -> Self::FfiType {
+        T::lower(obj)
+    }
+
+    fn lower_return(obj: Self) -> Result<Self::ReturnType, RustBuffer> {
+        T::lower_return(obj)
+    }
+
+    fn try_lift(v: Self::FfiType) -> Result<Self> {
+        T::try_lift(v)
+    }
+
+    fn lift_callback_return(buf: RustBuffer) -> Self {
+        T::lift_callback_error(buf)
+    }
+
+    fn lift_callback_error(buf: RustBuffer) -> Self {
+        T::lift_callback_error(buf)
+    }
+
+    fn handle_callback_unexpected_error(e: UnexpectedUniFFICallbackError) -> Self {
+        T::handle_callback_unexpected_error(e)
+    }
+
+    fn write(obj: Self, buf: &mut Vec<u8>) {
+        T::write(obj, buf)
+    }
+
+    fn try_read(buf: &mut &[u8]) -> Result<Self> {
+        T::try_read(buf)
+    }
+
+    fn invoke_future_callback(
+        callback: Self::FutureCallback,
+        callback_data: *const (),
+        return_value: Self::ReturnType,
+        call_status: RustCallStatus,
+    ) {
+        T::invoke_future_callback(callback, callback_data, return_value, call_status)
+    }
+
+    const TYPE_ID_META: MetadataBuffer = T::TYPE_ID_META;
+}

--- a/uniffi_macros/src/enum_.rs
+++ b/uniffi_macros/src/enum_.rs
@@ -84,6 +84,10 @@ fn enum_or_error_ffi_converter_impl(
 ) -> TokenStream {
     let name = ident_to_string(ident);
     let impl_spec = tagged_impl_header("FfiConverter", ident, tag);
+    let mod_path = match mod_path() {
+        Ok(p) => p,
+        Err(e) => return e.into_compile_error(),
+    };
     let write_match_arms = enum_.variants.iter().enumerate().map(|(i, v)| {
         let v_ident = &v.ident;
         let fields = v.fields.iter().map(|f| &f.ident);
@@ -140,6 +144,7 @@ fn enum_or_error_ffi_converter_impl(
             #handle_callback_unexpected_error
 
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(#metadata_type_code)
+                .concat_str(#mod_path)
                 .concat_str(#name);
         }
     }

--- a/uniffi_macros/src/error.rs
+++ b/uniffi_macros/src/error.rs
@@ -96,6 +96,10 @@ fn flat_error_ffi_converter_impl(
 ) -> TokenStream {
     let name = ident_to_string(ident);
     let impl_spec = tagged_impl_header("FfiConverter", ident, tag);
+    let mod_path = match mod_path() {
+        Ok(p) => p,
+        Err(e) => return e.into_compile_error(),
+    };
 
     let write_impl = {
         let match_arms = enum_.variants.iter().enumerate().map(|(i, v)| {
@@ -155,6 +159,7 @@ fn flat_error_ffi_converter_impl(
             #handle_callback_unexpected_error
 
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_ENUM)
+                .concat_str(#mod_path)
                 .concat_str(#name);
         }
     }

--- a/uniffi_macros/src/object.rs
+++ b/uniffi_macros/src/object.rs
@@ -4,7 +4,7 @@ use syn::{DeriveInput, Path};
 use uniffi_meta::free_fn_symbol_name;
 
 use crate::util::{
-    create_metadata_items, ident_to_string, tagged_impl_header, ArgumentNotAllowedHere,
+    create_metadata_items, ident_to_string, mod_path, tagged_impl_header, ArgumentNotAllowedHere,
     AttributeSliceExt, CommonAttr,
 };
 
@@ -50,12 +50,93 @@ pub(crate) fn expand_ffi_converter_interface(attr: CommonAttr, input: DeriveInpu
 
 pub(crate) fn interface_impl(ident: &Ident, tag: Option<&Path>) -> TokenStream {
     let name = ident_to_string(ident);
-    let impl_spec = tagged_impl_header("Interface", ident, tag);
+    let impl_spec = tagged_impl_header("FfiConverterArc", ident, tag);
+    let mod_path = match mod_path() {
+        Ok(p) => p,
+        Err(e) => return e.into_compile_error(),
+    };
+
     quote! {
         #[doc(hidden)]
         #[automatically_derived]
-        #impl_spec {
-            const NAME: &'static str = #name;
+        /// Support for passing reference-counted shared objects via the FFI.
+        ///
+        /// To avoid dealing with complex lifetime semantics over the FFI, any data passed
+        /// by reference must be encapsulated in an `Arc`, and must be safe to share
+        /// across threads.
+        unsafe #impl_spec {
+            // Don't use a pointer to <T> as that requires a `pub <T>`
+            type FfiType = *const ::std::os::raw::c_void;
+            type ReturnType = *const ::std::os::raw::c_void;
+            type FutureCallback = ::uniffi::FutureCallback<Self::ReturnType>;
+
+            /// When lowering, we have an owned `Arc` and we transfer that ownership
+            /// to the foreign-language code, "leaking" it out of Rust's ownership system
+            /// as a raw pointer. This works safely because we have unique ownership of `self`.
+            /// The foreign-language code is responsible for freeing this by calling the
+            /// `ffi_object_free` FFI function provided by the corresponding UniFFI type.
+            ///
+            /// Safety: when freeing the resulting pointer, the foreign-language code must
+            /// call the destructor function specific to the type `T`. Calling the destructor
+            /// function for other types may lead to undefined behaviour.
+            fn lower(obj: ::std::sync::Arc<Self>) -> Self::FfiType {
+                ::std::sync::Arc::into_raw(obj) as Self::FfiType
+            }
+
+            /// When lifting, we receive a "borrow" of the `Arc` that is owned by
+            /// the foreign-language code, and make a clone of it for our own use.
+            ///
+            /// Safety: the provided value must be a pointer previously obtained by calling
+            /// the `lower()` or `write()` method of this impl.
+            fn try_lift(v: Self::FfiType) -> ::uniffi::Result<::std::sync::Arc<Self>> {
+                let v = v as *const #ident;
+                // We musn't drop the `Arc` that is owned by the foreign-language code.
+                let foreign_arc = ::std::mem::ManuallyDrop::new(unsafe { ::std::sync::Arc::<Self>::from_raw(v) });
+                // Take a clone for our own use.
+                Ok(::std::sync::Arc::clone(&*foreign_arc))
+            }
+
+            /// When writing as a field of a complex structure, make a clone and transfer ownership
+            /// of it to the foreign-language code by writing its pointer into the buffer.
+            /// The foreign-language code is responsible for freeing this by calling the
+            /// `ffi_object_free` FFI function provided by the corresponding UniFFI type.
+            ///
+            /// Safety: when freeing the resulting pointer, the foreign-language code must
+            /// call the destructor function specific to the type `T`. Calling the destructor
+            /// function for other types may lead to undefined behaviour.
+            fn write(obj: ::std::sync::Arc<Self>, buf: &mut Vec<u8>) {
+                ::uniffi::deps::static_assertions::const_assert!(::std::mem::size_of::<*const ::std::ffi::c_void>() <= 8);
+                ::uniffi::deps::bytes::BufMut::put_u64(buf, <Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::lower(obj) as u64);
+            }
+
+            /// When reading as a field of a complex structure, we receive a "borrow" of the `Arc`
+            /// that is owned by the foreign-language code, and make a clone for our own use.
+            ///
+            /// Safety: the buffer must contain a pointer previously obtained by calling
+            /// the `lower()` or `write()` method of this impl.
+            fn try_read(buf: &mut &[u8]) -> ::uniffi::Result<::std::sync::Arc<Self>> {
+                ::uniffi::deps::static_assertions::const_assert!(::std::mem::size_of::<*const ::std::ffi::c_void>() <= 8);
+                ::uniffi::check_remaining(buf, 8)?;
+                <Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::try_lift(::uniffi::deps::bytes::Buf::get_u64(buf) as Self::FfiType)
+            }
+
+            fn lower_return(v: ::std::sync::Arc<Self>) -> ::std::result::Result<Self::FfiType, ::uniffi::RustBuffer> {
+                Ok(<Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::lower(v))
+            }
+
+            fn invoke_future_callback(
+                callback: Self::FutureCallback,
+                callback_data: *const (),
+                return_value: Self::ReturnType,
+                call_status: ::uniffi::RustCallStatus,
+            ) {
+                callback(callback_data, return_value, call_status);
+            }
+
+            const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_INTERFACE)
+                .concat_str(#mod_path)
+                .concat_str(#name)
+                .concat_bool(false);
         }
     }
 }

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -201,7 +201,7 @@ pub fn either_attribute_arg<T: ToTokens>(a: Option<T>, b: Option<T>) -> syn::Res
 
 pub(crate) fn tagged_impl_header(
     trait_name: &str,
-    ident: &Ident,
+    ident: &impl ToTokens,
     tag: Option<&Path>,
 ) -> TokenStream {
     let trait_name = Ident::new(trait_name, Span::call_site());
@@ -265,5 +265,22 @@ impl UniffiAttributeArgs for CommonAttr {
 impl Parse for CommonAttr {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         parse_comma_separated(input)
+    }
+}
+
+/// Specifies a type from a dependent crate
+pub struct ExternalTypeItem {
+    pub crate_ident: Ident,
+    pub sep: Token![,],
+    pub type_ident: Ident,
+}
+
+impl Parse for ExternalTypeItem {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        Ok(Self {
+            crate_ident: input.parse()?,
+            sep: input.parse()?,
+            type_ident: input.parse()?,
+        })
     }
 }

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -235,19 +235,24 @@ pub enum Type {
     ForeignExecutor,
     SystemTime,
     Enum {
+        module_path: String,
         name: String,
     },
     Record {
+        module_path: String,
         name: String,
     },
     ArcObject {
+        module_path: String,
         object_name: String,
         is_trait: bool,
     },
     CallbackInterface {
+        module_path: String,
         name: String,
     },
     Custom {
+        module_path: String,
         name: String,
         builtin: Box<Type>,
     },
@@ -261,6 +266,17 @@ pub enum Type {
         key_type: Box<Type>,
         value_type: Box<Type>,
     },
+    External {
+        module_path: String,
+        name: String,
+        kind: ExternalKind,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub enum ExternalKind {
+    DataClass,
+    Interface,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize)]

--- a/uniffi_meta/src/reader.rs
+++ b/uniffi_meta/src/reader.rs
@@ -122,19 +122,24 @@ impl<'a> MetadataReader<'a> {
             codes::TYPE_SYSTEM_TIME => Type::SystemTime,
             codes::TYPE_FOREIGN_EXECUTOR => Type::ForeignExecutor,
             codes::TYPE_RECORD => Type::Record {
+                module_path: self.read_string()?,
                 name: self.read_string()?,
             },
             codes::TYPE_ENUM => Type::Enum {
+                module_path: self.read_string()?,
                 name: self.read_string()?,
             },
             codes::TYPE_INTERFACE => Type::ArcObject {
+                module_path: self.read_string()?,
                 object_name: self.read_string()?,
                 is_trait: self.read_bool()?,
             },
             codes::TYPE_CALLBACK_INTERFACE => Type::CallbackInterface {
+                module_path: self.read_string()?,
                 name: self.read_string()?,
             },
             codes::TYPE_CUSTOM => Type::Custom {
+                module_path: self.read_string()?,
                 name: self.read_string()?,
                 builtin: Box::new(self.read_type()?),
             },
@@ -204,10 +209,10 @@ impl<'a> MetadataReader<'a> {
 
         return_type
             .filter(|t| {
-                *t == Type::ArcObject {
-                    object_name: self_name.clone(),
-                    is_trait: false,
-                }
+                matches!(
+                    t,
+                    Type::ArcObject { object_name, is_trait: false, .. } if object_name == &self_name
+                )
             })
             .context("Constructor return type must be Arc<Self>")?;
 


### PR DESCRIPTION
This allows proc-macro based libraries to use types defined in UDL files.  It also paves the way for proc-macros to support remote types from non-UniFFI types.

I'm hoping we can sneak this in to the `0.24` release.