### PR TITLE
kotlin: Use correct name when generating method which takes an error as an ar…

### DIFF
--- a/fixtures/proc-macro/src/callback_interface.rs
+++ b/fixtures/proc-macro/src/callback_interface.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::BasicError;
+use crate::{BasicError, Object};
 
 #[uniffi::export(callback_interface)]
 pub trait TestCallbackInterface {
@@ -10,4 +10,5 @@ pub trait TestCallbackInterface {
     fn add(&self, a: u32, b: u32) -> u32;
     fn optional(&self, a: Option<u32>) -> u32;
     fn try_parse_int(&self, value: String) -> Result<u32, BasicError>;
+    fn callback_handler(&self, h: std::sync::Arc<Object>) -> u32;
 }

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -80,6 +80,11 @@ impl Object {
     fn get_trait(&self, inc: Option<Arc<dyn Trait>>) -> Arc<dyn Trait> {
         inc.unwrap_or_else(|| Arc::new(TraitImpl {}))
     }
+
+    fn take_error(&self, e: BasicError) -> u32 {
+        assert!(matches!(e, BasicError::InvalidInput));
+        42
+    }
 }
 
 #[uniffi::export]
@@ -107,6 +112,7 @@ fn test_callback_interface(cb: Box<dyn TestCallbackInterface>) {
         cb.try_parse_int("force-unexpected-error".to_string()),
         Err(BasicError::UnexpectedError { .. }),
     ));
+    assert_eq!(42, cb.callback_handler(Object::new()));
 }
 
 // Type that's defined in the UDL and not wrapped with #[uniffi::export]

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
@@ -54,6 +54,11 @@ class KtTestCallbackInterface : TestCallbackInterface {
             throw BasicException.InvalidInput()
         }
     }
+
+    override fun callbackHandler(o: Object): UInt {
+        val v = o.takeError(BasicException.InvalidInput());
+        return v
+    }
 }
 
 testCallbackInterface(KtTestCallbackInterface())

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -62,4 +62,8 @@ class PyTestCallbackInterface(TestCallbackInterface):
         except BaseException:
             raise BasicError.InvalidInput()
 
+    def callback_handler(self, h):
+        v = h.take_error(BasicError.InvalidInput())
+        return v
+
 test_callback_interface(PyTestCallbackInterface())

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
@@ -60,6 +60,11 @@ class SwiftTestCallbackInterface : TestCallbackInterface {
             throw BasicError.InvalidInput
         }
     }
+
+    func callbackHandler(h: Object) -> UInt32 {
+        var v = h.takeError(e: BasicError.InvalidInput)
+        return v
+    }
 }
 
 testCallbackInterface(cb: SwiftTestCallbackInterface())

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -42,7 +42,7 @@
 
 {% macro arg_list_decl(func) %}
     {%- for arg in func.arguments() -%}
-        {{ arg.name()|var_name }}: {{ arg|type_name -}}
+        {{ arg.name()|var_name }}: {%- if !ci.is_name_used_as_error(arg|type_name) %} {{ arg|type_name -}} {%- else %} {{ arg|error_type_name -}} {% endif -%}
         {%- match arg.default_value() %}
         {%- when Some with(literal) %} = {{ literal|render_literal(arg) }}
         {%- else %}
@@ -53,7 +53,7 @@
 
 {% macro arg_list_protocol(func) %}
     {%- for arg in func.arguments() -%}
-        {{ arg.name()|var_name }}: {{ arg|type_name -}}
+        {{ arg.name()|var_name }}: {%- if !ci.is_name_used_as_error(arg|type_name) %} {{ arg|type_name -}} {%- else %} {{ arg|error_type_name -}} {% endif -%}
         {%- if !loop.last %}, {% endif -%}
     {%- endfor %}
 {%- endmacro %}


### PR DESCRIPTION
…gument

The name must be renamed `FooError` -> `FooException` to match transforms done elsewhere.

Without the other changes the test changes failed with:

```
uniffi-fixture-proc-macro-fb98904aa2d05965/uniffi/fixture/proc_macro/uniffi_proc_macro.kt:819:26: error: unresolved reference: BasicError
    fun `takeError`(`e`: BasicError): UInt
                         ^
uniffi-fixture-proc-macro-fb98904aa2d05965/uniffi/fixture/proc_macro/uniffi_proc_macro.kt:878:35: error: unresolved reference: BasicError
    override fun `takeError`(`e`: BasicError): UInt =
                                  ^
```

We need to apply the renaming to arg lists too.

Fixes: #1637

---

/cc @mhammond -- thanks for the tip re ci.is_name_used_as_error()!
