### PR TITLE
implemented buildMap todo for kotlin

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/MapTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/MapTemplate.kt
@@ -5,8 +5,8 @@ public object {{ ffi_converter_name }}: FfiConverterRustBuffer<Map<{{ key_type_n
         return buildMap<{{ key_type_name }}, {{ value_type_name }}> {
             val len = buf.getInt()
             repeat(len) {
-                val k = { { key_type|read_fn } }(buf)
-                val v = { { value_type|read_fn } }(buf)
+                val k = {{ key_type|read_fn }}(buf)
+                val v = {{ value_type|read_fn }}(buf)
                 this[k] = v
             }
         }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/MapTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/MapTemplate.kt
@@ -2,15 +2,14 @@
 {%- let value_type_name = value_type|type_name %}
 public object {{ ffi_converter_name }}: FfiConverterRustBuffer<Map<{{ key_type_name }}, {{ value_type_name }}>> {
     override fun read(buf: ByteBuffer): Map<{{ key_type_name }}, {{ value_type_name }}> {
-        // TODO: Once Kotlin's `buildMap` API is stabilized we should use it here.
-        val items : MutableMap<{{ key_type_name }}, {{ value_type_name }}> = mutableMapOf()
-        val len = buf.getInt()
-        repeat(len) {
-            val k = {{ key_type|read_fn }}(buf)
-            val v = {{ value_type|read_fn }}(buf)
-            items[k] = v
+        return buildMap<{{ key_type_name }}, {{ value_type_name }}> {
+            val len = buf.getInt()
+            repeat(len) {
+                val k = { { key_type|read_fn } }(buf)
+                val v = { { value_type|read_fn } }(buf)
+                this[k] = v
+            }
         }
-        return items
     }
 
     override fun allocationSize(value: Map<{{ key_type_name }}, {{ value_type_name }}>): Int {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/MapTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/MapTemplate.kt
@@ -2,8 +2,8 @@
 {%- let value_type_name = value_type|type_name %}
 public object {{ ffi_converter_name }}: FfiConverterRustBuffer<Map<{{ key_type_name }}, {{ value_type_name }}>> {
     override fun read(buf: ByteBuffer): Map<{{ key_type_name }}, {{ value_type_name }}> {
-        return buildMap<{{ key_type_name }}, {{ value_type_name }}> {
-            val len = buf.getInt()
+        val len = buf.getInt()
+        return buildMap<{{ key_type_name }}, {{ value_type_name }}>(len) {
             repeat(len) {
                 val k = {{ key_type|read_fn }}(buf)
                 val v = {{ value_type|read_fn }}(buf)


### PR DESCRIPTION
there was todo to use buildMap, it is stable since Kotlin 1.6
implemented todo

note - I was not able to run tests from doker image with 
```
error: failed to open: /mounted_workdir/target/debug/.cargo-lock
Caused by:
  Permission denied (os error 13)
```
But I hope they will run in PR flow now.
