### PR TITLE
Followup to #1680, update macro names for custom type macros.

### DIFF
--- a/docs/manual/src/proc_macro/index.md
+++ b/docs/manual/src/proc_macro/index.md
@@ -186,24 +186,21 @@ impl Foo {
 }
 ```
 
-## The `uniffi::CustomType` derive
+## The `uniffi::custom_type` and `uniffi::custom_newtype` macros
 
-The `CustomType` derive registers a type as a custom type and can be used on any struct that wants to be exposed
-as a builtin type. You must specify the builtin type using either the `builtin` or `newtype` attribute.
+There are 2 macros available which allow procmacros to support "custom types" as described in the
+[UDL documentation for Custom Types](../udl/custom_types.md)
 
-If you specify the `builtin` attribute, you must manually implement the `UniffiCustomTypeConverter` for your
-type as described in the [UDL documentation for Custom Types](../udl/custom_types.md). However, if you
-specify the `newtype` attribute UniFFI will generate the implementation of this trait assuming the type
-implements the "new type" idiom (ie, a tuple struct with the builtin as the only element).
-
-For example, this type does not use the "new type" idiom, so must specify the complete implementation.
+The `uniffi::custom_type!` macro requires you to specify the name of the custom type, and the name of the
+builtin which implements this type. Use of this macro requires you to manually implement the
+`UniffiCustomTypeConverter` trait for for your type, as shown below.
 ```rust
 pub struct Uuid {
     val: String,
 }
 
 // Use `url::Url` as a custom type, with `String` as the Builtin
-uniffi::impl_ffi_converter_custom_type!(Url, String);
+uniffi::custom_type!(Url, String);
 
 impl UniffiCustomTypeConverter for Uuid {
     type Builtin = String;
@@ -218,13 +215,17 @@ impl UniffiCustomTypeConverter for Uuid {
 }
 ```
 
-Whereas this type uses the "new type" idiom, so we can use `impl_ffi_converter_custom_newtype` to
-automatically implement `UniffiCustomTypeConverter`.
+There's also a `uniffi::custom_newtype!` macro, designed for custom types which use the
+"new type" idiom. You still need to specify the type name and builtin type, but because UniFFI
+is able to make assumptions about how the type is laid out, `UniffiCustomTypeConverter`
+is implemented automatically.
 
 ```rust
-impl_ffi_converter_custom_newtype!(NewTypeHandle, i64);
+uniffi::custom_newtype!(NewTypeHandle, i64);
 pub struct NewtypeHandle(i64);
 ```
+
+and that's it!
 
 ## The `uniffi::Error` derive
 

--- a/fixtures/ext-types/proc-macro-lib/src/lib.rs
+++ b/fixtures/ext-types/proc-macro-lib/src/lib.rs
@@ -145,7 +145,7 @@ pub struct Uuid {
 // Tell UniFfi we want to use am UniffiCustomTypeConverter to go to and
 // from a String.
 //  Note this could be done even if the above `struct` defn was external.
-::uniffi::impl_ffi_converter_custom_type!(Uuid, String);
+uniffi::custom_type!(Uuid, String);
 
 impl UniffiCustomTypeConverter for Uuid {
     type Builtin = String;
@@ -163,7 +163,7 @@ impl UniffiCustomTypeConverter for Uuid {
 pub struct NewtypeHandle(i64);
 
 // Uniffi can generate the UniffiCustomTypeConverter for us too.
-::uniffi::impl_ffi_converter_custom_newtype!(NewtypeHandle, i64);
+uniffi::custom_newtype!(NewtypeHandle, i64);
 
 #[uniffi::export]
 fn get_uuid(u: Option<Uuid>) -> Uuid {

--- a/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
@@ -13,5 +13,5 @@
 
 // We generate support for each Custom Type and the builtin type it uses.
 {%- for (name, builtin) in ci.iter_custom_types() %}
-::uniffi::impl_ffi_converter_custom_type!(r#{{ name }}, {{builtin|type_rs}});
+::uniffi::custom_type!(r#{{ name }}, {{builtin|type_rs}});
 {%- endfor -%}

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -134,7 +134,7 @@ pub fn derive_error(input: TokenStream) -> TokenStream {
 /// Generate the `FfiConverter` implementation for a Custom Type - ie,
 /// for a `<T>` which implements `UniffiCustomTypeConverter`.
 #[proc_macro]
-pub fn impl_ffi_converter_custom_type(tokens: TokenStream) -> TokenStream {
+pub fn custom_type(tokens: TokenStream) -> TokenStream {
     let input: IdentPair = syn::parse_macro_input!(tokens);
     custom::expand_ffi_converter_custom_type(
         &input.lhs,
@@ -149,7 +149,7 @@ pub fn impl_ffi_converter_custom_type(tokens: TokenStream) -> TokenStream {
 /// Custom Type - ie, for a `<T>` which implements `UniffiCustomTypeConverter` via the
 /// newtype idiom.
 #[proc_macro]
-pub fn impl_ffi_converter_custom_newtype(tokens: TokenStream) -> TokenStream {
+pub fn custom_newtype(tokens: TokenStream) -> TokenStream {
     let input: IdentPair = syn::parse_macro_input!(tokens);
     custom::expand_ffi_converter_custom_newtype(
         &input.lhs,


### PR DESCRIPTION
I forgot to re-push before landing that PR. I think the new names are better and I'd like to get this in before contributors start playing with it.