### PR TITLE
Avoid using a derive for custom types to support types defined elsewh…

### DIFF
--- a/docs/manual/src/proc_macro/index.md
+++ b/docs/manual/src/proc_macro/index.md
@@ -198,11 +198,12 @@ implements the "new type" idiom (ie, a tuple struct with the builtin as the only
 
 For example, this type does not use the "new type" idiom, so must specify the complete implementation.
 ```rust
-#[derive(uniffi::CustomType)]
-#[uniffi(builtin=String)]
 pub struct Uuid {
     val: String,
 }
+
+// Use `url::Url` as a custom type, with `String` as the Builtin
+uniffi::impl_ffi_converter_custom_type!(Url, String);
 
 impl UniffiCustomTypeConverter for Uuid {
     type Builtin = String;
@@ -217,11 +218,11 @@ impl UniffiCustomTypeConverter for Uuid {
 }
 ```
 
-Whereas this type uses the "new type" idiom, so `UniffiCustomTypeConverter` is automatically derived
+Whereas this type uses the "new type" idiom, so we can use `impl_ffi_converter_custom_newtype` to
+automatically implement `UniffiCustomTypeConverter`.
 
 ```rust
-#[derive(uniffi::CustomType)]
-#[uniffi(newtype=i64)]
+impl_ffi_converter_custom_newtype!(NewTypeHandle, i64);
 pub struct NewtypeHandle(i64);
 ```
 

--- a/fixtures/ext-types/proc-macro-lib/src/lib.rs
+++ b/fixtures/ext-types/proc-macro-lib/src/lib.rs
@@ -138,11 +138,14 @@ fn get_uniffi_one_interface() -> Arc<UniffiOneInterface> {
 
 // Some custom types via macros.
 // Another guid - here we use a regular struct.
-#[derive(uniffi::CustomType)]
-#[uniffi(builtin=String)]
 pub struct Uuid {
     val: String,
 }
+
+// Tell UniFfi we want to use am UniffiCustomTypeConverter to go to and
+// from a String.
+//  Note this could be done even if the above `struct` defn was external.
+::uniffi::impl_ffi_converter_custom_type!(Uuid, String);
 
 impl UniffiCustomTypeConverter for Uuid {
     type Builtin = String;
@@ -156,11 +159,11 @@ impl UniffiCustomTypeConverter for Uuid {
     }
 }
 
-// A custom type using the "newtype" idiom.
-// Uniffi can generate the UniffiCustomTypeConverter for us.
-#[derive(uniffi::CustomType)]
-#[uniffi(newtype=i64)]
+// A custom type using the "newtype" idiom. As above, could be external.
 pub struct NewtypeHandle(i64);
+
+// Uniffi can generate the UniffiCustomTypeConverter for us too.
+::uniffi::impl_ffi_converter_custom_newtype!(NewtypeHandle, i64);
 
 #[uniffi::export]
 fn get_uuid(u: Option<Uuid>) -> Uuid {

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -138,8 +138,4 @@ mod filters {
     pub fn crate_name_rs(nm: &str) -> Result<String, askama::Error> {
         Ok(format!("r#{}", nm.to_string().to_snake_case()))
     }
-
-    pub fn debug(d: &impl std::fmt::Debug) -> Result<String, askama::Error> {
-        Ok(format!("{d:?}"))
-    }
 }

--- a/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
@@ -11,12 +11,7 @@
 {%- endmatch %}
 {%- endfor %}
 
-// For custom scaffolding types we need to generate an FfiConverter impl based on the
-// UniffiCustomTypeConverter implementation that the library supplies
-{% for (name, builtin) in ci.iter_custom_types() %}
-
-// Type `{{ name }}` wraps a `{{ builtin|debug }}`
-#[::uniffi::ffi_converter_custom_type(builtin = {{ builtin|type_rs }}, tag = crate::UniFfiTag)]
-struct r#{{ name }} { }
-
+// We generate support for each Custom Type and the builtin type it uses.
+{%- for (name, builtin) in ci.iter_custom_types() %}
+::uniffi::impl_ffi_converter_custom_type!(r#{{ name }}, {{builtin|type_rs}});
 {%- endfor -%}

--- a/uniffi_macros/src/custom.rs
+++ b/uniffi_macros/src/custom.rs
@@ -2,65 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::util::{
-    either_attribute_arg, ident_to_string, mod_path, parse_comma_separated, tagged_impl_header,
-    AttributeSliceExt, UniffiAttributeArgs,
-};
+use crate::util::{ident_to_string, mod_path, tagged_impl_header};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
-use syn::{
-    parse::{Parse, ParseStream},
-    Data, DeriveInput, Path, Token,
-};
+use syn::Path;
 
-pub fn expand_custom(input: DeriveInput) -> syn::Result<TokenStream> {
-    if !matches!(input.data, Data::Struct(_)) {
-        return Err(syn::Error::new(
-            Span::call_site(),
-            "This derive must only be used on structs",
-        ));
-    };
-
-    let ident = &input.ident;
-    let attr = input.attrs.parse_uniffi_attr_args::<CustomTypeAttr>()?;
-
-    let ffi_converter = custom_ffi_converter_impl(ident, &attr)?;
-
-    let type_converter = match attr.newtype {
-        Some(builtin) => custom_ffi_type_converter(ident, &builtin)?,
-        None => TokenStream::new(),
-    };
-    Ok(quote! {
-        #ffi_converter
-        #type_converter
-    })
-}
-
+// Generate an FfiConverter impl based on the UniffiCustomTypeConverter
+// implementation that the library supplies
 pub(crate) fn expand_ffi_converter_custom_type(
-    attr: CustomTypeAttr,
-    input: DeriveInput,
-) -> syn::Result<TokenStream> {
-    custom_ffi_converter_impl(&input.ident, &attr)
-}
-
-// For custom scaffolding types we need to generate an FfiConverter impl based on the
-// UniffiCustomTypeConverter implementation that the library supplies
-pub(crate) fn custom_ffi_converter_impl(
     ident: &Ident,
-    attr: &CustomTypeAttr,
+    builtin: &Ident,
+    tag: Option<&Path>,
 ) -> syn::Result<TokenStream> {
-    if attr.builtin.is_some() && attr.newtype.is_some() {
-        return Err(syn::Error::new(
-            Span::call_site(),
-            "Custom types must not specify both `builtin` and `newtype`",
-        ));
-    }
-    let Some(builtin) = attr.builtin.as_ref().or(attr.newtype.as_ref()) else {
-        return Err(syn::Error::new(
-            Span::call_site(),
-            "Custom types must specify the builtin/newtype",
-        ));
-    };
     let ffi_name = match builtin.to_string().as_str() {
         "i8" | "u8" | "i16" | "u16" | "i32" | "u32" | "i64" | "u64" | "f32" | "f64" => {
             builtin.to_string()
@@ -77,7 +30,7 @@ pub(crate) fn custom_ffi_converter_impl(
 
     let ffi_path: TokenStream = ffi_name.parse()?;
 
-    let impl_spec = tagged_impl_header("FfiConverter", ident, attr.tag.as_ref());
+    let impl_spec = tagged_impl_header("FfiConverter", ident, tag);
     let name = ident_to_string(ident);
     let mod_path = mod_path()?;
 
@@ -111,6 +64,22 @@ pub(crate) fn custom_ffi_converter_impl(
     })
 }
 
+// Generate an FfiConverter impl *and* an UniffiCustomTypeConverter.
+pub(crate) fn expand_ffi_converter_custom_newtype(
+    ident: &Ident,
+    builtin: &Ident,
+    tag: Option<&Path>,
+) -> syn::Result<TokenStream> {
+    let ffi_converter = expand_ffi_converter_custom_type(ident, builtin, tag)?;
+    let type_converter = custom_ffi_type_converter(ident, builtin)?;
+
+    Ok(quote! {
+        #ffi_converter
+
+        #type_converter
+    })
+}
+
 fn custom_ffi_type_converter(ident: &Ident, builtin: &Ident) -> syn::Result<TokenStream> {
     Ok(quote! {
         impl UniffiCustomTypeConverter for #ident {
@@ -125,61 +94,4 @@ fn custom_ffi_type_converter(ident: &Ident, builtin: &Ident) -> syn::Result<Toke
             }
         }
     })
-}
-
-mod kw {
-    syn::custom_keyword!(tag);
-    syn::custom_keyword!(builtin);
-    syn::custom_keyword!(newtype);
-}
-
-#[derive(Default)]
-pub(crate) struct CustomTypeAttr {
-    tag: Option<Path>,
-    builtin: Option<Ident>,
-    newtype: Option<Ident>,
-}
-
-impl UniffiAttributeArgs for CustomTypeAttr {
-    fn parse_one(input: ParseStream<'_>) -> syn::Result<Self> {
-        let lookahead = input.lookahead1();
-        if lookahead.peek(kw::tag) {
-            let _: kw::tag = input.parse()?;
-            let _: Token![=] = input.parse()?;
-            Ok(Self {
-                tag: Some(input.parse()?),
-                ..Self::default()
-            })
-        } else if lookahead.peek(kw::builtin) {
-            let _: kw::builtin = input.parse()?;
-            let _: Token![=] = input.parse()?;
-            Ok(Self {
-                builtin: Some(input.parse()?),
-                ..Self::default()
-            })
-        } else if lookahead.peek(kw::newtype) {
-            let _: kw::newtype = input.parse()?;
-            let _: Token![=] = input.parse()?;
-            Ok(Self {
-                newtype: Some(input.parse()?),
-                ..Self::default()
-            })
-        } else {
-            Err(lookahead.error())
-        }
-    }
-
-    fn merge(self, other: Self) -> syn::Result<Self> {
-        Ok(Self {
-            tag: either_attribute_arg(self.tag, other.tag)?,
-            builtin: either_attribute_arg(self.builtin, other.builtin)?,
-            newtype: either_attribute_arg(self.newtype, other.newtype)?,
-        })
-    }
-}
-
-impl Parse for CustomTypeAttr {
-    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        parse_comma_separated(input)
-    }
 }


### PR DESCRIPTION
You need a struct definition to use a derive, but CustomTypes are designed to work even when the strict is defined externally. This PR allows for that to work.