### PR TITLE
Allow external generators to extract definitions from dynamic libraries.

### DIFF
--- a/uniffi_bindgen/src/library_mode.rs
+++ b/uniffi_bindgen/src/library_mode.rs
@@ -104,7 +104,7 @@ pub struct Source {
 }
 
 // If `library_path` is a C dynamic library, return its name
-fn calc_cdylib_name(library_path: &Utf8Path) -> Option<&str> {
+pub fn calc_cdylib_name(library_path: &Utf8Path) -> Option<&str> {
     let cdylib_extentions = [".so", ".dll", ".dylib"];
     let filename = library_path.file_name()?;
     let filename = filename.strip_prefix("lib").unwrap_or(filename);


### PR DESCRIPTION
The `generate_external_bindings` is the main function used by all external binding generators to generate bindings for their appropriate language. After the recent updates with proc-macros, UniFFI allowed for type definitions to be extracted from dynamic libraries. This was reflected in `generate_bindings` but not in `generate_external_bindings`. 

This PR extends the support for extraction of definitions from dynamic libraries to external generators by aligning the interface and implementation of `generate_bindings` and `generate_external_bindings`.