### PR TITLE
Fix export of Swift custom types which don't have a foreign type

### DIFF
--- a/fixtures/ext-types/guid/src/lib.rs
+++ b/fixtures/ext-types/guid/src/lib.rs
@@ -16,7 +16,7 @@ pub enum InternalError {
     Unexpected,
 }
 
-fn get_guid(guid: Option<Guid>) -> Guid {
+pub fn get_guid(guid: Option<Guid>) -> Guid {
     // This function doesn't return a Result, so all conversion errors are panics
     match guid {
         Some(guid) => {

--- a/fixtures/ext-types/proc-macro-lib/src/lib.rs
+++ b/fixtures/ext-types/proc-macro-lib/src/lib.rs
@@ -136,4 +136,9 @@ fn get_uniffi_one_interface() -> Arc<UniffiOneInterface> {
     Arc::new(UniffiOneInterface::new())
 }
 
+#[uniffi::export]
+fn get_guid_procmacro(g: Option<Guid>) -> Guid {
+    ext_types_guid::get_guid(g)
+}
+
 uniffi::include_scaffolding!("ext-types-lib");

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.kts
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.kts
@@ -36,3 +36,6 @@ assert(getMaybeUniffiOneEnum(uoe)!! == uoe)
 assert(getMaybeUniffiOneEnum(null) == null)
 assert(getUniffiOneEnums(listOf(uoe)) == listOf(uoe))
 assert(getMaybeUniffiOneEnums(listOf(uoe, null)) == listOf(uoe, null))
+
+val g = getGuidProcmacro(null)
+assert(g == getGuidProcmacro(g))

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.py
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.py
@@ -47,6 +47,9 @@ class TestIt(unittest.TestCase):
         self.assertEqual([e], get_uniffi_one_enums([e]))
         self.assertEqual([e, None], get_maybe_uniffi_one_enums([e, None]))
 
+    def test_get_guid_procmacro(self):
+        g = get_guid_procmacro(None)
+        self.assertEqual(g, get_guid_procmacro(g))
 
 if __name__=='__main__':
     unittest.main()

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.swift
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.swift
@@ -34,3 +34,6 @@ assert(getMaybeUniffiOneEnum(e: UniffiOneEnum.one)! == UniffiOneEnum.one)
 assert(getMaybeUniffiOneEnum(e: nil) == nil)
 assert(getUniffiOneEnums(es: [UniffiOneEnum.one]) == [UniffiOneEnum.one])
 assert(getMaybeUniffiOneEnums(es: [UniffiOneEnum.one, nil]) == [UniffiOneEnum.one, nil])
+
+let g = getGuidProcmacro(g: nil)
+assert(g == getGuidProcmacro(g: g))

--- a/uniffi_bindgen/src/bindings/swift/templates/CustomType.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CustomType.swift
@@ -70,6 +70,8 @@ public struct FfiConverterType{{ name }}: FfiConverter {
     }
 }
 
+{%- endmatch %}
+
 {#
 We always write these public functions just incase the type is used as
 an external type by another crate.
@@ -81,6 +83,4 @@ public func FfiConverterType{{ name }}_lift(_ value: {{ ffi_type_name }}) throws
 public func FfiConverterType{{ name }}_lower(_ value: {{ name }}) -> {{ ffi_type_name }} {
     return FfiConverterType{{ name }}.lower(value)
 }
-
-{%- endmatch %}
 


### PR DESCRIPTION
If a Custom Type doesn't have a custom foreign type (as specified in uniffi.toml), Swift fails to export the custom type meaning it can't be used externally.

In this example, Swift is treating the `Guid` as a plain string, which didn't export the public FFI functions.

