### PR TITLE
Make the foreign executor API public

### DIFF
--- a/examples/futures/src/lib.rs
+++ b/examples/futures/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use async_std::future::{pending, timeout};
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Async function that says something after a certain time.
@@ -11,6 +12,31 @@ pub async fn say_after(ms: u64, who: String) -> String {
     let never = pending::<()>();
     timeout(Duration::from_millis(ms), never).await.unwrap_err();
     format!("Hello, {who}!")
+}
+
+/// Simulates an object that performs a IO bound task in the background
+#[derive(uniffi::Object)]
+pub struct Store {
+    background_executor: uniffi::ForeignExecutor,
+}
+
+#[uniffi::export]
+impl Store {
+    #[uniffi::constructor]
+    pub fn new(background_executor: uniffi::ForeignExecutor) -> Arc<Self> {
+        Arc::new(Self {
+            background_executor,
+        })
+    }
+
+    /// Load an item from disk, using the background executor
+    pub async fn load_item(self: Arc<Self>) -> String {
+        uniffi::run!(self.background_executor, move || self.do_load_item()).await
+    }
+
+    fn do_load_item(&self) -> String {
+        "this was loaded from disk".into()
+    }
 }
 
 uniffi::setup_scaffolding!();

--- a/examples/futures/tests/bindings/test.kts
+++ b/examples/futures/tests/bindings/test.kts
@@ -1,0 +1,9 @@
+import uniffi.uniffi_example_futures.*
+import kotlinx.coroutines.*
+
+runBlocking {
+    assert(sayAfter(10U, "Alice") == "Hello, Alice!")
+
+    val store = Store(CoroutineScope(Dispatchers.IO))
+    assert(store.loadItem() == "this was loaded from disk")
+}

--- a/examples/futures/tests/bindings/test.py
+++ b/examples/futures/tests/bindings/test.py
@@ -3,6 +3,8 @@ from uniffi_example_futures import *
 
 async def main():
     assert(await say_after(20, 'Alice') == "Hello, Alice!")
+    store = Store(asyncio.get_running_loop())
+    assert(await store.load_item() == "this was loaded from disk")
 
 if __name__ == '__main__':
     asyncio.run(main())

--- a/examples/futures/tests/bindings/test.swift
+++ b/examples/futures/tests/bindings/test.swift
@@ -1,0 +1,18 @@
+import uniffi_example_futures
+import Foundation
+
+var counter = DispatchGroup()
+
+counter.enter()
+
+Task {
+    let result = await sayAfter(ms: 20, who: "Alice")
+    assert(result == "Hello, Alice!")
+
+    let store = Store(backgroundExecutor: UniFfiForeignExecutor(priority: TaskPriority.background))
+    let result2 = await store.loadItem()
+    assert(result2 == "this was loaded from disk")
+    counter.leave()
+}
+
+counter.wait()

--- a/examples/futures/tests/test_generated_bindings.rs
+++ b/examples/futures/tests/test_generated_bindings.rs
@@ -1,1 +1,5 @@
-uniffi::build_foreign_language_testcases!("tests/bindings/test.py",);
+uniffi::build_foreign_language_testcases!(
+    "tests/bindings/test.py",
+    "tests/bindings/test.swift",
+    "tests/bindings/test.kts",
+);

--- a/fixtures/futures/tests/bindings/test_futures.kts
+++ b/fixtures/futures/tests/bindings/test_futures.kts
@@ -203,3 +203,14 @@ runBlocking {
 
     assertApproximateTime(time, 500, "broken sleep")
 }
+
+// Test scheduling
+runBlocking {
+    val tester = SchedulingTester(CoroutineScope(Dispatchers.IO))
+    assert(tester.runCalculation() == 42)
+
+    assert(tester.getCounterValue() == 0)
+    tester.scheduleIncrement()
+    sleep(100U)
+    assert(tester.getCounterValue() == 1)
+}

--- a/fixtures/futures/tests/bindings/test_futures.py
+++ b/fixtures/futures/tests/bindings/test_futures.py
@@ -1,4 +1,4 @@
-from uniffi_futures import always_ready, void, sleep, say_after, new_megaphone, say_after_with_tokio, fallible_me, fallible_struct, MyError, MyRecord, new_my_record
+from uniffi_futures import always_ready, void, sleep, say_after, new_megaphone, say_after_with_tokio, fallible_me, fallible_struct, MyError, MyRecord, new_my_record, SchedulingTester
 import unittest
 from datetime import datetime
 import asyncio
@@ -145,6 +145,18 @@ class TestFutures(unittest.TestCase):
             # Awaiting the task should result in a CancelledError.
             with self.assertRaises(asyncio.CancelledError):
                 await task
+
+        asyncio.run(test())
+
+    def test_scheduling(self):
+        async def test():
+            tester = SchedulingTester(asyncio.get_running_loop())
+            self.assertEqual(await tester.run_calculation(), 42)
+
+            self.assertEqual(tester.get_counter_value(), 0)
+            tester.schedule_increment()
+            await asyncio.sleep(0.1)
+            self.assertEqual(tester.get_counter_value(), 1)
 
         asyncio.run(test())
 

--- a/fixtures/futures/tests/bindings/test_futures.swift
+++ b/fixtures/futures/tests/bindings/test_futures.swift
@@ -232,4 +232,17 @@ Task {
 	counter.leave()
 }
 
+// Test scheduling
+counter.enter()
+Task {
+	let tester = SchedulingTester(backgroundExecutor: UniFfiForeignExecutor(priority: TaskPriority.background))
+	let result = await tester.runCalculation()
+	assert(result == 42)
+	assert(tester.getCounterValue() == 0)
+	tester.scheduleIncrement()
+	let _ = await sleep(ms: 100)
+	assert(tester.getCounterValue() == 1)
+	counter.leave()
+}
+
 counter.wait()


### PR DESCRIPTION
Technically it was always `pub` since it was used in the generated scaffolding, but this makes it more usable in consumer code:
  - Make the `RunFuture.task` field Sync, otherwise the `ForeignExecutor` functions are not really usable.
  - Added macros to improve the ergonomics
  - Added tests and documentation