### PR TITLE
swift: Add cargo swift to "External resources" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Other tools we know of which try and solve a similarly shaped problem are:
 There are a few third-party resources that make it easier to work with UniFFI:
 
 * [Plugin support for `.udl` files](https://github.com/Lonami/uniffi-dl) for the IDEA platform ([*uniffi-dl* in the JetBrains marketplace](https://plugins.jetbrains.com/plugin/20527-uniffi-dl)). It provides syntax highlighting, code folding, code completion, reference resolution and navigation (among others features) for the [UniFFI Definition Language (UDL)](https://mozilla.github.io/uniffi-rs/).
+* [cargo swift](https://github.com/antoniusnaumann/cargo-swift), a cargo plugin to build a Swift Package from Rust code. It provides an init command for setting up a UniFFI crate and a package command for building a Swift package from Rust code - without the need for additional configuration or build scripts.
 
 (Please open a PR if you think other resources should be listed!)
 


### PR DESCRIPTION
I built a little cargo plugin, that helps with packaging a UniFFI project as Swift Package. The motivation behind this is to allow using Rust code in iOS and macOS apps without requiring additional build scripts or configuration. Building a Swift Package seems to be a good solution for this, since the Swift Package Manager is well integrated into XCode.

Additionally, this enables to distribute Rust + UniFFI crates as Swift Packages for use by other people unfamiliar with Rust or UniFFI.

I would appreciate it if my plugin would be listed in the README.