### PR TITLE
Render `Vec<u8>` via proc macros as `bytes` not `sequence<u8>`.

### DIFF
--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -151,8 +151,9 @@ mod test_type_ids {
         check_type_id::<Option<u8>>(Type::Optional {
             inner_type: Box::new(Type::UInt8),
         });
-        check_type_id::<Vec<u8>>(Type::Sequence {
-            inner_type: Box::new(Type::UInt8),
+        check_type_id::<Vec<u8>>(Type::Bytes);
+        check_type_id::<Vec<u16>>(Type::Sequence {
+            inner_type: Box::new(Type::UInt16),
         });
         check_type_id::<HashMap<String, u8>>(Type::Map {
             key_type: Box::new(Type::String),

--- a/fixtures/proc-macro/src/callback_interface.rs
+++ b/fixtures/proc-macro/src/callback_interface.rs
@@ -2,13 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::{BasicError, Object};
+use crate::{BasicError, Object, RecordWithBytes};
 
 #[uniffi::export(callback_interface)]
 pub trait TestCallbackInterface {
     fn do_nothing(&self);
     fn add(&self, a: u32, b: u32) -> u32;
     fn optional(&self, a: Option<u32>) -> u32;
+    fn with_bytes(&self, rwb: RecordWithBytes) -> Vec<u8>;
     fn try_parse_int(&self, value: String) -> Result<u32, BasicError>;
     fn callback_handler(&self, h: std::sync::Arc<Object>) -> u32;
 }

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -31,6 +31,11 @@ pub struct Three {
     obj: Arc<Object>,
 }
 
+#[derive(uniffi::Record, Debug, PartialEq)]
+pub struct RecordWithBytes {
+    some_bytes: Vec<u8>,
+}
+
 // An object that's not used anywhere (ie, in records, function signatures, etc)
 // should not break things.
 #[derive(uniffi::Object)]
@@ -98,11 +103,22 @@ fn take_two(two: Two) -> String {
 }
 
 #[uniffi::export]
+fn take_record_with_bytes(rwb: RecordWithBytes) -> Vec<u8> {
+    rwb.some_bytes
+}
+
+#[uniffi::export]
 fn test_callback_interface(cb: Box<dyn TestCallbackInterface>) {
     cb.do_nothing();
     assert_eq!(cb.add(1, 1), 2);
     assert_eq!(cb.optional(Some(1)), 1);
     assert_eq!(cb.optional(None), 0);
+    assert_eq!(
+        cb.with_bytes(RecordWithBytes {
+            some_bytes: vec![9, 8, 7],
+        }),
+        vec![9, 8, 7]
+    );
     assert_eq!(Ok(10), cb.try_parse_int("10".to_string()));
     assert_eq!(
         Err(BasicError::InvalidInput),
@@ -124,6 +140,13 @@ pub struct Zero {
 fn make_zero() -> Zero {
     Zero {
         inner: String::from("ZERO"),
+    }
+}
+
+#[uniffi::export]
+fn make_record_with_bytes() -> RecordWithBytes {
+    RecordWithBytes {
+        some_bytes: vec![0, 1, 2, 3, 4],
     }
 }
 

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
@@ -10,6 +10,9 @@ assert(one.inner == 123)
 val two = Two("a")
 assert(takeTwo(two) == "a")
 
+val rwb = RecordWithBytes(byteArrayOf(1,2,3).toUByteArray().toList())
+assert(takeRecordWithBytes(rwb).toUByteArray().toByteArray().contentEquals(byteArrayOf(1, 2, 3)))
+
 var obj = Object()
 obj = Object.namedCtor(1u)
 assert(obj.isHeavy() == MaybeBool.UNCERTAIN)
@@ -20,6 +23,7 @@ assert(enumIdentity(MaybeBool.TRUE) == MaybeBool.TRUE)
 val three = Three(obj)
 
 assert(makeZero().inner == "ZERO")
+assert(makeRecordWithBytes().someBytes.toUByteArray().toByteArray().contentEquals(byteArrayOf(0, 1, 2, 3, 4)))
 
 try {
     alwaysFails()
@@ -42,6 +46,8 @@ class KtTestCallbackInterface : TestCallbackInterface {
     override fun add(a: UInt, b: UInt) = a + b
 
     override fun optional(a: UInt?) = a ?: 0u
+
+    override fun withBytes(rwb: RecordWithBytes) = rwb.someBytes
 
     override fun tryParseInt(value: String): UInt {
         if (value == "force-unexpected-error") {

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
@@ -10,8 +10,8 @@ assert(one.inner == 123)
 val two = Two("a")
 assert(takeTwo(two) == "a")
 
-val rwb = RecordWithBytes(byteArrayOf(1,2,3).toUByteArray().toList())
-assert(takeRecordWithBytes(rwb).toUByteArray().toByteArray().contentEquals(byteArrayOf(1, 2, 3)))
+val rwb = RecordWithBytes(byteArrayOf(1,2,3))
+assert(takeRecordWithBytes(rwb).contentEquals(byteArrayOf(1, 2, 3)))
 
 var obj = Object()
 obj = Object.namedCtor(1u)
@@ -23,7 +23,7 @@ assert(enumIdentity(MaybeBool.TRUE) == MaybeBool.TRUE)
 val three = Three(obj)
 
 assert(makeZero().inner == "ZERO")
-assert(makeRecordWithBytes().someBytes.toUByteArray().toByteArray().contentEquals(byteArrayOf(0, 1, 2, 3, 4)))
+assert(makeRecordWithBytes().someBytes.contentEquals(byteArrayOf(0, 1, 2, 3, 4)))
 
 try {
     alwaysFails()

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -10,6 +10,9 @@ assert one.inner == 123
 two = Two("a")
 assert take_two(two) == "a"
 
+rwb = RecordWithBytes([1,2,3])
+assert take_record_with_bytes(rwb) == [1,2,3]
+
 obj = Object()
 obj = Object.named_ctor(1)
 assert obj.is_heavy() == MaybeBool.UNCERTAIN
@@ -24,6 +27,7 @@ assert enum_identity(MaybeBool.TRUE) == MaybeBool.TRUE
 three = Three(obj)
 
 assert(make_zero().inner == "ZERO")
+assert(make_record_with_bytes().some_bytes == [0, 1, 2, 3, 4])
 
 try:
     always_fails()
@@ -52,6 +56,9 @@ class PyTestCallbackInterface(TestCallbackInterface):
         if a is None:
             return 0
         return a
+
+    def with_bytes(self, rwb):
+        return rwb.some_bytes
 
     def try_parse_int(self, value):
         if value == "force-unexpected-error":

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -10,8 +10,8 @@ assert one.inner == 123
 two = Two("a")
 assert take_two(two) == "a"
 
-rwb = RecordWithBytes([1,2,3])
-assert take_record_with_bytes(rwb) == [1,2,3]
+rwb = RecordWithBytes(bytes([1,2,3]))
+assert take_record_with_bytes(rwb) == bytes([1,2,3])
 
 obj = Object()
 obj = Object.named_ctor(1)
@@ -27,7 +27,7 @@ assert enum_identity(MaybeBool.TRUE) == MaybeBool.TRUE
 three = Three(obj)
 
 assert(make_zero().inner == "ZERO")
-assert(make_record_with_bytes().some_bytes == [0, 1, 2, 3, 4])
+assert(make_record_with_bytes().some_bytes == bytes([0, 1, 2, 3, 4]))
 
 try:
     always_fails()

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import Foundation
+
 import uniffi_proc_macro
 
 let one = makeOne(inner: 123)
@@ -10,8 +12,8 @@ assert(one.inner == 123)
 let two = Two(a: "a")
 assert(takeTwo(two: two) == "a")
 
-let rwb = RecordWithBytes(someBytes: [1, 2, 3])
-assert(takeRecordWithBytes(rwb: rwb) == [1, 2, 3])
+let rwb = RecordWithBytes(someBytes: Data([1, 2, 3]))
+assert(takeRecordWithBytes(rwb: rwb) == Data([1, 2, 3]))
 
 var obj = Object()
 obj = Object.namedCtor(arg: 1)
@@ -23,7 +25,7 @@ assert(enumIdentity(value: .true) == .true)
 let three = Three(obj: obj)
 
 assert(makeZero().inner == "ZERO")
-assert(makeRecordWithBytes().someBytes == [0, 1, 2, 3, 4])
+assert(makeRecordWithBytes().someBytes == Data([0, 1, 2, 3, 4]))
 
 do {
     try alwaysFails()
@@ -52,7 +54,7 @@ class SwiftTestCallbackInterface : TestCallbackInterface {
         return a ?? 0;
     }
 
-    func withBytes(rwb: RecordWithBytes) -> [UInt8] {
+    func withBytes(rwb: RecordWithBytes) -> Data {
         return rwb.someBytes
     }
 

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
@@ -10,6 +10,9 @@ assert(one.inner == 123)
 let two = Two(a: "a")
 assert(takeTwo(two: two) == "a")
 
+let rwb = RecordWithBytes(someBytes: [1, 2, 3])
+assert(takeRecordWithBytes(rwb: rwb) == [1, 2, 3])
+
 var obj = Object()
 obj = Object.namedCtor(arg: 1)
 assert(obj.isHeavy() == .uncertain)
@@ -20,6 +23,7 @@ assert(enumIdentity(value: .true) == .true)
 let three = Three(obj: obj)
 
 assert(makeZero().inner == "ZERO")
+assert(makeRecordWithBytes().someBytes == [0, 1, 2, 3, 4])
 
 do {
     try alwaysFails()
@@ -46,6 +50,10 @@ class SwiftTestCallbackInterface : TestCallbackInterface {
 
     func `optional`(a: Optional<UInt32>) -> UInt32 {
         return a ?? 0;
+    }
+
+    func withBytes(rwb: RecordWithBytes) -> [UInt8] {
+        return rwb.someBytes
     }
 
     func tryParseInt(value: String) throws -> UInt32 {

--- a/uniffi_meta/src/reader.rs
+++ b/uniffi_meta/src/reader.rs
@@ -10,7 +10,7 @@ pub fn read_metadata(data: &[u8]) -> Result<Metadata> {
     MetadataReader::new(data).read_metadata()
 }
 
-// Read a metadat type, this is pub so that we can test it in the metadata fixture
+// Read a metadata type, this is pub so that we can test it in the metadata fixture
 pub fn read_metadata_type(data: &[u8]) -> Result<Type> {
     MetadataReader::new(data).read_type()
 }

--- a/uniffi_meta/src/reader.rs
+++ b/uniffi_meta/src/reader.rs
@@ -146,9 +146,16 @@ impl<'a> MetadataReader<'a> {
             codes::TYPE_OPTION => Type::Optional {
                 inner_type: Box::new(self.read_type()?),
             },
-            codes::TYPE_VEC => Type::Sequence {
-                inner_type: Box::new(self.read_type()?),
-            },
+            codes::TYPE_VEC => {
+                let inner_type = self.read_type()?;
+                if inner_type == Type::UInt8 {
+                    Type::Bytes
+                } else {
+                    Type::Sequence {
+                        inner_type: Box::new(inner_type),
+                    }
+                }
+            }
             codes::TYPE_HASH_MAP => Type::Map {
                 key_type: Box::new(self.read_type()?),
                 value_type: Box::new(self.read_type()?),


### PR DESCRIPTION
Based on the discussion in #1638, I'm not sure what the overall consensus there was (we got a little sidetracked by the concept of a default) but this is the very simplest thing which happens to satisfy my use-case in the hopes of making things a little more concrete.

Based on the discussion I think these are the other possibilities which were in the mix, in increasing order of (what I think is the) complexity

1. Plumb through the selection to a global option in `uniffii.toml` affecting all languages (conceptually simple but there's a lot of layers to plumb through to get to `MetadataReader::new()` and pass in the choice I think).
2. Plumb through the selection to a per-language option in `uniffii.toml` (not much different to 1 in terms of complexity I think?)
3. Add a `metadata::codes::TYPE_BYTES` and emit it unconditionally for any instance of a `Vec<u8>` (but how to recognise that in a proc macro in the face of aliases etc?)
4. Add a `metadata::codes::TYPE_BYTES` and do $something (an attribute? but then what about function return types?) in the proc macros to allow per field/argument choice "bytes or sequence" for `Vec<u8>` fields), which would feed into a choice when outputing `TYPE_ID_META` for the field/argument in question.
5. As for 3 but allow an arbitrary UDL type to be given.

Personally I don't need 1, 2, 4 or 5 (and 3 is really just an alternative implementation of this PR I think)

On reflection I think 5 is a huge can of worms wrt lifting and lowering and while it seems conceptually nice and general I can't actually think of a use case beyond bytes anyway.

4 is only a potential option because `bytes` and `sequence<u8>` map to the same thing in the FFI buffer (4 bytes length + that many bytes), I think that is by design and could be relied on?

I think @mhammond was concerned about backwards compatibility for consumers of libraries using this, 1 or 2 might satisfy this? Or would 4 be needed? I think, in general an API which mixes bytes and lists of u8 would seem a bit odd, but backwards compat might be a motivator for that.

I've not touched the UDL side of things, there `sequence<u8>` remains a list of `u8`'s. Mark mentioned perhaps wanting to do this for UDL too? It looks like maybe https://github.com/mozilla/uniffi-rs/blob/1696344a8f1643cfa1a36a3fac201340b0b62a98/uniffi_udl/src/resolver.rs#L120 is where that could happen (and then the utility of the `bytes` type in UDL becomes a bit questionable).