### PR TITLE
Python: Remove unused import

### DIFF
--- a/uniffi_bindgen/src/bindings/python/templates/wrapper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/wrapper.py
@@ -24,7 +24,6 @@ import typing
 {%- if ci.has_async_fns() %}
 import asyncio
 {%- endif %}
-import contextvars
 import platform
 {%- for req in self.imports() %}
 {{ req.render() }}


### PR DESCRIPTION
Also this broke Python 3.6 compatibility