### PR TITLE
Release process: Remove step to touch uniffi/CHANGELOG.md

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -21,13 +21,6 @@ Steps:
    * Anything that affects any UniFFI consumers should be listed, this includes consumers that
      use UniFFI to generate their scaffolding/bindings, external bindings generators, etc.
 
-1. Take a look over `uniffi/CHANGELOG.md` and make sure the "unreleased" section lists changes for
-   the release that affect users of the top-level `uniffi` crate.
-   * This should be a copy of the items from the top-level `CHANGELOG.md` that affects
-     scaffolding/bindings generation.
-   * Note that breaking changes for a particular `uniffi_*` crate are not necessarily breaking for
-     the `uniffi` crate.  See `./uniffi-versioning.md` for a discussion of this.
-
 1. Decide on a new version number for `uniffi` crate.  Since we are pre-`1.0`, if there are breaking
    changes then this should be a minor version bump, otherwise a patch version bump.
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -51,7 +51,7 @@ Steps:
          worthwhile anyway!.
    * Release the crates: `cargo release-backend-crates -x {MAJOR}.{MINOR}.{PATCH}`.
        * **This will publish the new releases on crates.io**
-   This will create a local git tag, but does not push it to github.
+       * This will **NOT** create a local git tag.
 
 1. Release `uniffi`
    * **Do not execute this before the previous step.**  It depends on the published crates from that step

--- a/release.toml
+++ b/release.toml
@@ -1,7 +1,7 @@
 tag-name = "v{{version}}"
 consolidate-commits = true
 
-shared-version=false
+shared-version = false
 
 # Disabling auto pushing for now to avoid accidents (although we can still "accidentally" publish
 # to crates.io, so it's not clear this is saving us anything?)


### PR DESCRIPTION
That file was ultimately not added in #1445.
We keep only a single changelog, listing all changes.