### PR TITLE
fix: Bindgen not picking up correct symbols

### DIFF
--- a/uniffi_bindgen/src/interface/universe.rs
+++ b/uniffi_bindgen/src/interface/universe.rs
@@ -8,6 +8,7 @@
 //!
 use anyhow::Result;
 use std::{collections::hash_map::Entry, collections::BTreeSet, collections::HashMap};
+use uniffi_meta::NamespaceMetadata;
 
 pub use uniffi_meta::{AsType, ExternalKind, ObjectImpl, Type, TypeIterator};
 
@@ -24,7 +25,7 @@ pub use uniffi_meta::{AsType, ExternalKind, ObjectImpl, Type, TypeIterator};
 #[derive(Debug, Default)]
 pub(crate) struct TypeUniverse {
     /// The unique prefix that we'll use for namespacing when exposing this component's API.
-    pub namespace: String,
+    pub namespace: NamespaceMetadata,
 
     // Named type definitions (including aliases).
     type_definitions: HashMap<String, Type>,

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -116,10 +116,16 @@ impl Checksum for &str {
 // The namespace of a Component interface.
 //
 // This is used to match up the macro metadata with the UDL items.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NamespaceMetadata {
     pub crate_name: String,
     pub name: String,
+}
+
+impl NamespaceMetadata {
+    pub fn is_empty(&self) -> bool {
+        self.crate_name.is_empty() && self.name.is_empty()
+    }
 }
 
 // UDL file included with `include_scaffolding!()`


### PR DESCRIPTION
Hi! 

I don't have a repro repo at hand this time (unfortunately, the repro env is quite complex to produce and I don't have much time :( ).
So this is a complicated one but in short: 

* In a certain configuration (see our FFI here https://github.com/wireapp/core-crypto/tree/6169072fe65fc3ccebfbe583db3bc101b88180e4/crypto-ffi)
* and in a pure proc-macro environment,

*Some* symbols were incorrectly named in the generated bindings; It seems the issue was centered around callback interfaces

* Given a library symbol that gets emitted as `uniffi_core_crypto_ffi_fn_init_callback_corecryptocallbacks`
	* Defined here https://github.com/wireapp/core-crypto/blob/6169072fe65fc3ccebfbe583db3bc101b88180e4/crypto-ffi/src/generic.rs#L649
* The resulting Swift, Python and Kotlin bindings were calling the following symbol: `uniffi_CoreCrypto_fn_init_callback_corecryptocallbacks`

This was most likely because of a disparity between the namespace "name" and its "ffi-name" - The issue being that both methods `namespace()` and `ffi_namespace()` were resolving to the same thing. 

My conclusion is that UniFFI "forgot" the actual name of the library (i.e. in my example `core_crypto_ffi`) and was using only the library namespace (i.e. `CoreCrypto`), resulting in the correct `.so` being generated but the bindings calling a non-existent symbol.

Feel free to ask any questions, and if really needed I can take the time to setup a repro repo in the next few days.

Cheers!

