### PR TITLE
Fixup Cargo.lock to reflect changes in how serde is used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,7 +1423,6 @@ version = "0.22.0"
 dependencies = [
  "anyhow",
  "bytes",
- "serde_json",
  "uniffi",
  "url",
 ]
@@ -1526,7 +1525,6 @@ version = "0.22.0"
 dependencies = [
  "anyhow",
  "bytes",
- "serde_json",
  "thiserror",
  "uniffi",
 ]
@@ -1538,7 +1536,6 @@ dependencies = [
  "anyhow",
  "bytes",
  "http",
- "serde_json",
  "thiserror",
  "uniffi",
 ]
@@ -1759,7 +1756,6 @@ dependencies = [
  "once_cell",
  "paste",
  "serde",
- "serde_json",
  "toml",
  "uniffi_meta",
  "uniffi_testing",
@@ -1830,7 +1826,6 @@ version = "0.24.1"
 dependencies = [
  "anyhow",
  "bytes",
- "serde",
  "siphasher",
  "uniffi_checksum_derive",
 ]
@@ -1844,8 +1839,6 @@ dependencies = [
  "cargo_metadata",
  "fs-err",
  "once_cell",
- "serde",
- "serde_json",
 ]
 
 [[package]]


### PR DESCRIPTION
I could have sworn I updated the new Cargo.lock, but apparently not!