### PR TITLE
swift: Avoid generating `try` on function calls which do not throw

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
@@ -28,7 +28,7 @@ fileprivate let {{ foreign_callback }} : ForeignCallback =
         {%- match meth.return_type() %}
         {%- when Some(return_type) %}
         func makeCall() throws -> Int32 {
-            let result = try swiftCallbackInterface.{{ meth.name()|fn_name }}(
+            let result = {% if meth.throws() %} try{% endif %} swiftCallbackInterface.{{ meth.name()|fn_name }}(
                     {% for arg in meth.arguments() -%}
                     {% if !config.omit_argument_labels() %}{{ arg.name()|var_name }}: {% endif %} try {{ arg|read_fn }}(from: &reader)
                     {%- if !loop.last %}, {% endif %}


### PR DESCRIPTION
```
uniffi-fixture-callbacks-129de7ccace1172c/fixture_callbacks.swift:1067:26: warning: no calls to throwing functions occur within 'try' expression
            let result = try swiftCallbackInterface.fromSimpleType(
                         ^
```

NB: the `swift::try` macro is concerned with the containing function calling subfunctions (it expands to `try` or `try!`) which is not what is needed here, we care about whether the subfunction being called throws.