### PR TITLE
swift: Only quote keywords in contexts where that is required

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -2,7 +2,7 @@
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 public enum {{ type_name }} {
     {% for variant in e.variants() %}
-    case {{ variant.name()|enum_variant_swift }}{% if variant.fields().len() > 0 %}({% call swift::field_list_decl(variant) %}){% endif -%}
+    case {{ variant.name()|enum_variant_swift_quoted }}{% if variant.fields().len() > 0 %}({% call swift::field_list_decl(variant) %}){% endif -%}
     {% endfor %}
 }
 
@@ -15,7 +15,7 @@ public struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
         {% for variant in e.variants() %}
         case {{ loop.index }}: return .{{ variant.name()|enum_variant_swift }}{% if variant.has_fields() %}(
             {%- for field in variant.fields() %}
-            {{ field.name()|var_name }}: try {{ field|read_fn }}(from: &buf)
+            {{ field.name()|arg_name }}: try {{ field|read_fn }}(from: &buf)
             {%- if !loop.last %}, {% endif %}
             {%- endfor %}
         ){%- endif %}

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -36,7 +36,7 @@ public struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> {{ type_name }} {
         return try {{ type_name }}(
             {%- for field in rec.fields() %}
-            {{ field.name()|var_name }}: {{ field|read_fn }}(from: &buf)
+            {{ field.name()|arg_name }}: {{ field|read_fn }}(from: &buf)
             {%- if !loop.last %}, {% endif %}
             {%- endfor %}
         )


### PR DESCRIPTION
Determined from https://docs.swift.org/swift-book/documentation/the-swift-programming-language/lexicalstructure/#Keywords-and-Punctuation

Previously lots of warning were generated of the form:
```
/tmp/target/tmp/uniffi-example-custom-types-2b18f735d09116c0/custom_types.swift:427:13: warning: keyword 'url' does not need to be escaped in argument list
            `url`: FfiConverterTypeUrl.read(from: &buf),
            ^   ~
```

When compiling generated Swift code.

Swift appears to be fairly tollerant of keyswords in some contexts, in particular:
* only a small subset of keywords need to be quoted when a name is used as an argument label when calling a function.
* enum variant names do not need to be quoted when they are used, only when they are defined.

Fixes: #1460

---

TBH I'm a bit worried about this PR re the chances of regressions: I'm not a Swift expert in any way and the contexts where quoting is required vs not required is a little bit of a mystery to me... I can say that the tests all still pass and in particular `uniffi-fixture-keywords-swift` works, but I don't know how comprehensive the coverage is there. One way to mitigate might be to add some config options to the `bindings.swift` bit of `uniffi.toml` to add keywords to the various lists (including maybe adding one for `enum_variant_swift` which in this PR does no quoting since it isn't needed it seems), i.e. a chicken switch of sorts..