### PR TITLE
Remove almost all references to `DOMString`

### DIFF
--- a/docs/manual/src/internals/lifting_and_lowering.md
+++ b/docs/manual/src/internals/lifting_and_lowering.md
@@ -64,7 +64,7 @@ Calling this function from foreign language code involves the following steps:
 | `duration` | `RustBuffer` struct pointing to a u64 representing seconds and a u32 representing nanoseconds |
 | `T?` | `RustBuffer` struct pointing to serialized bytes |
 | `sequence<T>` | `RustBuffer` struct pointing to serialized bytes |
-| `record<DOMString, T>` | `RustBuffer` struct pointing to serialized bytes |
+| `record<string, T>` | `RustBuffer` struct pointing to serialized bytes |
 | `enum` and `[Enum] interface` | `RustBuffer` struct pointing to serialized bytes |
 | `dictionary` | `RustBuffer` struct pointing to serialized bytes |
 | `interface` | `void*` opaque pointer to object on the heap |
@@ -86,7 +86,7 @@ The details of this format are internal only and may change between versions of 
 | `string` | Serialized `i32` length followed by utf-8 string bytes; no trailing null |
 | `T?` | If null, serialized `boolean` false; if non-null, serialized `boolean` true followed by serialized `T` |
 | `sequence<T>` | Serialized `i32` item count followed by serialized items; each item is a serialized `T` |
-| `record<DOMString, T>` | Serialized `i32` item count followed by serialized items; each item is a serialized `string` followed by a serialized `T` |
+| `record<string, T>` | Serialized `i32` item count followed by serialized items; each item is a serialized `string` followed by a serialized `T` |
 | `enum` and `[Enum] interface` | Serialized `i32` indicating variant, numbered in declaration order starting from 1, followed by the serialized values of the variant's fields in declaration order |
 | `dictionary` | The serialized value of each field, in declaration order |
 | `interface` | Fixed-width 8-byte unsigned integer encoding a pointer to the object on the heap |

--- a/docs/manual/src/udl/builtin_types.md
+++ b/docs/manual/src/udl/builtin_types.md
@@ -15,7 +15,7 @@ The following built-in types can be passed as arguments/returned by Rust methods
 | `&T`                 | `[ByRef] T`            | This works for `&str` and `&[T]`                                |
 | `Option<T>`          | `T?`                   |                                                                 |
 | `Vec<T>`             | `sequence<T>`          |                                                                 |
-| `HashMap<String, T>` | `record<DOMString, T>` | Only string keys are supported                                  |
+| `HashMap<String, T>` | `record<string, T>`    | Only string keys are supported                                  |
 | `()`                 | `void`                 | Empty return                                                    |
 | `Result<T, E>`       | N/A                    | See [Errors](./errors.md) section                               |
 

--- a/examples/rondpoint/src/rondpoint.udl
+++ b/examples/rondpoint/src/rondpoint.udl
@@ -2,7 +2,7 @@ namespace rondpoint {
   Dictionnaire copie_dictionnaire(Dictionnaire d);
   Enumeration copie_enumeration(Enumeration e);
   sequence<Enumeration> copie_enumerations(sequence<Enumeration> e);
-  record<DOMString, EnumerationAvecDonnees> copie_carte(record<DOMString, EnumerationAvecDonnees> c);
+  record<string, EnumerationAvecDonnees> copie_carte(record<string, EnumerationAvecDonnees> c);
   boolean switcheroo(boolean b);
 };
 

--- a/fixtures/regressions/fully-qualified-types/src/test.udl
+++ b/fixtures/regressions/fully-qualified-types/src/test.udl
@@ -9,5 +9,5 @@ dictionary Values {
 };
 
 namespace regression_test_i1015 {
-  record<DOMString, sequence<Values>>? test();
+  record<string, sequence<Values>>? test();
 };

--- a/uniffi_udl/src/resolver.rs
+++ b/uniffi_udl/src/resolver.rs
@@ -133,7 +133,7 @@ impl TypeResolver for weedle::types::RecordKeyType<'_> {
         match self {
             Byte(_) | USV(_) => bail!(
                 "WebIDL Byte or USV string type not implemented ({self:?}); \
-                 consider using DOMString or string",
+                 consider using a string",
             ),
             DOM(_) => Ok(Type::String),
             NonAny(t) => t.resolve_type_expression(types),


### PR DESCRIPTION
Someone mentioned the `DOMString` references in the docs confused them, and I'm not surprised!