### PR TITLE
Kotlin: Add deprecated annotation to override of deprecated function

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
@@ -77,6 +77,7 @@ private inline fun <U> rustCall(callback: (RustCallStatus) -> U): U {
 public class USize(value: Long = 0) : IntegerType(Native.SIZE_T_SIZE, value, true) {
     // This is needed to fill in the gaps of IntegerType's implementation of Number for Kotlin.
     override fun toByte() = toInt().toByte()
+    @Deprecated("Deprecated")
     override fun toChar() = toInt().toChar()
     override fun toShort() = toInt().toShort()
 


### PR DESCRIPTION
`toChar()` is deprecated in the latest Kotlin, and without this annotation, compiling the generated bindings will generate a warning (which causes an error with `-WError`). More details in https://github.com/mozilla/uniffi-rs/issues/1685

Verified this fixes the issue on my local repo.