### PR TITLE
Allow interfaces to be errors.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,6 +1677,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-fixture-error-types"
+version = "0.22.0"
+dependencies = [
+ "anyhow",
+ "thiserror",
+ "uniffi",
+]
+
+[[package]]
 name = "uniffi-fixture-ext-types"
 version = "0.22.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
   "fixtures/benchmarks",
   "fixtures/coverall",
   "fixtures/callbacks",
+  "fixtures/error-types",
 
   "fixtures/ext-types/guid",
   "fixtures/ext-types/http-headermap",

--- a/fixtures/error-types/Cargo.toml
+++ b/fixtures/error-types/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "uniffi-fixture-error-types"
+version = "0.22.0"
+edition = "2021"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "uniffi_error_types"
+
+[dependencies]
+uniffi = {path = "../../uniffi"}
+anyhow = "1"
+thiserror = "1.0"
+
+[build-dependencies]
+uniffi = {path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }
+

--- a/fixtures/error-types/build.rs
+++ b/fixtures/error-types/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::generate_scaffolding("./src/error_types.udl").unwrap();
+}

--- a/fixtures/error-types/src/error_types.udl
+++ b/fixtures/error-types/src/error_types.udl
@@ -1,0 +1,41 @@
+namespace error_types {
+    // Returns Err(anyhow::Error), which uniffi automagically turns into ErrorInterface.
+    [Throws=ErrorInterface]
+    void anyhow_bail(string message);
+
+    [Throws=ErrorInterface]
+    void anyhow_with_context(string message);
+
+    ErrorInterface get_error(string message);
+
+    [Throws=RichError]
+    void throw_rich(string message);
+
+    RichError get_rich_error(string message);
+};
+
+interface TestInterface {
+    constructor();
+
+    [Throws=ErrorInterface, Name="fallible_new"]
+    constructor();
+
+    [Throws=ErrorInterface]
+    void anyhow_bail(string message);
+};
+
+// A name that doesn't end in "Error" or "Exception" under the assumption
+// that some components might prefer a more natural name.
+// Bindings *may* still need to append "Error/Exception".
+[Traits=(Debug, Display)]
+interface ErrorInterface {
+    sequence<string> chain();
+    string? link(u64 index);
+};
+
+// A name that looks more like a traditional error.
+// Bindings may translate "Error" to "Exception".
+// Note also RichError is not an `anyhow` error (and doesn't even implement `std::result::Error`)
+[Traits=(Debug)]
+interface RichError {
+};

--- a/fixtures/error-types/src/lib.rs
+++ b/fixtures/error-types/src/lib.rs
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::sync::Arc;
+
+fn anyhow_bail(message: String) -> anyhow::Result<()> {
+    anyhow::bail!("{message}");
+}
+
+fn anyhow_with_context(message: String) -> anyhow::Result<()> {
+    Err(anyhow::Error::msg(message).context("because uniffi told me so"))
+}
+
+fn get_error(message: String) -> std::sync::Arc<ErrorInterface> {
+    std::sync::Arc::new(ErrorInterface {
+        e: anyhow::Error::msg(message),
+    })
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{e:?}")]
+pub struct ErrorInterface {
+    e: anyhow::Error,
+}
+
+impl ErrorInterface {
+    fn chain(&self) -> Vec<String> {
+        self.e.chain().map(ToString::to_string).collect()
+    }
+    fn link(&self, ndx: u64) -> Option<String> {
+        self.e.chain().nth(ndx as usize).map(ToString::to_string)
+    }
+}
+
+impl From<anyhow::Error> for ErrorInterface {
+    fn from(e: anyhow::Error) -> Self {
+        Self { e }
+    }
+}
+
+fn throw_rich(e: String) -> Result<(), RichError> {
+    Err(RichError { e })
+}
+
+fn get_rich_error(e: String) -> std::sync::Arc<RichError> {
+    std::sync::Arc::new(RichError { e })
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("RichError: {e:?}")]
+pub struct RichError {
+    e: String,
+}
+
+impl RichError {}
+
+struct TestInterface {}
+
+impl TestInterface {
+    fn new() -> Self {
+        TestInterface {}
+    }
+
+    fn fallible_new() -> anyhow::Result<Self> {
+        Err(anyhow::Error::msg("fallible_new"))
+    }
+
+    fn anyhow_bail(&self, message: String) -> anyhow::Result<()> {
+        anyhow::bail!("TestInterface - {message}");
+    }
+}
+
+// A procmacro as an error
+#[derive(Debug, uniffi::Error, thiserror::Error)]
+pub struct ProcErrorInterface {
+    e: String,
+}
+
+#[uniffi::export]
+impl ProcErrorInterface {
+    fn message(&self) -> String {
+        self.e.clone()
+    }
+}
+
+impl std::fmt::Display for ProcErrorInterface {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ProcErrorInterface {}", self.e)
+    }
+}
+
+// XXX - sadly no `From` support, making this not useful for structs etc returning
+// `anyhow::Error` - need ability to tell the procmaco what types to use in the ffi functions?
+#[uniffi::export]
+fn throw_proc_error(e: String) -> Result<(), Arc<ProcErrorInterface>> {
+    Err(Arc::new(ProcErrorInterface { e }))
+}
+
+#[uniffi::export]
+fn return_proc_error(e: String) -> Arc<ProcErrorInterface> {
+    Arc::new(ProcErrorInterface { e })
+}
+
+uniffi::include_scaffolding!("error_types");

--- a/fixtures/error-types/tests/bindings/test.py
+++ b/fixtures/error-types/tests/bindings/test.py
@@ -1,0 +1,65 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import unittest
+from error_types import *
+
+class TestErrorTypes(unittest.TestCase):
+    def test_normal_catch(self):
+        try:
+            anyhow_bail("oh no")
+            self.fail("must fail")
+        except ErrorInterface as e:
+           self.assertEqual(str(e), "oh no")
+
+    def test_interface_errors(self):
+        with self.assertRaises(ErrorInterface) as cm:
+            anyhow_with_context("oh no")
+        self.assertEqual(cm.exception.chain(), ["because uniffi told me so", "oh no"])
+        self.assertEqual(cm.exception.link(0), "because uniffi told me so")
+        self.assertEqual(repr(cm.exception), "ErrorInterface { e: because uniffi told me so\n\nCaused by:\n    oh no }")
+        self.assertEqual(str(cm.exception), "because uniffi told me so")
+
+    # Check we can still call a function which returns an error (as opposed to one which throws it)
+    def test_error_return(self):
+        e = get_error("the error")
+        self.assertEqual(e.chain(), ["the error"])
+        self.assertEqual(repr(e), "ErrorInterface { e: the error }")
+        self.assertEqual(str(e), "the error")
+
+    # RichError is not an anyhow error.
+    def test_rich_error(self):
+        try:
+            throw_rich("oh no")
+            self.fail("must fail")
+        except RichError as e:
+           self.assertEqual(repr(e), """RichError { e: "oh no" }""")
+           self.assertEqual(str(e), "") # XXX - this sucks?
+
+    def test_rich_error_return(self):
+        e = get_rich_error("the error")
+        self.assertEqual(repr(e), """RichError { e: "the error" }""")
+        self.assertEqual(str(e), "") # XXX - this sucks?
+
+    # TestInterface also throws.
+    def test_interface_errors(self):
+        with self.assertRaises(ErrorInterface) as cm:
+            TestInterface.fallible_new()
+        self.assertEqual(str(cm.exception), "fallible_new")
+
+        interface = TestInterface()
+        with self.assertRaises(ErrorInterface) as cm:
+            interface.anyhow_bail("oops")
+        self.assertEqual(str(cm.exception), "TestInterface - oops")
+
+    # TestInterface also throws.
+    def test_interface_errors(self):
+        with self.assertRaises(ProcErrorInterface) as cm:
+            throw_proc_error("eek")
+        self.assertEqual(cm.exception.message(), "eek")
+# No UniffiTrait support yet, so no __str__ etc.
+#        self.assertEqual(str(cm.exception), "eek")
+
+if __name__=='__main__':
+    unittest.main()

--- a/fixtures/error-types/tests/test_generated_bindings.rs
+++ b/fixtures/error-types/tests/test_generated_bindings.rs
@@ -1,0 +1,1 @@
+uniffi::build_foreign_language_testcases!("tests/bindings/test.py",);

--- a/uniffi_bindgen/src/bindings/python/templates/macros.py
+++ b/uniffi_bindgen/src/bindings/python/templates/macros.py
@@ -5,27 +5,29 @@
 #}
 
 {%- macro to_ffi_call(func) -%}
-    {%- match func.throws_type() -%}
-    {%- when Some with (e) -%}
-_rust_call_with_error({{ e|ffi_converter_name }},
-    {%- else -%}
-_rust_call(
-    {%- endmatch -%}
-    _UniffiLib.{{ func.ffi_func().name() }},
-    {%- call arg_list_lowered(func) -%}
-)
+{%- call _to_ffi_call_with_prefix_arg("", func) %}
 {%- endmacro -%}
 
 {%- macro to_ffi_call_with_prefix(prefix, func) -%}
-    {%- match func.throws_type() -%}
-    {%- when Some with (e) -%}
-_rust_call_with_error(
-    {{ e|ffi_converter_name }},
-    {%- else -%}
+{%- call _to_ffi_call_with_prefix_arg(format!("{},", prefix), func) %}
+{%- endmacro -%}
+
+{%- macro _to_ffi_call_with_prefix_arg(prefix, func) -%}
+{%- match func.throws_type() -%}
+{%-     when Some with (e) -%}
+{%-         match e -%}
+{%-             when Type::Enum { name, module_path } -%}
+_rust_call_with_error({{ e|ffi_converter_name }},
+{%-             when Type::Object { name, module_path, imp } -%}
+_rust_call_with_error({{ e|ffi_converter_name }}__as_error,
+{%-             else %}
+# unsupported error type!
+{%-         endmatch %}
+{%- else -%}
 _rust_call(
-    {%- endmatch -%}
+{%- endmatch -%}
     _UniffiLib.{{ func.ffi_func().name() }},
-    {{- prefix }},
+    {{- prefix }}
     {%- call arg_list_lowered(func) -%}
 )
 {%- endmacro -%}

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -665,7 +665,10 @@ impl ComponentInterface {
     /// Called by `APIBuilder` impls to add a newly-parsed object definition to the `ComponentInterface`.
     fn add_object_definition(&mut self, defn: Object) -> Result<()> {
         self.types.add_known_types(defn.iter_types())?;
-        self.objects.push(defn);
+        // add_known_types avoids dupes, we need to too.
+        if self.get_object_definition(defn.name()).is_none() {
+            self.objects.push(defn);
+        }
         Ok(())
     }
 
@@ -891,7 +894,7 @@ fn throws_name(throws: &Option<Type>) -> Option<&str> {
     // Type has no `name()` method, just `canonical_name()` which isn't what we want.
     match throws {
         None => None,
-        Some(Type::Enum { name, .. }) => Some(name),
+        Some(Type::Enum { name, .. }) | Some(Type::Object { name, .. }) => Some(name),
         _ => panic!("unknown throw type: {throws:?}"),
     }
 }

--- a/uniffi_bindgen/src/macro_metadata/ci.rs
+++ b/uniffi_bindgen/src/macro_metadata/ci.rs
@@ -124,6 +124,9 @@ fn add_item_to_ci(iface: &mut ComponentInterface, item: Metadata) -> anyhow::Res
                 ErrorMetadata::Enum { enum_, is_flat } => {
                     add_enum_to_ci(iface, enum_, is_flat)?;
                 }
+                ErrorMetadata::Object { ob } => {
+                    add_item_to_ci(iface, Metadata::Object(ob))?;
+                }
             };
         }
         Metadata::CustomType(meta) => {

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -105,7 +105,7 @@ impl ScaffoldingBits {
         let param_lifts = sig.lift_exprs();
         let simple_rust_fn_call = quote! { #ident(#(#param_lifts,)*) };
         let rust_fn_call = if udl_mode && sig.looks_like_result {
-            quote! { #simple_rust_fn_call.map_err(::std::convert::Into::into) }
+            quote! { #simple_rust_fn_call.map_err(|e| UniffiErrorConverter::convert(e)) }
         } else {
             simple_rust_fn_call
         };
@@ -139,7 +139,7 @@ impl ScaffoldingBits {
         let param_lifts = sig.lift_exprs();
         let simple_rust_fn_call = quote! { uniffi_self.#ident(#(#param_lifts,)*) };
         let rust_fn_call = if udl_mode && sig.looks_like_result {
-            quote! { #simple_rust_fn_call.map_err(::std::convert::Into::into) }
+            quote! { #simple_rust_fn_call.map_err(|e| UniffiErrorConverter::convert(e)) }
         } else {
             simple_rust_fn_call
         };
@@ -166,7 +166,7 @@ impl ScaffoldingBits {
             // For UDL
             (true, false) => quote! { ::std::sync::Arc::new(#simple_rust_fn_call) },
             (true, true) => {
-                quote! { #simple_rust_fn_call.map(::std::sync::Arc::new).map_err(::std::convert::Into::into) }
+                quote! { #simple_rust_fn_call.map(::std::sync::Arc::new).map_err(|e| UniffiErrorConverter::convert(e)) }
             }
             (false, _) => simple_rust_fn_call,
         };

--- a/uniffi_macros/src/setup_scaffolding.rs
+++ b/uniffi_macros/src/setup_scaffolding.rs
@@ -130,5 +130,32 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
             fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> where Self: Sized;
             fn from_custom(obj: Self) -> Self::Builtin;
         }
+
+        // A trait that allows us to convert from an error type returned by Rust functions
+        // into a type returned over the FFI.
+        pub trait UniffiErrorConverter<T> {
+            fn convert(value: T) -> Self;
+        }
+
+        // Any T by default returns itself.
+        impl<T> UniffiErrorConverter<T> for T {
+            fn convert(e: T) -> Self {
+                e
+            }
+        }
+
+        // Need something like this? Does not compile.
+        // impl<T, U> UniffiErrorConverter<T> for U where U: Into<T> + ?Sized {
+        //     fn convert(e: T) -> Self {
+        //         todo!();
+        //     }
+        // }
+
+        // A plain struct returned from Rust functions are converted to an Arc<>.
+        impl<T> UniffiErrorConverter<T> for ::std::sync::Arc<T> {
+            fn convert(e: T) -> Self {
+                ::std::sync::Arc::new(e)
+            }
+        }
     })
 }

--- a/uniffi_meta/src/group.rs
+++ b/uniffi_meta/src/group.rs
@@ -128,12 +128,6 @@ impl<'a> ExternalTypeConverter<'a> {
                 ..meta
             }),
             Metadata::Enum(meta) => Metadata::Enum(self.convert_enum(meta)),
-            Metadata::Error(meta) => Metadata::Error(match meta {
-                ErrorMetadata::Enum { enum_, is_flat } => ErrorMetadata::Enum {
-                    enum_: self.convert_enum(enum_),
-                    is_flat,
-                },
-            }),
             _ => item,
         }
     }

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -349,18 +349,21 @@ pub enum UniffiTraitMetadata {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ErrorMetadata {
     Enum { enum_: EnumMetadata, is_flat: bool },
+    Object { ob: ObjectMetadata },
 }
 
 impl ErrorMetadata {
     pub fn name(&self) -> &String {
         match self {
             Self::Enum { enum_, .. } => &enum_.name,
+            Self::Object { ob } => &ob.name,
         }
     }
 
     pub fn module_path(&self) -> &String {
         match self {
             Self::Enum { enum_, .. } => &enum_.module_path,
+            Self::Object { ob } => &ob.module_path,
         }
     }
 }


### PR DESCRIPTION
This is an implementation of adr-0008, as proposed in #1613. It has support for interfaces described in UDL and procmacros. This will remains as a draft until #1613 lands, but I think this is actually ready for review now.

It only supports Python - other bindings can come later and existing bindings are not impacted (unless you actually try and use the feature there).