### PR TITLE
swift: Move away from deprecated `Data` constructor

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/DataHelper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/DataHelper.swift
@@ -3,7 +3,7 @@ fileprivate struct FfiConverterData: FfiConverterRustBuffer {
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Data {
         let len: Int32 = try readInt(&buf)
-        return Data(bytes: try readBytes(&buf, count: Int(len)))
+        return Data(try readBytes(&buf, count: Int(len)))
     }
 
     public static func write(_ value: Data, into buf: inout [UInt8]) {


### PR DESCRIPTION
```
uniffi-fixture-coverall-af68e6307d32e36f/coverall.swift:490:16: warning: 'init(bytes:)' is deprecated: replaced by 'init(_:)'
        return Data(bytes: try readBytes(&buf, count: Int(len)))
               ^
uniffi-fixture-coverall-af68e6307d32e36f/coverall.swift:490:16: note: use 'init(_:)' instead
        return Data(bytes: try readBytes(&buf, count: Int(len)))
               ^    ~~~~~~~
```

According to the docs for the [deprecated][] method and the [replacement][] method the replacement is available in all the same versions as the deprecated function, so there should be no risk in removing.

AFAICT the deprecation was in 2018/19 timeframe.

[deprecated]: https://developer.apple.com/documentation/foundation/data/3020550-init
[replacement]: https://developer.apple.com/documentation/foundation/data/2852972-init