### PR TITLE
Add a relatively simple way to compile and generate Swift bindings.

### DIFF
--- a/docs/manual/src/SUMMARY.md
+++ b/docs/manual/src/SUMMARY.md
@@ -32,7 +32,7 @@
 - [Configuration](./swift/configuration.md)
 - [Building a Swift module](./swift/module.md)
 - [Integrating with Xcode](./swift/xcode.md)
-- [Framework](./swift/framework.md)
+- [Wrapped in Framework](./swift/framework.md)
 
 # Internals
 - [Design Principles](./internals/design_principles.md)

--- a/docs/manual/src/SUMMARY.md
+++ b/docs/manual/src/SUMMARY.md
@@ -32,6 +32,7 @@
 - [Configuration](./swift/configuration.md)
 - [Building a Swift module](./swift/module.md)
 - [Integrating with Xcode](./swift/xcode.md)
+- [Framework](./swift/framework.md)
 
 # Internals
 - [Design Principles](./internals/design_principles.md)

--- a/docs/manual/src/swift/framework.md
+++ b/docs/manual/src/swift/framework.md
@@ -1,0 +1,86 @@
+# Wrapped in Framework
+
+Wrap the Rust crate into an iOS Framework, allowing separate modifications to the related Rust code and UniFFI-generated program configurations for easier integration management and usage in the future.
+
+Overall, you need:
+
+1. Generate an Xcode project file for the Rust crate and compile it into a static library.
+2. Create a new iOS Framework project and import the generated target dependencies.
+3. Compile UDL file to generate related Swift bindings.
+4. Import the generated binding header file into the public header files of the Framework.
+
+## Compile Rust crate using `cargo-xcode`
+
+First, we need to install `cargo-xcode`. This tool can help us generate Xcode project files and compile them into static libraries.
+
+Run the command `cargo install cargo-xcode` to install.
+
+We need to modify the `Cargo.toml` file and add crate-type = ["lib", "staticlib"] in the [lib] section. Here you can add other types according to your needs, but only `staticlib` and `cdylib` can be recognized by `cargo-xcode`.
+
+```toml
+[lib]
+crate-type = ["lib", "staticlib"]
+```
+
+Then run `cargo xcode`, which will generate `<rust-project-name>.xcodeproj` file.
+
+## Create a Framework and add dependencies
+
+Create a new iOS Framework project and drag the `<rust-project-name>.xcodeproj` mentioned above into it.
+
+Add `<rust-project-name>-staticlib` to `Build Phases`-`Target Dependencies` in the iOS Framework.
+
+Add `lib<rust-project-name>_static.a` to the `Link Binary With Libraries` in iOS Framework.
+
+## Generate bindings
+
+In the iOS Framework's `Build Rules`, add a `Run Script` to handle `*.udl` and generate the corresponding bindings.
+
+* Add a build rule processing files with names matching *.udl.
+
+  * Use something like the following as the custom script:
+    * `$HOME/.cargo/bin/uniffi-bindgen-cli generate $INPUT_FILE_PATH --language swift --out-dir $INPUT_FILE_DIR/Generated`
+
+  * Add both the .swift file and the generated bridging header as output files:
+    * `$(INPUT_FILE_DIR)/Generated/$(INPUT_FILE_BASE).swift`
+    * `$(INPUT_FILE_DIR)/Generated/$(INPUT_FILE_BASE)FFI.h`
+
+* Add your `.udl` file to the `Compile Sources` build phase for your framework, so that Xcode will process it using the new build rule and will include the resulting outputs in the build.
+
+You do not need to add the generated Swift code to the list of `Compile Sources` and should not attempt to compile it explicitly; Xcode will figure out what it needs to do with this code based on it being generated from the Build Rule for your `.udl` file.
+
+## Import header files
+
+Import the generated header file in `<framework-name>.h` of iOS Framework.
+
+```c
+#import <Foundation/Foundation.h>
+
+//! Project version number for <framework-name>.
+FOUNDATION_EXPORT double <framework-name>VersionNumber;
+
+//! Project version string for <framework-name>.
+FOUNDATION_EXPORT const unsigned char <framework-name>VersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <framework-name>/PublicHeader.h>
+
+#import "Generated/<rust-project-name>FFI.h"
+
+```
+
+For this to work without complaint from Xcode, you also need to add the generated header file as a Public header in the "Headers" build phase of your project (which is why it's useful to generate this file somewhere in your source tree, rather than in a temporary build directory).
+
+## Examples
+
+After completing the above steps, you can use your Framework by dragging it into your project and importing `<framework-name>`.
+
+It also provides an [ios-with-framework](examples/app/ios-with-framework/) that you can check out under examples/app/ios-with-framework/.
+
+* `ios-with-framework`: Root directory of the sample project
+
+  * `iOS-UniFFI-Framework`: Includes handling of compiling Rust crates into static libraries and generating bindings.
+  * `iOS-UniFFI-App`: Includes the use of the generated framework.
+
+## Known issues
+
+* If you encounter an error when generating bindings, please check if `uniffi-bindgen-cli` is installed. If the path is incorrect, please modify the script path in `Build Rules`.

--- a/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App.xcodeproj/project.pbxproj
+++ b/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App.xcodeproj/project.pbxproj
@@ -1,0 +1,432 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		74B4608C2A5ACD84008F222C /* iOS_UniFFI_App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74B4608B2A5ACD84008F222C /* iOS_UniFFI_App.swift */; };
+		74B4608E2A5ACD84008F222C /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74B4608D2A5ACD84008F222C /* ContentView.swift */; };
+		74B460902A5ACD85008F222C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 74B4608F2A5ACD85008F222C /* Assets.xcassets */; };
+		74B460932A5ACD85008F222C /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 74B460922A5ACD85008F222C /* Preview Assets.xcassets */; };
+		74B460B42A5ACFC2008F222C /* iOS_UniFFI_Framework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74B460A02A5ACDCF008F222C /* iOS_UniFFI_Framework.framework */; };
+		74B460B52A5ACFC2008F222C /* iOS_UniFFI_Framework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 74B460A02A5ACDCF008F222C /* iOS_UniFFI_Framework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		74B4609F2A5ACDCF008F222C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 74B460992A5ACDCF008F222C /* iOS-UniFFI-Framework.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 747ACF602A5AC33C00CA052E;
+			remoteInfo = "iOS-UniFFI-Framework";
+		};
+		74B460A12A5ACDD8008F222C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 74B460992A5ACDCF008F222C /* iOS-UniFFI-Framework.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 747ACF5F2A5AC33C00CA052E;
+			remoteInfo = "iOS-UniFFI-Framework";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		74B460B62A5ACFC2008F222C /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				74B460B52A5ACFC2008F222C /* iOS_UniFFI_Framework.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		74B460882A5ACD84008F222C /* iOS-UniFFI-App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "iOS-UniFFI-App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		74B4608B2A5ACD84008F222C /* iOS_UniFFI_App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOS_UniFFI_App.swift; sourceTree = "<group>"; };
+		74B4608D2A5ACD84008F222C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		74B4608F2A5ACD85008F222C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		74B460922A5ACD85008F222C /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		74B460992A5ACDCF008F222C /* iOS-UniFFI-Framework.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "iOS-UniFFI-Framework.xcodeproj"; path = "../iOS-UniFFI-Framework/iOS-UniFFI-Framework.xcodeproj"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		74B460852A5ACD84008F222C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				74B460B42A5ACFC2008F222C /* iOS_UniFFI_Framework.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		74B4607F2A5ACD84008F222C = {
+			isa = PBXGroup;
+			children = (
+				74B460992A5ACDCF008F222C /* iOS-UniFFI-Framework.xcodeproj */,
+				74B4608A2A5ACD84008F222C /* iOS-UniFFI-App */,
+				74B460892A5ACD84008F222C /* Products */,
+				74B460A32A5ACDDC008F222C /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		74B460892A5ACD84008F222C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				74B460882A5ACD84008F222C /* iOS-UniFFI-App.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		74B4608A2A5ACD84008F222C /* iOS-UniFFI-App */ = {
+			isa = PBXGroup;
+			children = (
+				74B4608B2A5ACD84008F222C /* iOS_UniFFI_App.swift */,
+				74B4608D2A5ACD84008F222C /* ContentView.swift */,
+				74B4608F2A5ACD85008F222C /* Assets.xcassets */,
+				74B460912A5ACD85008F222C /* Preview Content */,
+			);
+			path = "iOS-UniFFI-App";
+			sourceTree = "<group>";
+		};
+		74B460912A5ACD85008F222C /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				74B460922A5ACD85008F222C /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		74B4609A2A5ACDCF008F222C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				74B460A02A5ACDCF008F222C /* iOS_UniFFI_Framework.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		74B460A32A5ACDDC008F222C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		74B460872A5ACD84008F222C /* iOS-UniFFI-App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 74B460962A5ACD85008F222C /* Build configuration list for PBXNativeTarget "iOS-UniFFI-App" */;
+			buildPhases = (
+				74B460842A5ACD84008F222C /* Sources */,
+				74B460852A5ACD84008F222C /* Frameworks */,
+				74B460862A5ACD84008F222C /* Resources */,
+				74B460B62A5ACFC2008F222C /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				74B460A22A5ACDD8008F222C /* PBXTargetDependency */,
+			);
+			name = "iOS-UniFFI-App";
+			productName = "iOS-UniFFI-App";
+			productReference = 74B460882A5ACD84008F222C /* iOS-UniFFI-App.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		74B460802A5ACD84008F222C /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1420;
+				LastUpgradeCheck = 1420;
+				TargetAttributes = {
+					74B460872A5ACD84008F222C = {
+						CreatedOnToolsVersion = 14.2;
+					};
+				};
+			};
+			buildConfigurationList = 74B460832A5ACD84008F222C /* Build configuration list for PBXProject "iOS-UniFFI-App" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 74B4607F2A5ACD84008F222C;
+			productRefGroup = 74B460892A5ACD84008F222C /* Products */;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 74B4609A2A5ACDCF008F222C /* Products */;
+					ProjectRef = 74B460992A5ACDCF008F222C /* iOS-UniFFI-Framework.xcodeproj */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+				74B460872A5ACD84008F222C /* iOS-UniFFI-App */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		74B460A02A5ACDCF008F222C /* iOS_UniFFI_Framework.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = iOS_UniFFI_Framework.framework;
+			remoteRef = 74B4609F2A5ACDCF008F222C /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+
+/* Begin PBXResourcesBuildPhase section */
+		74B460862A5ACD84008F222C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				74B460932A5ACD85008F222C /* Preview Assets.xcassets in Resources */,
+				74B460902A5ACD85008F222C /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		74B460842A5ACD84008F222C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				74B4608E2A5ACD84008F222C /* ContentView.swift in Sources */,
+				74B4608C2A5ACD84008F222C /* iOS_UniFFI_App.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		74B460A22A5ACDD8008F222C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "iOS-UniFFI-Framework";
+			targetProxy = 74B460A12A5ACDD8008F222C /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		74B460942A5ACD85008F222C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		74B460952A5ACD85008F222C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		74B460972A5ACD85008F222C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"iOS-UniFFI-App/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.example.uniffi.iOS-UniFFI-App";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		74B460982A5ACD85008F222C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"iOS-UniFFI-App/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.example.uniffi.iOS-UniFFI-App";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		74B460832A5ACD84008F222C /* Build configuration list for PBXProject "iOS-UniFFI-App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				74B460942A5ACD85008F222C /* Debug */,
+				74B460952A5ACD85008F222C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		74B460962A5ACD85008F222C /* Build configuration list for PBXNativeTarget "iOS-UniFFI-App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				74B460972A5ACD85008F222C /* Debug */,
+				74B460982A5ACD85008F222C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 74B460802A5ACD84008F222C /* Project object */;
+}

--- a/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App/Assets.xcassets/Contents.json
+++ b/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App/ContentView.swift
+++ b/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App/ContentView.swift
@@ -1,0 +1,53 @@
+//
+//  ContentView.swift
+//  iOS-UniFFI-App
+//
+//  Created by Chen on 2023/7/9.
+//
+
+import SwiftUI
+import iOS_UniFFI_Framework
+
+struct ContentView: View {
+    init(todoList: TodoList) {
+        self.todoList = todoList
+    }
+
+    var todoList: TodoList
+    let stride: UInt64 = UInt64(1)
+    @State private var clicked = UInt64.zero
+    @State private var text = ""
+    var body: some View {
+        VStack {
+            HStack {
+                Text("\(clicked)").padding()
+                TextField("New task", text: $text, onCommit:  {
+                    try! self.todoList.addEntry(entry: TodoEntry(text: "\(clicked) \(text)"))
+                    text = ""
+                    clicked = try! add(a: clicked,  b: stride)
+                }).padding()
+            }
+
+            List{
+                Section(header: Text("Still To Do")) {
+                    ForEach(todoList.getEntries(), id: \.self) { entry in
+                        Text(entry.text)
+                    }
+                    .onDelete { index in
+                        if let i = index.first {
+                            let entry = todoList.getEntries()[i]
+                            try! todoList.clearItem(todo: entry.text)
+                            clicked = try! sub(a: clicked,  b: stride)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView(todoList: TodoList())
+    }
+}

--- a/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App/iOS_UniFFI_App.swift
+++ b/examples/app/ios-with-framework/iOS-UniFFI-App/iOS-UniFFI-App/iOS_UniFFI_App.swift
@@ -1,0 +1,18 @@
+//
+//  iOS_UniFFI_App.swift
+//  iOS-UniFFI-App
+//
+//  Created by Chen on 2023/7/9.
+//
+
+import SwiftUI
+import iOS_UniFFI_Framework
+
+@main
+struct iOS_UniFFI_App: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView(todoList: TodoList())
+        }
+    }
+}

--- a/examples/app/ios-with-framework/iOS-UniFFI-Framework/iOS-UniFFI-Framework.xcodeproj/project.pbxproj
+++ b/examples/app/ios-with-framework/iOS-UniFFI-Framework/iOS-UniFFI-Framework.xcodeproj/project.pbxproj
@@ -1,0 +1,517 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		747ACF642A5AC33C00CA052E /* iOS_UniFFI_Framework.h in Headers */ = {isa = PBXBuildFile; fileRef = 747ACF632A5AC33C00CA052E /* iOS_UniFFI_Framework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		747ACF8D2A5AC4BE00CA052E /* libarithmetical_static.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 747ACF7C2A5AC49700CA052E /* libarithmetical_static.a */; };
+		74B460692A5AC4D8008F222C /* libuniffi_todolist_static.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 747ACF852A5AC49F00CA052E /* libuniffi_todolist_static.a */; };
+		74B4606B2A5AC4E3008F222C /* todolist.udl in Sources */ = {isa = PBXBuildFile; fileRef = 747ACF872A5AC4AE00CA052E /* todolist.udl */; };
+		74B4606C2A5AC4E3008F222C /* arithmetic.udl in Sources */ = {isa = PBXBuildFile; fileRef = 747ACF862A5AC4A600CA052E /* arithmetic.udl */; };
+		74B4607D2A5AC5C4008F222C /* arithmeticFFI.h in Headers */ = {isa = PBXBuildFile; fileRef = 74B4607B2A5AC59B008F222C /* arithmeticFFI.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		74B4607E2A5AC5C4008F222C /* todolistFFI.h in Headers */ = {isa = PBXBuildFile; fileRef = 74B4607C2A5AC59B008F222C /* todolistFFI.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXBuildRule section */
+		747ACF732A5AC48100CA052E /* PBXBuildRule */ = {
+			isa = PBXBuildRule;
+			compilerSpec = com.apple.compilers.proxy.script;
+			filePatterns = "*.udl";
+			fileType = pattern.proxy;
+			inputFiles = (
+			);
+			isEditable = 1;
+			outputFiles = (
+				"$(SRCROOT)/Generated/$(INPUT_FILE_BASE)FFI.h",
+				"$(SRCROOT)/Generated/$(INPUT_FILE_BASE).swift",
+			);
+			script = "# Generate swift bindings for the todolist rust library.\necho \"Generating files for $INPUT_FILE_PATH\"\n$HOME/.cargo/bin/uniffi-bindgen-cli \\\n    generate \"$INPUT_FILE_PATH\" \\\n    --language swift \\\n    --out-dir \"$SRCROOT/Generated\"\necho \"Generated files for $INPUT_FILE_BASE in $SRCROOT/Generated\"\n";
+		};
+/* End PBXBuildRule section */
+
+/* Begin PBXContainerItemProxy section */
+		747ACF792A5AC49700CA052E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 747ACF742A5AC49700CA052E /* uniffi-example-arithmetic.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CA60788175FB47D27A557773;
+			remoteInfo = "arithmetical-cdylib";
+		};
+		747ACF7B2A5AC49700CA052E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 747ACF742A5AC49700CA052E /* uniffi-example-arithmetic.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CA60EB84DE7515CCAA24E439;
+			remoteInfo = "arithmetical-staticlib";
+		};
+		747ACF822A5AC49F00CA052E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 747ACF7D2A5AC49E00CA052E /* uniffi-example-todolist.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CA60F5EB3FD0506C70C304D9;
+			remoteInfo = "uniffi_todolist-cdylib";
+		};
+		747ACF842A5AC49F00CA052E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 747ACF7D2A5AC49E00CA052E /* uniffi-example-todolist.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CA60B2A5E9A3ECFD86E21069;
+			remoteInfo = "uniffi_todolist-staticlib";
+		};
+		747ACF882A5AC4B900CA052E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 747ACF7D2A5AC49E00CA052E /* uniffi-example-todolist.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CA60B2A5E9A3FAD84444A21C;
+			remoteInfo = "uniffi_todolist-staticlib";
+		};
+		747ACF8A2A5AC4B900CA052E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 747ACF742A5AC49700CA052E /* uniffi-example-arithmetic.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CA60EB84DE75DFF35BF96DEC;
+			remoteInfo = "arithmetical-staticlib";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		747ACF602A5AC33C00CA052E /* iOS_UniFFI_Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = iOS_UniFFI_Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		747ACF632A5AC33C00CA052E /* iOS_UniFFI_Framework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iOS_UniFFI_Framework.h; sourceTree = "<group>"; };
+		747ACF742A5AC49700CA052E /* uniffi-example-arithmetic.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "uniffi-example-arithmetic.xcodeproj"; path = "../../../arithmetic/uniffi-example-arithmetic.xcodeproj"; sourceTree = "<group>"; };
+		747ACF7D2A5AC49E00CA052E /* uniffi-example-todolist.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "uniffi-example-todolist.xcodeproj"; path = "../../../todolist/uniffi-example-todolist.xcodeproj"; sourceTree = "<group>"; };
+		747ACF862A5AC4A600CA052E /* arithmetic.udl */ = {isa = PBXFileReference; lastKnownFileType = text; name = arithmetic.udl; path = ../../../arithmetic/src/arithmetic.udl; sourceTree = "<group>"; };
+		747ACF872A5AC4AE00CA052E /* todolist.udl */ = {isa = PBXFileReference; lastKnownFileType = text; name = todolist.udl; path = ../../../todolist/src/todolist.udl; sourceTree = "<group>"; };
+		74B4607B2A5AC59B008F222C /* arithmeticFFI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = arithmeticFFI.h; path = Generated/arithmeticFFI.h; sourceTree = "<group>"; };
+		74B4607C2A5AC59B008F222C /* todolistFFI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = todolistFFI.h; path = Generated/todolistFFI.h; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		747ACF5D2A5AC33C00CA052E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				74B460692A5AC4D8008F222C /* libuniffi_todolist_static.a in Frameworks */,
+				747ACF8D2A5AC4BE00CA052E /* libarithmetical_static.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		747ACF562A5AC33C00CA052E = {
+			isa = PBXGroup;
+			children = (
+				74B4607B2A5AC59B008F222C /* arithmeticFFI.h */,
+				74B4607C2A5AC59B008F222C /* todolistFFI.h */,
+				747ACF872A5AC4AE00CA052E /* todolist.udl */,
+				747ACF862A5AC4A600CA052E /* arithmetic.udl */,
+				747ACF7D2A5AC49E00CA052E /* uniffi-example-todolist.xcodeproj */,
+				747ACF742A5AC49700CA052E /* uniffi-example-arithmetic.xcodeproj */,
+				747ACF622A5AC33C00CA052E /* iOS-UniFFI-Framework */,
+				747ACF612A5AC33C00CA052E /* Products */,
+				747ACF8C2A5AC4BE00CA052E /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		747ACF612A5AC33C00CA052E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				747ACF602A5AC33C00CA052E /* iOS_UniFFI_Framework.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		747ACF622A5AC33C00CA052E /* iOS-UniFFI-Framework */ = {
+			isa = PBXGroup;
+			children = (
+				747ACF632A5AC33C00CA052E /* iOS_UniFFI_Framework.h */,
+			);
+			path = "iOS-UniFFI-Framework";
+			sourceTree = "<group>";
+		};
+		747ACF752A5AC49700CA052E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				747ACF7A2A5AC49700CA052E /* arithmetical.dylib */,
+				747ACF7C2A5AC49700CA052E /* libarithmetical_static.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		747ACF7E2A5AC49E00CA052E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				747ACF832A5AC49F00CA052E /* uniffi_todolist.dylib */,
+				747ACF852A5AC49F00CA052E /* libuniffi_todolist_static.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		747ACF8C2A5AC4BE00CA052E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		747ACF5B2A5AC33C00CA052E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				747ACF642A5AC33C00CA052E /* iOS_UniFFI_Framework.h in Headers */,
+				74B4607D2A5AC5C4008F222C /* arithmeticFFI.h in Headers */,
+				74B4607E2A5AC5C4008F222C /* todolistFFI.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		747ACF5F2A5AC33C00CA052E /* iOS-UniFFI-Framework */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 747ACF672A5AC33C00CA052E /* Build configuration list for PBXNativeTarget "iOS-UniFFI-Framework" */;
+			buildPhases = (
+				747ACF5C2A5AC33C00CA052E /* Sources */,
+				747ACF5D2A5AC33C00CA052E /* Frameworks */,
+				747ACF5B2A5AC33C00CA052E /* Headers */,
+				747ACF5E2A5AC33C00CA052E /* Resources */,
+			);
+			buildRules = (
+				747ACF732A5AC48100CA052E /* PBXBuildRule */,
+			);
+			dependencies = (
+				747ACF892A5AC4B900CA052E /* PBXTargetDependency */,
+				747ACF8B2A5AC4B900CA052E /* PBXTargetDependency */,
+			);
+			name = "iOS-UniFFI-Framework";
+			productName = "iOS-UniFFI-Framework";
+			productReference = 747ACF602A5AC33C00CA052E /* iOS_UniFFI_Framework.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		747ACF572A5AC33C00CA052E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastUpgradeCheck = 1420;
+				TargetAttributes = {
+					747ACF5F2A5AC33C00CA052E = {
+						CreatedOnToolsVersion = 14.2;
+					};
+				};
+			};
+			buildConfigurationList = 747ACF5A2A5AC33C00CA052E /* Build configuration list for PBXProject "iOS-UniFFI-Framework" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 747ACF562A5AC33C00CA052E;
+			productRefGroup = 747ACF612A5AC33C00CA052E /* Products */;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 747ACF752A5AC49700CA052E /* Products */;
+					ProjectRef = 747ACF742A5AC49700CA052E /* uniffi-example-arithmetic.xcodeproj */;
+				},
+				{
+					ProductGroup = 747ACF7E2A5AC49E00CA052E /* Products */;
+					ProjectRef = 747ACF7D2A5AC49E00CA052E /* uniffi-example-todolist.xcodeproj */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+				747ACF5F2A5AC33C00CA052E /* iOS-UniFFI-Framework */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		747ACF7A2A5AC49700CA052E /* arithmetical.dylib */ = {
+			isa = PBXReferenceProxy;
+			fileType = "compiled.mach-o.dylib";
+			path = arithmetical.dylib;
+			remoteRef = 747ACF792A5AC49700CA052E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		747ACF7C2A5AC49700CA052E /* libarithmetical_static.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libarithmetical_static.a;
+			remoteRef = 747ACF7B2A5AC49700CA052E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		747ACF832A5AC49F00CA052E /* uniffi_todolist.dylib */ = {
+			isa = PBXReferenceProxy;
+			fileType = "compiled.mach-o.dylib";
+			path = uniffi_todolist.dylib;
+			remoteRef = 747ACF822A5AC49F00CA052E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		747ACF852A5AC49F00CA052E /* libuniffi_todolist_static.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libuniffi_todolist_static.a;
+			remoteRef = 747ACF842A5AC49F00CA052E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+
+/* Begin PBXResourcesBuildPhase section */
+		747ACF5E2A5AC33C00CA052E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		747ACF5C2A5AC33C00CA052E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				74B4606B2A5AC4E3008F222C /* todolist.udl in Sources */,
+				74B4606C2A5AC4E3008F222C /* arithmetic.udl in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		747ACF892A5AC4B900CA052E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "uniffi_todolist-staticlib";
+			targetProxy = 747ACF882A5AC4B900CA052E /* PBXContainerItemProxy */;
+		};
+		747ACF8B2A5AC4B900CA052E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "arithmetical-staticlib";
+			targetProxy = 747ACF8A2A5AC4B900CA052E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		747ACF652A5AC33C00CA052E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		747ACF662A5AC33C00CA052E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		747ACF682A5AC33C00CA052E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.example.uniffi.iOS-UniFFI-Framework";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		747ACF692A5AC33C00CA052E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.example.uniffi.iOS-UniFFI-Framework";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		747ACF5A2A5AC33C00CA052E /* Build configuration list for PBXProject "iOS-UniFFI-Framework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				747ACF652A5AC33C00CA052E /* Debug */,
+				747ACF662A5AC33C00CA052E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		747ACF672A5AC33C00CA052E /* Build configuration list for PBXNativeTarget "iOS-UniFFI-Framework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				747ACF682A5AC33C00CA052E /* Debug */,
+				747ACF692A5AC33C00CA052E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 747ACF572A5AC33C00CA052E /* Project object */;
+}

--- a/examples/app/ios-with-framework/iOS-UniFFI-Framework/iOS-UniFFI-Framework.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/examples/app/ios-with-framework/iOS-UniFFI-Framework/iOS-UniFFI-Framework.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/examples/app/ios-with-framework/iOS-UniFFI-Framework/iOS-UniFFI-Framework.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/app/ios-with-framework/iOS-UniFFI-Framework/iOS-UniFFI-Framework.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/app/ios-with-framework/iOS-UniFFI-Framework/iOS-UniFFI-Framework/iOS_UniFFI_Framework.h
+++ b/examples/app/ios-with-framework/iOS-UniFFI-Framework/iOS-UniFFI-Framework/iOS_UniFFI_Framework.h
@@ -1,0 +1,20 @@
+//
+//  iOS_UniFFI_Framework.h
+//  iOS-UniFFI-Framework
+//
+//  Created by Chen on 2023/7/9.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for iOS_UniFFI_Framework.
+FOUNDATION_EXPORT double iOS_UniFFI_FrameworkVersionNumber;
+
+//! Project version string for iOS_UniFFI_Framework.
+FOUNDATION_EXPORT const unsigned char iOS_UniFFI_FrameworkVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <iOS_UniFFI_Framework/PublicHeader.h>
+
+#import <iOS_UniFFI_Framework/iOS_UniFFI_Framework.h>
+#import <iOS_UniFFI_Framework/arithmeticFFI.h>
+#import <iOS_UniFFI_Framework/todolistFFI.h>

--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib", "cdylib", "staticlib"]
 name = "arithmetical"
 
 [dependencies]

--- a/examples/arithmetic/uniffi-example-arithmetic.xcodeproj/project.pbxproj
+++ b/examples/arithmetic/uniffi-example-arithmetic.xcodeproj/project.pbxproj
@@ -1,0 +1,323 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 53;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		CA60EF77A13D32DE2C7E5A9F /* Cargo.toml in Sources */ = {isa = PBXBuildFile; fileRef = CA60ABAEDDD63EF4668187A5 /* Cargo.toml */; settings = {COMPILER_FLAGS = "--lib"; }; };
+		CA60EF77A13DDFF35BF96DEC /* Cargo.toml in Sources */ = {isa = PBXBuildFile; fileRef = CA60ABAEDDD63EF4668187A5 /* Cargo.toml */; settings = {COMPILER_FLAGS = "--lib"; }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXBuildRule section */
+		CA60ABAEDDD6AC6C1400ACA8 /* PBXBuildRule */ = {
+			isa = PBXBuildRule;
+			compilerSpec = com.apple.compilers.proxy.script;
+			dependencyFile = "$(DERIVED_FILE_DIR)/$(CARGO_XCODE_TARGET_ARCH)-$(EXECUTABLE_NAME).d";
+			filePatterns = "*/Cargo.toml";
+			fileType = pattern.proxy;
+			inputFiles = (
+			);
+			isEditable = 0;
+			name = "Cargo project build";
+			outputFiles = (
+				"$(OBJECT_FILE_DIR)/$(CARGO_XCODE_TARGET_ARCH)-$(EXECUTABLE_NAME)",
+			);
+			script = "# generated with cargo-xcode 1.5.0\n\nset -eu; export PATH=\"$PATH:$HOME/.cargo/bin:/usr/local/bin\";\nif [ \"${IS_MACCATALYST-NO}\" = YES ]; then\n    CARGO_XCODE_TARGET_TRIPLE=\"${CARGO_XCODE_TARGET_ARCH}-apple-ios-macabi\"\nelse\n    CARGO_XCODE_TARGET_TRIPLE=\"${CARGO_XCODE_TARGET_ARCH}-apple-${CARGO_XCODE_TARGET_OS}\"\nfi\nif [ \"$CARGO_XCODE_TARGET_OS\" != \"darwin\" ]; then\n    PATH=\"${PATH/\\/Contents\\/Developer\\/Toolchains\\/XcodeDefault.xctoolchain\\/usr\\/bin:/xcode-provided-ld-cant-link-lSystem-for-the-host-build-script:}\"\nfi\nPATH=\"$PATH:/opt/homebrew/bin\" # Rust projects often depend on extra tools like nasm, which Xcode lacks\nif [ \"$CARGO_XCODE_BUILD_MODE\" == release ]; then\n    OTHER_INPUT_FILE_FLAGS=\"${OTHER_INPUT_FILE_FLAGS} --release\"\nfi\nif command -v rustup &> /dev/null; then\n    if ! rustup target list --installed | egrep -q \"${CARGO_XCODE_TARGET_TRIPLE}\"; then\n        echo \"warning: this build requires rustup toolchain for $CARGO_XCODE_TARGET_TRIPLE, but it isn't installed\"\n        rustup target add \"${CARGO_XCODE_TARGET_TRIPLE}\" || echo >&2 \"warning: can't install $CARGO_XCODE_TARGET_TRIPLE\"\n    fi\nfi\nif [ \"$ACTION\" = clean ]; then\n ( set -x; cargo clean --manifest-path=\"$SCRIPT_INPUT_FILE\" ${OTHER_INPUT_FILE_FLAGS} --target=\"${CARGO_XCODE_TARGET_TRIPLE}\"; );\nelse\n ( set -x; cargo build --manifest-path=\"$SCRIPT_INPUT_FILE\" --features=\"${CARGO_XCODE_FEATURES:-}\" ${OTHER_INPUT_FILE_FLAGS} --target=\"${CARGO_XCODE_TARGET_TRIPLE}\"; );\nfi\n# it's too hard to explain Cargo's actual exe path to Xcode build graph, so hardlink to a known-good path instead\nBUILT_SRC=\"${CARGO_TARGET_DIR}/${CARGO_XCODE_TARGET_TRIPLE}/${CARGO_XCODE_BUILD_MODE}/${CARGO_XCODE_CARGO_FILE_NAME}\"\nln -f -- \"$BUILT_SRC\" \"$SCRIPT_OUTPUT_FILE_0\"\n\n# xcode generates dep file, but for its own path, so append our rename to it\nDEP_FILE_SRC=\"${CARGO_TARGET_DIR}/${CARGO_XCODE_TARGET_TRIPLE}/${CARGO_XCODE_BUILD_MODE}/${CARGO_XCODE_CARGO_DEP_FILE_NAME}\"\nif [ -f \"$DEP_FILE_SRC\" ]; then\n    DEP_FILE_DST=\"${DERIVED_FILE_DIR}/${CARGO_XCODE_TARGET_ARCH}-${EXECUTABLE_NAME}.d\"\n    cp -f \"$DEP_FILE_SRC\" \"$DEP_FILE_DST\"\n    echo >> \"$DEP_FILE_DST\" \"$SCRIPT_OUTPUT_FILE_0: $BUILT_SRC\"\nfi\n\n# lipo script needs to know all the platform-specific files that have been built\n# archs is in the file name, so that paths don't stay around after archs change\n# must match input for LipoScript\nFILE_LIST=\"${DERIVED_FILE_DIR}/${ARCHS}-${EXECUTABLE_NAME}.xcfilelist\"\ntouch \"$FILE_LIST\"\nif ! egrep -q \"$SCRIPT_OUTPUT_FILE_0\" \"$FILE_LIST\" ; then\n    echo >> \"$FILE_LIST\" \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
+		};
+/* End PBXBuildRule section */
+
+/* Begin PBXFileReference section */
+		ADDEDBA66A6E1 /* libresolv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = usr/lib/libresolv.tbd; sourceTree = SDKROOT; };
+		CA60788175FB47D27A557773 /* arithmetical.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = arithmetical.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		CA60ABAEDDD63EF4668187A5 /* Cargo.toml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Cargo.toml; sourceTree = "<group>"; };
+		CA60EB84DE7515CCAA24E439 /* libarithmetical_static.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libarithmetical_static.a; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		ADDEDBA66A6E2 /* Required for static linking */ = {
+			isa = PBXGroup;
+			children = (
+				ADDEDBA66A6E1 /* libresolv.tbd */,
+			);
+			name = "Required for static linking";
+			sourceTree = "<group>";
+		};
+		CA60ABAEDDD622869D176AE5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CA60788175FB47D27A557773 /* arithmetical.dylib */,
+				CA60EB84DE7515CCAA24E439 /* libarithmetical_static.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		CA60ABAEDDD698AF0B5890DB /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				ADDEDBA66A6E2 /* Required for static linking */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		CA60ABAEDDD6D65BC3C892A8 = {
+			isa = PBXGroup;
+			children = (
+				CA60ABAEDDD63EF4668187A5 /* Cargo.toml */,
+				CA60ABAEDDD622869D176AE5 /* Products */,
+				CA60ABAEDDD698AF0B5890DB /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		CA60788175FB32DE2C7E5A9F /* arithmetical-cdylib */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CA60AB3B365E32DE2C7E5A9F /* Build configuration list for PBXNativeTarget "arithmetical-cdylib" */;
+			buildPhases = (
+				CA60205076DB32DE2C7E5A9F /* Sources */,
+				CA60ABAEDDD6AF6EBB7F357C /* Universal Binary lipo */,
+			);
+			buildRules = (
+				CA60ABAEDDD6AC6C1400ACA8 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = "arithmetical-cdylib";
+			productName = arithmetical.dylib;
+			productReference = CA60788175FB47D27A557773 /* arithmetical.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		CA60EB84DE75DFF35BF96DEC /* arithmetical-staticlib */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CA60AB3B365EDFF35BF96DEC /* Build configuration list for PBXNativeTarget "arithmetical-staticlib" */;
+			buildPhases = (
+				CA60205076DBDFF35BF96DEC /* Sources */,
+				CA60ABAEDDD6AF6EBB7F357C /* Universal Binary lipo */,
+			);
+			buildRules = (
+				CA60ABAEDDD6AC6C1400ACA8 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = "arithmetical-staticlib";
+			productName = libarithmetical_static.a;
+			productReference = CA60EB84DE7515CCAA24E439 /* libarithmetical_static.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CA60ABAEDDD6E04653AD465F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1300;
+				TargetAttributes = {
+					CA60788175FB32DE2C7E5A9F = {
+						CreatedOnToolsVersion = 9.2;
+						ProvisioningStyle = Automatic;
+					};
+					CA60EB84DE75DFF35BF96DEC = {
+						CreatedOnToolsVersion = 9.2;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = CA60ABAEDDD680E02D6C7F57 /* Build configuration list for PBXProject "uniffi-example-arithmetic" */;
+			compatibilityVersion = "Xcode 11.4";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = CA60ABAEDDD6D65BC3C892A8;
+			productRefGroup = CA60ABAEDDD622869D176AE5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CA60788175FB32DE2C7E5A9F /* arithmetical-cdylib */,
+				CA60EB84DE75DFF35BF96DEC /* arithmetical-staticlib */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		CA60ABAEDDD6AF6EBB7F357C /* Universal Binary lipo */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(DERIVED_FILE_DIR)/$(ARCHS)-$(EXECUTABLE_NAME).xcfilelist",
+			);
+			name = "Universal Binary lipo";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# generated with cargo-xcode 1.5.0\n\n            set -eux; cat \"$DERIVED_FILE_DIR/$ARCHS-$EXECUTABLE_NAME.xcfilelist\" | tr '\\n' '\\0' | xargs -0 lipo -create -output \"$TARGET_BUILD_DIR/$EXECUTABLE_PATH\"\n            if [ ${LD_DYLIB_INSTALL_NAME:+1} ]; then\n                install_name_tool -id \"$LD_DYLIB_INSTALL_NAME\" \"$TARGET_BUILD_DIR/$EXECUTABLE_PATH\"\n            fi\n        ";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CA60205076DB32DE2C7E5A9F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CA60EF77A13D32DE2C7E5A9F /* Cargo.toml in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CA60205076DBDFF35BF96DEC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CA60EF77A13DDFF35BF96DEC /* Cargo.toml in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		CA600CBD1ABB228BE02872F8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CARGO_TARGET_DIR = "$(PROJECT_TEMP_DIR)/cargo_target";
+				CARGO_XCODE_BUILD_MODE = debug;
+				CARGO_XCODE_FEATURES = "";
+				"CARGO_XCODE_TARGET_ARCH[arch=arm64*]" = aarch64;
+				"CARGO_XCODE_TARGET_ARCH[arch=i386]" = i686;
+				"CARGO_XCODE_TARGET_ARCH[arch=x86_64*]" = x86_64;
+				"CARGO_XCODE_TARGET_OS[sdk=appletvos*]" = tvos;
+				"CARGO_XCODE_TARGET_OS[sdk=appletvsimulator*]" = tvos;
+				"CARGO_XCODE_TARGET_OS[sdk=iphoneos*]" = ios;
+				"CARGO_XCODE_TARGET_OS[sdk=iphonesimulator*]" = "ios-sim";
+				"CARGO_XCODE_TARGET_OS[sdk=iphonesimulator*][arch=x86_64*]" = ios;
+				"CARGO_XCODE_TARGET_OS[sdk=macosx*]" = darwin;
+				CURRENT_PROJECT_VERSION = 0.22;
+				MARKETING_VERSION = 0.22.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "uniffi-example-arithmetic";
+				SDKROOT = macosx;
+				SUPPORTS_MACCATALYST = YES;
+			};
+			name = Debug;
+		};
+		CA600CBD1ABB3CC16B37690B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CARGO_TARGET_DIR = "$(PROJECT_TEMP_DIR)/cargo_target";
+				CARGO_XCODE_BUILD_MODE = release;
+				CARGO_XCODE_FEATURES = "";
+				"CARGO_XCODE_TARGET_ARCH[arch=arm64*]" = aarch64;
+				"CARGO_XCODE_TARGET_ARCH[arch=i386]" = i686;
+				"CARGO_XCODE_TARGET_ARCH[arch=x86_64*]" = x86_64;
+				"CARGO_XCODE_TARGET_OS[sdk=appletvos*]" = tvos;
+				"CARGO_XCODE_TARGET_OS[sdk=appletvsimulator*]" = tvos;
+				"CARGO_XCODE_TARGET_OS[sdk=iphoneos*]" = ios;
+				"CARGO_XCODE_TARGET_OS[sdk=iphonesimulator*]" = "ios-sim";
+				"CARGO_XCODE_TARGET_OS[sdk=iphonesimulator*][arch=x86_64*]" = ios;
+				"CARGO_XCODE_TARGET_OS[sdk=macosx*]" = darwin;
+				CURRENT_PROJECT_VERSION = 0.22;
+				MARKETING_VERSION = 0.22.0;
+				PRODUCT_NAME = "uniffi-example-arithmetic";
+				SDKROOT = macosx;
+				SUPPORTS_MACCATALYST = YES;
+			};
+			name = Release;
+		};
+		CA604E7D374832DE2C7E5A9F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CARGO_XCODE_CARGO_DEP_FILE_NAME = libarithmetical.d;
+				CARGO_XCODE_CARGO_FILE_NAME = libarithmetical.dylib;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				PRODUCT_NAME = arithmetical;
+				SUPPORTED_PLATFORMS = macosx;
+			};
+			name = Release;
+		};
+		CA604E7D3748DFF35BF96DEC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CARGO_XCODE_CARGO_DEP_FILE_NAME = libarithmetical.d;
+				CARGO_XCODE_CARGO_FILE_NAME = libarithmetical.a;
+				INSTALL_GROUP = "";
+				INSTALL_MODE_FLAG = "";
+				INSTALL_OWNER = "";
+				PRODUCT_NAME = arithmetical_static;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+			};
+			name = Release;
+		};
+		CA60502B5E5D32DE2C7E5A9F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CARGO_XCODE_CARGO_DEP_FILE_NAME = libarithmetical.d;
+				CARGO_XCODE_CARGO_FILE_NAME = libarithmetical.dylib;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				PRODUCT_NAME = arithmetical;
+				SUPPORTED_PLATFORMS = macosx;
+			};
+			name = Debug;
+		};
+		CA60502B5E5DDFF35BF96DEC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CARGO_XCODE_CARGO_DEP_FILE_NAME = libarithmetical.d;
+				CARGO_XCODE_CARGO_FILE_NAME = libarithmetical.a;
+				INSTALL_GROUP = "";
+				INSTALL_MODE_FLAG = "";
+				INSTALL_OWNER = "";
+				PRODUCT_NAME = arithmetical_static;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CA60AB3B365E32DE2C7E5A9F /* Build configuration list for PBXNativeTarget "arithmetical-cdylib" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CA604E7D374832DE2C7E5A9F /* Release */,
+				CA60502B5E5D32DE2C7E5A9F /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CA60AB3B365EDFF35BF96DEC /* Build configuration list for PBXNativeTarget "arithmetical-staticlib" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CA604E7D3748DFF35BF96DEC /* Release */,
+				CA60502B5E5DDFF35BF96DEC /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CA60ABAEDDD680E02D6C7F57 /* Build configuration list for PBXProject "uniffi-example-arithmetic" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CA600CBD1ABB3CC16B37690B /* Release */,
+				CA600CBD1ABB228BE02872F8 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = CA60ABAEDDD6E04653AD465F /* Project object */;
+}

--- a/examples/arithmetic/uniffi-example-arithmetic.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/examples/arithmetic/uniffi-example-arithmetic.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/examples/arithmetic/uniffi-example-arithmetic.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/arithmetic/uniffi-example-arithmetic.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/todolist/Cargo.toml
+++ b/examples/todolist/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib", "cdylib", "staticlib"]
 name = "uniffi_todolist"
 
 [dependencies]

--- a/examples/todolist/uniffi-example-todolist.xcodeproj/project.pbxproj
+++ b/examples/todolist/uniffi-example-todolist.xcodeproj/project.pbxproj
@@ -1,0 +1,323 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 53;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		CA604A62DD00C9127F1ADDE7 /* Cargo.toml in Sources */ = {isa = PBXBuildFile; fileRef = CA6071FFDD3D3EF4668187A5 /* Cargo.toml */; settings = {COMPILER_FLAGS = "--lib"; }; };
+		CA604A62DD00FAD84444A21C /* Cargo.toml in Sources */ = {isa = PBXBuildFile; fileRef = CA6071FFDD3D3EF4668187A5 /* Cargo.toml */; settings = {COMPILER_FLAGS = "--lib"; }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXBuildRule section */
+		CA6071FFDD3DAC6C1400ACA8 /* PBXBuildRule */ = {
+			isa = PBXBuildRule;
+			compilerSpec = com.apple.compilers.proxy.script;
+			dependencyFile = "$(DERIVED_FILE_DIR)/$(CARGO_XCODE_TARGET_ARCH)-$(EXECUTABLE_NAME).d";
+			filePatterns = "*/Cargo.toml";
+			fileType = pattern.proxy;
+			inputFiles = (
+			);
+			isEditable = 0;
+			name = "Cargo project build";
+			outputFiles = (
+				"$(OBJECT_FILE_DIR)/$(CARGO_XCODE_TARGET_ARCH)-$(EXECUTABLE_NAME)",
+			);
+			script = "# generated with cargo-xcode 1.5.0\n\nset -eu; export PATH=\"$PATH:$HOME/.cargo/bin:/usr/local/bin\";\nif [ \"${IS_MACCATALYST-NO}\" = YES ]; then\n    CARGO_XCODE_TARGET_TRIPLE=\"${CARGO_XCODE_TARGET_ARCH}-apple-ios-macabi\"\nelse\n    CARGO_XCODE_TARGET_TRIPLE=\"${CARGO_XCODE_TARGET_ARCH}-apple-${CARGO_XCODE_TARGET_OS}\"\nfi\nif [ \"$CARGO_XCODE_TARGET_OS\" != \"darwin\" ]; then\n    PATH=\"${PATH/\\/Contents\\/Developer\\/Toolchains\\/XcodeDefault.xctoolchain\\/usr\\/bin:/xcode-provided-ld-cant-link-lSystem-for-the-host-build-script:}\"\nfi\nPATH=\"$PATH:/opt/homebrew/bin\" # Rust projects often depend on extra tools like nasm, which Xcode lacks\nif [ \"$CARGO_XCODE_BUILD_MODE\" == release ]; then\n    OTHER_INPUT_FILE_FLAGS=\"${OTHER_INPUT_FILE_FLAGS} --release\"\nfi\nif command -v rustup &> /dev/null; then\n    if ! rustup target list --installed | egrep -q \"${CARGO_XCODE_TARGET_TRIPLE}\"; then\n        echo \"warning: this build requires rustup toolchain for $CARGO_XCODE_TARGET_TRIPLE, but it isn't installed\"\n        rustup target add \"${CARGO_XCODE_TARGET_TRIPLE}\" || echo >&2 \"warning: can't install $CARGO_XCODE_TARGET_TRIPLE\"\n    fi\nfi\nif [ \"$ACTION\" = clean ]; then\n ( set -x; cargo clean --manifest-path=\"$SCRIPT_INPUT_FILE\" ${OTHER_INPUT_FILE_FLAGS} --target=\"${CARGO_XCODE_TARGET_TRIPLE}\"; );\nelse\n ( set -x; cargo build --manifest-path=\"$SCRIPT_INPUT_FILE\" --features=\"${CARGO_XCODE_FEATURES:-}\" ${OTHER_INPUT_FILE_FLAGS} --target=\"${CARGO_XCODE_TARGET_TRIPLE}\"; );\nfi\n# it's too hard to explain Cargo's actual exe path to Xcode build graph, so hardlink to a known-good path instead\nBUILT_SRC=\"${CARGO_TARGET_DIR}/${CARGO_XCODE_TARGET_TRIPLE}/${CARGO_XCODE_BUILD_MODE}/${CARGO_XCODE_CARGO_FILE_NAME}\"\nln -f -- \"$BUILT_SRC\" \"$SCRIPT_OUTPUT_FILE_0\"\n\n# xcode generates dep file, but for its own path, so append our rename to it\nDEP_FILE_SRC=\"${CARGO_TARGET_DIR}/${CARGO_XCODE_TARGET_TRIPLE}/${CARGO_XCODE_BUILD_MODE}/${CARGO_XCODE_CARGO_DEP_FILE_NAME}\"\nif [ -f \"$DEP_FILE_SRC\" ]; then\n    DEP_FILE_DST=\"${DERIVED_FILE_DIR}/${CARGO_XCODE_TARGET_ARCH}-${EXECUTABLE_NAME}.d\"\n    cp -f \"$DEP_FILE_SRC\" \"$DEP_FILE_DST\"\n    echo >> \"$DEP_FILE_DST\" \"$SCRIPT_OUTPUT_FILE_0: $BUILT_SRC\"\nfi\n\n# lipo script needs to know all the platform-specific files that have been built\n# archs is in the file name, so that paths don't stay around after archs change\n# must match input for LipoScript\nFILE_LIST=\"${DERIVED_FILE_DIR}/${ARCHS}-${EXECUTABLE_NAME}.xcfilelist\"\ntouch \"$FILE_LIST\"\nif ! egrep -q \"$SCRIPT_OUTPUT_FILE_0\" \"$FILE_LIST\" ; then\n    echo >> \"$FILE_LIST\" \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
+		};
+/* End PBXBuildRule section */
+
+/* Begin PBXFileReference section */
+		ADDEDBA66A6E1 /* libresolv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = usr/lib/libresolv.tbd; sourceTree = SDKROOT; };
+		CA6071FFDD3D3EF4668187A5 /* Cargo.toml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Cargo.toml; sourceTree = "<group>"; };
+		CA60B2A5E9A3ECFD86E21069 /* libuniffi_todolist_static.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libuniffi_todolist_static.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		CA60F5EB3FD0506C70C304D9 /* uniffi_todolist.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = uniffi_todolist.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		ADDEDBA66A6E2 /* Required for static linking */ = {
+			isa = PBXGroup;
+			children = (
+				ADDEDBA66A6E1 /* libresolv.tbd */,
+			);
+			name = "Required for static linking";
+			sourceTree = "<group>";
+		};
+		CA6071FFDD3D22869D176AE5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CA60F5EB3FD0506C70C304D9 /* uniffi_todolist.dylib */,
+				CA60B2A5E9A3ECFD86E21069 /* libuniffi_todolist_static.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		CA6071FFDD3D98AF0B5890DB /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				ADDEDBA66A6E2 /* Required for static linking */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		CA6071FFDD3DD65BC3C892A8 = {
+			isa = PBXGroup;
+			children = (
+				CA6071FFDD3D3EF4668187A5 /* Cargo.toml */,
+				CA6071FFDD3D22869D176AE5 /* Products */,
+				CA6071FFDD3D98AF0B5890DB /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		CA60B2A5E9A3FAD84444A21C /* uniffi_todolist-staticlib */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CA609AAE9F76FAD84444A21C /* Build configuration list for PBXNativeTarget "uniffi_todolist-staticlib" */;
+			buildPhases = (
+				CA609E47F9BBFAD84444A21C /* Sources */,
+				CA6071FFDD3DAF6EBB7F357C /* Universal Binary lipo */,
+			);
+			buildRules = (
+				CA6071FFDD3DAC6C1400ACA8 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = "uniffi_todolist-staticlib";
+			productName = libuniffi_todolist_static.a;
+			productReference = CA60B2A5E9A3ECFD86E21069 /* libuniffi_todolist_static.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		CA60F5EB3FD0C9127F1ADDE7 /* uniffi_todolist-cdylib */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CA609AAE9F76C9127F1ADDE7 /* Build configuration list for PBXNativeTarget "uniffi_todolist-cdylib" */;
+			buildPhases = (
+				CA609E47F9BBC9127F1ADDE7 /* Sources */,
+				CA6071FFDD3DAF6EBB7F357C /* Universal Binary lipo */,
+			);
+			buildRules = (
+				CA6071FFDD3DAC6C1400ACA8 /* PBXBuildRule */,
+			);
+			dependencies = (
+			);
+			name = "uniffi_todolist-cdylib";
+			productName = uniffi_todolist.dylib;
+			productReference = CA60F5EB3FD0506C70C304D9 /* uniffi_todolist.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CA6071FFDD3DE04653AD465F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1300;
+				TargetAttributes = {
+					CA60B2A5E9A3FAD84444A21C = {
+						CreatedOnToolsVersion = 9.2;
+						ProvisioningStyle = Automatic;
+					};
+					CA60F5EB3FD0C9127F1ADDE7 = {
+						CreatedOnToolsVersion = 9.2;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = CA6071FFDD3D80E02D6C7F57 /* Build configuration list for PBXProject "uniffi-example-todolist" */;
+			compatibilityVersion = "Xcode 11.4";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = CA6071FFDD3DD65BC3C892A8;
+			productRefGroup = CA6071FFDD3D22869D176AE5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CA60F5EB3FD0C9127F1ADDE7 /* uniffi_todolist-cdylib */,
+				CA60B2A5E9A3FAD84444A21C /* uniffi_todolist-staticlib */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		CA6071FFDD3DAF6EBB7F357C /* Universal Binary lipo */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(DERIVED_FILE_DIR)/$(ARCHS)-$(EXECUTABLE_NAME).xcfilelist",
+			);
+			name = "Universal Binary lipo";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# generated with cargo-xcode 1.5.0\n\n            set -eux; cat \"$DERIVED_FILE_DIR/$ARCHS-$EXECUTABLE_NAME.xcfilelist\" | tr '\\n' '\\0' | xargs -0 lipo -create -output \"$TARGET_BUILD_DIR/$EXECUTABLE_PATH\"\n            if [ ${LD_DYLIB_INSTALL_NAME:+1} ]; then\n                install_name_tool -id \"$LD_DYLIB_INSTALL_NAME\" \"$TARGET_BUILD_DIR/$EXECUTABLE_PATH\"\n            fi\n        ";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CA609E47F9BBC9127F1ADDE7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CA604A62DD00C9127F1ADDE7 /* Cargo.toml in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CA609E47F9BBFAD84444A21C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CA604A62DD00FAD84444A21C /* Cargo.toml in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		CA6026136BA0C9127F1ADDE7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CARGO_XCODE_CARGO_DEP_FILE_NAME = libuniffi_todolist.d;
+				CARGO_XCODE_CARGO_FILE_NAME = libuniffi_todolist.dylib;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				PRODUCT_NAME = uniffi_todolist;
+				SUPPORTED_PLATFORMS = macosx;
+			};
+			name = Debug;
+		};
+		CA6026136BA0FAD84444A21C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CARGO_XCODE_CARGO_DEP_FILE_NAME = libuniffi_todolist.d;
+				CARGO_XCODE_CARGO_FILE_NAME = libuniffi_todolist.a;
+				INSTALL_GROUP = "";
+				INSTALL_MODE_FLAG = "";
+				INSTALL_OWNER = "";
+				PRODUCT_NAME = uniffi_todolist_static;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+			};
+			name = Debug;
+		};
+		CA603D28B393228BE02872F8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CARGO_TARGET_DIR = "$(PROJECT_TEMP_DIR)/cargo_target";
+				CARGO_XCODE_BUILD_MODE = debug;
+				CARGO_XCODE_FEATURES = "";
+				"CARGO_XCODE_TARGET_ARCH[arch=arm64*]" = aarch64;
+				"CARGO_XCODE_TARGET_ARCH[arch=i386]" = i686;
+				"CARGO_XCODE_TARGET_ARCH[arch=x86_64*]" = x86_64;
+				"CARGO_XCODE_TARGET_OS[sdk=appletvos*]" = tvos;
+				"CARGO_XCODE_TARGET_OS[sdk=appletvsimulator*]" = tvos;
+				"CARGO_XCODE_TARGET_OS[sdk=iphoneos*]" = ios;
+				"CARGO_XCODE_TARGET_OS[sdk=iphonesimulator*]" = "ios-sim";
+				"CARGO_XCODE_TARGET_OS[sdk=iphonesimulator*][arch=x86_64*]" = ios;
+				"CARGO_XCODE_TARGET_OS[sdk=macosx*]" = darwin;
+				CURRENT_PROJECT_VERSION = 0.22;
+				MARKETING_VERSION = 0.22.0;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "uniffi-example-todolist";
+				SDKROOT = macosx;
+				SUPPORTS_MACCATALYST = YES;
+			};
+			name = Debug;
+		};
+		CA603D28B3933CC16B37690B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CARGO_TARGET_DIR = "$(PROJECT_TEMP_DIR)/cargo_target";
+				CARGO_XCODE_BUILD_MODE = release;
+				CARGO_XCODE_FEATURES = "";
+				"CARGO_XCODE_TARGET_ARCH[arch=arm64*]" = aarch64;
+				"CARGO_XCODE_TARGET_ARCH[arch=i386]" = i686;
+				"CARGO_XCODE_TARGET_ARCH[arch=x86_64*]" = x86_64;
+				"CARGO_XCODE_TARGET_OS[sdk=appletvos*]" = tvos;
+				"CARGO_XCODE_TARGET_OS[sdk=appletvsimulator*]" = tvos;
+				"CARGO_XCODE_TARGET_OS[sdk=iphoneos*]" = ios;
+				"CARGO_XCODE_TARGET_OS[sdk=iphonesimulator*]" = "ios-sim";
+				"CARGO_XCODE_TARGET_OS[sdk=iphonesimulator*][arch=x86_64*]" = ios;
+				"CARGO_XCODE_TARGET_OS[sdk=macosx*]" = darwin;
+				CURRENT_PROJECT_VERSION = 0.22;
+				MARKETING_VERSION = 0.22.0;
+				PRODUCT_NAME = "uniffi-example-todolist";
+				SDKROOT = macosx;
+				SUPPORTS_MACCATALYST = YES;
+			};
+			name = Release;
+		};
+		CA60FA72E96AC9127F1ADDE7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CARGO_XCODE_CARGO_DEP_FILE_NAME = libuniffi_todolist.d;
+				CARGO_XCODE_CARGO_FILE_NAME = libuniffi_todolist.dylib;
+				DYLIB_COMPATIBILITY_VERSION = 0;
+				PRODUCT_NAME = uniffi_todolist;
+				SUPPORTED_PLATFORMS = macosx;
+			};
+			name = Release;
+		};
+		CA60FA72E96AFAD84444A21C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CARGO_XCODE_CARGO_DEP_FILE_NAME = libuniffi_todolist.d;
+				CARGO_XCODE_CARGO_FILE_NAME = libuniffi_todolist.a;
+				INSTALL_GROUP = "";
+				INSTALL_MODE_FLAG = "";
+				INSTALL_OWNER = "";
+				PRODUCT_NAME = uniffi_todolist_static;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CA6071FFDD3D80E02D6C7F57 /* Build configuration list for PBXProject "uniffi-example-todolist" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CA603D28B3933CC16B37690B /* Release */,
+				CA603D28B393228BE02872F8 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CA609AAE9F76C9127F1ADDE7 /* Build configuration list for PBXNativeTarget "uniffi_todolist-cdylib" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CA60FA72E96AC9127F1ADDE7 /* Release */,
+				CA6026136BA0C9127F1ADDE7 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CA609AAE9F76FAD84444A21C /* Build configuration list for PBXNativeTarget "uniffi_todolist-staticlib" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CA60FA72E96AFAD84444A21C /* Release */,
+				CA6026136BA0FAD84444A21C /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = CA6071FFDD3DE04653AD465F /* Project object */;
+}

--- a/examples/todolist/uniffi-example-todolist.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/examples/todolist/uniffi-example-todolist.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/examples/todolist/uniffi-example-todolist.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/todolist/uniffi-example-todolist.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
As mentioned in issue #1623 , by using the `cargo-xcode` crate, Rust crates can be quickly compiled into static (or dynamic) libraries. Then, by wrapping the generated code with UniFFI into a Framework, the process of integrating Rust crates can be simplified.