### PR TITLE
Hack: Copy metadata module to avoid uniffi_core dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@
 
 - Crates can now use proc-macros without UDL files to export their interface.  See the "Procedural Macros: Attributes and Derives" manual section for details.
 
+## v0.24.2 (backend crates: v0.24.2) - (_2023-07-25_)
+
+[All changes in v0.24.2](https://github.com/mozilla/uniffi-rs/compare/v0.24.1...v0.24.2).
+
+### What's changed?
+
+- Inline the metadata module in `uniffi_meta` to avoid a dependency of `uniffi_core` to avoid hitting an upstream bug during link time ([#1666](https://github.com/mozilla/uniffi-rs/pull/1666))
+
 ## v0.24.1 (backend crates: v0.24.1) - (_2023-06-23_)
 
 [All changes in v0.24.1](https://github.com/mozilla/uniffi-rs/compare/v0.24.0...v0.24.1).

--- a/uniffi_meta/Cargo.toml
+++ b/uniffi_meta/Cargo.toml
@@ -14,4 +14,3 @@ bytes = "1.3"
 serde = { version = "1.0.136", features = ["derive"] }
 siphasher = "0.3"
 uniffi_checksum_derive = { version = "0.24.1", path = "../uniffi_checksum_derive" }
-uniffi_core = { path = "../uniffi_core", version = "=0.24.1" }

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -19,6 +19,8 @@ pub use reader::{read_metadata, read_metadata_type};
 mod types;
 pub use types::{AsType, ExternalKind, ObjectImpl, Type, TypeIterator};
 
+mod metadata;
+
 // This needs to match the minor version of the `uniffi` crate.  See
 // `docs/uniffi-versioning.md` for details.
 //

--- a/uniffi_meta/src/metadata.rs
+++ b/uniffi_meta/src/metadata.rs
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Copied from uniffi_core/src/metadata.rs
+// Due to a [Rust bug](https://github.com/rust-lang/rust/issues/113104) we don't want to pull in
+// `uniffi_core`.
+// This is the easy way out of that issue and is a temporary hacky solution.
+
+/// Metadata constants, make sure to keep this in sync with copy in `uniffi_meta::reader`
+pub mod codes {
+    // Top-level metadata item codes
+    pub const FUNC: u8 = 0;
+    pub const METHOD: u8 = 1;
+    pub const RECORD: u8 = 2;
+    pub const ENUM: u8 = 3;
+    pub const INTERFACE: u8 = 4;
+    pub const ERROR: u8 = 5;
+    pub const NAMESPACE: u8 = 6;
+    pub const CONSTRUCTOR: u8 = 7;
+    pub const UDL_FILE: u8 = 8;
+    pub const CALLBACK_INTERFACE: u8 = 9;
+    pub const TRAIT_METHOD: u8 = 10;
+    //pub const UNKNOWN: u8 = 255;
+
+    // Type codes
+    pub const TYPE_U8: u8 = 0;
+    pub const TYPE_U16: u8 = 1;
+    pub const TYPE_U32: u8 = 2;
+    pub const TYPE_U64: u8 = 3;
+    pub const TYPE_I8: u8 = 4;
+    pub const TYPE_I16: u8 = 5;
+    pub const TYPE_I32: u8 = 6;
+    pub const TYPE_I64: u8 = 7;
+    pub const TYPE_F32: u8 = 8;
+    pub const TYPE_F64: u8 = 9;
+    pub const TYPE_BOOL: u8 = 10;
+    pub const TYPE_STRING: u8 = 11;
+    pub const TYPE_OPTION: u8 = 12;
+    pub const TYPE_RECORD: u8 = 13;
+    pub const TYPE_ENUM: u8 = 14;
+    // 15 no longer used.
+    pub const TYPE_INTERFACE: u8 = 16;
+    pub const TYPE_VEC: u8 = 17;
+    pub const TYPE_HASH_MAP: u8 = 18;
+    pub const TYPE_SYSTEM_TIME: u8 = 19;
+    pub const TYPE_DURATION: u8 = 20;
+    pub const TYPE_CALLBACK_INTERFACE: u8 = 21;
+    pub const TYPE_CUSTOM: u8 = 22;
+    pub const TYPE_RESULT: u8 = 23;
+    //pub const TYPE_FUTURE: u8 = 24;
+    pub const TYPE_FOREIGN_EXECUTOR: u8 = 25;
+    pub const TYPE_UNIT: u8 = 255;
+
+    // Literal codes
+    pub const LIT_STR: u8 = 0;
+    pub const LIT_INT: u8 = 1;
+    pub const LIT_FLOAT: u8 = 2;
+    pub const LIT_BOOL: u8 = 3;
+    pub const LIT_NULL: u8 = 4;
+}
+
+// Create a checksum for a MetadataBuffer
+//
+// This is used by the bindings code to verify that the library they link to is the same one
+// that the bindings were generated from.
+pub const fn checksum_metadata(buf: &[u8]) -> u16 {
+    calc_checksum(buf, buf.len())
+}
+
+const fn calc_checksum(bytes: &[u8], size: usize) -> u16 {
+    // Taken from the fnv_hash() function from the FNV crate (https://github.com/servo/rust-fnv/blob/master/lib.rs).
+    // fnv_hash() hasn't been released in a version yet.
+    const INITIAL_STATE: u64 = 0xcbf29ce484222325;
+    const PRIME: u64 = 0x100000001b3;
+
+    let mut hash = INITIAL_STATE;
+    let mut i = 0;
+    while i < size {
+        hash ^= bytes[i] as u64;
+        hash = hash.wrapping_mul(PRIME);
+        i += 1;
+    }
+    // Convert the 64-bit hash to a 16-bit hash by XORing everything together
+    (hash ^ (hash >> 16) ^ (hash >> 32) ^ (hash >> 48)) as u16
+}

--- a/uniffi_meta/src/reader.rs
+++ b/uniffi_meta/src/reader.rs
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::metadata::{checksum_metadata, codes};
 use crate::*;
 use anyhow::{bail, ensure, Context, Result};
-use uniffi_core::metadata::{checksum_metadata, codes};
 
 pub fn read_metadata(data: &[u8]) -> Result<Metadata> {
     MetadataReader::new(data).read_metadata()


### PR DESCRIPTION
In m-c we're running into linking issues in `uniffi_macros`, where it's missing symbols coming from `uniffi_core`:

    /bin/ld: uniffi_foreign_executor_callback_set: undefined version:
    /bin/ld: failed to set dynamic section sizes: bad value

That's most likely this issue on Rust:
https://github.com/rust-lang/rust/issues/111888
It's called out that this likely actually broke because of another PR: https://github.com/rust-lang/rust/pull/99944

Despite this bug there's a bit of an issue in UniFFI to begin with: We're exporting `extern "C"` functions from a crate that is a dependency of some other crates, including `uniffi_macros`, and thus the symbols land in a part where they are not needed.

However for `uniffi_meta` in particular we don't need much from `uniffi_core`, so for now we just copy the necessary bits to get it all working.

---

This is tackling the issues uncovered in https://bugzilla.mozilla.org/show_bug.cgi?id=1840044
It's a short-term fix that I want to release as a patch version 0.24.2 without anything else from `main` (I have a separate patch for only the 0.24.2 fix then