### PR TITLE
Provide Kotlin companion objects for generated types

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceTemplate.kt
@@ -17,6 +17,7 @@ public interface {{ type_name }} {
     {%- else -%}
     {%- endmatch %}
     {% endfor %}
+    companion object
 }
 
 // The ForeignCallback that is passed to Rust.

--- a/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
@@ -11,6 +11,7 @@ enum class {{ type_name }} {
     {% for variant in e.variants() -%}
     {{ variant|variant_name }}{% if loop.last %};{% else %},{% endif %}
     {%- endfor %}
+    companion object
 }
 
 public object {{ e|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
@@ -38,7 +39,9 @@ sealed class {{ type_name }}{% if contains_object_references %}: Disposable {% e
         {% for field in variant.fields() -%}
         val {{ field.name()|var_name }}: {{ field|type_name}}{% if loop.last %}{% else %}, {% endif %}
         {% endfor -%}
-    ) : {{ type_name }}()
+    ) : {{ type_name }}() {
+        companion object
+    }
     {%- endif %}
     {% endfor %}
 
@@ -58,6 +61,7 @@ sealed class {{ type_name }}{% if contains_object_references %}: Disposable {% e
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     {% endif %}
+    companion object
 }
 
 public object {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }}>{

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -21,6 +21,7 @@ public interface {{ type_name }}Interface {
     {%- endmatch -%}
 
     {% endfor %}
+    companion object
 }
 
 class {{ type_name }}(
@@ -110,6 +111,8 @@ class {{ type_name }}(
             {{ type_name }}({% call kt::to_ffi_call(cons) %})
         {% endfor %}
     }
+    {% else %}
+    companion object
     {% endif %}
 }
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
@@ -16,6 +16,7 @@ data class {{ type_name }} (
         {% call kt::destroy_fields(rec) %}
     }
     {% endif %}
+    companion object
 }
 
 public object {{ rec|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {


### PR DESCRIPTION
Since associated functions are unsupported as of now, an alternative to associated functions would be using (prefixed) global functions instead. A developer could then utilize the generated, global functions and wrap them within target-language specific type-associated extension functions.

While it's possible without any further ado to simply extend Protocols, Classes & Structs in Swift even with associated functions and generated properties, any Kotlin type is required to provide a companion object in order to mimic or enable such extensions (there's no static or associated in Kotlin, hence a companion object is required).
Kotlin does not provide a capibility to attach a companion object from anywhere but the types's declaration itself.

This PR therefore attaches a `companion object` to any generated `data class`, `class` or `enum class` by default.

**Edit**: Add `interface` companions as well.