### PR TITLE
Async cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,6 +649,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +851,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "pin-utils",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,6 +930,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,10 +974,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "oneshot"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc22d22931513428ea6cc089e942d38600e3d00976eef8c86de6b8a3aadec6eb"
+dependencies = [
+ "loom",
+]
+
+[[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -1061,8 +1122,17 @@ checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.3.6",
+ "regex-syntax 0.7.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1073,8 +1143,14 @@ checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.4",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1116,6 +1192,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,6 +1211,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -1197,6 +1285,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6805d8ff0f66aa61fb79a97a51ba210dcae753a797336dea8a36a3168196fab"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1307,12 @@ checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
@@ -1284,6 +1387,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,6 +1438,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1787,9 +1962,8 @@ dependencies = [
  "async-compat",
  "bytes",
  "camino",
- "cargo_metadata",
  "log",
- "once_cell",
+ "oneshot",
  "paste",
  "static_assertions",
 ]
@@ -1876,6 +2050,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
@@ -2019,6 +2199,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/uniffi_core/Cargo.toml
+++ b/uniffi_core/Cargo.toml
@@ -17,9 +17,9 @@ async-compat = { version = "0.2.1", optional = true }
 bytes = "1.3"
 camino = "1.0.8"
 log = "0.4"
-once_cell = "1.12"
+# Enable "async" so that receivers implement Future, no need for "std" since we don't block on them.
+oneshot = { version = "0.1", features = ["async"] }
 # Regular dependencies
-cargo_metadata = "0.15"
 paste = "1.0"
 static_assertions = "1.1.0"
 

--- a/uniffi_core/src/ffi/callbackinterface.rs
+++ b/uniffi_core/src/ffi/callbackinterface.rs
@@ -1,0 +1,234 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Callback interfaces are traits specified in UDL which can be implemented by foreign languages.
+//!
+//! # Using callback interfaces
+//!
+//! 1. Define a Rust trait.
+//!
+//! This toy example defines a way of Rust accessing a key-value store exposed
+//! by the host operating system (e.g. the key chain).
+//!
+//! ```
+//! trait Keychain: Send {
+//!   fn get(&self, key: String) -> Option<String>;
+//!   fn put(&self, key: String, value: String);
+//! }
+//! ```
+//!
+//! 2. Define a callback interface in the UDL
+//!
+//! ```idl
+//! callback interface Keychain {
+//!     string? get(string key);
+//!     void put(string key, string data);
+//! };
+//! ```
+//!
+//! 3. And allow it to be passed into Rust.
+//!
+//! Here, we define a constructor to pass the keychain to rust, and then another method
+//! which may use it.
+//!
+//! In UDL:
+//! ```idl
+//! object Authenticator {
+//!     constructor(Keychain keychain);
+//!     void login();
+//! }
+//! ```
+//!
+//! In Rust:
+//!
+//! ```
+//!# trait Keychain: Send {
+//!#  fn get(&self, key: String) -> Option<String>;
+//!#  fn put(&self, key: String, value: String);
+//!# }
+//! struct Authenticator {
+//!   keychain: Box<dyn Keychain>,
+//! }
+//!
+//! impl Authenticator {
+//!   pub fn new(keychain: Box<dyn Keychain>) -> Self {
+//!     Self { keychain }
+//!   }
+//!   pub fn login(&self) {
+//!     let username = self.keychain.get("username".into());
+//!     let password = self.keychain.get("password".into());
+//!   }
+//! }
+//! ```
+//! 4. Create an foreign language implementation of the callback interface.
+//!
+//! In this example, here's a Kotlin implementation.
+//!
+//! ```kotlin
+//! class AndroidKeychain: Keychain {
+//!     override fun get(key: String): String? {
+//!         // … elide the implementation.
+//!         return value
+//!     }
+//!     override fun put(key: String) {
+//!         // … elide the implementation.
+//!     }
+//! }
+//! ```
+//! 5. Pass the implementation to Rust.
+//!
+//! Again, in Kotlin
+//!
+//! ```kotlin
+//! val authenticator = Authenticator(AndroidKeychain())
+//! authenticator.login()
+//! ```
+//!
+//! # How it works.
+//!
+//! ## High level
+//!
+//! Uniffi generates a protocol or interface in client code in the foreign language must implement.
+//!
+//! For each callback interface, a `CallbackInternals` (on the Foreign Language side) and `ForeignCallbackInternals`
+//! (on Rust side) manages the process through a `ForeignCallback`. There is one `ForeignCallback` per callback interface.
+//!
+//! Passing a callback interface implementation from foreign language (e.g. `AndroidKeychain`) into Rust causes the
+//! `KeychainCallbackInternals` to store the instance in a handlemap.
+//!
+//! The object handle is passed over to Rust, and used to instantiate a struct `KeychainProxy` which implements
+//! the trait. This proxy implementation is generate by Uniffi. The `KeychainProxy` object is then passed to
+//! client code as `Box<dyn Keychain>`.
+//!
+//! Methods on `KeychainProxy` objects (e.g. `self.keychain.get("username".into())`) encode the arguments into a `RustBuffer`.
+//! Using the `ForeignCallback`, it calls the `CallbackInternals` object on the foreign language side using the
+//! object handle, and the method selector.
+//!
+//! The `CallbackInternals` object unpacks the arguments from the passed buffer, gets the object out from the handlemap,
+//! and calls the actual implementation of the method.
+//!
+//! If there's a return value, it is packed up in to another `RustBuffer` and used as the return value for
+//! `ForeignCallback`. The caller of `ForeignCallback`, the `KeychainProxy` unpacks the returned buffer into the correct
+//! type and then returns to client code.
+//!
+
+use crate::{FfiConverter, ForeignCallback, ForeignCallbackCell, RustBuffer};
+use std::fmt;
+
+/// The method index used by the Drop trait to communicate to the foreign language side that Rust has finished with it,
+/// and it can be deleted from the handle map.
+pub const IDX_CALLBACK_FREE: u32 = 0;
+
+/// Result of a foreign callback invocation
+#[repr(i32)]
+#[derive(Debug, PartialEq, Eq)]
+pub enum CallbackResult {
+    /// Successful call.
+    /// The return value is serialized to `buf_ptr`.
+    Success = 0,
+    /// Expected error.
+    /// This is returned when a foreign method throws an exception that corresponds to the Rust Err half of a Result.
+    /// The error value is serialized to `buf_ptr`.
+    Error = 1,
+    /// Unexpected error.
+    /// An error message string is serialized to `buf_ptr`.
+    UnexpectedError = 2,
+}
+
+impl TryFrom<i32> for CallbackResult {
+    // On errors we return the unconverted value
+    type Error = i32;
+
+    fn try_from(value: i32) -> Result<Self, i32> {
+        match value {
+            0 => Ok(Self::Success),
+            1 => Ok(Self::Error),
+            2 => Ok(Self::UnexpectedError),
+            n => Err(n),
+        }
+    }
+}
+
+/// Struct to hold a foreign callback.
+pub struct ForeignCallbackInternals {
+    callback_cell: ForeignCallbackCell,
+}
+
+impl ForeignCallbackInternals {
+    pub const fn new() -> Self {
+        ForeignCallbackInternals {
+            callback_cell: ForeignCallbackCell::new(),
+        }
+    }
+
+    pub fn set_callback(&self, callback: ForeignCallback) {
+        self.callback_cell.set(callback);
+    }
+
+    /// Invoke a callback interface method on the foreign side and return the result
+    pub fn invoke_callback<R, UniFfiTag>(&self, handle: u64, method: u32, args: RustBuffer) -> R
+    where
+        R: FfiConverter<UniFfiTag>,
+    {
+        let mut ret_rbuf = RustBuffer::new();
+        let callback = self.callback_cell.get();
+        let raw_result = unsafe {
+            callback(
+                handle,
+                method,
+                args.data_pointer(),
+                args.len() as i32,
+                &mut ret_rbuf,
+            )
+        };
+        let result = CallbackResult::try_from(raw_result)
+            .unwrap_or_else(|code| panic!("Callback failed with unexpected return code: {code}"));
+        match result {
+            CallbackResult::Success => R::lift_callback_return(ret_rbuf),
+            CallbackResult::Error => R::lift_callback_error(ret_rbuf),
+            CallbackResult::UnexpectedError => {
+                let reason = if !ret_rbuf.is_empty() {
+                    match <String as FfiConverter<UniFfiTag>>::try_lift(ret_rbuf) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            log::error!("{{ trait_name }} Error reading ret_buf: {e}");
+                            String::from("[Error reading reason]")
+                        }
+                    }
+                } else {
+                    RustBuffer::destroy(ret_rbuf);
+                    String::from("[Unknown Reason]")
+                };
+                R::handle_callback_unexpected_error(UnexpectedUniFFICallbackError { reason })
+            }
+        }
+    }
+}
+
+/// Used when internal/unexpected error happened when calling a foreign callback, for example when
+/// a unknown exception is raised
+///
+/// User callback error types must implement a From impl from this type to their own error type.
+#[derive(Debug)]
+pub struct UnexpectedUniFFICallbackError {
+    pub reason: String,
+}
+
+impl UnexpectedUniFFICallbackError {
+    pub fn from_reason(reason: String) -> Self {
+        Self { reason }
+    }
+}
+
+impl fmt::Display for UnexpectedUniFFICallbackError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "UnexpectedUniFFICallbackError(reason: {:?})",
+            self.reason
+        )
+    }
+}
+
+impl std::error::Error for UnexpectedUniFFICallbackError {}

--- a/uniffi_core/src/ffi/foreigncallbacks.rs
+++ b/uniffi_core/src/ffi/foreigncallbacks.rs
@@ -2,120 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-//! Callback interfaces are traits specified in UDL which can be implemented by foreign languages.
-//!
-//! # Using callback interfaces
-//!
-//! 1. Define a Rust trait.
-//!
-//! This toy example defines a way of Rust accessing a key-value store exposed
-//! by the host operating system (e.g. the key chain).
-//!
-//! ```
-//! trait Keychain: Send {
-//!   fn get(&self, key: String) -> Option<String>;
-//!   fn put(&self, key: String, value: String);
-//! }
-//! ```
-//!
-//! 2. Define a callback interface in the UDL
-//!
-//! ```idl
-//! callback interface Keychain {
-//!     string? get(string key);
-//!     void put(string key, string data);
-//! };
-//! ```
-//!
-//! 3. And allow it to be passed into Rust.
-//!
-//! Here, we define a constructor to pass the keychain to rust, and then another method
-//! which may use it.
-//!
-//! In UDL:
-//! ```idl
-//! object Authenticator {
-//!     constructor(Keychain keychain);
-//!     void login();
-//! }
-//! ```
-//!
-//! In Rust:
-//!
-//! ```
-//!# trait Keychain: Send {
-//!#  fn get(&self, key: String) -> Option<String>;
-//!#  fn put(&self, key: String, value: String);
-//!# }
-//! struct Authenticator {
-//!   keychain: Box<dyn Keychain>,
-//! }
-//!
-//! impl Authenticator {
-//!   pub fn new(keychain: Box<dyn Keychain>) -> Self {
-//!     Self { keychain }
-//!   }
-//!   pub fn login(&self) {
-//!     let username = self.keychain.get("username".into());
-//!     let password = self.keychain.get("password".into());
-//!   }
-//! }
-//! ```
-//! 4. Create an foreign language implementation of the callback interface.
-//!
-//! In this example, here's a Kotlin implementation.
-//!
-//! ```kotlin
-//! class AndroidKeychain: Keychain {
-//!     override fun get(key: String): String? {
-//!         // … elide the implementation.
-//!         return value
-//!     }
-//!     override fun put(key: String) {
-//!         // … elide the implementation.
-//!     }
-//! }
-//! ```
-//! 5. Pass the implementation to Rust.
-//!
-//! Again, in Kotlin
-//!
-//! ```kotlin
-//! val authenticator = Authenticator(AndroidKeychain())
-//! authenticator.login()
-//! ```
-//!
-//! # How it works.
-//!
-//! ## High level
-//!
-//! Uniffi generates a protocol or interface in client code in the foreign language must implement.
-//!
-//! For each callback interface, a `CallbackInternals` (on the Foreign Language side) and `ForeignCallbackInternals`
-//! (on Rust side) manages the process through a `ForeignCallback`. There is one `ForeignCallback` per callback interface.
-//!
-//! Passing a callback interface implementation from foreign language (e.g. `AndroidKeychain`) into Rust causes the
-//! `KeychainCallbackInternals` to store the instance in a handlemap.
-//!
-//! The object handle is passed over to Rust, and used to instantiate a struct `KeychainProxy` which implements
-//! the trait. This proxy implementation is generate by Uniffi. The `KeychainProxy` object is then passed to
-//! client code as `Box<dyn Keychain>`.
-//!
-//! Methods on `KeychainProxy` objects (e.g. `self.keychain.get("username".into())`) encode the arguments into a `RustBuffer`.
-//! Using the `ForeignCallback`, it calls the `CallbackInternals` object on the foreign language side using the
-//! object handle, and the method selector.
-//!
-//! The `CallbackInternals` object unpacks the arguments from the passed buffer, gets the object out from the handlemap,
-//! and calls the actual implementation of the method.
-//!
-//! If there's a return value, it is packed up in to another `RustBuffer` and used as the return value for
-//! `ForeignCallback`. The caller of `ForeignCallback`, the `KeychainProxy` unpacks the returned buffer into the correct
-//! type and then returns to client code.
-//!
+//! This module contains code to handle foreign callbacks - C-ABI functions that are defined by a
+//! foreign language, then registered with UniFFI.  These callbacks are used to implement callback
+//! interfaces, async scheduling etc. Foreign callbacks are registered at startup, when the foreign
+//! code loads the exported library. For each callback type, we also define a "cell" type for
+//! storing the callback.
 
-use crate::{FfiConverter, RustBuffer};
-use std::fmt;
 use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::{ForeignExecutorHandle, RustBuffer, RustTaskCallback};
 
 /// ForeignCallback is the Rust representation of a foreign language function.
 /// It is the basis for all callbacks interfaces. It is registered exactly once per callback interface,
@@ -132,7 +27,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 ///   arguments from the buffer and passes them to the user's callback.
 /// * `buf_ptr` is a pointer to where the resulting buffer will be written. UniFFI will allocate a
 ///   buffer to write the result into.
-/// * Callbacks return on of the `CallbackResult` values
+/// * Callbacks return one of the `CallbackResult` values
 ///   Note: The output buffer might still contain 0 bytes of data.
 pub type ForeignCallback = unsafe extern "C" fn(
     handle: u64,
@@ -142,162 +37,67 @@ pub type ForeignCallback = unsafe extern "C" fn(
     buf_ptr: *mut RustBuffer,
 ) -> i32;
 
-/// The method index used by the Drop trait to communicate to the foreign language side that Rust has finished with it,
-/// and it can be deleted from the handle map.
-pub const IDX_CALLBACK_FREE: u32 = 0;
-
-/// Result of a foreign callback invocation
-#[repr(i32)]
-#[derive(Debug, PartialEq, Eq)]
-pub enum CallbackResult {
-    /// Successful call.
-    /// The return value is serialized to `buf_ptr`.
-    Success = 0,
-    /// Expected error.
-    /// This is returned when a foreign method throws an exception that corresponds to the Rust Err half of a Result.
-    /// The error value is serialized to `buf_ptr`.
-    Error = 1,
-    /// Unexpected error.
-    /// An error message string is serialized to `buf_ptr`.
-    UnexpectedError = 2,
-}
-
-impl TryFrom<i32> for CallbackResult {
-    // On errors we return the unconverted value
-    type Error = i32;
-
-    fn try_from(value: i32) -> Result<Self, i32> {
-        match value {
-            0 => Ok(Self::Success),
-            1 => Ok(Self::Error),
-            2 => Ok(Self::UnexpectedError),
-            n => Err(n)
-        }
-    }
-}
-
-// Overly-paranoid sanity checking to ensure that these types are
-// convertible between each-other. `transmute` actually should check this for
-// us too, but this helps document the invariants we rely on in this code.
-//
-// Note that these are guaranteed by
-// https://rust-lang.github.io/unsafe-code-guidelines/layout/function-pointers.html
-// and thus this is a little paranoid.
-static_assertions::assert_eq_size!(usize, ForeignCallback);
-static_assertions::assert_eq_size!(usize, Option<ForeignCallback>);
-
-/// Struct to hold a foreign callback.
-pub struct ForeignCallbackInternals {
-    callback_ptr: AtomicUsize,
-}
-
-const EMPTY_PTR: usize = 0;
-
-impl ForeignCallbackInternals {
-    pub const fn new() -> Self {
-        ForeignCallbackInternals {
-            callback_ptr: AtomicUsize::new(EMPTY_PTR),
-        }
-    }
-
-    pub fn set_callback(&self, callback: ForeignCallback) {
-        let as_usize = callback as usize;
-        let old_ptr = self.callback_ptr.compare_exchange(
-            EMPTY_PTR,
-            as_usize,
-            Ordering::SeqCst,
-            Ordering::SeqCst,
-        );
-        match old_ptr {
-            // We get the previous value back. If this is anything except EMPTY_PTR,
-            // then this has been set before we get here.
-            Ok(EMPTY_PTR) => (),
-            _ =>
-            // This is an internal bug, the other side of the FFI should ensure
-            // it sets this only once.
-            {
-                panic!("Bug: call set_callback multiple times. This is likely a uniffi bug")
-            }
-        };
-    }
-
-    fn call_callback(
-        &self,
-        handle: u64,
-        method: u32,
-        args: RustBuffer,
-        ret_rbuf: &mut RustBuffer,
-    ) -> i32 {
-        let ptr_value = self.callback_ptr.load(Ordering::SeqCst);
-        unsafe {
-            // SAFETY: `callback_ptr` was set in `set_callback` from a ForeignCallback pointer, so
-            // it's safe to transmute it back here.
-            let callback = std::mem::transmute::<usize, Option<ForeignCallback>>(ptr_value)
-                .expect("Callback interface handler not set");
-            callback(
-                handle,
-                method,
-                args.data_pointer(),
-                args.len() as i32,
-                ret_rbuf,
-            )
-        }
-    }
-
-    /// Invoke a callback interface method on the foreign side and return the result
-    pub fn invoke_callback<R, UniFfiTag>(&self, handle: u64, method: u32, args: RustBuffer) -> R
-    where
-        R: FfiConverter<UniFfiTag>,
-    {
-        let mut ret_rbuf = RustBuffer::new();
-        let raw_result = self.call_callback(handle, method, args, &mut ret_rbuf);
-        let result = CallbackResult::try_from(raw_result)
-            .unwrap_or_else(|code| panic!("Callback failed with unexpected return code: {code}"));
-        match result {
-            CallbackResult::Success => R::lift_callback_return(ret_rbuf),
-            CallbackResult::Error => R::lift_callback_error(ret_rbuf),
-            CallbackResult::UnexpectedError => {
-                let reason = if !ret_rbuf.is_empty() {
-                    match <String as FfiConverter<UniFfiTag>>::try_lift(ret_rbuf) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            log::error!("{{ trait_name }} Error reading ret_buf: {e}");
-                            String::from("[Error reading reason]")
-                        }
-                    }
-                } else {
-                    RustBuffer::destroy(ret_rbuf);
-                    String::from("[Unknown Reason]")
-                };
-                R::handle_callback_unexpected_error(UnexpectedUniFFICallbackError { reason })
-            }
-        }
-    }
-}
-
-/// Used when internal/unexpected error happened when calling a foreign callback, for example when
-/// a unknown exception is raised
+/// Callback to schedule a Rust call with a `ForeignExecutor`. The bindings code registers exactly
+/// one of these with the Rust code.
 ///
-/// User callback error types must implement a From impl from this type to their own error type.
-#[derive(Debug)]
-pub struct UnexpectedUniFFICallbackError {
-    pub reason: String,
+/// Delay is an approximate amount of ms to wait before scheduling the call.  Delay is usually 0,
+/// which means schedule sometime soon.
+///
+/// As a special case, when Rust drops the foreign executor, with `task=null`.  The foreign
+/// bindings should release the reference to the executor that was reserved for Rust.
+///
+/// This callback can be invoked from any thread, including threads created by Rust.
+///
+/// The callback should return one of the `ForeignExecutorCallbackResult` values.
+pub type ForeignExecutorCallback = extern "C" fn(
+    executor: ForeignExecutorHandle,
+    delay: u32,
+    task: Option<RustTaskCallback>,
+    task_data: *const (),
+) -> i8;
+
+/// Store a [ForeignCallback] pointer
+pub(crate) struct ForeignCallbackCell(AtomicUsize);
+
+/// Store a [ForeignExecutorCallback] pointer
+pub(crate) struct ForeignExecutorCallbackCell(AtomicUsize);
+
+/// Macro to define foreign callback types as well as the callback cell.
+macro_rules! impl_foreign_callback_cell {
+    ($callback_type:ident, $cell_type:ident) => {
+        // Overly-paranoid sanity checking to ensure that these types are
+        // convertible between each-other. `transmute` actually should check this for
+        // us too, but this helps document the invariants we rely on in this code.
+        //
+        // Note that these are guaranteed by
+        // https://rust-lang.github.io/unsafe-code-guidelines/layout/function-pointers.html
+        // and thus this is a little paranoid.
+        static_assertions::assert_eq_size!(usize, $callback_type);
+        static_assertions::assert_eq_size!(usize, Option<$callback_type>);
+
+        impl $cell_type {
+            pub const fn new() -> Self {
+                Self(AtomicUsize::new(0))
+            }
+
+            pub fn set(&self, callback: $callback_type) {
+                // Store the pointer using Ordering::Relaxed.  This is sufficient since callback
+                // should be set at startup, before there's any chance of using them.
+                self.0.store(callback as usize, Ordering::Relaxed);
+            }
+
+            pub fn get(&self) -> $callback_type {
+                let ptr_value = self.0.load(Ordering::Relaxed);
+                unsafe {
+                    // SAFETY: self.0 was set in `set` from our function pointer type, so
+                    // it's safe to transmute it back here.
+                    ::std::mem::transmute::<usize, Option<$callback_type>>(ptr_value)
+                        .expect("Bug: callback not set.  This is likely a uniffi bug.")
+                }
+            }
+        }
+    };
 }
 
-impl UnexpectedUniFFICallbackError {
-    pub fn from_reason(reason: String) -> Self {
-        Self { reason }
-    }
-}
-
-impl fmt::Display for UnexpectedUniFFICallbackError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "UnexpectedUniFFICallbackError(reason: {:?})",
-            self.reason
-        )
-    }
-}
-
-impl std::error::Error for UnexpectedUniFFICallbackError {}
+impl_foreign_callback_cell!(ForeignCallback, ForeignCallbackCell);
+impl_foreign_callback_cell!(ForeignExecutorCallback, ForeignExecutorCallbackCell);

--- a/uniffi_core/src/ffi/foreignexecutor.rs
+++ b/uniffi_core/src/ffi/foreignexecutor.rs
@@ -5,15 +5,8 @@
 //! Schedule tasks using a foreign executor.
 
 use std::{
-    cell::UnsafeCell,
-    future::Future,
     panic,
-    pin::Pin,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc, Mutex,
-    },
-    task::{Context, Poll, Waker},
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 /// Opaque handle for a foreign task executor.
@@ -150,7 +143,19 @@ impl ForeignExecutor {
     ///   - 'static: since it runs at an arbitrary time, so all references need to be 'static
     ///   - panic::UnwindSafe: if the closure panics, it should not corrupt any data
     pub fn schedule<F: FnOnce() + Send + 'static + panic::UnwindSafe>(&self, delay: u32, task: F) {
-        ScheduledTask::new(task).schedule_callback(self.handle, delay)
+        let leaked_ptr: *mut F = Box::leak(Box::new(task));
+        if !schedule_raw(
+            self.handle,
+            delay,
+            schedule_callback::<F>,
+            leaked_ptr as *const (),
+        ) {
+            // If schedule_raw() failed, drop the leaked box since `schedule_callback()` has not been
+            // scheduled to run.
+            unsafe {
+                drop(Box::<F>::from_raw(leaked_ptr));
+            };
+        }
     }
 
     /// Schedule a closure to be run and get a Future for the result
@@ -159,14 +164,28 @@ impl ForeignExecutor {
     ///   - Send: since the closure will likely run on a different thread
     ///   - 'static: since it runs at an arbitrary time, so all references need to be 'static
     ///   - panic::UnwindSafe: if the closure panics, it should not corrupt any data
-    pub fn run<F: FnOnce() -> T + Send + 'static + panic::UnwindSafe, T>(
-        &self,
-        delay: u32,
-        closure: F,
-    ) -> impl Future<Output = T> {
-        let future = RunFuture::new(closure);
-        future.schedule_callback(self.handle, delay);
-        future
+    pub async fn run<F, T>(&self, delay: u32, closure: F) -> T
+    where
+        F: FnOnce() -> T + Send + 'static + panic::UnwindSafe,
+        T: Send + 'static,
+    {
+        // Create a oneshot channel to handle the future
+        let (sender, receiver) = oneshot::channel();
+        // We can use `AssertUnwindSafe` here because:
+        //   - The closure is unwind safe
+        //   - `Sender` is not marked unwind safe, maybe this is just an oversight in the oneshot
+        //     library.  However, calling `send()` and dropping the Sender should certainly be
+        //     unwind safe.  `send()` should probably not panic at all and if it does it shouldn't
+        //     do it in a way that breaks the Receiver.
+        //   - Calling `expect` may result in a panic, but this should should not break either the
+        //     Sender or Receiver.
+        self.schedule(
+            delay,
+            panic::AssertUnwindSafe(move || {
+                sender.send(closure()).expect("Error sending future result")
+            }),
+        );
+        receiver.await.expect("Error receiving future result")
     }
 }
 
@@ -191,119 +210,16 @@ impl Drop for ForeignExecutor {
         (get_foreign_executor_callback())(self.handle, 0, None, std::ptr::null());
     }
 }
-/// Struct that handles the ForeignExecutor::schedule() method
-struct ScheduledTask<F> {
-    task: F,
-}
 
-impl<F> ScheduledTask<F>
+extern "C" fn schedule_callback<F>(data: *const (), status_code: RustTaskCallbackCode)
 where
     F: FnOnce() + Send + 'static + panic::UnwindSafe,
 {
-    fn new(task: F) -> Self {
-        Self { task }
-    }
-
-    fn schedule_callback(self, handle: ForeignExecutorHandle, delay: u32) {
-        let leaked_ptr: *mut Self = Box::leak(Box::new(self));
-        if !schedule_raw(handle, delay, Self::callback, leaked_ptr as *const ()) {
-            // If schedule_raw() failed, drop the leaked box since `Self::callback()` has not been
-            // scheduled to run.
-            unsafe {
-                // Note: specifying the Box generic is a good safety measure.  Things would go very
-                // bad if Rust inferred the wrong type.
-                drop(Box::<Self>::from_raw(leaked_ptr));
-            };
-        }
-    }
-
-    extern "C" fn callback(data: *const (), status_code: RustTaskCallbackCode) {
-        // No matter what, we need to call Box::from_raw() to balance the Box::leak() call.
-        let scheduled_task = unsafe { Box::from_raw(data as *mut Self) };
-        if status_code == RustTaskCallbackCode::Success {
-            run_task(scheduled_task.task);
-        }
-    }
-}
-
-/// Struct that handles the ForeignExecutor::run() method
-struct RunFuture<T, F> {
-    inner: Arc<RunFutureInner<T, F>>,
-}
-
-// State inside the RunFuture Arc<>
-struct RunFutureInner<T, F> {
-    // SAFETY: we only access this once in the scheduled callback
-    task: UnsafeCell<Option<F>>,
-    mutex: Mutex<RunFutureInner2<T>>,
-}
-
-// State inside the RunFuture Mutex<>
-struct RunFutureInner2<T> {
-    result: Option<T>,
-    waker: Option<Waker>,
-}
-
-impl<T, F> RunFuture<T, F>
-where
-    F: FnOnce() -> T + Send + 'static + panic::UnwindSafe,
-{
-    fn new(task: F) -> Self {
-        Self {
-            inner: Arc::new(RunFutureInner {
-                task: UnsafeCell::new(Some(task)),
-                mutex: Mutex::new(RunFutureInner2 {
-                    result: None,
-                    waker: None,
-                }),
-            }),
-        }
-    }
-
-    fn schedule_callback(&self, handle: ForeignExecutorHandle, delay: u32) {
-        let raw_ptr = Arc::into_raw(Arc::clone(&self.inner));
-        if !schedule_raw(handle, delay, Self::callback, raw_ptr as *const ()) {
-            // If `schedule_raw()` failed, make sure to decrement the ref count since
-            // `Self::callback()` has not been scheduled to run.
-            unsafe {
-                // Note: specifying the Arc generic is a good safety measure.  Things would go very
-                // bad if Rust inferred the wrong type.
-                Arc::<RunFutureInner<T, F>>::decrement_strong_count(raw_ptr);
-            };
-        }
-    }
-
-    extern "C" fn callback(data: *const (), status_code: RustTaskCallbackCode) {
-        // No matter what, call `Arc::from_raw()` to balance the `Arc::into_raw()` call in
-        // `schedule_callback()`.
-        let inner = unsafe { Arc::from_raw(data as *const RunFutureInner<T, F>) };
-
-        // Only drive the future forward on `RustTaskCallbackCode::Success`.
-        if status_code == RustTaskCallbackCode::Success {
-            let task = unsafe { (*inner.task.get()).take().unwrap() };
-            if let Some(result) = run_task(task) {
-                let mut inner2 = inner.mutex.lock().unwrap();
-                inner2.result = Some(result);
-                if let Some(waker) = inner2.waker.take() {
-                    waker.wake();
-                }
-            }
-        }
-    }
-}
-
-impl<T, F> Future for RunFuture<T, F> {
-    type Output = T;
-
-    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<T> {
-        let mut inner2 = self.inner.mutex.lock().unwrap();
-        match inner2.result.take() {
-            Some(v) => Poll::Ready(v),
-            None => {
-                inner2.waker = Some(context.waker().clone());
-                Poll::Pending
-            }
-        }
+    // No matter what, we need to call Box::from_raw() to balance the Box::leak() call.
+    let task = unsafe { Box::from_raw(data as *mut F) };
+    // Skip running the task for the `RustTaskCallbackCode::Cancelled` code
+    if status_code == RustTaskCallbackCode::Success {
+        run_task(task);
     }
 }
 
@@ -333,11 +249,15 @@ pub use test::MockEventLoop;
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::sync::{
-        atomic::{AtomicU32, Ordering},
-        Once,
+    use std::{
+        future::Future,
+        pin::Pin,
+        sync::{
+            atomic::{AtomicU32, Ordering},
+            Arc, Mutex, Once,
+        },
+        task::{Context, Poll, Wake, Waker},
     };
-    use std::task::Wake;
 
     /// Simulate an event loop / task queue / coroutine scope on the foreign side
     ///
@@ -504,17 +424,24 @@ mod test {
         assert_eq!(eventloop.call_count(), 0);
 
         let mut future = executor.run(0, move || "test-return-value");
+        unsafe {
+            assert_eq!(
+                Pin::new_unchecked(&mut future).poll(&mut context),
+                Poll::Pending
+            );
+        }
         assert_eq!(eventloop.call_count(), 1);
-        assert_eq!(Pin::new(&mut future).poll(&mut context), Poll::Pending);
         assert_eq!(mock_waker.wake_count.load(Ordering::Relaxed), 0);
 
         eventloop.run_all_calls();
         assert_eq!(eventloop.call_count(), 0);
         assert_eq!(mock_waker.wake_count.load(Ordering::Relaxed), 1);
-        assert_eq!(
-            Pin::new(&mut future).poll(&mut context),
-            Poll::Ready("test-return-value")
-        );
+        unsafe {
+            assert_eq!(
+                Pin::new_unchecked(&mut future).poll(&mut context),
+                Poll::Ready("test-return-value")
+            );
+        }
     }
 
     #[test]

--- a/uniffi_core/src/ffi/mod.rs
+++ b/uniffi_core/src/ffi/mod.rs
@@ -4,6 +4,7 @@
 
 //! Types that can cross the FFI boundary.
 
+pub mod callbackinterface;
 pub mod ffidefault;
 pub mod foreignbytes;
 pub mod foreigncallbacks;
@@ -12,6 +13,7 @@ pub mod rustbuffer;
 pub mod rustcalls;
 pub mod rustfuture;
 
+pub use callbackinterface::*;
 pub use ffidefault::FfiDefault;
 pub use foreignbytes::*;
 pub use foreigncallbacks::*;


### PR DESCRIPTION
This PR contains a variety of code cleanups related to the async and callback interface code.  This is prep work for a couple of improvements I hope to make in the near future.

I think the only change that might be controversial is the first commit that adds the `oneshot` dependency.  Here's my justification from the commit message:

> `oneshot` seems like a reasonable dependency to add.  It's small,
fairly popular, and replaces a lot of messy code.
>
> I doubt the performance matters, but FWIW I think it should perform much
better than my naive mutex-based implementation for sending/receiving
the value.  We do lose one optimization: `RunFuture` stored the closure
alongside the rest of the future internals which meant one less heap
allocation.  However, even that optimization comes at the cost of not
being able to free the closure memory until the future was awaited and
dropped by the consumer.  Overall this seems like a win.

