### PR TITLE
Callback interface via export missing method argument types

### DIFF
--- a/fixtures/proc-macro/src/callback_interface.rs
+++ b/fixtures/proc-macro/src/callback_interface.rs
@@ -8,5 +8,6 @@ use crate::BasicError;
 pub trait TestCallbackInterface {
     fn do_nothing(&self);
     fn add(&self, a: u32, b: u32) -> u32;
+    fn optional(&self, a: Option<u32>) -> u32;
     fn try_parse_int(&self, value: String) -> Result<u32, BasicError>;
 }

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -95,6 +95,8 @@ fn take_two(two: Two) -> String {
 fn test_callback_interface(cb: Box<dyn TestCallbackInterface>) {
     cb.do_nothing();
     assert_eq!(cb.add(1, 1), 2);
+    assert_eq!(cb.optional(Some(1)), 1);
+    assert_eq!(cb.optional(None), 0);
     assert_eq!(Ok(10), cb.try_parse_int("10".to_string()));
     assert_eq!(
         Err(BasicError::InvalidInput),

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
@@ -41,6 +41,8 @@ class KtTestCallbackInterface : TestCallbackInterface {
 
     override fun add(a: UInt, b: UInt) = a + b
 
+    override fun optional(a: UInt?) = a ?: 0
+
     override fun tryParseInt(value: String): UInt {
         if (value == "force-unexpected-error") {
             // raise an error that's not expected

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
@@ -41,7 +41,7 @@ class KtTestCallbackInterface : TestCallbackInterface {
 
     override fun add(a: UInt, b: UInt) = a + b
 
-    override fun optional(a: UInt?) = a ?: 0
+    override fun optional(a: UInt?) = a ?: 0u
 
     override fun tryParseInt(value: String): UInt {
         if (value == "force-unexpected-error") {

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -48,6 +48,11 @@ class PyTestCallbackInterface(TestCallbackInterface):
     def add(self, a, b):
         return a + b
 
+    def optional(self, a):
+        if a is None:
+            return 0
+        return a
+
     def try_parse_int(self, value):
         if value == "force-unexpected-error":
             # raise an error that's not expected

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
@@ -44,6 +44,10 @@ class SwiftTestCallbackInterface : TestCallbackInterface {
         return a + b;
     }
 
+    func `optional`(a: Optional<UInt32>) -> UInt32 {
+        return a ?? 0;
+    }
+
     func tryParseInt(value: String) throws -> UInt32 {
         if (value == "force-unexpected-error") {
             // raise an error that's not expected

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -754,7 +754,12 @@ impl ComponentInterface {
                     meta.index,
                 );
             }
-            cbi.methods.push(meta.into());
+            let defn: Method = meta.into();
+            for arg in defn.iter_types() {
+                self.types.add_known_type(arg);
+            }
+
+            cbi.methods.push(defn);
         } else {
             self.add_method_meta(meta)?;
         }


### PR DESCRIPTION
Using `#[uniffi::export(callback_interface)]` on a trait which has methods taking `Option<T>` arguments currently fails because `FfiConverterOptional$T` is not defined in the generated Kotlin code (at least).

Here a failing test is added to the `proc-macro` fixtures and then fixed by registering the types in the CB related path of `ComponentInterface::add_trait_method_meta`.

I did try just making it call `ComponentInterface::add_method_meta` but this hit the "object ... not found" assertion in there. Perhaps I should have done a deeper refactoring to also allow more consolidation?

@bendk you recently consolidated some code in ba28e9d50cef1ed857599e939e39782eddc7365b which I think is related, although by inspection I think the issue was already present before that.