### PR TITLE
Fix Kotlin callback handler reference handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 - [Custom Types](https://mozilla.github.io/uniffi-rs/proc_macro/index.html#the-unifficustomtype-derive) are now supported for proc-macros, including a very
   low-friction way of exposing types implementing the new-type idiom.
 
+### What's Fixed
+
+- Kotlin: Fixed low-level issue with exported async APIs
+
 ## v0.24.3 (backend crates: v0.24.3) - (_2023-08-01_)
 
 [All changes in v0.24.3](https://github.com/mozilla/uniffi-rs/compare/v0.24.2...v0.24.3).

--- a/fixtures/futures/tests/bindings/test_futures.kts
+++ b/fixtures/futures/tests/bindings/test_futures.kts
@@ -203,3 +203,7 @@ runBlocking {
 
     assertApproximateTime(time, 500, "broken sleep")
 }
+
+
+// Test that we properly cleaned up future callback references
+assert(uniffiActiveFutureCallbacks.size == 0)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
@@ -9,16 +9,12 @@
 suspend fun {{ func.name()|fn_name }}({%- call kt::arg_list_decl(func) -%}){% match func.return_type() %}{% when Some with (return_type) %} : {{ return_type|type_name }}{% when None %}{%- endmatch %} {
     // Create a new `CoroutineScope` for this operation, suspend the coroutine, and call the
     // scaffolding function, passing it one of the callback handlers from `AsyncTypes.kt`.
-    //
-    // Make sure to retain a reference to the callback handler to ensure that it's not GCed before
-    // it's invoked
-    var callbackHolder: {{ func.result_type().borrow()|future_callback_handler }}? = null
     return coroutineScope {
         val scope = this
         return@coroutineScope suspendCoroutine { continuation ->
             try {
                 val callback = {{ func.result_type().borrow()|future_callback_handler }}(continuation)
-                callbackHolder = callback
+                uniffiActiveFutureCallbacks.add(callback)
                 rustCall { status ->
                     _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}(
                         {% call kt::arg_list_lowered(func) %}


### PR DESCRIPTION
When we execute a future on Kotlin, we create a `jni.Callback` instance that Rust calls when the Future is ready.  We need to hold a reference to that object or else the JVM will finalize it and when Rust tries to invoke the callback bad things will happen. In the unit tests this causes them to stall because the Kotlin coroutine continutation is never completed.

The `callbackHolder` variable was intended to hold a reference, but it doesn't seem to be working (see [arg0d's analysis](https://github.com/mozilla/uniffi-rs/pull/1677#issuecomment-1660663156)). I belive the issue is that variable isn't actually used anywhere so Kotlin frees it before the coroutine has completed and the reason #1684 fixes the issue is that it uses the variable in the completion handler (https://github.com/mozilla/uniffi-rs/pull/1684/files#diff-f564b605a6ba32d19bcb47128dc9c5c2f01169e2a41fa60ffaaf0b6eea13845cR34)

This commit changes things so instead of using a local variable, there's a global set that stores all active callbacks.  It seems to fix the issue for me when using arg0d's `repeat(1000) { ... }` test.