### PR TITLE
Allows crates to use only proc-macros and not UDL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.24.1...HEAD).
 
+### What's new
+
+- Crates can now use proc-macros without UDL files to export their interface.  See the "Procedural Macros: Attributes and Derives" manual section for details.
+
 ## v0.24.1 (backend crates: v0.24.1) - (_2023-06-23_)
 
 [All changes in v0.24.1](https://github.com/mozilla/uniffi-rs/compare/v0.24.0...v0.24.1).

--- a/docs/manual/src/proc_macro/index.md
+++ b/docs/manual/src/proc_macro/index.md
@@ -23,10 +23,15 @@ true for all of UniFFI, so proceed with caution and the knowledge that things ma
 
 ## Build workflow
 
-Before any of the things discussed below work, make sure to update your bindings generation steps
-to start with a build of your library and add
-`--lib-file <CARGO WORKSPACE>/target/<TARGET>/<BUILT CDYLIB OR STATICLIB>` to your `uniffi-bindgen`
-command line invocation.
+Library mode is recommended when using UniFFI proc-macros (See the [Foreign language bindings docs](../tutorial/foreign_language_bindings.md) for more info).
+
+If your crate's API is declared using only proc-macros and not UDL files, call the `uniffi::setup_scaffolding` macro at the top of your source code:
+
+```rust
+uniffi::setup_scaffolding!();
+```
+
+**⚠ Warning ⚠** Do not call both `uniffi::setup_scaffolding!()` and `uniffi::include_scaffolding!!()` in the same crate.
 
 ## The `#[uniffi::export]` attribute
 

--- a/fixtures/simple-iface/build.rs
+++ b/fixtures/simple-iface/build.rs
@@ -1,7 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-fn main() {
-    uniffi::generate_scaffolding("src/simple-iface.udl").unwrap();
-}

--- a/fixtures/simple-iface/src/lib.rs
+++ b/fixtures/simple-iface/src/lib.rs
@@ -26,4 +26,4 @@ impl Object {
     }
 }
 
-uniffi::include_scaffolding!("simple-iface");
+uniffi::setup_scaffolding!();

--- a/fixtures/simple-iface/src/simple-iface.udl
+++ b/fixtures/simple-iface/src/simple-iface.udl
@@ -1,1 +1,0 @@
-namespace uniffi_simple_iface {};

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -71,13 +71,11 @@ pub use record::{Field, Record};
 pub mod ffi;
 pub use ffi::{FfiArgument, FfiFunction, FfiType};
 pub use uniffi_meta::Radix;
-use uniffi_meta::{ConstructorMetadata, LiteralMetadata, ObjectMetadata, TraitMethodMetadata};
+use uniffi_meta::{
+    ConstructorMetadata, LiteralMetadata, ObjectMetadata, TraitMethodMetadata,
+    UNIFFI_CONTRACT_VERSION,
+};
 pub type Literal = LiteralMetadata;
-// This needs to match the minor version of the `uniffi` crate.  See
-// `docs/uniffi-versioning.md` for details.
-//
-// Once we get to 1.0, then we'll need to update the scheme to something like 100 + major_version
-const UNIFFI_CONTRACT_VERSION: u32 = 22;
 
 /// The main public interface for this module, representing the complete details of an interface exposed
 /// by a rust component and the details of consuming it via an extern-C FFI layer.

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -92,15 +92,13 @@
 #![warn(rust_2018_idioms, unused_qualifications)]
 #![allow(unknown_lints)]
 
-const BINDGEN_VERSION: &str = env!("CARGO_PKG_VERSION");
-
 use anyhow::{anyhow, bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use fs_err::{self as fs, File};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::io::prelude::*;
 use std::io::ErrorKind;
-use std::{collections::HashMap, env, process::Command, str::FromStr};
+use std::{collections::HashMap, process::Command, str::FromStr};
 
 pub mod backend;
 pub mod bindings;

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -7,20 +7,16 @@ use askama::Template;
 use std::borrow::Borrow;
 
 use super::interface::*;
-use heck::{ToShoutySnakeCase, ToSnakeCase};
+use heck::ToSnakeCase;
 
 #[derive(Template)]
 #[template(syntax = "rs", escape = "none", path = "scaffolding_template.rs")]
 pub struct RustScaffolding<'a> {
     ci: &'a ComponentInterface,
-    uniffi_version: &'static str,
 }
 impl<'a> RustScaffolding<'a> {
     pub fn new(ci: &'a ComponentInterface) -> Self {
-        Self {
-            ci,
-            uniffi_version: crate::BINDGEN_VERSION,
-        }
+        Self { ci }
     }
 }
 mod filters {

--- a/uniffi_bindgen/src/scaffolding/templates/scaffolding_template.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/scaffolding_template.rs
@@ -2,30 +2,7 @@
 // Trust me, you don't want to mess with it!
 {% import "macros.rs" as rs %}
 
-// Unit struct to parameterize the FfiConverter trait.
-//
-// We use FfiConverter<UniFfiTag> to handle lowering/lifting/serializing types for this crate.  See
-// https://mozilla.github.io/uniffi-rs/internals/lifting_and_lowering.html#code-generation-and-the-fficonverter-trait
-// for details.
-//
-// This is pub, since we need to access it to support external types
-#[doc(hidden)]
-pub struct UniFfiTag;
-
-#[allow(clippy::missing_safety_doc, missing_docs)]
-#[doc(hidden)]
-#[no_mangle]
-pub extern "C" fn {{ ci.ffi_uniffi_contract_version().name() }}() -> u32 {
-    {{ ci.uniffi_contract_version() }}
-}
-
-{%- include "namespace_metadata.rs" %}
-
-// Check for compatibility between `uniffi` and `uniffi_bindgen` versions.
-// Note that we have an error message on the same line as the assertion.
-// This is important, because if the assertion fails, the compiler only
-// seems to show that single line as context for the user.
-uniffi::assert_compatible_version!("{{ uniffi_version }}"); // Please check that you depend on version {{ uniffi_version }} of the `uniffi` crate.
+::uniffi::setup_scaffolding!("{{ ci.namespace() }}");
 
 {% for ty in ci.iter_types() %}
 {%- match ty %}
@@ -35,8 +12,6 @@ uniffi::deps::static_assertions::assert_impl_all!({{ k|type_rs }}: ::std::cmp::E
 {%- else %}
 {%- endmatch %}
 {% endfor %}
-
-{% include "RustBuffer.rs" %}
 
 {% for e in ci.enum_definitions() %}
 {% if ci.is_name_used_as_error(e.name()) %}
@@ -71,10 +46,5 @@ uniffi::deps::static_assertions::assert_impl_all!({{ k|type_rs }}: ::std::cmp::E
 // External and Wrapped types
 {% include "ExternalTypesTemplate.rs" %}
 
-// Export scaffolding checksums
+// Export scaffolding checksums for UDL items
 {% include "Checksums.rs" %}
-
-// The `reexport_uniffi_scaffolding` macro
-{% include "ReexportUniFFIScaffolding.rs" %}
-
-{%- import "macros.rs" as rs -%}

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -23,6 +23,7 @@ mod export;
 mod fnsig;
 mod object;
 mod record;
+mod setup_scaffolding;
 mod test;
 mod util;
 
@@ -48,6 +49,24 @@ use self::{
 #[proc_macro]
 pub fn build_foreign_language_testcases(tokens: TokenStream) -> TokenStream {
     test::build_foreign_language_testcases(tokens)
+}
+
+/// Top-level initialization macro
+///
+/// The optional namespace argument is only used by the scaffolding templates to pass in the
+/// CI namespace.
+#[proc_macro]
+pub fn setup_scaffolding(tokens: TokenStream) -> TokenStream {
+    let namespace = match syn::parse_macro_input!(tokens as Option<LitStr>) {
+        Some(lit_str) => lit_str.value(),
+        None => match util::mod_path() {
+            Ok(v) => v,
+            Err(e) => return e.into_compile_error().into(),
+        },
+    };
+    setup_scaffolding::setup_scaffolding(namespace)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
 }
 
 #[proc_macro_attribute]

--- a/uniffi_macros/src/setup_scaffolding.rs
+++ b/uniffi_macros/src/setup_scaffolding.rs
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::Result;
+
+use crate::util::mod_path;
+use uniffi_meta::UNIFFI_CONTRACT_VERSION;
+
+pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
+    let module_path = mod_path()?;
+    let ffi_contract_version_ident = format_ident!("ffi_{namespace}_uniffi_contract_version");
+    let namespace_upper = namespace.to_ascii_uppercase();
+    let namespace_const_ident = format_ident!("UNIFFI_META_CONST_NAMESPACE_{namespace_upper}");
+    let namespace_static_ident = format_ident!("UNIFFI_META_NAMESPACE_{namespace_upper}");
+    let ffi_rustbuffer_alloc_ident = format_ident!("ffi_{namespace}_rustbuffer_alloc");
+    let ffi_rustbuffer_from_bytes_ident = format_ident!("ffi_{namespace}_rustbuffer_from_bytes");
+    let ffi_rustbuffer_free_ident = format_ident!("ffi_{namespace}_rustbuffer_free");
+    let ffi_rustbuffer_reserve_ident = format_ident!("ffi_{namespace}_rustbuffer_reserve");
+    let reexport_hack_ident = format_ident!("{namespace}_uniffi_reexport_hack");
+
+    Ok(quote! {
+        // Unit struct to parameterize the FfiConverter trait.
+        //
+        // We use FfiConverter<UniFfiTag> to handle lowering/lifting/serializing types for this crate.  See
+        // https://mozilla.github.io/uniffi-rs/internals/lifting_and_lowering.html#code-generation-and-the-fficonverter-trait
+        // for details.
+        //
+        // This is pub, since we need to access it to support external types
+        #[doc(hidden)]
+        pub struct UniFfiTag;
+
+        #[allow(clippy::missing_safety_doc, missing_docs)]
+        #[doc(hidden)]
+        #[no_mangle]
+        pub extern "C" fn #ffi_contract_version_ident() -> u32 {
+            #UNIFFI_CONTRACT_VERSION
+        }
+
+
+        /// Export namespace metadata.
+        ///
+        /// See `uniffi_bindgen::macro_metadata` for how this is used.
+
+        const #namespace_const_ident: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::NAMESPACE)
+            .concat_str(#module_path)
+            .concat_str(#namespace);
+
+        #[doc(hidden)]
+        #[no_mangle]
+        pub static #namespace_static_ident: [u8; #namespace_const_ident.size] = #namespace_const_ident.into_array();
+
+        // Everybody gets basic buffer support, since it's needed for passing complex types over the FFI.
+        //
+        // See `uniffi/src/ffi/rustbuffer.rs` for documentation on these functions
+
+        #[allow(clippy::missing_safety_doc, missing_docs)]
+        #[doc(hidden)]
+        #[no_mangle]
+        pub extern "C" fn #ffi_rustbuffer_alloc_ident(size: i32, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
+            uniffi::ffi::uniffi_rustbuffer_alloc(size, call_status)
+        }
+
+        #[allow(clippy::missing_safety_doc, missing_docs)]
+        #[doc(hidden)]
+        #[no_mangle]
+        pub unsafe extern "C" fn #ffi_rustbuffer_from_bytes_ident(bytes: uniffi::ForeignBytes, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
+            uniffi::ffi::uniffi_rustbuffer_from_bytes(bytes, call_status)
+        }
+
+        #[allow(clippy::missing_safety_doc, missing_docs)]
+        #[doc(hidden)]
+        #[no_mangle]
+        pub unsafe extern "C" fn #ffi_rustbuffer_free_ident(buf: uniffi::RustBuffer, call_status: &mut uniffi::RustCallStatus) {
+            uniffi::ffi::uniffi_rustbuffer_free(buf, call_status);
+        }
+
+        #[allow(clippy::missing_safety_doc, missing_docs)]
+        #[doc(hidden)]
+        #[no_mangle]
+        pub unsafe extern "C" fn #ffi_rustbuffer_reserve_ident(buf: uniffi::RustBuffer, additional: i32, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
+            uniffi::ffi::uniffi_rustbuffer_reserve(buf, additional, call_status)
+        }
+
+        // Code to re-export the UniFFI scaffolding functions.
+        //
+        // Rust won't always re-export the functions from dependencies
+        // ([rust-lang#50007](https://github.com/rust-lang/rust/issues/50007))
+        //
+        // A workaround for this is to have the dependent crate reference a function from its dependency in
+        // an extern "C" function. This is clearly hacky and brittle, but at least we have some unittests
+        // that check if this works (fixtures/reexport-scaffolding-macro).
+        //
+        // The main way we use this macro is for that contain multiple UniFFI components (libxul,
+        // megazord).  The combined library has a cargo dependency for each component and calls
+        // uniffi_reexport_scaffolding!() for each one.
+
+        #[allow(missing_docs)]
+        #[doc(hidden)]
+        pub const fn uniffi_reexport_hack() {}
+
+        #[doc(hidden)]
+        #[macro_export]
+        macro_rules! uniffi_reexport_scaffolding {
+            () => {
+                #[doc(hidden)]
+                #[no_mangle]
+                pub extern "C" fn #reexport_hack_ident() {
+                    $crate::uniffi_reexport_hack()
+                }
+            };
+        }
+
+    })
+}

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -18,6 +18,13 @@ pub use reader::{read_metadata, read_metadata_type};
 
 mod types;
 pub use types::{AsType, ExternalKind, ObjectImpl, Type, TypeIterator};
+
+// This needs to match the minor version of the `uniffi` crate.  See
+// `docs/uniffi-versioning.md` for details.
+//
+// Once we get to 1.0, then we'll need to update the scheme to something like 100 + major_version
+pub const UNIFFI_CONTRACT_VERSION: u32 = 22;
+
 /// Similar to std::hash::Hash.
 ///
 /// Implementations of this trait are expected to update the hasher state in


### PR DESCRIPTION
- Added a `setup_scaffolding` proc-macro.  This does things like generate `crate::UniffiTag` and export the rustbuffer scaffolding functions.
- Updated the Askama scaffolding template to call `setup_scaffolding!()`
- Removed the scaffolding check that `uniffi_bindgen` and `uniffi` have the same version.  I don't think this is needed anymore now that users only depend on `uniffi` and get their `uniffi_bindgen` dependency transitively.  Note: we still need a similar check in the bindings, but this commit only changes the scaffolding generation.
- Updated `fixtures/simple-iface` to test the new system
- Updated docs