### PR TITLE
Fix external types namespace/crate_name confusion.

### DIFF
--- a/docs/manual/src/udl/ext_types_external.md
+++ b/docs/manual/src/udl/ext_types_external.md
@@ -29,6 +29,9 @@ dictionary ConsumingDict {
 
 ```
 
+If in the above example, `DemoDict` was actually "exported" via a procmacro
+you should instead use `ExternExport`
+
 (Note the special type `extern` used on the `typedef`. It is not currently enforced that the
 literal `extern` is used, but we hope to enforce this later, so please use it!)
 

--- a/fixtures/ext-types/lib/src/ext-types-lib.udl
+++ b/fixtures/ext-types/lib/src/ext-types-lib.udl
@@ -18,6 +18,7 @@ namespace imported_types_lib {
 
     UniffiOneInterface get_uniffi_one_interface();
     ExternalCrateInterface get_external_crate_interface(string val);
+    UniffiOneProcMacroType get_uniffi_one_proc_macro_type(UniffiOneProcMacroType t);
 };
 
 // A type defined in a .udl file in the `uniffi-one` crate (ie, in
@@ -32,6 +33,10 @@ typedef extern UniffiOneEnum;
 // An interface in the same crate
 [ExternalInterface="uniffi_one"]
 typedef extern UniffiOneInterface;
+
+// A type defined via procmacros in an external crate
+[ExternalExport="uniffi_one"]
+typedef extern UniffiOneProcMacroType;
 
 // A "wrapped" type defined in the guid crate (ie, defined in `../../guid/src/lib.rs` and
 // "declared" in `../../guid/src/guid.udl`). But it's still "external" from our POV,

--- a/fixtures/ext-types/lib/src/lib.rs
+++ b/fixtures/ext-types/lib/src/lib.rs
@@ -2,7 +2,7 @@ use custom_types::Handle;
 use ext_types_external_crate::{ExternalCrateDictionary, ExternalCrateInterface};
 use ext_types_guid::Guid;
 use std::sync::Arc;
-use uniffi_one::{UniffiOneEnum, UniffiOneInterface, UniffiOneType};
+use uniffi_one::{UniffiOneEnum, UniffiOneInterface, UniffiOneProcMacroType, UniffiOneType};
 use url::Url;
 
 pub struct CombinedType {
@@ -111,6 +111,10 @@ fn get_maybe_uniffi_one_enums(es: Vec<Option<UniffiOneEnum>>) -> Vec<Option<Unif
 
 fn get_uniffi_one_interface() -> Arc<UniffiOneInterface> {
     Arc::new(UniffiOneInterface::new())
+}
+
+fn get_uniffi_one_proc_macro_type(t: UniffiOneProcMacroType) -> UniffiOneProcMacroType {
+    t
 }
 
 fn get_external_crate_interface(val: String) -> Arc<ExternalCrateInterface> {

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.kts
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.kts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import uniffi.imported_types_lib.*
-import uniffi.uniffi_one.*
+import uniffi.uniffi_one_ns.*
 
 val ct = getCombinedType(null)
 assert(ct.uot.sval == "hello")
@@ -26,6 +26,10 @@ assert(getMaybeUniffiOneType(uot)!! == uot)
 assert(getMaybeUniffiOneType(null) == null)
 assert(getUniffiOneTypes(listOf(uot)) == listOf(uot))
 assert(getMaybeUniffiOneTypes(listOf(uot, null)) == listOf(uot, null))
+
+val uopmt = UniffiOneProcMacroType("hello from proc-macro world")
+assert(getUniffiOneProcMacroType(uopmt) == uopmt)
+assert(getMyProcMacroType(uopmt) == uopmt)
 
 val uoe = UniffiOneEnum.ONE
 assert(getUniffiOneEnum(uoe) == uoe)

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.py
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.py
@@ -5,7 +5,7 @@
 import unittest
 import urllib
 from imported_types_lib import *
-from uniffi_one import *
+from uniffi_one_ns import *
 
 class TestIt(unittest.TestCase):
     def test_it(self):
@@ -47,6 +47,11 @@ class TestIt(unittest.TestCase):
         ct = get_combined_type(None)
         self.assertEqual(ct.ecd.sval, "ecd");
         self.assertEqual(get_external_crate_interface("foo").value(), "foo")
+
+    def test_procmacro_types(self):
+        t1 = UniffiOneProcMacroType("hello")
+        self.assertEqual(t1, get_uniffi_one_proc_macro_type(t1))
+        self.assertEqual(t1, get_my_proc_macro_type(t1))
 
 if __name__=='__main__':
     unittest.main()

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.swift
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.swift
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import imported_types_lib
-//import uniffi_one
 import Foundation
 
 let ct = getCombinedType(value: nil)
@@ -26,6 +25,7 @@ assert(getMaybeUniffiOneType(t: UniffiOneType(sval: "hello"))!.sval == "hello")
 assert(getMaybeUniffiOneType(t: nil) == nil)
 assert(getUniffiOneTypes(ts: [UniffiOneType(sval: "hello")]) == [UniffiOneType(sval: "hello")])
 assert(getMaybeUniffiOneTypes(ts: [UniffiOneType(sval: "hello"), nil]) == [UniffiOneType(sval: "hello"), nil])
+assert(getMyProcMacroType(t: UniffiOneProcMacroType(sval: "proc-macros")).sval == "proc-macros")
 
 assert(getUniffiOneEnum(e: UniffiOneEnum.one) == UniffiOneEnum.one)
 assert(getMaybeUniffiOneEnum(e: UniffiOneEnum.one)! == UniffiOneEnum.one)

--- a/fixtures/ext-types/proc-macro-lib/build.rs
+++ b/fixtures/ext-types/proc-macro-lib/build.rs
@@ -1,7 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-fn main() {
-    uniffi::generate_scaffolding("src/ext-types-lib.udl").unwrap();
-}

--- a/fixtures/ext-types/proc-macro-lib/src/ext-types-lib.udl
+++ b/fixtures/ext-types/proc-macro-lib/src/ext-types-lib.udl
@@ -1,1 +1,0 @@
-namespace imported_types_lib { };

--- a/fixtures/ext-types/proc-macro-lib/src/lib.rs
+++ b/fixtures/ext-types/proc-macro-lib/src/lib.rs
@@ -196,4 +196,4 @@ fn get_guid_procmacro(g: Option<Guid>) -> Guid {
     ext_types_guid::get_guid(g)
 }
 
-uniffi::include_scaffolding!("ext-types-lib");
+uniffi::setup_scaffolding!("imported_types_lib");

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.kts
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.kts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import uniffi.imported_types_lib.*
-import uniffi.uniffi_one.*
+import uniffi.uniffi_one_ns.*
 
 val ct = getCombinedType(null)
 assert(ct.uot.sval == "hello")
@@ -29,6 +29,7 @@ assert(getMaybeUniffiOneTypes(listOf(uot, null)) == listOf(uot, null))
 
 val uopmt = UniffiOneProcMacroType("hello from proc-macro world")
 assert(getUniffiOneProcMacroType(uopmt) == uopmt)
+assert(getMyProcMacroType(uopmt) == uopmt)
 
 val uoe = UniffiOneEnum.ONE
 assert(getUniffiOneEnum(uoe) == uoe)

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.py
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.py
@@ -6,7 +6,7 @@ import unittest
 import urllib
 from ext_types_guid import *
 from imported_types_lib import *
-from uniffi_one import *
+from uniffi_one_ns import *
 
 class TestIt(unittest.TestCase):
     def test_it(self):

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.swift
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.swift
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import imported_types_lib
-//import uniffi_one
 import Foundation
 
 let ct = getCombinedType(value: nil)
@@ -28,6 +27,7 @@ assert(getUniffiOneTypes(ts: [UniffiOneType(sval: "hello")]) == [UniffiOneType(s
 assert(getMaybeUniffiOneTypes(ts: [UniffiOneType(sval: "hello"), nil]) == [UniffiOneType(sval: "hello"), nil])
 
 assert(getUniffiOneProcMacroType(t: UniffiOneProcMacroType(sval: "hello from proc-macro world")).sval == "hello from proc-macro world")
+assert(getMyProcMacroType(t: UniffiOneProcMacroType(sval: "proc-macros all the way down")).sval == "proc-macros all the way down")
 
 assert(getUniffiOneEnum(e: UniffiOneEnum.one) == UniffiOneEnum.one)
 assert(getMaybeUniffiOneEnum(e: UniffiOneEnum.one)! == UniffiOneEnum.one)

--- a/fixtures/ext-types/uniffi-one/Cargo.toml
+++ b/fixtures/ext-types/uniffi-one/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [lib]
 crate-type = ["lib", "cdylib"]
+# Note the crate name is different from the namespace used by this crate.
 name = "uniffi_one"
 
 [dependencies]

--- a/fixtures/ext-types/uniffi-one/src/lib.rs
+++ b/fixtures/ext-types/uniffi-one/src/lib.rs
@@ -29,4 +29,9 @@ impl UniffiOneInterface {
     }
 }
 
+#[uniffi::export]
+fn get_my_proc_macro_type(t: UniffiOneProcMacroType) -> UniffiOneProcMacroType {
+    t
+}
+
 uniffi::include_scaffolding!("uniffi-one");

--- a/fixtures/ext-types/uniffi-one/src/uniffi-one.udl
+++ b/fixtures/ext-types/uniffi-one/src/uniffi-one.udl
@@ -1,4 +1,4 @@
-namespace uniffi_one {};
+namespace uniffi_one_ns {};
 
 dictionary UniffiOneType {
     string sval;

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -144,11 +144,13 @@ impl<'a> TypeRenderer<'a> {
     }
 
     // Get the package name for an external type
-    fn external_type_package_name(&self, module_path: &str) -> String {
+    fn external_type_package_name(&self, module_path: &str, namespace: &str) -> String {
+        // config overrides are keyed by the crate name, default fallback is the namespace.
         let crate_name = module_path.split("::").next().unwrap();
         match self.kotlin_config.external_packages.get(crate_name) {
             Some(name) => name.clone(),
-            None => crate_name.to_string(),
+            // unreachable in library mode - all deps are in our config with correct namespace.
+            None => format!("uniffi.{namespace}"),
         }
     }
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ExternalTypeTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ExternalTypeTemplate.kt
@@ -1,4 +1,4 @@
-{%- let package_name=self.external_type_package_name(module_path) %}
+{%- let package_name=self.external_type_package_name(module_path, namespace) %}
 {%- let fully_qualified_type_name = "{}.{}"|format(package_name, name) %}
 {%- let fully_qualified_ffi_converter_name = "{}.FfiConverterType{}"|format(package_name, name) %}
 {%- let fully_qualified_rustbuffer_name = "{}.RustBuffer"|format(package_name) %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
@@ -94,7 +94,7 @@
 {%- when Type::Custom { module_path, name, builtin } %}
 {% include "CustomTypeTemplate.kt" %}
 
-{%- when Type::External { module_path, name, kind } %}
+{%- when Type::External { module_path, name, namespace, kind, tagged } %}
 {% include "ExternalTypeTemplate.kt" %}
 
 {%- else %}

--- a/uniffi_bindgen/src/bindings/python/templates/ExternalTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ExternalTemplate.py
@@ -1,8 +1,9 @@
-{%- let mod_name = module_path|fn_name %}
+{%- let ns = namespace|fn_name %}
 
+# External type {{name}} is in namespace "{{namespace}}", crate {{module_path}}
 {%- let ffi_converter_name = "_UniffiConverterType{}"|format(name) %}
-{{ self.add_import_of(mod_name, ffi_converter_name) }}
-{{ self.add_import_of(mod_name, name) }} {#- import the type alias itself -#}
+{{ self.add_import_of(ns, ffi_converter_name) }}
+{{ self.add_import_of(ns, name) }} {#- import the type alias itself -#}
 
 {%- let rustbuffer_local_name = "_UniffiRustBuffer{}"|format(name) %}
-{{ self.add_import_of_as(mod_name, "_UniffiRustBuffer", rustbuffer_local_name) }}
+{{ self.add_import_of_as(ns, "_UniffiRustBuffer", rustbuffer_local_name) }}

--- a/uniffi_bindgen/src/bindings/python/templates/Types.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Types.py
@@ -91,7 +91,7 @@
 {%- when Type::Custom { name, module_path, builtin } %}
 {%- include "CustomType.py" %}
 
-{%- when Type::External { name, module_path, kind } %}
+{%- when Type::External { name, module_path, namespace, kind, tagged } %}
 {%- include "ExternalTemplate.py" %}
 
 {%- when Type::ForeignExecutor %}

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -252,16 +252,21 @@ impl ComponentInterface {
 
     /// Get details about all `Type::External` types.
     /// Returns an iterator of (name, crate_name, kind)
-    pub fn iter_external_types(&self) -> impl Iterator<Item = (&String, String, ExternalKind)> {
+    pub fn iter_external_types(
+        &self,
+    ) -> impl Iterator<Item = (&String, String, ExternalKind, bool)> {
         self.types.iter_known_types().filter_map(|t| match t {
             Type::External {
                 name,
                 module_path,
                 kind,
+                tagged,
+                ..
             } => Some((
                 name,
                 module_path.split("::").next().unwrap().to_string(),
                 *kind,
+                *tagged,
             )),
             _ => None,
         })

--- a/uniffi_bindgen/src/macro_metadata/ci.rs
+++ b/uniffi_bindgen/src/macro_metadata/ci.rs
@@ -4,7 +4,9 @@
 
 use crate::interface::{CallbackInterface, ComponentInterface, Enum, Record, Type};
 use anyhow::{bail, Context};
-use uniffi_meta::{group_metadata, EnumMetadata, ErrorMetadata, Metadata, MetadataGroup};
+use uniffi_meta::{
+    create_metadata_groups, group_metadata, EnumMetadata, ErrorMetadata, Metadata, MetadataGroup,
+};
 
 /// Add Metadata items to the ComponentInterface
 ///
@@ -18,7 +20,9 @@ pub fn add_to_ci(
     iface: &mut ComponentInterface,
     metadata_items: Vec<Metadata>,
 ) -> anyhow::Result<()> {
-    for group in group_metadata(metadata_items)? {
+    let mut group_map = create_metadata_groups(&metadata_items);
+    group_metadata(&mut group_map, metadata_items)?;
+    for group in group_map.into_values() {
         if group.items.is_empty() {
             continue;
         }

--- a/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
@@ -1,14 +1,17 @@
 // Support for external types.
 
 // Types with an external `FfiConverter`...
-{% for (name, crate_name, kind) in ci.iter_external_types() %}
+{% for (name, crate_name, kind, tagged) in ci.iter_external_types() %}
 // The FfiConverter for `{{ name }}` is defined in `{{ crate_name }}`
+// If it has its existing FfiConverter defined with a UniFFITag, it needs forwarding.
+{% if tagged %}
 {%- match kind %}
 {%- when ExternalKind::DataClass %}
 ::uniffi::ffi_converter_forward!(r#{{ name }}, ::{{ crate_name|crate_name_rs }}::UniFfiTag, crate::UniFfiTag);
 {%- when ExternalKind::Interface %}
 ::uniffi::ffi_converter_arc_forward!(r#{{ name }}, ::{{ crate_name|crate_name_rs }}::UniFfiTag, crate::UniFfiTag);
 {%- endmatch %}
+{% endif %}
 {%- endfor %}
 
 // We generate support for each Custom Type and the builtin type it uses.

--- a/uniffi_checksum_derive/src/lib.rs
+++ b/uniffi_checksum_derive/src/lib.rs
@@ -81,9 +81,12 @@ pub fn checksum_derive(input: TokenStream) -> TokenStream {
                             .named
                             .iter()
                             .map(|field| field.ident.as_ref().unwrap());
-                        let field_stmts = field_idents
-                            .clone()
-                            .map(|ident| quote! { Checksum::checksum(#ident, state); });
+                        let field_stmts = fields.named.iter()
+                            .filter(|field| !has_ignore_attribute(&field.attrs))
+                            .map(|field| {
+                                    let ident = field.ident.as_ref().unwrap();
+                                    quote! { Checksum::checksum(#ident, state); }
+                            });
                         quote! {
                             Self::#ident { #(#field_idents,)* } => {
                                 #discriminant;

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -9,7 +9,7 @@ mod ffi_names;
 pub use ffi_names::*;
 
 mod group;
-pub use group::{group_metadata, MetadataGroup};
+pub use group::{create_metadata_groups, fixup_external_type, group_metadata, MetadataGroup};
 
 mod reader;
 pub use reader::{read_metadata, read_metadata_type};
@@ -402,6 +402,23 @@ pub enum Metadata {
 impl Metadata {
     pub fn read(data: &[u8]) -> anyhow::Result<Self> {
         read_metadata(data)
+    }
+
+    pub(crate) fn module_path(&self) -> &String {
+        match self {
+            Metadata::Namespace(meta) => &meta.crate_name,
+            Metadata::UdlFile(meta) => &meta.module_path,
+            Metadata::Func(meta) => &meta.module_path,
+            Metadata::Constructor(meta) => &meta.module_path,
+            Metadata::Method(meta) => &meta.module_path,
+            Metadata::Record(meta) => &meta.module_path,
+            Metadata::Enum(meta) => &meta.module_path,
+            Metadata::Object(meta) => &meta.module_path,
+            Metadata::CallbackInterface(meta) => &meta.module_path,
+            Metadata::TraitMethod(meta) => &meta.module_path,
+            Metadata::Error(meta) => meta.module_path(),
+            Metadata::CustomType(meta) => &meta.module_path,
+        }
     }
 }
 

--- a/uniffi_meta/src/types.rs
+++ b/uniffi_meta/src/types.rs
@@ -114,7 +114,10 @@ pub enum Type {
     External {
         module_path: String,
         name: String,
+        #[checksum_ignore] // The namespace is not known generating scaffolding.
+        namespace: String,
         kind: ExternalKind,
+        tagged: bool, // does its FfiConverter use <UniFFITag>?
     },
     // Custom type on the scaffolding side
     Custom {

--- a/uniffi_udl/src/finder.rs
+++ b/uniffi_udl/src/finder.rs
@@ -130,7 +130,8 @@ impl TypeFinder for weedle::TypedefDefinition<'_> {
                 },
             )
         } else {
-            let kind = attrs.external_kind().expect("ExternalKind missing");
+            let kind = attrs.external_kind().expect("External missing");
+            let tagged = attrs.external_tagged().expect("External missing");
             // A crate which can supply an `FfiConverter`.
             // We don't reference `self._type`, so ideally we could insist on it being
             // the literal 'extern' but that's tricky
@@ -138,8 +139,10 @@ impl TypeFinder for weedle::TypedefDefinition<'_> {
                 name,
                 Type::External {
                     name: name.to_string(),
+                    namespace: "".to_string(), // we don't know this yet
                     module_path: attrs.get_crate_name(),
                     kind,
+                    tagged,
                 },
             )
         }
@@ -249,11 +252,11 @@ mod test {
         "#,
             |types| {
                 assert!(
-                    matches!(types.get_type_definition("ExternalType").unwrap(), Type::External { name, module_path, kind: ExternalKind::DataClass }
+                    matches!(types.get_type_definition("ExternalType").unwrap(), Type::External { name, module_path, kind: ExternalKind::DataClass, .. }
                                                                                  if name == "ExternalType" && module_path == "crate-name")
                 );
                 assert!(
-                    matches!(types.get_type_definition("ExternalInterfaceType").unwrap(), Type::External { name, module_path, kind: ExternalKind::Interface }
+                    matches!(types.get_type_definition("ExternalInterfaceType").unwrap(), Type::External { name, module_path, kind: ExternalKind::Interface, .. }
                                                                                  if name == "ExternalInterfaceType" && module_path == "crate-name")
                 );
                 assert!(


### PR DESCRIPTION
This improves coverage and functionality sharing external types between crates and between UDL and proc-macro implementations.