### PR TITLE
Mangle rustbuffer & foreign_executor_callback_set functions

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/ForeignExecutorTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ForeignExecutorTemplate.kt
@@ -50,7 +50,12 @@ public object FfiConverterForeignExecutor: FfiConverter<CoroutineScope, USize> {
     }
 
     internal fun register(lib: _UniFFILib) {
-        lib.uniffi_foreign_executor_callback_set(UniFfiForeignExecutorCallback)
+        {%- match ci.ffi_foreign_executor_callback_set() %}
+        {%- when Some with (fn) %}
+        lib.{{ fn.name() }}(UniFfiForeignExecutorCallback)
+        {%- when None %}
+        {#- No foreign executor, we don't set anything #}
+        {% endmatch %}
     }
 
     // Number of live handles, exposed so we can test the memory management

--- a/uniffi_bindgen/src/bindings/python/templates/ForeignExecutorTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ForeignExecutorTemplate.py
@@ -55,4 +55,9 @@ def _uniffi_executor_callback(eventloop_address, delay, task_ptr, task_data):
         return _UNIFFI_FOREIGN_EXECUTOR_CALLBACK_SUCCESS
 
 # Register the callback with the scaffolding
-_UniffiLib.uniffi_foreign_executor_callback_set(_uniffi_executor_callback)
+{%- match ci.ffi_foreign_executor_callback_set() %}
+{%- when Some with (fn) %}
+_UniffiLib.{{ fn.name() }}(_uniffi_executor_callback)
+{%- when None %}
+{#- No foreign executor, we don't set anything #}
+{% endmatch %}

--- a/uniffi_bindgen/src/bindings/swift/templates/ForeignExecutorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ForeignExecutorTemplate.swift
@@ -21,7 +21,7 @@ public struct UniFfiForeignExecutor {
 
 fileprivate struct FfiConverterForeignExecutor: FfiConverter {
     typealias SwiftType = UniFfiForeignExecutor
-    // Rust uses a pointer to represent the FfiConverterForeignExecutor, but we only need a u8. 
+    // Rust uses a pointer to represent the FfiConverterForeignExecutor, but we only need a u8.
     // let's use `Int`, which is equivalent to `size_t`
     typealias FfiType = Int
 
@@ -60,5 +60,10 @@ fileprivate func uniffiForeignExecutorCallback(executorHandle: Int, delayMs: UIn
 }
 
 fileprivate func uniffiInitForeignExecutor() {
-    uniffi_foreign_executor_callback_set(uniffiForeignExecutorCallback)
+    {%- match ci.ffi_foreign_executor_callback_set() %}
+    {%- when Some with (fn) %}
+    {{ fn.name() }}(uniffiForeignExecutorCallback)
+    {%- when None %}
+    {#- No foreign executor, we don't set anything #}
+    {% endmatch %}
 }

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -487,7 +487,7 @@ impl ComponentInterface {
     pub fn ffi_foreign_executor_callback_set(&self) -> Option<FfiFunction> {
         if self.types.contains(&Type::ForeignExecutor) {
             Some(FfiFunction {
-                name: "uniffi_foreign_executor_callback_set".into(),
+                name: format!("ffi_{}_foreign_executor_callback_set", self.ffi_namespace()),
                 arguments: vec![FfiArgument {
                     name: "callback".into(),
                     type_: FfiType::ForeignExecutorCallback,

--- a/uniffi_core/Cargo.toml
+++ b/uniffi_core/Cargo.toml
@@ -25,6 +25,8 @@ static_assertions = "1.1.0"
 
 [features]
 default = []
+# `no_mangle` RustBuffer FFI functions
+extern-rustbuffer = []
 
 # Enable support for Tokio's futures.
 # This must still be opted into on a per-function basis using `#[uniffi::export(async_runtime = "tokio")]`.

--- a/uniffi_core/src/ffi/foreignexecutor.rs
+++ b/uniffi_core/src/ffi/foreignexecutor.rs
@@ -88,8 +88,7 @@ static FOREIGN_EXECUTOR_CALLBACK: ForeignExecutorCallbackCell = ForeignExecutorC
 
 /// Set the global ForeignExecutorCallback.  This is called by the foreign bindings, normally
 /// during initialization.
-#[no_mangle]
-pub extern "C" fn uniffi_foreign_executor_callback_set(callback: ForeignExecutorCallback) {
+pub fn foreign_executor_callback_set(callback: ForeignExecutorCallback) {
     FOREIGN_EXECUTOR_CALLBACK.set(callback);
 }
 
@@ -253,7 +252,7 @@ mod test {
         pub fn new() -> Arc<Self> {
             // Make sure we install a foreign executor callback that can deal with mock event loops
             FOREIGN_EXECUTOR_CALLBACK_INIT
-                .call_once(|| uniffi_foreign_executor_callback_set(mock_executor_callback));
+                .call_once(|| foreign_executor_callback_set(mock_executor_callback));
 
             Arc::new(Self {
                 inner: Mutex::new(MockEventLoopInner {

--- a/uniffi_core/src/ffi/rustbuffer.rs
+++ b/uniffi_core/src/ffi/rustbuffer.rs
@@ -212,11 +212,7 @@ impl Default for RustBuffer {
 /// to the foreign-language code as a `RustBuffer` struct. Callers must eventually
 /// free the resulting buffer, either by explicitly calling [`uniffi_rustbuffer_free`] defined
 /// below, or by passing ownership of the buffer back into Rust code.
-#[no_mangle]
-pub extern "C" fn uniffi_rustbuffer_alloc(
-    size: i32,
-    call_status: &mut RustCallStatus,
-) -> RustBuffer {
+pub fn uniffi_rustbuffer_alloc(size: i32, call_status: &mut RustCallStatus) -> RustBuffer {
     rust_call(call_status, || {
         Ok(RustBuffer::new_with_size(size.max(0) as usize))
     })
@@ -230,8 +226,7 @@ pub extern "C" fn uniffi_rustbuffer_alloc(
 /// # Safety
 /// This function will dereference a provided pointer in order to copy bytes from it, so
 /// make sure the `ForeignBytes` struct contains a valid pointer and length.
-#[no_mangle]
-pub unsafe extern "C" fn uniffi_rustbuffer_from_bytes(
+pub fn uniffi_rustbuffer_from_bytes(
     bytes: ForeignBytes,
     call_status: &mut RustCallStatus,
 ) -> RustBuffer {
@@ -247,8 +242,7 @@ pub unsafe extern "C" fn uniffi_rustbuffer_from_bytes(
 /// The argument *must* be a uniquely-owned `RustBuffer` previously obtained from a call
 /// into the Rust code that returned a buffer, or you'll risk freeing unowned memory or
 /// corrupting the allocator state.
-#[no_mangle]
-pub unsafe extern "C" fn uniffi_rustbuffer_free(buf: RustBuffer, call_status: &mut RustCallStatus) {
+pub fn uniffi_rustbuffer_free(buf: RustBuffer, call_status: &mut RustCallStatus) {
     rust_call(call_status, || {
         RustBuffer::destroy(buf);
         Ok(())
@@ -270,8 +264,7 @@ pub unsafe extern "C" fn uniffi_rustbuffer_free(buf: RustBuffer, call_status: &m
 /// The first argument *must* be a uniquely-owned `RustBuffer` previously obtained from a call
 /// into the Rust code that returned a buffer, or you'll risk freeing unowned memory or
 /// corrupting the allocator state.
-#[no_mangle]
-pub unsafe extern "C" fn uniffi_rustbuffer_reserve(
+pub fn uniffi_rustbuffer_reserve(
     buf: RustBuffer,
     additional: i32,
     call_status: &mut RustCallStatus,

--- a/uniffi_core/src/ffi/rustbuffer.rs
+++ b/uniffi_core/src/ffi/rustbuffer.rs
@@ -212,7 +212,21 @@ impl Default for RustBuffer {
 /// to the foreign-language code as a `RustBuffer` struct. Callers must eventually
 /// free the resulting buffer, either by explicitly calling [`uniffi_rustbuffer_free`] defined
 /// below, or by passing ownership of the buffer back into Rust code.
+#[cfg(feature = "extern-rustbuffer")]
+#[no_mangle]
+pub extern "C" fn uniffi_rustbuffer_alloc(
+    size: i32,
+    call_status: &mut RustCallStatus,
+) -> RustBuffer {
+    _uniffi_rustbuffer_alloc(size, call_status)
+}
+
+#[cfg(not(feature = "extern-rustbuffer"))]
 pub fn uniffi_rustbuffer_alloc(size: i32, call_status: &mut RustCallStatus) -> RustBuffer {
+    _uniffi_rustbuffer_alloc(size, call_status)
+}
+
+fn _uniffi_rustbuffer_alloc(size: i32, call_status: &mut RustCallStatus) -> RustBuffer {
     rust_call(call_status, || {
         Ok(RustBuffer::new_with_size(size.max(0) as usize))
     })
@@ -226,7 +240,24 @@ pub fn uniffi_rustbuffer_alloc(size: i32, call_status: &mut RustCallStatus) -> R
 /// # Safety
 /// This function will dereference a provided pointer in order to copy bytes from it, so
 /// make sure the `ForeignBytes` struct contains a valid pointer and length.
+#[cfg(feature = "extern-rustbuffer")]
+#[no_mangle]
+pub extern "C" fn uniffi_rustbuffer_from_bytes(
+    bytes: ForeignBytes,
+    call_status: &mut RustCallStatus,
+) -> RustBuffer {
+    _uniffi_rustbuffer_from_bytes(bytes, call_status)
+}
+
+#[cfg(not(feature = "extern-rustbuffer"))]
 pub fn uniffi_rustbuffer_from_bytes(
+    bytes: ForeignBytes,
+    call_status: &mut RustCallStatus,
+) -> RustBuffer {
+    _uniffi_rustbuffer_from_bytes(bytes, call_status)
+}
+
+fn _uniffi_rustbuffer_from_bytes(
     bytes: ForeignBytes,
     call_status: &mut RustCallStatus,
 ) -> RustBuffer {
@@ -242,7 +273,18 @@ pub fn uniffi_rustbuffer_from_bytes(
 /// The argument *must* be a uniquely-owned `RustBuffer` previously obtained from a call
 /// into the Rust code that returned a buffer, or you'll risk freeing unowned memory or
 /// corrupting the allocator state.
+#[cfg(feature = "extern-rustbuffer")]
+#[no_mangle]
+pub extern "C" fn uniffi_rustbuffer_free(buf: RustBuffer, call_status: &mut RustCallStatus) {
+    _uniffi_rustbuffer_free(buf, call_status)
+}
+
+#[cfg(not(feature = "extern-rustbuffer"))]
 pub fn uniffi_rustbuffer_free(buf: RustBuffer, call_status: &mut RustCallStatus) {
+    _uniffi_rustbuffer_free(buf, call_status)
+}
+
+fn _uniffi_rustbuffer_free(buf: RustBuffer, call_status: &mut RustCallStatus) {
     rust_call(call_status, || {
         RustBuffer::destroy(buf);
         Ok(())
@@ -264,7 +306,26 @@ pub fn uniffi_rustbuffer_free(buf: RustBuffer, call_status: &mut RustCallStatus)
 /// The first argument *must* be a uniquely-owned `RustBuffer` previously obtained from a call
 /// into the Rust code that returned a buffer, or you'll risk freeing unowned memory or
 /// corrupting the allocator state.
+#[cfg(feature = "extern-rustbuffer")]
+#[no_mangle]
+pub extern "C" fn uniffi_rustbuffer_reserve(
+    buf: RustBuffer,
+    additional: i32,
+    call_status: &mut RustCallStatus,
+) -> RustBuffer {
+    _uniffi_rustbuffer_reserve(buf, additional, call_status)
+}
+
+#[cfg(not(feature = "extern-rustbuffer"))]
 pub fn uniffi_rustbuffer_reserve(
+    buf: RustBuffer,
+    additional: i32,
+    call_status: &mut RustCallStatus,
+) -> RustBuffer {
+    _uniffi_rustbuffer_reserve(buf, additional, call_status)
+}
+
+fn _uniffi_rustbuffer_reserve(
     buf: RustBuffer,
     additional: i32,
     call_status: &mut RustCallStatus,

--- a/uniffi_macros/src/setup_scaffolding.rs
+++ b/uniffi_macros/src/setup_scaffolding.rs
@@ -20,6 +20,8 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
     let ffi_rustbuffer_free_ident = format_ident!("ffi_{namespace}_rustbuffer_free");
     let ffi_rustbuffer_reserve_ident = format_ident!("ffi_{namespace}_rustbuffer_reserve");
     let reexport_hack_ident = format_ident!("{namespace}_uniffi_reexport_hack");
+    let ffi_foreign_executor_callback_set_ident =
+        format_ident!("ffi_{namespace}_foreign_executor_callback_set");
 
     Ok(quote! {
         // Unit struct to parameterize the FfiConverter trait.
@@ -82,6 +84,13 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
         #[no_mangle]
         pub unsafe extern "C" fn #ffi_rustbuffer_reserve_ident(buf: uniffi::RustBuffer, additional: i32, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
             uniffi::ffi::uniffi_rustbuffer_reserve(buf, additional, call_status)
+        }
+
+        #[allow(clippy::missing_safety_doc, missing_docs)]
+        #[doc(hidden)]
+        #[no_mangle]
+        pub extern "C" fn #ffi_foreign_executor_callback_set_ident(callback: uniffi::ffi::ForeignExecutorCallback) {
+            uniffi::ffi::foreign_executor_callback_set(callback)
         }
 
         // Code to re-export the UniFFI scaffolding functions.


### PR DESCRIPTION
Not mangling these functions cause duplicate symbol errors when
attempting to link 2 static libraries containing different uniffi
versions. The error also appears when linking 2 static libraries
containing the same uniffi version, but when the libraries are
compiled on different architecture machies, e.g. MacOS Intel and MacOS
Arm.

These Rust buffer functions are already exposed with a namespace prefix
in RustBuffer.

---

This is the alternative to #1718 that should help us land this in m-c as well (I still need to test this).