### PR TITLE
Python: Type Hints for class instance variables & other type hints

### DIFF
--- a/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
@@ -19,7 +19,11 @@ class {{ type_name }}:
     # Each enum variant is a nested class of the enum itself.
     {% for variant in e.variants() -%}
     class {{ variant.name()|enum_variant_py }}:
-        def __init__(self,{% for field in variant.fields() %}{{ field.name()|var_name }}{% if loop.last %}{% else %}, {% endif %}{% endfor %}):
+        {% for field in variant.fields() %}
+            {{- field.name()|var_name }}: "{{- field|type_name }}";
+        {%- endfor %}
+
+        def __init__(self,{% for field in variant.fields() %}{{ field.name()|var_name }}: "{{- field|type_name }}"{% if loop.last %}{% else %}, {% endif %}{% endfor %}):
             {% if variant.has_fields() %}
             {%- for field in variant.fields() %}
             self.{{ field.name()|var_name }} = {{ field.name()|var_name }}

--- a/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
@@ -23,6 +23,7 @@ class {{ type_name }}:
             {{- field.name()|var_name }}: "{{- field|type_name }}";
         {%- endfor %}
 
+        @typing.no_type_check
         def __init__(self,{% for field in variant.fields() %}{{ field.name()|var_name }}: "{{- field|type_name }}"{% if loop.last %}{% else %}, {% endif %}{% endfor %}):
             {% if variant.has_fields() %}
             {%- for field in variant.fields() %}

--- a/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
@@ -4,6 +4,7 @@ class {{ type_name }}:
         {{- field.name()|var_name }}: "{{- field|type_name }}";
     {%- endfor %}
 
+    @typing.no_type_check
     def __init__(self, {% for field in rec.fields() %}
     {{- field.name()|var_name }}: "{{- field|type_name }}"
     {%- if field.default_value().is_some() %} = _DEFAULT{% endif %}

--- a/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
@@ -1,5 +1,8 @@
 {%- let rec = ci|get_record_definition(name) %}
 class {{ type_name }}:
+    {% for field in rec.fields() %}
+        {{- field.name()|var_name }}: "{{- field|type_name }}";
+    {%- endfor %}
 
     def __init__(self, {% for field in rec.fields() %}
     {{- field.name()|var_name }}

--- a/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
@@ -5,7 +5,7 @@ class {{ type_name }}:
     {%- endfor %}
 
     def __init__(self, {% for field in rec.fields() %}
-    {{- field.name()|var_name }}
+    {{- field.name()|var_name }}: "{{- field|type_name }}"
     {%- if field.default_value().is_some() %} = _DEFAULT{% endif %}
     {%- if !loop.last %}, {% endif %}
     {%- endfor %}):

--- a/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
@@ -12,7 +12,7 @@ async def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}):
 {%- match func.return_type() -%}
 {%- when Some with (return_type) %}
 
-def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}):
+def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}) -> "{{ return_type|type_name }}":
     {%- call py::setup_args(func) %}
     return {{ return_type|lift_fn }}({% call py::to_ffi_call(func) %})
 {% when None %}


### PR DESCRIPTION
I'm beginning to make use of the generated Python bindings for a few of the things that I am building and have noticed that the generated bindings are missing type hints in some areas:

1. Instance variables on classes (UniFFI records, not objects) and their associated `__init__` method.
2. Instance variables on non-flat enum variants and their associated `__init__` method.
3. In the returns of top-level functions.

For the first two points, this PR adds type hints to classes in accordance to PEP-526's section on "[Class and instance variable annotations](https://peps.python.org/pep-0526/#class-and-instance-variable-annotations)" where the type hints are added as seen below:

```py
class Human:
    name: "str"
    age: "int"
    country: "Country"

    def __init__(self, name: "str", age: "int", country: "Country"):
        pass
```

For the third item, the type hints follow the general function type hints seen in PEP-484.

I took some of the generated bindings after this change out for a spin and my IDE was finally able to figure out the type of instance variables, whether an instance variable exists or not, and the IDE support felt overall better because the IDE was able to take advantage of the added type hints.