### PR TITLE
Allow use of `uniffi::custom_newtype!` from non-root modules

### DIFF
--- a/fixtures/ext-types/proc-macro-lib/src/lib.rs
+++ b/fixtures/ext-types/proc-macro-lib/src/lib.rs
@@ -159,11 +159,15 @@ impl UniffiCustomTypeConverter for Uuid {
     }
 }
 
-// A custom type using the "newtype" idiom. As above, could be external.
-pub struct NewtypeHandle(i64);
+mod submodule {
+    // A custom type using the "newtype" idiom.
+    // Uniffi can generate the UniffiCustomTypeConverter for us.
+    pub struct NewtypeHandle(pub(super) i64);
 
-// Uniffi can generate the UniffiCustomTypeConverter for us too.
-uniffi::custom_newtype!(NewtypeHandle, i64);
+    // Uniffi can generate the UniffiCustomTypeConverter for us too.
+    uniffi::custom_newtype!(NewtypeHandle, i64);
+}
+pub use submodule::NewtypeHandle;
 
 #[uniffi::export]
 fn get_uuid(u: Option<Uuid>) -> Uuid {

--- a/uniffi_macros/src/custom.rs
+++ b/uniffi_macros/src/custom.rs
@@ -39,19 +39,19 @@ pub(crate) fn expand_ffi_converter_custom_type(
         unsafe #impl_spec {
             type FfiType = #ffi_path;
             fn lower(obj: #ident ) -> Self::FfiType {
-                <#builtin as ::uniffi::FfiConverter<crate::UniFfiTag>>::lower(<#ident as UniffiCustomTypeConverter>::from_custom(obj))
+                <#builtin as ::uniffi::FfiConverter<crate::UniFfiTag>>::lower(<#ident as crate::UniffiCustomTypeConverter>::from_custom(obj))
             }
 
             fn try_lift(v: Self::FfiType) -> uniffi::Result<#ident> {
-                <#ident as UniffiCustomTypeConverter>::into_custom(<#builtin as ::uniffi::FfiConverter<crate::UniFfiTag>>::try_lift(v)?)
+                <#ident as crate::UniffiCustomTypeConverter>::into_custom(<#builtin as ::uniffi::FfiConverter<crate::UniFfiTag>>::try_lift(v)?)
             }
 
             fn write(obj: #ident, buf: &mut Vec<u8>) {
-                <#builtin as ::uniffi::FfiConverter<crate::UniFfiTag>>::write(<#ident as UniffiCustomTypeConverter>::from_custom(obj), buf);
+                <#builtin as ::uniffi::FfiConverter<crate::UniFfiTag>>::write(<#ident as crate::UniffiCustomTypeConverter>::from_custom(obj), buf);
             }
 
             fn try_read(buf: &mut &[u8]) -> uniffi::Result<#ident> {
-                <#ident as UniffiCustomTypeConverter>::into_custom(<#builtin as ::uniffi::FfiConverter<crate::UniFfiTag>>::try_read(buf)?)
+                <#ident as crate::UniffiCustomTypeConverter>::into_custom(<#builtin as ::uniffi::FfiConverter<crate::UniFfiTag>>::try_read(buf)?)
             }
 
             ::uniffi::ffi_converter_default_return!(crate::UniFfiTag);
@@ -82,7 +82,7 @@ pub(crate) fn expand_ffi_converter_custom_newtype(
 
 fn custom_ffi_type_converter(ident: &Ident, builtin: &Ident) -> syn::Result<TokenStream> {
     Ok(quote! {
-        impl UniffiCustomTypeConverter for #ident {
+        impl crate::UniffiCustomTypeConverter for #ident {
             type Builtin = #builtin;
 
             fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {


### PR DESCRIPTION
After moving `NewtypeHandle` in the fixture to a submodule I got:

    error[E0433]: failed to resolve: use of undeclared type `UniffiCustomTypeConverter`
       --> fixtures/ext-types/proc-macro-lib/src/lib.rs:168:5
        |
    168 |     uniffi::custom_newtype!(NewtypeHandle, i64);
        |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `UniffiCustomTypeConverter`
        |
        = note: this error originates in the macro `uniffi::custom_newtype` (in Nightly builds, run with -Z macro-backtrace for more info)

Giving the full path to the type defined in the scaffolding resolves this.

---
/cc @mhammond as mentioned in https://github.com/mozilla/uniffi-rs/issues/1639#issuecomment-1669784472

Fixes: #1639
