### PR TITLE
Use proc-macros for all exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,11 @@
     be used to avoid this and use the specified value.
 
 - Crates can now use proc-macros without UDL files to export their interface.  See the "Procedural Macros: Attributes and Derives" manual section for details.
-
 - [Custom Types](https://mozilla.github.io/uniffi-rs/proc_macro/index.html#the-unifficustomtype-derive) are now supported for proc-macros, including a very
   low-friction way of exposing types implementing the new-type idiom.
 - Proc-macros: Added support for ByRef arguments
+- Proc-macros: Implemented custom type conversion error handling (https://mozilla.github.io/uniffi-rs/udl/custom_types.html#error-handling-during-conversion)
+- Error types must now implement `Error + Send + Sync + 'static`.
 
 ### What's Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1749,6 +1749,7 @@ name = "uniffi-fixture-futures"
 version = "0.21.0"
 dependencies = [
  "once_cell",
+ "thiserror",
  "tokio",
  "uniffi",
 ]
@@ -1979,6 +1980,7 @@ dependencies = [
 name = "uniffi_fixture_metadata"
 version = "0.1.0"
 dependencies = [
+ "thiserror",
  "uniffi",
  "uniffi_core",
  "uniffi_meta",
@@ -2036,6 +2038,7 @@ dependencies = [
 name = "uniffi_uitests"
 version = "0.22.0"
 dependencies = [
+ "thiserror",
  "trybuild",
  "uniffi",
  "uniffi_macros",

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -54,7 +54,9 @@ fn throw_flat_macro_error() -> Result<(), CoverallFlatMacroError> {
     Err(CoverallFlatMacroError::TooManyVariants { num: 88 })
 }
 
+#[derive(Debug, thiserror::Error)]
 pub enum CoverallRichErrorNoVariantData {
+    #[error("TooManyPlainVariants")]
     TooManyPlainVariants,
 }
 

--- a/fixtures/futures/Cargo.toml
+++ b/fixtures/futures/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/bin.rs"
 
 [dependencies]
 uniffi = { path = "../../uniffi", version = "0.24", features = ["tokio", "cli"] }
+thiserror = "1.0"
 tokio = { version = "1.24.1", features = ["time", "sync"] }
 once_cell = "1.18.0"
 

--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -101,8 +101,9 @@ pub async fn sleep(ms: u16) -> bool {
 }
 
 // Our error.
-#[derive(uniffi::Error, Debug)]
+#[derive(thiserror::Error, uniffi::Error, Debug)]
 pub enum MyError {
+    #[error("Foo")]
     Foo,
 }
 
@@ -283,8 +284,9 @@ pub struct SharedResourceOptions {
 }
 
 // Our error.
-#[derive(uniffi::Error, Debug)]
+#[derive(thiserror::Error, uniffi::Error, Debug)]
 pub enum AsyncError {
+    #[error("Timeout")]
     Timeout,
 }
 

--- a/fixtures/metadata/Cargo.toml
+++ b/fixtures/metadata/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 name = "uniffi_fixture_metadata"
 
 [dependencies]
+thiserror = "1.0"
 uniffi = { path = "../../uniffi", version = "0.24" }
 uniffi_meta = { path = "../../uniffi_meta" }
 uniffi_core = { path = "../../uniffi_core" }

--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -39,44 +39,25 @@ mod state {
 
 mod error {
     use super::Weapon;
-    use std::fmt;
 
-    #[derive(uniffi::Error)]
+    #[derive(Debug, thiserror::Error, uniffi::Error)]
     #[uniffi(flat_error)]
     #[allow(dead_code)]
     pub enum FlatError {
+        #[error("Overflow")]
         Overflow(String), // UniFFI should ignore this field, since `flat_error` was specified
+        #[error("DivideByZero")]
         DivideByZero,
     }
 
-    #[derive(uniffi::Error)]
+    #[derive(Debug, thiserror::Error, uniffi::Error)]
     pub enum ComplexError {
+        #[error("NotFound")]
         NotFound,
+        #[error("PermissionDenied")]
         PermissionDenied { reason: String },
+        #[error("InvalidWeapon")]
         InvalidWeapon { weapon: Weapon },
-    }
-
-    impl fmt::Display for FlatError {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            match self {
-                Self::Overflow(s) => write!(f, "FlatError::Overflow({s})"),
-                Self::DivideByZero => write!(f, "FlatError::DivideByZero"),
-            }
-        }
-    }
-
-    impl fmt::Display for ComplexError {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            match self {
-                Self::NotFound => write!(f, "ComplexError::NotFound()"),
-                Self::PermissionDenied { reason } => {
-                    write!(f, "ComplexError::PermissionDenied({reason})")
-                }
-                Self::InvalidWeapon { weapon } => {
-                    write!(f, "ComplexError::InvalidWeapon({weapon:?})")
-                }
-            }
-        }
     }
 }
 

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -13,6 +13,11 @@ pub struct One {
     inner: i32,
 }
 
+#[uniffi::export]
+pub fn one_inner_by_ref(one: &One) -> i32 {
+    one.inner
+}
+
 #[derive(uniffi::Record)]
 pub struct Two {
     a: String,
@@ -171,11 +176,14 @@ fn enum_identity(value: MaybeBool) -> MaybeBool {
     value
 }
 
-#[derive(uniffi::Error, Debug, PartialEq, Eq)]
+#[derive(thiserror::Error, uniffi::Error, Debug, PartialEq, Eq)]
 #[uniffi(handle_unknown_callback_error)]
 pub enum BasicError {
+    #[error("InvalidInput")]
     InvalidInput,
+    #[error("OsError")]
     OsError,
+    #[error("UnexpectedError")]
     UnexpectedError { reason: String },
 }
 

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
@@ -6,6 +6,7 @@ import uniffi.fixture.proc_macro.*;
 
 val one = makeOne(123)
 assert(one.inner == 123)
+assert(oneInnerByRef(one) == 123)
 
 val two = Two("a")
 assert(takeTwo(two) == "a")

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -6,6 +6,7 @@ from proc_macro import *
 
 one = make_one(123)
 assert one.inner == 123
+assert one_inner_by_ref(one) == 123
 
 two = Two("a")
 assert take_two(two) == "a"

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
@@ -7,6 +7,7 @@ import proc_macro
 
 let one = makeOne(inner: 123)
 assert(one.inner == 123)
+assert(oneInnerByRef(one: one) == 123)
 
 let two = Two(a: "a")
 assert(takeTwo(two: two) == "a")

--- a/fixtures/uitests/Cargo.toml
+++ b/fixtures/uitests/Cargo.toml
@@ -12,6 +12,7 @@ name = "uniffi_uitests"
 [dependencies]
 uniffi = {path = "../../uniffi", version = "0.24" }
 uniffi_macros = {path = "../../uniffi_macros"}
+thiserror = "1.0"
 
 [dev-dependencies]
 trybuild = "1.0.76"

--- a/fixtures/uitests/tests/ui/fieldless_errors_used_in_callbacks_cant_have_fields.rs
+++ b/fixtures/uitests/tests/ui/fieldless_errors_used_in_callbacks_cant_have_fields.rs
@@ -3,20 +3,17 @@ uniffi_macros::generate_and_include_scaffolding!("../../../../fixtures/uitests/s
 
 fn main() { /* empty main required by `trybuild` */}
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 enum ArithmeticError {
-  IntegerOverflow,
-  // Since this is listed in the UDL as not having fields and is used in a callback interface, it
-  // really needs to have no fields.
-  DivisionByZero { numerator: u64 },
-  // Tuple-style fields are also invalid
-  UnexpectedError(String),
-}
-
-impl std::fmt::Display for ArithmeticError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        <Self as std::fmt::Debug>::fmt(self, f)
-    }
+    #[error("IntegerOverflow")]
+    IntegerOverflow,
+    // Since this is listed in the UDL as not having fields and is used in a callback interface, it
+    // really needs to have no fields.
+    #[error("DivisionByZero")]
+    DivisionByZero { numerator: u64 },
+    // Tuple-style fields are also invalid
+    #[error("UnexpectedError: {0}")]
+    UnexpectedError(String),
 }
 
 impl From<uniffi::UnexpectedUniFFICallbackError> for ArithmeticError {

--- a/fixtures/uitests/tests/ui/fieldless_errors_used_in_callbacks_cant_have_fields.stderr
+++ b/fixtures/uitests/tests/ui/fieldless_errors_used_in_callbacks_cant_have_fields.stderr
@@ -1,12 +1,11 @@
 error[E0533]: expected value, found struct variant `Self::DivisionByZero`
  --> $OUT_DIR[uniffi_uitests]/errors.uniffi.rs
   |
-  | / #[::uniffi::ffi_converter_error(
-  | |     tag = crate::UniFfiTag,
+  | / #[::uniffi::derive_error_for_udl(
   | |     flat_error,
   | |     with_try_read,
   | |     handle_unknown_callback_error,
   | | )]
   | |__^ not a value
   |
-  = note: this error originates in the attribute macro `::uniffi::ffi_converter_error` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the attribute macro `::uniffi::derive_error_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/fixtures/uitests/tests/ui/interface_cannot_use_mut_self.stderr
+++ b/fixtures/uitests/tests/ui/interface_cannot_use_mut_self.stderr
@@ -1,8 +1,8 @@
-error[E0308]: mismatched types
+error[E0596]: cannot borrow data in an `Arc` as mutable
  --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
   |
-  |             Ok(ref val) => val,
-  |                            ^^^ types differ in mutability
+  | #[::uniffi::export_for_udl]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
   |
-  = note: expected mutable reference `&mut Counter`
-                     found reference `&Arc<Counter>`
+  = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `Arc<Counter>`
+  = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/fixtures/uitests/tests/ui/interface_trait_not_sync_and_send.stderr
+++ b/fixtures/uitests/tests/ui/interface_trait_not_sync_and_send.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `(dyn Trait + 'static)` cannot be shared between threads safely
  --> $OUT_DIR[uniffi_uitests]/trait.uniffi.rs
   |
-  | ::uniffi::expand_trait_interface_support!(r#Trait);
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Trait + 'static)` cannot be shared between threads safely
+  | #[::uniffi::export_for_udl]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Trait + 'static)` cannot be shared between threads safely
   |
   = help: the trait `Sync` is not implemented for `(dyn Trait + 'static)`
 note: required by a bound in `FfiConverterArc`
@@ -10,13 +10,13 @@ note: required by a bound in `FfiConverterArc`
   |
   | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
   |                                              ^^^^ required by this bound in `FfiConverterArc`
-  = note: this error originates in the macro `::uniffi::expand_trait_interface_support` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `(dyn Trait + 'static)` cannot be sent between threads safely
  --> $OUT_DIR[uniffi_uitests]/trait.uniffi.rs
   |
-  | ::uniffi::expand_trait_interface_support!(r#Trait);
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Trait + 'static)` cannot be sent between threads safely
+  | #[::uniffi::export_for_udl]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Trait + 'static)` cannot be sent between threads safely
   |
   = help: the trait `Send` is not implemented for `(dyn Trait + 'static)`
 note: required by a bound in `FfiConverterArc`
@@ -24,7 +24,7 @@ note: required by a bound in `FfiConverterArc`
   |
   | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
   |                                       ^^^^ required by this bound in `FfiConverterArc`
-  = note: this error originates in the macro `::uniffi::expand_trait_interface_support` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `(dyn ProcMacroTrait + 'static)` cannot be shared between threads safely
   --> tests/ui/interface_trait_not_sync_and_send.rs:11:1

--- a/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
+++ b/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `f32: Hash` is not satisfied
  --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
   |
-  | )  -> <std::collections::HashMap<f32, u64> as ::uniffi::FfiConverter<crate::UniFfiTag>>::ReturnType {
-  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Hash` is not implemented for `f32`
+  | #[::uniffi::export_for_udl]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Hash` is not implemented for `f32`
   |
   = help: the following other types implement trait `Hash`:
             i128
@@ -15,12 +15,13 @@ error[E0277]: the trait bound `f32: Hash` is not satisfied
             u16
           and $N others
   = note: required for `HashMap<f32, u64>` to implement `FfiConverter<UniFfiTag>`
+  = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
  --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
   |
-  | )  -> <std::collections::HashMap<f32, u64> as ::uniffi::FfiConverter<crate::UniFfiTag>>::ReturnType {
-  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `f32`
+  | #[::uniffi::export_for_udl]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `f32`
   |
   = help: the following other types implement trait `std::cmp::Eq`:
             i128
@@ -33,9 +34,10 @@ error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
             u16
           and $N others
   = note: required for `HashMap<f32, u64>` to implement `FfiConverter<UniFfiTag>`
+  = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find function `get_dict` in this scope
  --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
   |
-  |             r#get_dict())
-  |             ^^^^^^^^^^ not found in this scope
+  | pub fn r#get_dict(
+  |        ^^^^^^^^^^ not found in this scope

--- a/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
@@ -7,7 +7,7 @@
 // public so other crates can refer to it via an `[External='crate'] typedef`
 #}
 
-#[::uniffi::ffi_converter_enum(tag = crate::UniFfiTag)]
+#[::uniffi::derive_enum_for_udl]
 enum r#{{ e.name() }} {
     {%- for variant in e.variants() %}
     r#{{ variant.name() }} {

--- a/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
@@ -7,8 +7,7 @@
 // public so other crates can refer to it via an `[External='crate'] typedef`
 #}
 
-#[::uniffi::ffi_converter_error(
-    tag = crate::UniFfiTag,
+#[::uniffi::derive_error_for_udl(
     {% if e.is_flat() -%}
     flat_error,
     {% if ci.should_generate_error_read(e) -%}

--- a/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
@@ -7,7 +7,7 @@
 {%- when ExternalKind::DataClass %}
 ::uniffi::ffi_converter_forward!(r#{{ name }}, ::{{ crate_name|crate_name_rs }}::UniFfiTag, crate::UniFfiTag);
 {%- when ExternalKind::Interface %}
-::uniffi::ffi_converter_forward!(::std::sync::Arc<r#{{ name }}>, ::{{ crate_name|crate_name_rs }}::UniFfiTag, crate::UniFfiTag);
+::uniffi::ffi_converter_arc_forward!(r#{{ name }}, ::{{ crate_name|crate_name_rs }}::UniFfiTag, crate::UniFfiTag);
 {%- endmatch %}
 {%- endfor %}
 

--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -12,57 +12,67 @@
 
 {%- match obj.imp() -%}
 {%- when ObjectImpl::Trait %}
-::uniffi::expand_trait_interface_support!(r#{{ obj.name() }});
-{% else %}
-#[::uniffi::expand_interface_support(tag = crate::UniFfiTag)]
-struct {{ obj.rust_name() }} { }
-{% endmatch %}
-
-{% let ffi_free = obj.ffi_object_free() -%}
-#[doc(hidden)]
-#[no_mangle]
-pub extern "C" fn {{ ffi_free.name() }}(ptr: *const std::os::raw::c_void, call_status: &mut uniffi::RustCallStatus) {
-    uniffi::rust_call(call_status, || {
-        assert!(!ptr.is_null());
-        {%- match obj.imp() -%}
-        {%- when ObjectImpl::Trait %}
-        {#- turn it into a Box<Arc<T> and explicitly drop it. #}
-        drop(unsafe { Box::from_raw(ptr as *mut std::sync::Arc<{{ obj.rust_name() }}>) });
-        {%- when ObjectImpl::Struct %}
-        {#- turn it into an Arc and explicitly drop it. #}
-        drop(unsafe { ::std::sync::Arc::from_raw(ptr as *const {{ obj.rust_name() }}) });
-        {% endmatch %}
-        Ok(())
-    })
+#[::uniffi::export_for_udl]
+pub trait r#{{ obj.name() }} {
+    {%- for meth in obj.methods() %}
+    fn {{ meth.name() }}(
+        {% if meth.takes_self_by_arc()%}self: Arc<Self>{% else %}&self{% endif %},
+        {%- for arg in meth.arguments() %}
+        {{ arg.name() }}: {% if arg.by_ref() %}&{% endif %}{{ arg.as_type().borrow()|type_rs }},
+        {%- endfor %}
+    )
+    {%- match meth.return_type() %}
+    {%- when Some(return_type) %} -> {{ return_type|type_rs }};
+    {%- when None %};
+    {%- endmatch %}
+    {% endfor %}
 }
+{% when ObjectImpl::Struct %}
+#[::uniffi::derive_object_for_udl]
+struct {{ obj.rust_name() }} { }
 
 {%- for cons in obj.constructors() %}
-    #[doc(hidden)]
-    #[no_mangle]
-    pub extern "C" fn r#{{ cons.ffi_func().name() }}(
-        {%- call rs::arg_list_ffi_decl(cons.ffi_func()) %}
-    ) -> *const std::os::raw::c_void /* *const {{ obj.name() }} */ {
-        uniffi::deps::log::debug!("{{ cons.ffi_func().name() }}");
-
-        // If the constructor does not have the same signature as declared in the UDL, then
-        // this attempt to call it will fail with a (somewhat) helpful compiler error.
-        uniffi::rust_call(call_status, || {
-            {{ cons|return_ffi_converter }}::lower_return(
-                {%- if cons.throws() %}
-                {{ obj.rust_name() }}::{% call rs::to_rs_call(cons) %}.map(::std::sync::Arc::new).map_err(Into::into)
-                {%- else %}
-                ::std::sync::Arc::new({{ obj.rust_name() }}::{% call rs::to_rs_call(cons) %})
-                {%- endif %}
-            )
-        })
+#[::uniffi::export_for_udl(constructor)]
+impl {{ obj.rust_name() }} {
+    pub fn r#{{ cons.name() }}(
+        {%- for arg in cons.arguments() %}
+        r#{{ arg.name() }}: {% if arg.by_ref() %}&{% endif %}{{ arg.as_type().borrow()|type_rs }},
+        {%- endfor %}
+    )
+    {%- match (cons.return_type(), cons.throws_type()) %}
+    {%- when (Some(return_type), None) %} -> {{ return_type|type_rs }}
+    {%- when (Some(return_type), Some(error_type)) %} -> ::std::result::Result::<{{ return_type|type_rs }}, {{ error_type|type_rs }}>
+    {%- when (None, Some(error_type)) %} -> ::std::result::Result::<(), {{ error_type|type_rs }}>
+    {%- when (None, None) %}
+    {%- endmatch %}
+    {
+        unreachable!()
     }
+}
 {%- endfor %}
 
 {%- for meth in obj.methods() %}
-    {% call rs::method_decl_prelude(meth) %}
-            <{{ obj.rust_name() }}>::{% call rs::to_rs_call(meth) %}
-    {% call rs::method_decl_postscript(meth) %}
-{% endfor %}
+#[::uniffi::export_for_udl]
+impl {{ obj.rust_name() }} {
+    pub fn r#{{ meth.name() }}(
+        {% if meth.takes_self_by_arc()%}self: Arc<Self>{% else %}&self{% endif %},
+        {%- for arg in meth.arguments() %}
+        r#{{ arg.name() }}: {% if arg.by_ref() %}&{% endif %}{{ arg.as_type().borrow()|type_rs }},
+        {%- endfor %}
+    )
+    {%- match (meth.return_type(), meth.throws_type()) %}
+    {%- when (Some(return_type), None) %} -> {{ return_type|type_rs }}
+    {%- when (Some(return_type), Some(error_type)) %} -> ::std::result::Result::<{{ return_type|type_rs }}, {{ error_type|type_rs }}>
+    {%- when (None, Some(error_type)) %} -> ::std::result::Result::<(), {{ error_type|type_rs }}>
+    {%- when (None, None) %}
+    {%- endmatch %}
+    {
+        unreachable!()
+    }
+}
+{%- endfor %}
+
+{% endmatch %}
 
 {%- for tm in obj.uniffi_traits() %}
 {#      All magic methods get an explicit shim #}

--- a/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
@@ -8,7 +8,7 @@
 // public so other crates can refer to it via an `[External='crate'] typedef`
 #}
 
-#[::uniffi::ffi_converter_record(tag = crate::UniFfiTag)]
+#[::uniffi::derive_record_for_udl]
 struct r#{{ rec.name() }} {
     {%- for field in rec.fields() %}
     r#{{ field.name() }}: {{ field.as_type().borrow()|type_rs }},

--- a/uniffi_bindgen/src/scaffolding/templates/TopLevelFunctionTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/TopLevelFunctionTemplate.rs
@@ -1,19 +1,15 @@
-{#
-// For each top-level function declared in the UDL, we assume the caller has provided a corresponding
-// rust function of the same name. We provide a `pub extern "C"` wrapper that does type conversions to
-// send data across the FFI, which will fail to compile if the provided function does not match what's
-// specified in the UDL.    
-#}
-#[doc(hidden)]
-#[no_mangle]
-#[allow(clippy::let_unit_value,clippy::unit_arg)] // The generated code uses the unit type like other types to keep things uniform
-pub extern "C" fn r#{{ func.ffi_func().name() }}(
-    {% call rs::arg_list_ffi_decl(func.ffi_func()) %}
-) {% call rs::return_signature(func) %} {
-    // If the provided function does not match the signature specified in the UDL
-    // then this attempt to call it will not compile, and will give guidance as to why.
-    uniffi::deps::log::debug!("{{ func.ffi_func().name() }}");
-    uniffi::rust_call(call_status, || {{ func|return_ffi_converter }}::lower_return(
-            {% call rs::to_rs_call(func) %}){% if func.throws() %}.map_err(Into::into){% endif %}
-    )
+#[::uniffi::export_for_udl]
+pub fn r#{{ func.name() }}(
+    {%- for arg in func.arguments() %}
+    r#{{ arg.name() }}: {% if arg.by_ref() %}&{% endif %}{{ arg.as_type().borrow()|type_rs }},
+    {%- endfor %}
+)
+{%- match (func.return_type(), func.throws_type()) %}
+{%- when (Some(return_type), None) %} -> {{ return_type|type_rs }}
+{%- when (Some(return_type), Some(error_type)) %} -> ::std::result::Result::<{{ return_type|type_rs }}, {{ error_type|type_rs }}>
+{%- when (None, Some(error_type)) %} -> ::std::result::Result::<(), {{ error_type|type_rs }}>
+{%- when (None, None) %}
+{%- endmatch %}
+{
+    unreachable!()
 }

--- a/uniffi_core/src/ffi/rustcalls.rs
+++ b/uniffi_core/src/ffi/rustcalls.rs
@@ -172,36 +172,13 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{
-        ffi_converter_default_return, ffi_converter_rust_buffer_lift_and_lower, MetadataBuffer,
-        UniFfiTag,
-    };
+    use crate::test_util::TestError;
 
     fn create_call_status() -> RustCallStatus {
         RustCallStatus {
             code: 0,
             error_buf: MaybeUninit::new(RustBuffer::new()),
         }
-    }
-
-    #[derive(Debug, PartialEq)]
-    struct TestError(String);
-
-    // Use FfiConverter to simplify lifting TestError out of RustBuffer to check it
-    unsafe impl FfiConverter<UniFfiTag> for TestError {
-        ffi_converter_rust_buffer_lift_and_lower!(UniFfiTag);
-        ffi_converter_default_return!(UniFfiTag);
-
-        fn write(obj: TestError, buf: &mut Vec<u8>) {
-            <String as FfiConverter<UniFfiTag>>::write(obj.0, buf);
-        }
-
-        fn try_read(buf: &mut &[u8]) -> anyhow::Result<TestError> {
-            <String as FfiConverter<UniFfiTag>>::try_read(buf).map(TestError)
-        }
-
-        // Use a dummy value here since we don't actually need TYPE_ID_META
-        const TYPE_ID_META: MetadataBuffer = MetadataBuffer::new();
     }
 
     fn test_callback(a: u8) -> Result<i8, TestError> {

--- a/uniffi_core/src/ffi/rustfuture.rs
+++ b/uniffi_core/src/ffi/rustfuture.rs
@@ -374,14 +374,14 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{try_lift_from_rust_buffer, MockEventLoop};
+    use crate::{test_util::TestError, try_lift_from_rust_buffer, MockEventLoop};
     use std::sync::Weak;
 
     // Mock future that we can manually control using an Option<>
-    struct MockFuture(Option<Result<bool, String>>);
+    struct MockFuture(Option<Result<bool, TestError>>);
 
     impl Future for MockFuture {
-        type Output = Result<bool, String>;
+        type Output = Result<bool, TestError>;
 
         fn poll(self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<Self::Output> {
             match &self.0 {
@@ -392,7 +392,7 @@ mod tests {
     }
 
     // Type alias for the RustFuture we'll use in our tests
-    type TestRustFuture = RustFuture<MockFuture, Result<bool, String>, crate::UniFfiTag>;
+    type TestRustFuture = RustFuture<MockFuture, Result<bool, TestError>, crate::UniFfiTag>;
 
     // Stores the result that we send to the foreign code
     #[derive(Default)]
@@ -441,7 +441,7 @@ mod tests {
             Arc::downgrade(&Pin::into_inner(Clone::clone(&self.rust_future)))
         }
 
-        fn complete_future(&self, value: Result<bool, String>) {
+        fn complete_future(&self, value: Result<bool, TestError>) {
             unsafe {
                 (*self.rust_future.future.get()).0 = Some(value);
             }

--- a/uniffi_macros/src/custom.rs
+++ b/uniffi_macros/src/custom.rs
@@ -12,9 +12,10 @@ use syn::Path;
 pub(crate) fn expand_ffi_converter_custom_type(
     ident: &Ident,
     builtin: &Path,
-    tag: Option<&Path>,
+    udl_mode: bool,
 ) -> syn::Result<TokenStream> {
-    let impl_spec = tagged_impl_header("FfiConverter", ident, tag);
+    let impl_spec = tagged_impl_header("FfiConverter", ident, udl_mode);
+    let lift_ref_impl_spec = tagged_impl_header("LiftRef", ident, udl_mode);
     let name = ident_to_string(ident);
     let mod_path = mod_path()?;
 
@@ -45,6 +46,10 @@ pub(crate) fn expand_ffi_converter_custom_type(
                 .concat_str(#name)
                 .concat(<#builtin as ::uniffi::FfiConverter<crate::UniFfiTag>>::TYPE_ID_META);
         }
+
+        #lift_ref_impl_spec {
+            type LiftType = Self;
+        }
     })
 }
 
@@ -52,9 +57,9 @@ pub(crate) fn expand_ffi_converter_custom_type(
 pub(crate) fn expand_ffi_converter_custom_newtype(
     ident: &Ident,
     builtin: &Path,
-    tag: Option<&Path>,
+    udl_mode: bool,
 ) -> syn::Result<TokenStream> {
-    let ffi_converter = expand_ffi_converter_custom_type(ident, builtin, tag)?;
+    let ffi_converter = expand_ffi_converter_custom_type(ident, builtin, udl_mode)?;
     let type_converter = custom_ffi_type_converter(ident, builtin)?;
 
     Ok(quote! {

--- a/uniffi_macros/src/enum_.rs
+++ b/uniffi_macros/src/enum_.rs
@@ -1,60 +1,44 @@
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
-use syn::{Data, DataEnum, DeriveInput, Field, Index, Path};
+use syn::{Data, DataEnum, DeriveInput, Field, Index};
 
 use crate::util::{
     create_metadata_items, ident_to_string, mod_path, tagged_impl_header,
-    try_metadata_value_from_usize, try_read_field, ArgumentNotAllowedHere, AttributeSliceExt,
-    CommonAttr,
+    try_metadata_value_from_usize, try_read_field,
 };
 
-pub fn expand_enum(input: DeriveInput) -> TokenStream {
+pub fn expand_enum(input: DeriveInput, udl_mode: bool) -> syn::Result<TokenStream> {
     let enum_ = match input.data {
         Data::Enum(e) => e,
         _ => {
-            return syn::Error::new(Span::call_site(), "This derive must only be used on enums")
-                .into_compile_error();
+            return Err(syn::Error::new(
+                Span::call_site(),
+                "This derive must only be used on enums",
+            ))
         }
     };
-
     let ident = &input.ident;
-    let attr_error = input
-        .attrs
-        .parse_uniffi_attr_args::<ArgumentNotAllowedHere>()
-        .err()
-        .map(syn::Error::into_compile_error);
-    let ffi_converter_impl = enum_ffi_converter_impl(ident, &enum_, None);
+    let ffi_converter_impl = enum_ffi_converter_impl(ident, &enum_, udl_mode);
 
-    let meta_static_var =
-        enum_meta_static_var(ident, &enum_).unwrap_or_else(syn::Error::into_compile_error);
+    let meta_static_var = (!udl_mode).then(|| {
+        enum_meta_static_var(ident, &enum_).unwrap_or_else(syn::Error::into_compile_error)
+    });
 
-    quote! {
-        #attr_error
+    Ok(quote! {
         #ffi_converter_impl
         #meta_static_var
-    }
-}
-
-pub(crate) fn expand_enum_ffi_converter(attr: CommonAttr, input: DeriveInput) -> TokenStream {
-    match input.data {
-        Data::Enum(e) => enum_ffi_converter_impl(&input.ident, &e, attr.tag.as_ref()),
-        _ => syn::Error::new(
-            proc_macro2::Span::call_site(),
-            "This attribute must only be used on enums",
-        )
-        .into_compile_error(),
-    }
+    })
 }
 
 pub(crate) fn enum_ffi_converter_impl(
     ident: &Ident,
     enum_: &DataEnum,
-    tag: Option<&Path>,
+    udl_mode: bool,
 ) -> TokenStream {
     enum_or_error_ffi_converter_impl(
         ident,
         enum_,
-        tag,
+        udl_mode,
         false,
         quote! { ::uniffi::metadata::codes::TYPE_ENUM },
     )
@@ -63,13 +47,13 @@ pub(crate) fn enum_ffi_converter_impl(
 pub(crate) fn rich_error_ffi_converter_impl(
     ident: &Ident,
     enum_: &DataEnum,
-    tag: Option<&Path>,
+    udl_mode: bool,
     handle_unknown_callback_error: bool,
 ) -> TokenStream {
     enum_or_error_ffi_converter_impl(
         ident,
         enum_,
-        tag,
+        udl_mode,
         handle_unknown_callback_error,
         quote! { ::uniffi::metadata::codes::TYPE_ENUM },
     )
@@ -78,12 +62,13 @@ pub(crate) fn rich_error_ffi_converter_impl(
 fn enum_or_error_ffi_converter_impl(
     ident: &Ident,
     enum_: &DataEnum,
-    tag: Option<&Path>,
+    udl_mode: bool,
     handle_unknown_callback_error: bool,
     metadata_type_code: TokenStream,
 ) -> TokenStream {
     let name = ident_to_string(ident);
-    let impl_spec = tagged_impl_header("FfiConverter", ident, tag);
+    let impl_spec = tagged_impl_header("FfiConverter", ident, udl_mode);
+    let lift_ref_impl_spec = tagged_impl_header("LiftRef", ident, udl_mode);
     let mod_path = match mod_path() {
         Ok(p) => p,
         Err(e) => return e.into_compile_error(),
@@ -146,6 +131,10 @@ fn enum_or_error_ffi_converter_impl(
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(#metadata_type_code)
                 .concat_str(#mod_path)
                 .concat_str(#name);
+        }
+
+        #lift_ref_impl_spec {
+            type LiftType = Self;
         }
     }
 }

--- a/uniffi_macros/src/export/attributes.rs
+++ b/uniffi_macros/src/export/attributes.rs
@@ -1,4 +1,4 @@
-use crate::util::{either_attribute_arg, parse_comma_separated, UniffiAttributeArgs};
+use crate::util::{either_attribute_arg, kw, parse_comma_separated, UniffiAttributeArgs};
 
 use proc_macro2::TokenStream;
 use quote::ToTokens;
@@ -7,15 +7,11 @@ use syn::{
     Attribute, LitStr, Meta, PathArguments, PathSegment, Token,
 };
 
-pub(crate) mod kw {
-    syn::custom_keyword!(async_runtime);
-    syn::custom_keyword!(callback_interface);
-}
-
 #[derive(Default)]
 pub struct ExportAttributeArguments {
     pub(crate) async_runtime: Option<AsyncRuntime>,
     pub(crate) callback_interface: Option<kw::callback_interface>,
+    pub(crate) constructor: Option<kw::constructor>,
 }
 
 impl Parse for ExportAttributeArguments {
@@ -39,6 +35,11 @@ impl UniffiAttributeArgs for ExportAttributeArguments {
                 callback_interface: input.parse()?,
                 ..Self::default()
             })
+        } else if lookahead.peek(kw::constructor) {
+            Ok(Self {
+                constructor: input.parse()?,
+                ..Self::default()
+            })
         } else {
             Ok(Self::default())
         }
@@ -51,6 +52,7 @@ impl UniffiAttributeArgs for ExportAttributeArguments {
                 self.callback_interface,
                 other.callback_interface,
             )?,
+            constructor: either_attribute_arg(self.constructor, other.constructor)?,
         })
     }
 }

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -12,6 +12,7 @@ use crate::fnsig::{FnKind, FnSignature, NamedArg};
 pub(super) fn gen_fn_scaffolding(
     sig: FnSignature,
     arguments: &ExportAttributeArguments,
+    udl_mode: bool,
 ) -> syn::Result<TokenStream> {
     if sig.receiver.is_some() {
         return Err(syn::Error::new(
@@ -27,8 +28,11 @@ pub(super) fn gen_fn_scaffolding(
             ));
         }
     }
-    let metadata_items = sig.metadata_items()?;
-    let scaffolding_func = gen_ffi_function(&sig, arguments)?;
+    let metadata_items = (!udl_mode).then(|| {
+        sig.metadata_items()
+            .unwrap_or_else(syn::Error::into_compile_error)
+    });
+    let scaffolding_func = gen_ffi_function(&sig, arguments, udl_mode)?;
     Ok(quote! {
         #scaffolding_func
         #metadata_items
@@ -38,6 +42,7 @@ pub(super) fn gen_fn_scaffolding(
 pub(super) fn gen_constructor_scaffolding(
     sig: FnSignature,
     arguments: &ExportAttributeArguments,
+    udl_mode: bool,
 ) -> syn::Result<TokenStream> {
     if sig.receiver.is_some() {
         return Err(syn::Error::new(
@@ -48,8 +53,11 @@ pub(super) fn gen_constructor_scaffolding(
     if sig.is_async {
         return Err(syn::Error::new(sig.span, "constructors can't be async"));
     }
-    let metadata_items = sig.metadata_items()?;
-    let scaffolding_func = gen_ffi_function(&sig, arguments)?;
+    let metadata_items = (!udl_mode).then(|| {
+        sig.metadata_items()
+            .unwrap_or_else(syn::Error::into_compile_error)
+    });
+    let scaffolding_func = gen_ffi_function(&sig, arguments, udl_mode)?;
     Ok(quote! {
         #scaffolding_func
         #metadata_items
@@ -59,6 +67,7 @@ pub(super) fn gen_constructor_scaffolding(
 pub(super) fn gen_method_scaffolding(
     sig: FnSignature,
     arguments: &ExportAttributeArguments,
+    udl_mode: bool,
 ) -> syn::Result<TokenStream> {
     let scaffolding_func = if sig.receiver.is_none() {
         return Err(syn::Error::new(
@@ -66,10 +75,13 @@ pub(super) fn gen_method_scaffolding(
             "associated functions are not currently supported",
         ));
     } else {
-        gen_ffi_function(&sig, arguments)?
+        gen_ffi_function(&sig, arguments, udl_mode)?
     };
 
-    let metadata_items = sig.metadata_items()?;
+    let metadata_items = (!udl_mode).then(|| {
+        sig.metadata_items()
+            .unwrap_or_else(syn::Error::into_compile_error)
+    });
     Ok(quote! {
         #scaffolding_func
         #metadata_items
@@ -87,19 +99,30 @@ struct ScaffoldingBits {
 }
 
 impl ScaffoldingBits {
-    fn new_for_function(sig: &FnSignature) -> Self {
+    fn new_for_function(sig: &FnSignature, udl_mode: bool) -> Self {
         let ident = &sig.ident;
         let params: Vec<_> = sig.args.iter().map(NamedArg::scaffolding_param).collect();
         let param_lifts = sig.lift_exprs();
+        let simple_rust_fn_call = quote! { #ident(#(#param_lifts,)*) };
+        let rust_fn_call = if udl_mode && sig.looks_like_result {
+            quote! { #simple_rust_fn_call.map_err(::std::convert::Into::into) }
+        } else {
+            simple_rust_fn_call
+        };
 
         Self {
             params,
             pre_fn_call: quote! {},
-            rust_fn_call: quote! { #ident(#(#param_lifts,)*) },
+            rust_fn_call,
         }
     }
 
-    fn new_for_method(sig: &FnSignature, self_ident: &Ident, is_trait: bool) -> Self {
+    fn new_for_method(
+        sig: &FnSignature,
+        self_ident: &Ident,
+        is_trait: bool,
+        udl_mode: bool,
+    ) -> Self {
         let ident = &sig.ident;
         let ffi_converter = if is_trait {
             quote! {
@@ -114,27 +137,44 @@ impl ScaffoldingBits {
             .chain(sig.scaffolding_params())
             .collect();
         let param_lifts = sig.lift_exprs();
+        let simple_rust_fn_call = quote! { uniffi_self.#ident(#(#param_lifts,)*) };
+        let rust_fn_call = if udl_mode && sig.looks_like_result {
+            quote! { #simple_rust_fn_call.map_err(::std::convert::Into::into) }
+        } else {
+            simple_rust_fn_call
+        };
+        let return_ffi_converter = sig.return_ffi_converter();
 
         Self {
             params,
             pre_fn_call: quote! {
-                let uniffi_self = #ffi_converter::try_lift(uniffi_self_lowered).unwrap_or_else(|err| {
-                    ::std::panic!("Failed to convert arg 'self': {}", err)
-                });
+                let uniffi_self = match #ffi_converter::try_lift(uniffi_self_lowered) {
+                    Ok(v) => v,
+                    Err(e) => return Err(#return_ffi_converter::handle_failed_lift("self", e)),
+                };
             },
-            rust_fn_call: quote! { uniffi_self.#ident(#(#param_lifts,)*) },
+            rust_fn_call,
         }
     }
 
-    fn new_for_constructor(sig: &FnSignature, self_ident: &Ident) -> Self {
+    fn new_for_constructor(sig: &FnSignature, self_ident: &Ident, udl_mode: bool) -> Self {
         let ident = &sig.ident;
         let params: Vec<_> = sig.args.iter().map(NamedArg::scaffolding_param).collect();
         let param_lifts = sig.lift_exprs();
+        let simple_rust_fn_call = quote! { #self_ident::#ident(#(#param_lifts,)*) };
+        let rust_fn_call = match (udl_mode, sig.looks_like_result) {
+            // For UDL
+            (true, false) => quote! { ::std::sync::Arc::new(#simple_rust_fn_call) },
+            (true, true) => {
+                quote! { #simple_rust_fn_call.map(::std::sync::Arc::new).map_err(::std::convert::Into::into) }
+            }
+            (false, _) => simple_rust_fn_call,
+        };
 
         Self {
             params,
             pre_fn_call: quote! {},
-            rust_fn_call: quote! { #self_ident::#ident(#(#param_lifts,)*) },
+            rust_fn_call,
         }
     }
 }
@@ -146,18 +186,29 @@ impl ScaffoldingBits {
 fn gen_ffi_function(
     sig: &FnSignature,
     arguments: &ExportAttributeArguments,
+    udl_mode: bool,
 ) -> syn::Result<TokenStream> {
     let ScaffoldingBits {
         params,
         pre_fn_call,
         rust_fn_call,
     } = match &sig.kind {
-        FnKind::Function => ScaffoldingBits::new_for_function(sig),
-        FnKind::Method { self_ident } => ScaffoldingBits::new_for_method(sig, self_ident, false),
-        FnKind::TraitMethod { self_ident, .. } => {
-            ScaffoldingBits::new_for_method(sig, self_ident, true)
+        FnKind::Function => ScaffoldingBits::new_for_function(sig, udl_mode),
+        FnKind::Method { self_ident } => {
+            ScaffoldingBits::new_for_method(sig, self_ident, false, udl_mode)
         }
-        FnKind::Constructor { self_ident } => ScaffoldingBits::new_for_constructor(sig, self_ident),
+        FnKind::TraitMethod { self_ident, .. } => {
+            ScaffoldingBits::new_for_method(sig, self_ident, true, udl_mode)
+        }
+        FnKind::Constructor { self_ident } => {
+            ScaffoldingBits::new_for_constructor(sig, self_ident, udl_mode)
+        }
+    };
+    // Scaffolding functions are logically `pub`, but we don't use that in UDL mode since UDL has
+    // historically not required types to be `pub`
+    let vis = match udl_mode {
+        false => quote! { pub },
+        true => quote! {},
     };
 
     let ffi_ident = sig.scaffolding_fn_ident()?;
@@ -168,14 +219,16 @@ fn gen_ffi_function(
         quote! {
             #[doc(hidden)]
             #[no_mangle]
-            pub extern "C" fn #ffi_ident(
+            #vis extern "C" fn #ffi_ident(
                 #(#params,)*
                 call_status: &mut ::uniffi::RustCallStatus,
             ) -> <#return_ty as ::uniffi::FfiConverter<crate::UniFfiTag>>::ReturnType {
                 ::uniffi::deps::log::debug!(#name);
                 ::uniffi::rust_call(call_status, || {
                     #pre_fn_call
-                    <#return_ty as ::uniffi::FfiConverter<crate::UniFfiTag>>::lower_return(#rust_fn_call)
+                    <#return_ty as ::uniffi::FfiConverter<crate::UniFfiTag>>::lower_return(
+                        #rust_fn_call
+                    )
                 })
             }
         }
@@ -188,7 +241,7 @@ fn gen_ffi_function(
         quote! {
             #[doc(hidden)]
             #[no_mangle]
-            pub extern "C" fn #ffi_ident(
+            #vis extern "C" fn #ffi_ident(
                 #(#params,)*
                 uniffi_executor_handle: ::uniffi::ForeignExecutorHandle,
                 uniffi_callback: <#return_ty as ::uniffi::FfiConverter<crate::UniFfiTag>>::FutureCallback,


### PR DESCRIPTION
Reworked UDL-based scaffolding generation so that it forwards the work to the proc-macro code.  This means that almost all scaffolding generation now flows through the proc-macros and we no longer need to keep 2 implementations of it.  The only major thing left is built-in traits.

The scaffolding templates now generate stub interfaces and wrap them with a `[uniffi::export]` macro. Added the `udl_mode` argument to the `export` macro to support this.

- Added support for [ByArc] in callback interfaces
- Moved all keywords into a single module.
- Renamed the existing macros that did similar work to `derive_[thing]_for_udl`.
- The derive macros now also support the `#[uniffi(udl_mode)]` attribute. I doubt any users will use this, but the code seemed cleaner this way so why not?