### PR TITLE
Bug 1846223 - uniffi_macros: Force-include the `Cargo.toml` to read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@
 - [Custom Types](https://mozilla.github.io/uniffi-rs/proc_macro/index.html#the-unifficustomtype-derive) are now supported for proc-macros, including a very
   low-friction way of exposing types implementing the new-type idiom.
 
+## v0.24.3 (backend crates: v0.24.3) - (_2023-08-01_)
+
+[All changes in v0.24.3](https://github.com/mozilla/uniffi-rs/compare/v0.24.2...v0.24.3).
+
+### What's changed?
+
+- `uniffi_macros`: Force-include the Cargo.toml to read ([#1683](https://github.com/mozilla/uniffi-rs/pull/1683))
+
 ## v0.24.2 (backend crates: v0.24.2) - (_2023-07-25_)
 
 [All changes in v0.24.2](https://github.com/mozilla/uniffi-rs/compare/v0.24.1...v0.24.2).

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -271,8 +271,30 @@ pub fn include_scaffolding(component_name: TokenStream) -> TokenStream {
             },
             None,
         );
+
+        let toml_path = match util::manifest_path() {
+            Ok(path) => path.display().to_string(),
+            Err(_) => {
+                return quote! {
+                    compile_error!("This macro assumes the crate has a build.rs script, but $OUT_DIR is not present");
+                }.into();
+            }
+        };
+
         quote! {
             #metadata
+
+            // FIXME(HACK):
+            // Include the `Cargo.toml` file into the build.
+            // That way cargo tracks the file and other tools relying on file
+            // tracking see it as well.
+            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1846223
+            // In the future we should handle that by using the `track_path::path` API,
+            // see https://github.com/rust-lang/rust/pull/84029
+            #[allow(dead_code)]
+            mod __unused {
+                const _: &[u8] = include_bytes!(#toml_path);
+            }
 
             include!(concat!(env!("OUT_DIR"), "/", #name, ".uniffi.rs"));
         }


### PR DESCRIPTION
It's another "hack" but needed to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1846223 for now