### PR TITLE
Improve async-related sanity checks in scaffolding generation

### DIFF
--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -171,6 +171,23 @@ impl Megaphone {
     }
 }
 
+// The async_runtime attribute used to error when *any* function in the impl block was not async,
+// now it should work as long as at least one function *is* async.
+#[uniffi::export(async_runtime = "tokio")]
+impl Megaphone {
+    /// A sync method that yells something immediately.
+    pub fn say_now(&self, who: String) -> String {
+        format!("Hello, {who}!").to_uppercase()
+    }
+
+    /// An async method that yells something after a certain time.
+    ///
+    /// Uses tokio's timer functionality.
+    pub async fn say_after_with_tokio(self: Arc<Self>, ms: u16, who: String) -> String {
+        say_after_with_tokio(ms, who).await.to_uppercase()
+    }
+}
+
 // Say something after a certain amount of time, by using `tokio::time::sleep`
 // instead of our own `TimerFuture`.
 #[uniffi::export(async_runtime = "tokio")]

--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -42,6 +42,18 @@ pub(crate) fn expand_export(
     match metadata {
         ExportItem::Function { sig } => gen_fn_scaffolding(sig, &args),
         ExportItem::Impl { items, self_ident } => {
+            if let Some(rt) = &args.async_runtime {
+                if items
+                    .iter()
+                    .all(|item| !matches!(item, ImplItem::Method(sig) if sig.is_async))
+                {
+                    return Err(syn::Error::new_spanned(
+                        rt,
+                        "no async methods in this impl block",
+                    ));
+                }
+            }
+
             let item_tokens: TokenStream = items
                 .into_iter()
                 .map(|item| match item {

--- a/uniffi_macros/src/export/item.rs
+++ b/uniffi_macros/src/export/item.rs
@@ -14,11 +14,11 @@ pub(super) enum ExportItem {
     },
     Impl {
         self_ident: Ident,
-        items: Vec<syn::Result<ImplItem>>,
+        items: Vec<ImplItem>,
     },
     Trait {
         self_ident: Ident,
-        items: Vec<syn::Result<ImplItem>>,
+        items: Vec<ImplItem>,
         callback_interface: bool,
     },
 }
@@ -94,7 +94,7 @@ impl ExportItem {
 
                 Ok(item)
             })
-            .collect();
+            .collect::<syn::Result<_>>()?;
 
         Ok(Self::Impl {
             items,
@@ -142,7 +142,7 @@ impl ExportItem {
 
                 Ok(item)
             })
-            .collect();
+            .collect::<syn::Result<_>>()?;
 
         Ok(Self::Trait {
             items,

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -37,6 +37,9 @@ pub(super) fn gen_constructor_scaffolding(
             "constructors must not have a self parameter",
         ));
     }
+    if sig.is_async {
+        return Err(syn::Error::new(sig.span, "constructors can't be async"));
+    }
     let metadata_items = sig.metadata_items()?;
     let scaffolding_func = gen_ffi_function(&sig, arguments)?;
     Ok(quote! {

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -19,6 +19,14 @@ pub(super) fn gen_fn_scaffolding(
             "Unexpected self param (Note: uniffi::export must be used on the impl block, not its containing fn's)"
         ));
     }
+    if !sig.is_async {
+        if let Some(async_runtime) = &arguments.async_runtime {
+            return Err(syn::Error::new_spanned(
+                async_runtime,
+                "this attribute is only allowed on async functions",
+            ));
+        }
+    }
     let metadata_items = sig.metadata_items()?;
     let scaffolding_func = gen_ffi_function(&sig, arguments)?;
     Ok(quote! {
@@ -157,13 +165,6 @@ fn gen_ffi_function(
     let return_ty = &sig.return_ty;
 
     Ok(if !sig.is_async {
-        if let Some(async_runtime) = &arguments.async_runtime {
-            return Err(syn::Error::new_spanned(
-                async_runtime,
-                "this attribute is only allowed on async functions",
-            ));
-        }
-
         quote! {
             #[doc(hidden)]
             #[no_mangle]


### PR DESCRIPTION
This allows

```rust
#[uniffi::export(async_runtime = "tokio")]
impl Foo {
    fn just_a_regular_fn(&self) { /* ... */ }
    async fn my_async_fn(&self) { /* run within the context of a tokio runtime */ }
}
```

which used to complain that "this attribute is only allowed on async functions" (pointing to the `"tokio"` string).