### PR TITLE
Don't require objects to always be wrapped in `Arc<>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Add support for [docstrings in UDL](https://mozilla.github.io/uniffi-rs/udl/docstrings.html)
 - Ability for UDL to use external trait interfaces [#1831](https://github.com/mozilla/uniffi-rs/issues/1831)
 - Add support for docstrings via procmacros [#1862](https://github.com/mozilla/uniffi-rs/pull/1862)
+- Objects can now be returned from functions/constructors/methods without wrapping them in an `Arc<>`.
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.25.2...HEAD).
 

--- a/docs/manual/src/proc_macro/index.md
+++ b/docs/manual/src/proc_macro/index.md
@@ -55,9 +55,9 @@ struct MyObject {
 #[uniffi::export]
 impl MyObject {
     // Constructors need to be annotated as such.
-    // As of right now, they must return `Arc<Self>`, this might change.
-    // If the constructor is named `new`, it is treated as the primary
-    // constructor, so in most languages this is invoked with `MyObject()`.
+    // The return value can be either `Self` or `Arc<Self>`
+    // It is treated as the primary constructor, so in most languages this is invoked with
+    `MyObject()`.
     #[uniffi::constructor]
     fn new(argument: String) -> Arc<Self> {
         // ...
@@ -75,7 +75,7 @@ impl MyObject {
         // ...
     }
 
-    // `Arc<Self>` is also supported
+    // Returning objects is also supported, either as `Self` or `Arc<Self>`
     fn method_b(self: Arc<Self>) {
         // ...
     }

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -78,9 +78,11 @@ impl Object {
     }
 
     #[uniffi::constructor]
-    fn named_ctor(arg: u32) -> Arc<Self> {
+    fn named_ctor(arg: u32) -> Self {
         _ = arg;
-        Self::new()
+        // This constructor returns Self directly.  UniFFI ensures that it's wrapped in an Arc
+        // before sending it across the FFI.
+        Self
     }
 
     fn is_heavy(&self) -> MaybeBool {

--- a/uniffi_macros/src/object.rs
+++ b/uniffi_macros/src/object.rs
@@ -62,6 +62,7 @@ pub fn expand_object(input: DeriveInput, udl_mode: bool) -> syn::Result<TokenStr
 pub(crate) fn interface_impl(ident: &Ident, udl_mode: bool) -> TokenStream {
     let name = ident_to_string(ident);
     let impl_spec = tagged_impl_header("FfiConverterArc", ident, udl_mode);
+    let lower_return_impl_spec = tagged_impl_header("LowerReturn", ident, udl_mode);
     let lift_ref_impl_spec = tagged_impl_header("LiftRef", ident, udl_mode);
     let mod_path = match mod_path() {
         Ok(p) => p,
@@ -133,6 +134,16 @@ pub(crate) fn interface_impl(ident: &Ident, udl_mode: bool) -> TokenStream {
                 .concat_str(#mod_path)
                 .concat_str(#name)
                 .concat_bool(false);
+        }
+
+        unsafe #lower_return_impl_spec {
+            type ReturnType = <Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::FfiType;
+
+            fn lower_return(obj: Self) -> Result<Self::ReturnType, ::uniffi::RustBuffer> {
+                Ok(<Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::lower(::std::sync::Arc::new(obj)))
+            }
+
+            const TYPE_ID_META: ::uniffi::MetadataBuffer = <Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::TYPE_ID_META;
         }
 
         unsafe #lift_ref_impl_spec {


### PR DESCRIPTION
When reviewing #1662 I felt like I would be very annoyed to always have to wrap error objects with `Arc::new()`, this is an attempt to see if can avoid that.  It contains a general `FfiConverter` implementation for the struct itself, that simply wraps the value in `Arc::new()` then forwards the call to the normal `Arc<>` impl.

For constructors and other methods that return an object, UniFFI can wrap the object in an `Arc<>` just fine, the library doesn't need to do this.  Allowing the library to skip the wrapping can improve ergonomics, especially if we start to allow interfaces as errors.