### PR TITLE
Fix documentation so it doesn't use an invalid `&mut self`

### DIFF
--- a/docs/manual/src/udl/interfaces.md
+++ b/docs/manual/src/udl/interfaces.md
@@ -18,7 +18,7 @@ impl TodoList {
         }
     }
 
-    fn add_item(&mut self, todo: String) {
+    fn add_item(&self, todo: String) {
         self.items.write().unwrap().push(todo);
     }
 


### PR DESCRIPTION
The introduction to interfaces is wrong - it uses `&mut self` in a place where it can't be used.