### PR TITLE
Failing test case for future cancellation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ orbs:
 jobs:
   Check Rust formatting:
     docker:
-      - image: cimg/rust:1.69
+      - image: cimg/rust:1.71
     resource_class: small
     steps:
       - checkout
@@ -49,7 +49,7 @@ jobs:
       - run: cargo fmt -- --check
   Lint Rust with clippy:
     docker:
-      - image: cimg/rust:1.69
+      - image: cimg/rust:1.71
     resource_class: small
     steps:
       - checkout
@@ -59,7 +59,7 @@ jobs:
       - run: cargo clippy --all --all-targets -- -D warnings
   Lint Rust Docs:
     docker:
-      - image: cimg/rust:1.69
+      - image: cimg/rust:1.71
     resource_class: small
     steps:
       - checkout
@@ -117,7 +117,7 @@ jobs:
       - run: cargo test -- --skip trybuild_ui_tests
   Deploy website:
     docker:
-      - image: cimg/rust:1.69
+      - image: cimg/rust:1.71
     resource_class: small
     steps:
       - checkout

--- a/fixtures/futures/Cargo.toml
+++ b/fixtures/futures/Cargo.toml
@@ -16,7 +16,8 @@ path = "src/bin.rs"
 
 [dependencies]
 uniffi = { path = "../../uniffi", version = "0.24", features = ["tokio", "cli"] }
-tokio = { version = "1.24.1", features = ["time"] }
+tokio = { version = "1.24.1", features = ["sync", "time"] }
+once_cell = "1.18.0"
 
 [build-dependencies]
 uniffi = { path = "../../uniffi", version = "0.24", features = ["build"] }

--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -276,4 +276,16 @@ pub async fn broken_sleep(ms: u16, fail_after: u16) {
     .await;
 }
 
+use once_cell::sync::Lazy;
+use tokio::sync::Mutex as TokioMutex;
+
+#[uniffi::export(async_runtime = "tokio")]
+pub async fn use_shared_resource() {
+    static MUTEX: Lazy<TokioMutex<()>> = Lazy::new(|| TokioMutex::new(()));
+    let guard = dbg!(&*MUTEX).lock().await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    drop(guard);
+    dbg!();
+}
+
 uniffi::include_scaffolding!("uniffi_futures");

--- a/fixtures/futures/tests/bindings/test_futures.kts
+++ b/fixtures/futures/tests/bindings/test_futures.kts
@@ -203,3 +203,17 @@ runBlocking {
 
     assertApproximateTime(time, 500, "broken sleep")
 }
+
+// Test cancellation - broken!
+runBlocking {
+    val job = launch {
+        useSharedResource()
+    }
+
+    delay(50L)
+    job.cancel()
+
+    withTimeout(1.seconds) {
+        useSharedResource()
+    }
+}

--- a/fixtures/futures/tests/bindings/test_futures.kts
+++ b/fixtures/futures/tests/bindings/test_futures.kts
@@ -210,10 +210,10 @@ runBlocking {
         useSharedResource()
     }
 
-    delay(50L)
+    delay(50)
     job.cancel()
 
-    withTimeout(1.seconds) {
+    withTimeout(1000) {
         useSharedResource()
     }
 }


### PR DESCRIPTION
Output from CI:

```
[fixtures/futures/src/lib.rs:285] &*MUTEX = Mutex {
    data: (),
}
[fixtures/futures/src/lib.rs:285] &*MUTEX = Mutex {
    data: <locked>,
}
test uniffi_foreign_language_testcase_test_futures_kts has been running for over 60 seconds

Too long with no output (exceeded 10m0s): context deadline exceeded
```