### PR TITLE
Allow different crate types when using library mode

### DIFF
--- a/uniffi_bindgen/src/library_mode.rs
+++ b/uniffi_bindgen/src/library_mode.rs
@@ -158,9 +158,9 @@ fn find_package_by_crate_name(
         .packages
         .iter()
         .filter(|p| {
-            p.targets.iter().any(|t| {
-                t.name.replace('-', "_") == crate_name && t.crate_types.iter().any(|ct| ct == "lib")
-            })
+            p.targets
+                .iter()
+                .any(|t| t.name.replace('-', "_") == crate_name)
         })
         .collect();
     match matching.len() {


### PR DESCRIPTION
This makes library mode work when the dependent crate doesn't include "lib" in their `crate-type` list.  I think that check was leftover from older code and isn't needed anymore.