### PR TITLE
Delay contract checks until after all functions are defined

### DIFF
--- a/uniffi_bindgen/src/bindings/python/templates/NamespaceLibraryTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/NamespaceLibraryTemplate.py
@@ -52,8 +52,6 @@ def loadIndirect():
     libname = libname.format("{{ config.cdylib_name() }}")
     path = str(Path(__file__).parent / libname)
     lib = ctypes.cdll.LoadLibrary(path)
-    uniffi_check_contract_api_version(lib)
-    uniffi_check_api_checksums(lib)
     return lib
 
 def uniffi_check_contract_api_version(lib):
@@ -82,3 +80,6 @@ _UniFFILib.{{ func.name() }}.argtypes = (
 )
 _UniFFILib.{{ func.name() }}.restype = {% match func.return_type() %}{% when Some with (type_) %}{{ type_|ffi_type_name }}{% when None %}None{% endmatch %}
 {%- endfor %}
+{# Ensure to call the contract verification only after we defined all functions. -#}
+uniffi_check_contract_api_version(_UniFFILib)
+uniffi_check_api_checksums(_UniFFILib)


### PR DESCRIPTION
Otherwise we might call it with the wrong ABI.
This so far wasn't an issue on platforms UniFFI tests on, but can be observed on Windows (at leats in Wine), where suddenly the checksums won't match, e.g.
39784 is expected, but the call gets 33135464 back. The former is 0x9b68 and fits well within a 16-bit unsigned integer. The latter is 0x1f99b68 which does not fit (but it has the same suffix, guess why...)