### PR TITLE
swift: Remove unused value warning

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
@@ -56,7 +56,7 @@ public struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
         {% if e.is_flat() %}
 
         {% for variant in e.variants() %}
-        case let .{{ variant.name()|class_name }}(message):
+        case .{{ variant.name()|class_name }}(_ /* message is ignored*/):
             writeInt(&buf, Int32({{ loop.index }}))
         {%- endfor %}
 


### PR DESCRIPTION
The generated code was producing a warning (seen a couple of dozen times in the fixtures):

```
unary_result_alias.swift:373:32: warning: immutable value 'message' was never used; consider replacing with '_' or removing it
        case let .AllGoneWrong(message):
                               ^~~~~~~
                               _
```

The call of `write_fn` on `message` was removed back in 734050dbf149 ("Refactoring the callback interface return code").

Comparing with the Kotlin and Python equivalents the pattern is that the foreign enum/error has the message field but it is not propagated to Rust for flat enums. So replace with `_` as suggested.

Doing so then results in:

```
unary_result_alias.swift:373:14: warning: 'let' pattern has no effect; sub-pattern didn't bind any variables
        case let .AllGoneWrong(_ /* message is ignored*/):
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

So drop the `let` too.