### PR TITLE
Split up FfiConverter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 - Proc-macros: Added support for ByRef arguments
 - Proc-macros: Implemented custom type conversion error handling (https://mozilla.github.io/uniffi-rs/udl/custom_types.html#error-handling-during-conversion)
 - Error types must now implement `Error + Send + Sync + 'static`.
+- Proc-macros: The `handle_unknown_callback_error` attribute is no longer needed for callback
+  interface errors
 
 ### What's Fixed
 

--- a/docs/manual/src/proc_macro/index.md
+++ b/docs/manual/src/proc_macro/index.md
@@ -331,35 +331,6 @@ pub trait Person {
 // }
 ```
 
-### Exception handling in callback interfaces
-
-Most languages allow arbitrary exceptions to be thrown, which presents issues for callback
-interfaces.  If a callback interface function returns a non-Result type, then any exception will
-result in a panic on the Rust side.
-
-To avoid panics, callback interfaces can use `Result<T, E>` types for all return values.  If the callback
-interface implementation throws the exception that corresponds to the `E` parameter, `Err(E)` will
-be returned to the Rust code.  However, in most languages it's still possible for the implementation
-to throw other exceptions.  To avoid panics in those cases, the error type must be wrapped
-with the `#[uniffi(handle_unknown_callback_error)]` attribute and
-`From<UnexpectedUniFFICallbackError>` must be implemented:
-
-```rust
-#[derive(uniffi::Error)]
-#[uniffi(handle_unknown_callback_error)]
-pub enum MyApiError {
-    IOError,
-    ValueError,
-    UnexpectedError { reason: String },
-}
-
-impl From<UnexpectedUniFFICallbackError> for MyApiError {
-    fn from(e: UnexpectedUniFFICallbackError) -> Self {
-        Self::UnexpectedError { reason: e.reason }
-    }
-}
-```
-
 ## Types from dependent crates
 
 When using proc-macros, you can use types from dependent crates in your exported library, as long as

--- a/fixtures/keywords/kotlin/src/keywords.udl
+++ b/fixtures/keywords/kotlin/src/keywords.udl
@@ -9,7 +9,7 @@ interface break {
 
 callback interface continue {
     return return(return v);
-    continue? continue(sequence<continue> continue);
+    continue? continue();
     record<u8, break> break(break? v);
     while while(sequence<while> while);
     record<u8, sequence<class>>? class(record<u8, sequence<class>> v);
@@ -32,7 +32,6 @@ interface false {
     true(u8 object);
 };
 
-[Error]
 enum class {
     "object",
 };

--- a/fixtures/keywords/kotlin/src/lib.rs
+++ b/fixtures/keywords/kotlin/src/lib.rs
@@ -17,7 +17,7 @@ impl r#break {
 #[allow(non_camel_case_types)]
 trait r#continue {
     fn r#return(&self, v: r#return) -> r#return;
-    fn r#continue(&self, v: Vec<Box<dyn r#continue>>) -> Option<Box<dyn r#continue>>;
+    fn r#continue(&self) -> Option<Box<dyn r#continue>>;
     fn r#break(&self, _v: Option<Arc<r#break>>) -> HashMap<u8, Arc<r#break>>;
     fn r#while(&self, _v: Vec<r#while>) -> r#while;
     fn class(&self, _v: HashMap<u8, Vec<class>>) -> Option<HashMap<u8, Vec<class>>>;
@@ -44,9 +44,8 @@ pub enum r#false {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum class {
-    #[error("object error")]
     object,
 }
 

--- a/fixtures/keywords/rust/src/keywords.udl
+++ b/fixtures/keywords/rust/src/keywords.udl
@@ -7,7 +7,7 @@ namespace keywords_rust {
 
 interface break {
     return return(return v);
-    sequence<continue>? continue(sequence<continue> continue);
+    void continue(sequence<continue> continue);
     record<u8, break>? break(record<u8, break> v);
     void yield(u8 async);
     void async(u8? yield);
@@ -15,7 +15,7 @@ interface break {
 
 callback interface continue {
     return return(return v);
-    continue? continue(sequence<continue> continue);
+    continue? continue();
     record<u8, break> break(break? v);
     while while(sequence<while> while);
     record<u8, sequence<yield>>? yield(record<u8, sequence<yield>> v);
@@ -28,7 +28,7 @@ dictionary return {
 
 dictionary while {
     return return;
-    sequence<continue> continue;
+    sequence<yield> yield;
     record<u8, break> break;
     break? for;
     sequence<return> async;
@@ -39,7 +39,6 @@ interface async {
     as(u8 async);
 };
 
-[Error]
 enum yield {
     "async",
 };

--- a/fixtures/keywords/rust/src/lib.rs
+++ b/fixtures/keywords/rust/src/lib.rs
@@ -16,9 +16,7 @@ impl r#break {
     pub fn r#break(&self, v: HashMap<u8, Arc<r#break>>) -> Option<HashMap<u8, Arc<r#break>>> {
         Some(v)
     }
-    fn r#continue(&self, v: Vec<Box<dyn r#continue>>) -> Option<Vec<Box<dyn r#continue>>> {
-        Some(v)
-    }
+    fn r#continue(&self, _v: Vec<Box<dyn r#continue>>) {}
     pub fn r#yield(&self, _async: u8) {}
     pub fn r#async(&self, _yield: Option<u8>) {}
 }
@@ -26,7 +24,7 @@ impl r#break {
 #[allow(non_camel_case_types)]
 pub trait r#continue {
     fn r#return(&self, v: r#return) -> r#return;
-    fn r#continue(&self, v: Vec<Box<dyn r#continue>>) -> Option<Box<dyn r#continue>>;
+    fn r#continue(&self) -> Option<Box<dyn r#continue>>;
     fn r#break(&self, _v: Option<Arc<r#break>>) -> HashMap<u8, Arc<r#break>>;
     fn r#while(&self, _v: Vec<r#while>) -> r#while;
     fn r#yield(&self, _v: HashMap<u8, Vec<r#yield>>) -> Option<HashMap<u8, Vec<r#yield>>>;
@@ -42,7 +40,7 @@ pub struct r#return {
 #[allow(non_camel_case_types)]
 pub struct r#while {
     r#return: r#return,
-    r#continue: Vec<Box<dyn r#continue>>,
+    r#yield: Vec<r#yield>,
     r#break: HashMap<u8, Arc<r#break>>,
     r#for: Option<Arc<r#break>>,
     r#async: Vec<r#return>,
@@ -55,9 +53,8 @@ pub enum r#async {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum r#yield {
-    #[error("async error")]
     r#async,
 }
 

--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -81,9 +81,9 @@ mod test_type_ids {
     use super::*;
     use std::collections::HashMap;
     use std::sync::Arc;
-    use uniffi_core::FfiConverter;
+    use uniffi_core::Lower;
 
-    fn check_type_id<T: FfiConverter<UniFfiTag>>(correct_type: Type) {
+    fn check_type_id<T: Lower<UniFfiTag>>(correct_type: Type) {
         let buf = &mut T::TYPE_ID_META.as_ref();
         assert_eq!(
             uniffi_meta::read_metadata_type(buf).unwrap(),

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -188,7 +188,6 @@ fn enum_identity(value: MaybeBool) -> MaybeBool {
 }
 
 #[derive(thiserror::Error, uniffi::Error, Debug, PartialEq, Eq)]
-#[uniffi(handle_unknown_callback_error)]
 pub enum BasicError {
     #[error("InvalidInput")]
     InvalidInput,

--- a/fixtures/uitests/tests/ui/fieldless_errors_used_in_callbacks_cant_have_fields.stderr
+++ b/fixtures/uitests/tests/ui/fieldless_errors_used_in_callbacks_cant_have_fields.stderr
@@ -4,7 +4,6 @@ error[E0533]: expected value, found struct variant `Self::DivisionByZero`
   | / #[::uniffi::derive_error_for_udl(
   | |     flat_error,
   | |     with_try_read,
-  | |     handle_unknown_callback_error,
   | | )]
   | |__^ not a value
   |

--- a/fixtures/uitests/tests/ui/invalid_types_in_signatures.rs
+++ b/fixtures/uitests/tests/ui/invalid_types_in_signatures.rs
@@ -1,0 +1,25 @@
+fn main() { /* empty main required by `trybuild` */}
+
+#[derive(Debug, uniffi::Error, thiserror::Error)]
+pub enum ErrorType {
+    #[error("Foo")]
+    Foo,
+}
+
+#[uniffi::export]
+pub fn input_error(_e: ErrorType) { }
+
+#[uniffi::export]
+pub fn output_error() -> ErrorType {
+    ErrorType::Foo
+}
+
+#[uniffi::export]
+pub fn input_result(_r: Result<(), ErrorType>) { }
+
+#[uniffi::export]
+pub fn return_option_result() -> Option<Result<(), ErrorType>> {
+    Some(Ok(()))
+}
+
+uniffi_macros::setup_scaffolding!();

--- a/fixtures/uitests/tests/ui/invalid_types_in_signatures.stderr
+++ b/fixtures/uitests/tests/ui/invalid_types_in_signatures.stderr
@@ -1,0 +1,53 @@
+error[E0277]: the trait bound `Result<(), ErrorType>: Lift<UniFfiTag>` is not satisfied
+  --> tests/ui/invalid_types_in_signatures.rs:17:1
+   |
+17 | #[uniffi::export]
+   | ^^^^^^^^^^^^^^^^^ the trait `Lift<UniFfiTag>` is not implemented for `Result<(), ErrorType>`
+   |
+   = help: the following other types implement trait `Lift<UT>`:
+             Arc<T>
+             Duration
+             ErrorType
+             ForeignExecutor
+             HashMap<K, V>
+             Option<T>
+             String
+             SystemTime
+           and $N others
+   = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant used
+  --> tests/ui/invalid_types_in_signatures.rs:17:1
+   |
+17 | #[uniffi::export]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Result<(), ErrorType>: Lower<UniFfiTag>` is not satisfied
+  --> tests/ui/invalid_types_in_signatures.rs:20:1
+   |
+20 | #[uniffi::export]
+   | ^^^^^^^^^^^^^^^^^ the trait `Lower<UniFfiTag>` is not implemented for `Result<(), ErrorType>`
+   |
+   = help: the following other types implement trait `Lower<UT>`:
+             Arc<T>
+             Duration
+             ErrorType
+             ForeignExecutor
+             HashMap<K, V>
+             Option<T>
+             String
+             SystemTime
+           and $N others
+   = note: required for `Option<Result<(), ErrorType>>` to implement `Lower<UniFfiTag>`
+   = note: required for `Option<Result<(), ErrorType>>` to implement `LowerReturn<UniFfiTag>`
+   = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant used
+  --> tests/ui/invalid_types_in_signatures.rs:20:1
+   |
+20 | #[uniffi::export]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
+++ b/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
@@ -14,7 +14,8 @@ error[E0277]: the trait bound `f32: Hash` is not satisfied
             u128
             u16
           and $N others
-  = note: required for `HashMap<f32, u64>` to implement `FfiConverter<UniFfiTag>`
+  = note: required for `HashMap<f32, u64>` to implement `Lower<UniFfiTag>`
+  = note: required for `HashMap<f32, u64>` to implement `LowerReturn<UniFfiTag>`
   = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
@@ -33,7 +34,8 @@ error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
             u128
             u16
           and $N others
-  = note: required for `HashMap<f32, u64>` to implement `FfiConverter<UniFfiTag>`
+  = note: required for `HashMap<f32, u64>` to implement `Lower<UniFfiTag>`
+  = note: required for `HashMap<f32, u64>` to implement `LowerReturn<UniFfiTag>`
   = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find function `get_dict` in this scope

--- a/fixtures/uitests/tests/ui/trait_methods_no_trait.stderr
+++ b/fixtures/uitests/tests/ui/trait_methods_no_trait.stderr
@@ -16,7 +16,7 @@ note: required by a bound in `uniffi_uniffi_trait_methods_fn_method_traitmethods
 error[E0277]: `TraitMethods` doesn't implement `std::fmt::Display`
  --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
   |
-  | /                 match<std::sync::Arc<r#TraitMethods> as ::uniffi::FfiConverter<crate::UniFfiTag>>::try_lift(r#ptr) {
+  | /                 match<std::sync::Arc<r#TraitMethods> as ::uniffi::Lift<crate::UniFfiTag>>::try_lift(r#ptr) {
   | |                     Ok(ref val) => val,
   | |                     Err(err) => panic!("Failed to convert arg '{}': {}", "ptr", err),
   | |                 }

--- a/uniffi/tests/ui/proc_macro_arc.stderr
+++ b/uniffi/tests/ui/proc_macro_arc.stderr
@@ -4,8 +4,10 @@ error[E0277]: the trait bound `Foo: FfiConverterArc<UniFfiTag>` is not satisfied
 10 | #[uniffi::export]
    | ^^^^^^^^^^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `Foo`
    |
-   = help: the trait `FfiConverter<UT>` is implemented for `Arc<T>`
+   = help: the trait `LowerReturn<UT>` is implemented for `Arc<T>`
    = note: required for `Arc<Foo>` to implement `FfiConverter<UniFfiTag>`
+   = note: required for `Arc<Foo>` to implement `Lower<UniFfiTag>`
+   = note: required for `Arc<Foo>` to implement `LowerReturn<UniFfiTag>`
    = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant used
@@ -22,8 +24,9 @@ error[E0277]: the trait bound `child::Foo: FfiConverterArc<UniFfiTag>` is not sa
 20 |     #[uniffi::export]
    |     ^^^^^^^^^^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `child::Foo`
    |
-   = help: the trait `FfiConverter<UT>` is implemented for `Arc<T>`
+   = help: the trait `Lift<UT>` is implemented for `Arc<T>`
    = note: required for `Arc<child::Foo>` to implement `FfiConverter<UniFfiTag>`
+   = note: required for `Arc<child::Foo>` to implement `Lift<UniFfiTag>`
    = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant used

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -290,10 +290,6 @@ impl ComponentInterface {
         self.types.get_type_definition(name)
     }
 
-    pub fn is_callback_interface_throws_type(&self, type_: Type) -> bool {
-        self.callback_interface_throws_types.contains(&type_)
-    }
-
     /// Iterate over all types contained in the given item.
     ///
     /// This method uses `iter_types` to iterate over the types contained within the given type,

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -92,20 +92,20 @@ mod filters {
         })
     }
 
-    // Map a type to Rust code that specifies the FfiConverter implementation.
+    // Map a type a ffi converter trait impl
     //
-    // This outputs something like `<TheFfiConverterStruct as FfiConverter>`
-    pub fn ffi_converter(type_: &Type) -> Result<String, askama::Error> {
+    // This outputs something like `<MyStruct as Lift<crate::UniFfiTag>>`
+    pub fn ffi_trait(type_: &Type, trait_name: &str) -> Result<String, askama::Error> {
         Ok(match type_ {
             Type::External {
                 name,
                 kind: ExternalKind::Interface,
                 ..
             } => {
-                format!("<::std::sync::Arc<r#{name}> as ::uniffi::FfiConverter<crate::UniFfiTag>>")
+                format!("<::std::sync::Arc<r#{name}> as ::uniffi::{trait_name}<crate::UniFfiTag>>")
             }
             _ => format!(
-                "<{} as ::uniffi::FfiConverter<crate::UniFfiTag>>",
+                "<{} as ::uniffi::{trait_name}<crate::UniFfiTag>>",
                 type_rs(type_)?
             ),
         })
@@ -124,14 +124,6 @@ mod filters {
             Some(e) => format!("::std::result::Result<{return_type}, {}>", type_rs(&e)?),
             None => return_type,
         })
-    }
-
-    // Map return types to their fully-qualified `FfiConverter` impl.
-    pub fn return_ffi_converter<T: Callable>(callable: &T) -> Result<String, askama::Error> {
-        let return_type = return_type(callable)?;
-        Ok(format!(
-            "<{return_type} as ::uniffi::FfiConverter<crate::UniFfiTag>>"
-        ))
     }
 
     // Turns a `crate-name` into the `crate_name` the .rs code needs to specify.

--- a/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
@@ -69,7 +69,7 @@ impl r#{{ trait_name }} for {{ trait_impl }} {
         let mut args_buf = Vec::new();
         {% endif -%}
         {%- for arg in meth.arguments() %}
-        {{ arg.as_type().borrow()|ffi_converter }}::write(r#{{ arg.name() }}, &mut args_buf);
+        {{ arg.as_type().borrow()|ffi_trait("Lower") }}::write(r#{{ arg.name() }}, &mut args_buf);
         {%- endfor -%}
         let args_rbuf = uniffi::RustBuffer::from_vec(args_buf);
 

--- a/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
@@ -14,9 +14,6 @@
     with_try_read,
     {%- endif %}
     {%- endif %}
-    {%- if ci.is_callback_interface_throws_type(e.as_type()) %}
-    handle_unknown_callback_error,
-    {%- endif %}
 )]
 enum r#{{ e.name() }} {
     {%- for variant in e.variants() %}

--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -83,7 +83,7 @@ impl {{ obj.rust_name() }} {
             uniffi::deps::static_assertions::assert_impl_all!({{ obj.rust_name() }}: std::fmt::Debug); // This object has a trait method which requires `Debug` be implemented.
             format!(
                 "{:?}",
-                match<std::sync::Arc<{{ obj.rust_name() }}> as ::uniffi::FfiConverter<crate::UniFfiTag>>::try_lift(r#ptr) {
+                match<std::sync::Arc<{{ obj.rust_name() }}> as ::uniffi::Lift<crate::UniFfiTag>>::try_lift(r#ptr) {
                     Ok(ref val) => val,
                     Err(err) => panic!("Failed to convert arg '{}': {}", "ptr", err),
                 }
@@ -96,7 +96,7 @@ impl {{ obj.rust_name() }} {
             uniffi::deps::static_assertions::assert_impl_all!({{ obj.rust_name() }}: std::fmt::Display); // This object has a trait method which requires `Display` be implemented.
             format!(
                 "{}",
-                match<std::sync::Arc<{{ obj.rust_name() }}> as ::uniffi::FfiConverter<crate::UniFfiTag>>::try_lift(r#ptr) {
+                match<std::sync::Arc<{{ obj.rust_name() }}> as ::uniffi::Lift<crate::UniFfiTag>>::try_lift(r#ptr) {
                     Ok(ref val) => val,
                     Err(err) => panic!("Failed to convert arg '{}': {}", "ptr", err),
                 }
@@ -109,7 +109,7 @@ impl {{ obj.rust_name() }} {
                 use ::std::hash::{Hash, Hasher};
                 uniffi::deps::static_assertions::assert_impl_all!({{ obj.rust_name() }}: Hash); // This object has a trait method which requires `Hash` be implemented.
                 let mut s = ::std::collections::hash_map::DefaultHasher::new();
-                Hash::hash(match<std::sync::Arc<{{ obj.rust_name() }}> as ::uniffi::FfiConverter<crate::UniFfiTag>>::try_lift(r#ptr) {
+                Hash::hash(match<std::sync::Arc<{{ obj.rust_name() }}> as ::uniffi::Lift<crate::UniFfiTag>>::try_lift(r#ptr) {
                     Ok(ref val) => val,
                     Err(err) => panic!("Failed to convert arg '{}': {}", "ptr", err),
                 }, &mut s);

--- a/uniffi_core/src/ffi_converter_impls.rs
+++ b/uniffi_core/src/ffi_converter_impls.rs
@@ -22,17 +22,18 @@
 /// consumer crates.  To do this, it defines blanket impls like `impl<UT> FFIConverter<UT> for u8`.
 /// "UT" means an abitrary `UniFfiTag` type.
 use crate::{
-    check_remaining, ffi_converter_default_return, ffi_converter_rust_buffer_lift_and_lower,
-    lower_into_rust_buffer, metadata, try_lift_from_rust_buffer, FfiConverter, LiftRef,
-    MetadataBuffer, Result, RustBuffer, UnexpectedUniFFICallbackError,
+    check_remaining, derive_ffi_traits, ffi_converter_rust_buffer_lift_and_lower, metadata,
+    FfiConverter, ForeignExecutor, Lift, LiftReturn, Lower, LowerReturn, MetadataBuffer, Result,
+    RustBuffer, UnexpectedUniFFICallbackError,
 };
 use anyhow::bail;
 use bytes::buf::{Buf, BufMut};
 use paste::paste;
 use std::{
     collections::HashMap,
-    convert::{Infallible, TryFrom},
+    convert::TryFrom,
     error::Error,
+    sync::Arc,
     time::{Duration, SystemTime},
 };
 
@@ -44,8 +45,6 @@ macro_rules! impl_ffi_converter_for_num_primitive {
     ($T:ty, $type_code:expr) => {
         paste! {
             unsafe impl<UT> FfiConverter<UT> for $T {
-                ffi_converter_default_return!(UT);
-
                 type FfiType = $T;
 
                 fn lower(obj: $T) -> Self::FfiType {
@@ -87,8 +86,6 @@ impl_ffi_converter_for_num_primitive!(f64, metadata::codes::TYPE_F64);
 /// Booleans are passed as an `i8` in order to avoid problems with handling
 /// C-compatible boolean values on JVM-based languages.
 unsafe impl<UT> FfiConverter<UT> for bool {
-    ffi_converter_default_return!(UT);
-
     type FfiType = i8;
 
     fn lower(obj: bool) -> Self::FfiType {
@@ -115,56 +112,6 @@ unsafe impl<UT> FfiConverter<UT> for bool {
     const TYPE_ID_META: MetadataBuffer = MetadataBuffer::from_code(metadata::codes::TYPE_BOOL);
 }
 
-/// Support unit-type returns via the FFI.
-unsafe impl<UT> FfiConverter<UT> for () {
-    // This actually isn't used, but we need to specify something
-    type FfiType = ();
-    // Returning `()` is FFI-safe, since it gets translated into a void return
-    type ReturnType = ();
-
-    fn try_lift(_: Self::FfiType) -> Result<()> {
-        Ok(())
-    }
-
-    fn lower(_: ()) -> Self::FfiType {}
-
-    fn write(_: (), _: &mut Vec<u8>) {}
-
-    fn try_read(_: &mut &[u8]) -> Result<()> {
-        Ok(())
-    }
-
-    fn lower_return(_: ()) -> Result<Self::ReturnType, RustBuffer> {
-        Ok(())
-    }
-
-    const TYPE_ID_META: MetadataBuffer = MetadataBuffer::from_code(metadata::codes::TYPE_UNIT);
-}
-
-unsafe impl<UT> FfiConverter<UT> for Infallible {
-    ffi_converter_default_return!(UT);
-
-    type FfiType = RustBuffer;
-
-    fn try_lift(_: Self::FfiType) -> Result<Infallible> {
-        unreachable!()
-    }
-
-    fn lower(_: Infallible) -> Self::FfiType {
-        unreachable!()
-    }
-
-    fn write(_: Infallible, _: &mut Vec<u8>) {
-        unreachable!()
-    }
-
-    fn try_read(_: &mut &[u8]) -> Result<Infallible> {
-        unreachable!()
-    }
-
-    const TYPE_ID_META: MetadataBuffer = MetadataBuffer::new();
-}
-
 /// Support for passing Strings via the FFI.
 ///
 /// Unlike many other implementations of `FfiConverter`, this passes a struct containing
@@ -177,8 +124,6 @@ unsafe impl<UT> FfiConverter<UT> for Infallible {
 /// followed by utf8-encoded bytes. (It's a signed integer because unsigned types are
 /// currently experimental in Kotlin).
 unsafe impl<UT> FfiConverter<UT> for String {
-    ffi_converter_default_return!(UT);
-
     type FfiType = RustBuffer;
 
     // This returns a struct with a raw pointer to the underlying bytes, so it's very
@@ -240,7 +185,6 @@ unsafe impl<UT> FfiConverter<UT> for String {
 /// if the total offset should be added to or subtracted from the unix epoch.
 unsafe impl<UT> FfiConverter<UT> for SystemTime {
     ffi_converter_rust_buffer_lift_and_lower!(UT);
-    ffi_converter_default_return!(UT);
 
     fn write(obj: SystemTime, buf: &mut Vec<u8>) {
         let mut sign = 1;
@@ -286,7 +230,6 @@ unsafe impl<UT> FfiConverter<UT> for SystemTime {
 /// and 999,999,999.
 unsafe impl<UT> FfiConverter<UT> for Duration {
     ffi_converter_rust_buffer_lift_and_lower!(UT);
-    ffi_converter_default_return!(UT);
 
     fn write(obj: Duration, buf: &mut Vec<u8>) {
         buf.put_u64(obj.as_secs());
@@ -301,18 +244,18 @@ unsafe impl<UT> FfiConverter<UT> for Duration {
     const TYPE_ID_META: MetadataBuffer = MetadataBuffer::from_code(metadata::codes::TYPE_DURATION);
 }
 
-/// Support for passing optional values via the FFI.
-///
-/// Optional values are currently always passed by serializing to a buffer.
-/// We write either a zero byte for `None`, or a one byte followed by the containing
-/// item for `Some`.
-///
-/// In future we could do the same optimization as rust uses internally, where the
-/// `None` option is represented as a null pointer and the `Some` as a valid pointer,
-/// but that seems more fiddly and less safe in the short term, so it can wait.
-unsafe impl<UT, T: FfiConverter<UT>> FfiConverter<UT> for Option<T> {
-    ffi_converter_rust_buffer_lift_and_lower!(UT);
-    ffi_converter_default_return!(UT);
+// Support for passing optional values via the FFI.
+//
+// Optional values are currently always passed by serializing to a buffer.
+// We write either a zero byte for `None`, or a one byte followed by the containing
+// item for `Some`.
+//
+// In future we could do the same optimization as rust uses internally, where the
+// `None` option is represented as a null pointer and the `Some` as a valid pointer,
+// but that seems more fiddly and less safe in the short term, so it can wait.
+
+unsafe impl<UT, T: Lower<UT>> Lower<UT> for Option<T> {
+    type FfiType = RustBuffer;
 
     fn write(obj: Option<T>, buf: &mut Vec<u8>) {
         match obj {
@@ -324,6 +267,17 @@ unsafe impl<UT, T: FfiConverter<UT>> FfiConverter<UT> for Option<T> {
         }
     }
 
+    fn lower(obj: Option<T>) -> RustBuffer {
+        Self::lower_into_rust_buffer(obj)
+    }
+
+    const TYPE_ID_META: MetadataBuffer =
+        MetadataBuffer::from_code(metadata::codes::TYPE_OPTION).concat(T::TYPE_ID_META);
+}
+
+unsafe impl<UT, T: Lift<UT>> Lift<UT> for Option<T> {
+    type FfiType = RustBuffer;
+
     fn try_read(buf: &mut &[u8]) -> Result<Option<T>> {
         check_remaining(buf, 1)?;
         Ok(match buf.get_i8() {
@@ -333,40 +287,38 @@ unsafe impl<UT, T: FfiConverter<UT>> FfiConverter<UT> for Option<T> {
         })
     }
 
+    fn try_lift(buf: RustBuffer) -> Result<Option<T>> {
+        Self::try_lift_from_rust_buffer(buf)
+    }
+
     const TYPE_ID_META: MetadataBuffer =
         MetadataBuffer::from_code(metadata::codes::TYPE_OPTION).concat(T::TYPE_ID_META);
 }
 
-/// Support for passing vectors of values via the FFI.
-///
-/// Vectors are currently always passed by serializing to a buffer.
-/// We write a `i32` item count followed by each item in turn.
-/// (It's a signed type due to limits of the JVM).
-///
-/// Ideally we would pass `Vec<u8>` directly as a `RustBuffer` rather
-/// than serializing, and perhaps even pass other vector types using a
-/// similar struct. But that's for future work.
-unsafe impl<UT, T: FfiConverter<UT>> FfiConverter<UT> for Vec<T> {
-    ffi_converter_rust_buffer_lift_and_lower!(UT);
-    ffi_converter_default_return!(UT);
+// Support for passing vectors of values via the FFI.
+//
+// Vectors are currently always passed by serializing to a buffer.
+// We write a `i32` item count followed by each item in turn.
+// (It's a signed type due to limits of the JVM).
+//
+// Ideally we would pass `Vec<u8>` directly as a `RustBuffer` rather
+// than serializing, and perhaps even pass other vector types using a
+// similar struct. But that's for future work.
+
+unsafe impl<UT, T: Lower<UT>> Lower<UT> for Vec<T> {
+    type FfiType = RustBuffer;
 
     fn write(obj: Vec<T>, buf: &mut Vec<u8>) {
         // TODO: would be nice not to panic here :-/
         let len = i32::try_from(obj.len()).unwrap();
         buf.put_i32(len); // We limit arrays to i32::MAX items
         for item in obj {
-            <T as FfiConverter<UT>>::write(item, buf);
+            <T as Lower<UT>>::write(item, buf);
         }
     }
 
-    fn try_read(buf: &mut &[u8]) -> Result<Vec<T>> {
-        check_remaining(buf, 4)?;
-        let len = usize::try_from(buf.get_i32())?;
-        let mut vec = Vec::with_capacity(len);
-        for _ in 0..len {
-            vec.push(<T as FfiConverter<UT>>::try_read(buf)?)
-        }
-        Ok(vec)
+    fn lower(obj: Vec<T>) -> RustBuffer {
+        Self::lower_into_rust_buffer(obj)
     }
 
     const TYPE_ID_META: MetadataBuffer =
@@ -378,34 +330,74 @@ unsafe impl<UT, T: FfiConverter<UT>> FfiConverter<UT> for Vec<T> {
 /// We write a `i32` entries count followed by each entry (string
 /// key followed by the value) in turn.
 /// (It's a signed type due to limits of the JVM).
-unsafe impl<K, V, UT> FfiConverter<UT> for HashMap<K, V>
+unsafe impl<UT, T: Lift<UT>> Lift<UT> for Vec<T> {
+    type FfiType = RustBuffer;
+
+    fn try_read(buf: &mut &[u8]) -> Result<Vec<T>> {
+        check_remaining(buf, 4)?;
+        let len = usize::try_from(buf.get_i32())?;
+        let mut vec = Vec::with_capacity(len);
+        for _ in 0..len {
+            vec.push(<T as Lift<UT>>::try_read(buf)?)
+        }
+        Ok(vec)
+    }
+
+    fn try_lift(buf: RustBuffer) -> Result<Vec<T>> {
+        Self::try_lift_from_rust_buffer(buf)
+    }
+
+    const TYPE_ID_META: MetadataBuffer =
+        MetadataBuffer::from_code(metadata::codes::TYPE_VEC).concat(T::TYPE_ID_META);
+}
+
+unsafe impl<K, V, UT> Lower<UT> for HashMap<K, V>
 where
-    K: FfiConverter<UT> + std::hash::Hash + Eq,
-    V: FfiConverter<UT>,
+    K: Lower<UT> + std::hash::Hash + Eq,
+    V: Lower<UT>,
 {
-    ffi_converter_rust_buffer_lift_and_lower!(UT);
-    ffi_converter_default_return!(UT);
+    type FfiType = RustBuffer;
 
     fn write(obj: HashMap<K, V>, buf: &mut Vec<u8>) {
         // TODO: would be nice not to panic here :-/
         let len = i32::try_from(obj.len()).unwrap();
         buf.put_i32(len); // We limit HashMaps to i32::MAX entries
         for (key, value) in obj {
-            <K as FfiConverter<UT>>::write(key, buf);
-            <V as FfiConverter<UT>>::write(value, buf);
+            <K as Lower<UT>>::write(key, buf);
+            <V as Lower<UT>>::write(value, buf);
         }
     }
+
+    fn lower(obj: HashMap<K, V>) -> RustBuffer {
+        Self::lower_into_rust_buffer(obj)
+    }
+
+    const TYPE_ID_META: MetadataBuffer = MetadataBuffer::from_code(metadata::codes::TYPE_HASH_MAP)
+        .concat(K::TYPE_ID_META)
+        .concat(V::TYPE_ID_META);
+}
+
+unsafe impl<K, V, UT> Lift<UT> for HashMap<K, V>
+where
+    K: Lift<UT> + std::hash::Hash + Eq,
+    V: Lift<UT>,
+{
+    type FfiType = RustBuffer;
 
     fn try_read(buf: &mut &[u8]) -> Result<HashMap<K, V>> {
         check_remaining(buf, 4)?;
         let len = usize::try_from(buf.get_i32())?;
         let mut map = HashMap::with_capacity(len);
         for _ in 0..len {
-            let key = <K as FfiConverter<UT>>::try_read(buf)?;
-            let value = <V as FfiConverter<UT>>::try_read(buf)?;
+            let key = <K as Lift<UT>>::try_read(buf)?;
+            let value = <V as Lift<UT>>::try_read(buf)?;
             map.insert(key, value);
         }
         Ok(map)
+    }
+
+    fn try_lift(buf: RustBuffer) -> Result<HashMap<K, V>> {
+        Self::try_lift_from_rust_buffer(buf)
     }
 
     const TYPE_ID_META: MetadataBuffer = MetadataBuffer::from_code(metadata::codes::TYPE_HASH_MAP)
@@ -418,7 +410,7 @@ where
 /// These are passed over the FFI as opaque pointer-sized types representing the foreign executor.
 /// The foreign bindings may use an actual pointer to the executor object, or a usized integer
 /// handle.
-unsafe impl<UT> FfiConverter<UT> for crate::ForeignExecutor {
+unsafe impl<UT> FfiConverter<UT> for ForeignExecutor {
     type FfiType = crate::ForeignExecutorHandle;
 
     // Passing these back to the foreign bindings is currently not supported
@@ -437,7 +429,7 @@ unsafe impl<UT> FfiConverter<UT> for crate::ForeignExecutor {
     }
 
     fn try_lift(executor: Self::FfiType) -> Result<Self> {
-        Ok(crate::ForeignExecutor::new(executor))
+        Ok(ForeignExecutor::new(executor))
     }
 
     fn try_read(buf: &mut &[u8]) -> Result<Self> {
@@ -450,44 +442,81 @@ unsafe impl<UT> FfiConverter<UT> for crate::ForeignExecutor {
         <Self as FfiConverter<UT>>::try_lift(crate::ForeignExecutorHandle(usize_val as *const ()))
     }
 
-    ffi_converter_default_return!(UT);
-
     const TYPE_ID_META: MetadataBuffer =
         MetadataBuffer::from_code(metadata::codes::TYPE_FOREIGN_EXECUTOR);
 }
 
-/// Support `Result<>` via the FFI.
-///
-/// This is currently supported for function returns. Lifting/lowering Result<> arguments is not
-/// implemented.
-unsafe impl<UT, R, E> FfiConverter<UT> for Result<R, E>
+derive_ffi_traits!(blanket u8);
+derive_ffi_traits!(blanket i8);
+derive_ffi_traits!(blanket u16);
+derive_ffi_traits!(blanket i16);
+derive_ffi_traits!(blanket u32);
+derive_ffi_traits!(blanket i32);
+derive_ffi_traits!(blanket u64);
+derive_ffi_traits!(blanket i64);
+derive_ffi_traits!(blanket f32);
+derive_ffi_traits!(blanket f64);
+derive_ffi_traits!(blanket bool);
+derive_ffi_traits!(blanket String);
+derive_ffi_traits!(blanket Duration);
+derive_ffi_traits!(blanket SystemTime);
+derive_ffi_traits!(blanket ForeignExecutor);
+
+// For composite types, derive LowerReturn, LiftReturn, etc, from Lift/Lower.
+//
+// Note that this means we don't get specialized return handling.  For example, if we could return
+// an `Option<Result<>>` we would always return that type directly and never throw.
+derive_ffi_traits!(impl<T, UT> LowerReturn<UT> for Option<T> where Option<T>: Lower<UT>);
+derive_ffi_traits!(impl<T, UT> LiftReturn<UT> for Option<T> where Option<T>: Lift<UT>);
+derive_ffi_traits!(impl<T, UT> LiftRef<UT> for Option<T> where Option<T>: Lift<UT>);
+
+derive_ffi_traits!(impl<T, UT> LowerReturn<UT> for Vec<T> where Vec<T>: Lower<UT>);
+derive_ffi_traits!(impl<T, UT> LiftReturn<UT> for Vec<T> where Vec<T>: Lift<UT>);
+derive_ffi_traits!(impl<T, UT> LiftRef<UT> for Vec<T> where Vec<T>: Lift<UT>);
+
+derive_ffi_traits!(impl<K, V, UT> LowerReturn<UT> for HashMap<K, V> where HashMap<K, V>: Lower<UT>);
+derive_ffi_traits!(impl<K, V, UT> LiftReturn<UT> for HashMap<K, V> where HashMap<K, V>: Lift<UT>);
+derive_ffi_traits!(impl<K, V, UT> LiftRef<UT> for HashMap<K, V> where HashMap<K, V>: Lift<UT>);
+
+// For Arc we derive all the traits, but have to write it all out because we need an unsized T bound
+derive_ffi_traits!(impl<T, UT> Lower<UT> for Arc<T> where Arc<T>: FfiConverter<UT>, T: ?Sized);
+derive_ffi_traits!(impl<T, UT> Lift<UT> for Arc<T> where Arc<T>: FfiConverter<UT>, T: ?Sized);
+derive_ffi_traits!(impl<T, UT> LowerReturn<UT> for Arc<T> where Arc<T>: Lower<UT>, T: ?Sized);
+derive_ffi_traits!(impl<T, UT> LiftReturn<UT> for Arc<T> where Arc<T>: Lift<UT>, T: ?Sized);
+derive_ffi_traits!(impl<T, UT> LiftRef<UT> for Arc<T> where Arc<T>: Lift<UT>, T: ?Sized);
+
+// Implement LowerReturn/LiftReturn for the unit type (void returns)
+
+unsafe impl<UT> LowerReturn<UT> for () {
+    type ReturnType = ();
+
+    fn lower_return(_: ()) -> Result<Self::ReturnType, RustBuffer> {
+        Ok(())
+    }
+
+    const TYPE_ID_META: MetadataBuffer = MetadataBuffer::from_code(metadata::codes::TYPE_UNIT);
+}
+
+unsafe impl<UT> LiftReturn<UT> for () {
+    fn lift_callback_return(_buf: RustBuffer) -> Self {}
+
+    const TYPE_ID_META: MetadataBuffer = MetadataBuffer::from_code(metadata::codes::TYPE_UNIT);
+}
+
+// Implement LowerReturn/LiftReturn for `Result<R, E>`.  This is where we handle exceptions/Err
+// results.
+
+unsafe impl<UT, R, E> LowerReturn<UT> for Result<R, E>
 where
-    R: FfiConverter<UT>,
-    E: FfiConverter<UT> + Error + Send + Sync + 'static,
+    R: LowerReturn<UT>,
+    E: Lower<UT> + Error + Send + Sync + 'static,
 {
-    type FfiType = (); // Placeholder while lower/lift/serializing is unimplemented
     type ReturnType = R::ReturnType;
-
-    fn try_lift(_: Self::FfiType) -> Result<Self> {
-        unimplemented!("try_lift");
-    }
-
-    fn lower(_: Self) -> Self::FfiType {
-        unimplemented!("lower");
-    }
-
-    fn write(_: Self, _: &mut Vec<u8>) {
-        unimplemented!("write");
-    }
-
-    fn try_read(_: &mut &[u8]) -> Result<Self> {
-        unimplemented!("try_read");
-    }
 
     fn lower_return(v: Self) -> Result<Self::ReturnType, RustBuffer> {
         match v {
             Ok(r) => R::lower_return(r),
-            Err(e) => Err(lower_into_rust_buffer(e)),
+            Err(e) => Err(E::lower_into_rust_buffer(e)),
         }
     }
 
@@ -498,56 +527,36 @@ where
         }
     }
 
-    fn lift_callback_return(buf: RustBuffer) -> Self {
-        Ok(try_lift_from_rust_buffer::<R, UT>(buf)
-            .expect("Error reading callback interface result"))
-    }
-
-    fn lift_callback_error(buf: RustBuffer) -> Self {
-        Err(try_lift_from_rust_buffer::<E, UT>(buf)
-            .expect("Error reading callback interface Err result"))
-    }
-
-    fn handle_callback_unexpected_error(e: UnexpectedUniFFICallbackError) -> Self {
-        Err(E::handle_callback_unexpected_error(e))
-    }
-
     const TYPE_ID_META: MetadataBuffer = MetadataBuffer::from_code(metadata::codes::TYPE_RESULT)
         .concat(R::TYPE_ID_META)
         .concat(E::TYPE_ID_META);
 }
 
-macro_rules! simple_lift_ref_impl {
-    ($($t:ty),* $(,)?) => {
-        $(
-            impl<UT> LiftRef<UT> for $t {
-                type LiftType = $t;
-            }
-        )*
+unsafe impl<UT, R, E> LiftReturn<UT> for Result<R, E>
+where
+    R: LiftReturn<UT>,
+    E: Lift<UT> + From<UnexpectedUniFFICallbackError>,
+{
+    fn lift_callback_return(buf: RustBuffer) -> Self {
+        Ok(R::lift_callback_return(buf))
     }
-}
 
-simple_lift_ref_impl!(
-    u8, i8, u16, i16, u32, i32, u64, i64, f32, f64, bool, String, Duration, SystemTime
-);
+    fn lift_callback_error(buf: RustBuffer) -> Self {
+        match E::try_lift_from_rust_buffer(buf) {
+            Ok(lifted_error) => Err(lifted_error),
+            Err(anyhow_error) => {
+                Self::handle_callback_unexpected_error(UnexpectedUniFFICallbackError {
+                    reason: format!("Error lifting from rust buffer: {anyhow_error}"),
+                })
+            }
+        }
+    }
 
-impl<UT, T> LiftRef<UT> for Option<T>
-where
-    Option<T>: FfiConverter<UT>,
-{
-    type LiftType = Self;
-}
+    fn handle_callback_unexpected_error(e: UnexpectedUniFFICallbackError) -> Self {
+        Err(E::from(e))
+    }
 
-impl<UT, T> LiftRef<UT> for Vec<T>
-where
-    Vec<T>: FfiConverter<UT>,
-{
-    type LiftType = Self;
-}
-
-impl<UT, K, V> LiftRef<UT> for HashMap<K, V>
-where
-    HashMap<K, V>: FfiConverter<UT>,
-{
-    type LiftType = Self;
+    const TYPE_ID_META: MetadataBuffer = MetadataBuffer::from_code(metadata::codes::TYPE_RESULT)
+        .concat(R::TYPE_ID_META)
+        .concat(E::TYPE_ID_META);
 }

--- a/uniffi_core/src/ffi_converter_traits.rs
+++ b/uniffi_core/src/ffi_converter_traits.rs
@@ -2,54 +2,70 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+//! Traits that define how to transfer values via the FFI layer.
+//!
+//! These traits define how to pass values over the FFI in various ways: as arguments or as return
+//! values, from Rust to the foreign side and vice-versa.  These traits are mainly used by the
+//! proc-macro generated code.  The goal is to allow the proc-macros to go from a type name to the
+//! correct function for a given FFI operation.
+//!
+//! The traits form a sort-of tree structure from general to specific:
+//! ```ignore
+//!
+//!                   [FfiConverter]
+//!                        |
+//!           -----------------------------
+//!           |                           |
+//!       [Lower]                      [Lift]
+//!           |                           |
+//!           |                       --------------
+//!           |                       |            |
+//!       [LowerReturn]           [LiftRef]  [LiftReturn]
+//! ```
+//!
+//! The `derive_ffi_traits` macro can be used to derive the specific traits from the general ones.
+//! Here's the main ways we implement these traits:
+//!
+//! * For most types we implement [FfiConverter] and use [derive_ffi_traits] to implement the rest
+//! * If a type can only be lifted/lowered, then we implement [Lift] or [Lower] and use
+//!   [derive_ffi_traits] to implement the rest
+//! * If a type needs special-case handling, like `Result<>` and `()`, we implement the traits
+//!   directly.
+//!
+//! FfiConverter has a generic parameter, that's filled in with a type local to the UniFFI consumer crate.
+//! This allows us to work around the Rust orphan rules for remote types. See
+//! `https://mozilla.github.io/uniffi-rs/internals/lifting_and_lowering.html#code-generation-and-the-fficonverter-trait`
+//! for details.
+//!
+//! ## Safety
+//!
+//! All traits are unsafe (implementing it requires `unsafe impl`) because we can't guarantee
+//! that it's safe to pass your type out to foreign-language code and back again. Buggy
+//! implementations of this trait might violate some assumptions made by the generated code,
+//! or might not match with the corresponding code in the generated foreign-language bindings.
+//! These traits should not be used directly, only in generated code, and the generated code should
+//! have fixture tests to test that everything works correctly together.
+
 use std::{borrow::Borrow, sync::Arc};
 
-use crate::{
-    try_lift_from_rust_buffer, FfiDefault, MetadataBuffer, Result, RustBuffer,
-    UnexpectedUniFFICallbackError,
-};
+use anyhow::bail;
+use bytes::Buf;
 
-/// Trait defining how to transfer values via the FFI layer.
+use crate::{FfiDefault, MetadataBuffer, Result, RustBuffer, UnexpectedUniFFICallbackError};
+
+/// Generalized FFI conversions
 ///
-/// The `FfiConverter` trait defines how to pass values of a particular type back-and-forth over
-/// the uniffi generated FFI layer, both as standalone argument or return values, and as
-/// part of serialized compound data structures. `FfiConverter` is mainly used in generated code.
-/// The goal is to make it easy for the code generator to name the correct FFI-related function for
-/// a given type.
-///
-/// FfiConverter has a generic parameter, that's filled in with a type local to the UniFFI consumer crate.
-/// This allows us to work around the Rust orphan rules for remote types. See
-/// `https://mozilla.github.io/uniffi-rs/internals/lifting_and_lowering.html#code-generation-and-the-fficonverter-trait`
-/// for details.
-///
-/// ## Scope
-///
-/// It could be argued that FfiConverter handles too many concerns and should be split into
-/// separate traits (like `FfiLiftAndLower`, `FfiSerialize`, `FfiReturn`).  However, there are good
-/// reasons to keep all the functionality in one trait.
-///
-/// The main reason is that splitting the traits requires fairly complex blanket implementations,
-/// for example `impl<UT, T> FfiReturn<UT> for T: FfiLiftAndLower<UT>`.  Writing these impls often
-/// means fighting with `rustc` over what counts as a conflicting implementation.  In fact, as of
-/// Rust 1.66, that previous example conflicts with `impl<UT> FfiReturn<UT> for ()`, since other
-/// crates can implement `impl FfiReturn<MyLocalType> for ()`. In general, this path gets
-/// complicated very quickly and that distracts from the logic that we want to define, which is
-/// fairly simple.
-///
-/// The main downside of having a single `FfiConverter` trait is that we need to implement it for
-/// types that only support some of the functionality.  For example, `Result<>` supports returning
-/// values, but not lifting/lowering/serializing them.  This is a bit weird, but works okay --
-/// especially since `FfiConverter` is rarely used outside of generated code.
+/// This trait is not used directly by the code generation, but implement this and calling
+/// [derive_ffi_traits] is a simple way to implement all the traits that are.
 ///
 /// ## Safety
 ///
-/// This is an unsafe trait (implementing it requires `unsafe impl`) because we can't guarantee
+/// All traits are unsafe (implementing it requires `unsafe impl`) because we can't guarantee
 /// that it's safe to pass your type out to foreign-language code and back again. Buggy
 /// implementations of this trait might violate some assumptions made by the generated code,
 /// or might not match with the corresponding code in the generated foreign-language bindings.
-///
-/// In general, you should not need to implement this trait by hand, and should instead rely on
-/// implementations generated from your component UDL via the `uniffi-bindgen scaffolding` command.
+/// These traits should not be used directly, only in generated code, and the generated code should
+/// have fixture tests to test that everything works correctly together.
 pub unsafe trait FfiConverter<UT>: Sized {
     /// The low-level type used for passing values of this type over the FFI.
     ///
@@ -60,12 +76,9 @@ pub unsafe trait FfiConverter<UT>: Sized {
     /// the data for transfer. In theory it could be possible to build a matching
     /// `#[repr(C)]` struct for a complex data type and pass that instead, but explicit
     /// serialization is simpler and safer as a starting point.
-    type FfiType;
-
-    /// The type that should be returned by scaffolding functions for this type.
     ///
-    /// This is usually the same as `FfiType`, but `Result<>` has specialized handling.
-    type ReturnType: FfiDefault;
+    /// If a type implements multiple FFI traits, `FfiType` must be the same for all of them.
+    type FfiType: FfiDefault;
 
     /// Lower a rust value of the target type, into an FFI value of type Self::FfiType.
     ///
@@ -77,24 +90,6 @@ pub unsafe trait FfiConverter<UT>: Sized {
     /// the foreign language code, e.g. by boxing the value and passing a pointer.
     fn lower(obj: Self) -> Self::FfiType;
 
-    /// Lower this value for scaffolding function return
-    ///
-    /// This method converts values into the `Result<>` type that [rust_call] expects. For
-    /// successful calls, return `Ok(lower_return)`.  For errors that should be translated into
-    /// thrown exceptions on the foreign code, serialize the error into a RustBuffer and return
-    /// `Err(buf)`
-    fn lower_return(obj: Self) -> Result<Self::ReturnType, RustBuffer>;
-
-    /// If possible, get a serialized error for failed argument lifts
-    ///
-    /// By default, we just panic and let `rust_call` handle things.  However, for `Result<_, E>`
-    /// returns, if the anyhow error can be downcast to `E`, then serialize that and return it.
-    /// This results in the foreign code throwing a "normal" exception, rather than an unexpected
-    /// exception.
-    fn handle_failed_lift(arg_name: &str, e: anyhow::Error) -> Self {
-        panic!("Failed to convert arg '{arg_name}': {e}")
-    }
-
     /// Lift a rust value of the target type, from an FFI value of type Self::FfiType.
     ///
     /// This trait method is used for receiving data from the foreign language code in rust,
@@ -104,32 +99,6 @@ pub unsafe trait FfiConverter<UT>: Sized {
     /// Since we cannot statically guarantee that the foreign-language code will send valid
     /// values of type Self::FfiType, this method is fallible.
     fn try_lift(v: Self::FfiType) -> Result<Self>;
-
-    /// Lift a Rust value for a callback interface method result
-    fn lift_callback_return(buf: RustBuffer) -> Self {
-        try_lift_from_rust_buffer(buf).expect("Error reading callback interface result")
-    }
-
-    /// Lift a Rust value for a callback interface method error result
-    ///
-    /// This is called for "expected errors" -- the callback method returns a Result<> type and the
-    /// foreign code throws an exception that corresponds to the error type.
-    fn lift_callback_error(_buf: RustBuffer) -> Self {
-        panic!("Callback interface method returned unexpected error")
-    }
-
-    /// Lift a Rust value for an unexpected callback interface error
-    ///
-    /// The main reason this is called is when the callback interface throws an error type that
-    /// doesn't match the Rust trait definition.  It's also called for corner cases, like when the
-    /// foreign code doesn't follow the FFI contract.
-    ///
-    /// The default implementation panics unconditionally.  Errors used in callback interfaces
-    /// handle this using the `From<UnexpectedUniFFICallbackError>` impl that the library author
-    /// must provide.
-    fn handle_callback_unexpected_error(e: UnexpectedUniFFICallbackError) -> Self {
-        panic!("Callback interface failure: {e}")
-    }
 
     /// Write a rust value into a buffer, to send over the FFI in serialized form.
     ///
@@ -155,7 +124,9 @@ pub unsafe trait FfiConverter<UT>: Sized {
     /// from it (but will not mutate the actual contents of the slice).
     fn try_read(buf: &mut &[u8]) -> Result<Self>;
 
-    /// Type ID metadata, serialized into a [MetadataBuffer]
+    /// Type ID metadata, serialized into a [MetadataBuffer].
+    ///
+    /// If a type implements multiple FFI traits, `TYPE_ID_META` must be the same for all of them.
     const TYPE_ID_META: MetadataBuffer;
 }
 
@@ -169,23 +140,17 @@ pub unsafe trait FfiConverter<UT>: Sized {
 ///
 /// ## Safety
 ///
-/// This has the same safety considerations as FfiConverter
+/// All traits are unsafe (implementing it requires `unsafe impl`) because we can't guarantee
+/// that it's safe to pass your type out to foreign-language code and back again. Buggy
+/// implementations of this trait might violate some assumptions made by the generated code,
+/// or might not match with the corresponding code in the generated foreign-language bindings.
+/// These traits should not be used directly, only in generated code, and the generated code should
+/// have fixture tests to test that everything works correctly together.
 pub unsafe trait FfiConverterArc<UT>: Send + Sync {
-    type FfiType;
-    type ReturnType: FfiDefault;
+    type FfiType: FfiDefault;
 
     fn lower(obj: Arc<Self>) -> Self::FfiType;
-    fn lower_return(obj: Arc<Self>) -> Result<Self::ReturnType, RustBuffer>;
     fn try_lift(v: Self::FfiType) -> Result<Arc<Self>>;
-    fn lift_callback_return(buf: RustBuffer) -> Arc<Self> {
-        try_lift_from_rust_buffer(buf).expect("Error reading callback interface result")
-    }
-    fn lift_callback_error(_buf: RustBuffer) -> Arc<Self> {
-        panic!("Callback interface method returned unexpected error")
-    }
-    fn handle_callback_unexpected_error(e: UnexpectedUniFFICallbackError) -> Arc<Self> {
-        panic!("Callback interface failure: {e}")
-    }
     fn write(obj: Arc<Self>, buf: &mut Vec<u8>);
     fn try_read(buf: &mut &[u8]) -> Result<Arc<Self>>;
 
@@ -197,30 +162,13 @@ where
     T: FfiConverterArc<UT> + ?Sized,
 {
     type FfiType = T::FfiType;
-    type ReturnType = T::ReturnType;
 
     fn lower(obj: Self) -> Self::FfiType {
         T::lower(obj)
     }
 
-    fn lower_return(obj: Self) -> Result<Self::ReturnType, RustBuffer> {
-        T::lower_return(obj)
-    }
-
     fn try_lift(v: Self::FfiType) -> Result<Self> {
         T::try_lift(v)
-    }
-
-    fn lift_callback_return(buf: RustBuffer) -> Self {
-        T::lift_callback_error(buf)
-    }
-
-    fn lift_callback_error(buf: RustBuffer) -> Self {
-        T::lift_callback_error(buf)
-    }
-
-    fn handle_callback_unexpected_error(e: UnexpectedUniFFICallbackError) -> Self {
-        T::handle_callback_unexpected_error(e)
     }
 
     fn write(obj: Self, buf: &mut Vec<u8>) {
@@ -234,13 +182,270 @@ where
     const TYPE_ID_META: MetadataBuffer = T::TYPE_ID_META;
 }
 
-/// Trait used to lift references
+/// Lift values passed by the foreign code over the FFI into Rust values
 ///
-/// This is needed because if we see a `&T` parameter, it's not clear which FfiConverter to use to
-/// lift it.  Normally it's just `T`, but for interfaces it's `Arc<T>` and for callback interfaces
-/// it's `Box<T>`.
+/// This is used by the code generation to handle arguments.  It's usually derived from
+/// [FfiConverter], except for types that only support lifting but not lowering.
 ///
-/// This trait provides the proc-macros with a way to name the correct type.
-pub trait LiftRef<UT> {
-    type LiftType: FfiConverter<UT> + Borrow<Self>;
+/// See [FfiConverter] for a discussion of the methods
+///
+/// ## Safety
+///
+/// All traits are unsafe (implementing it requires `unsafe impl`) because we can't guarantee
+/// that it's safe to pass your type out to foreign-language code and back again. Buggy
+/// implementations of this trait might violate some assumptions made by the generated code,
+/// or might not match with the corresponding code in the generated foreign-language bindings.
+/// These traits should not be used directly, only in generated code, and the generated code should
+/// have fixture tests to test that everything works correctly together.
+pub unsafe trait Lift<UT>: Sized {
+    type FfiType;
+
+    fn try_lift(v: Self::FfiType) -> Result<Self>;
+
+    fn try_read(buf: &mut &[u8]) -> Result<Self>;
+
+    /// Convenience method
+    fn try_lift_from_rust_buffer(v: RustBuffer) -> Result<Self> {
+        let vec = v.destroy_into_vec();
+        let mut buf = vec.as_slice();
+        let value = Self::try_read(&mut buf)?;
+        match Buf::remaining(&buf) {
+            0 => Ok(value),
+            n => bail!("junk data left in buffer after lifting (count: {n})",),
+        }
+    }
+
+    const TYPE_ID_META: MetadataBuffer;
+}
+
+/// Lower Rust values to pass them to the foreign code
+///
+/// This is used to pass arguments to callback interfaces. It's usually derived from
+/// [FfiConverter], except for types that only support lowering but not lifting.
+///
+/// See [FfiConverter] for a discussion of the methods
+///
+/// ## Safety
+///
+/// All traits are unsafe (implementing it requires `unsafe impl`) because we can't guarantee
+/// that it's safe to pass your type out to foreign-language code and back again. Buggy
+/// implementations of this trait might violate some assumptions made by the generated code,
+/// or might not match with the corresponding code in the generated foreign-language bindings.
+/// These traits should not be used directly, only in generated code, and the generated code should
+/// have fixture tests to test that everything works correctly together.
+pub unsafe trait Lower<UT>: Sized {
+    type FfiType: FfiDefault;
+
+    fn lower(obj: Self) -> Self::FfiType;
+
+    fn write(obj: Self, buf: &mut Vec<u8>);
+
+    /// Convenience method
+    fn lower_into_rust_buffer(obj: Self) -> RustBuffer {
+        let mut buf = ::std::vec::Vec::new();
+        Self::write(obj, &mut buf);
+        RustBuffer::from_vec(buf)
+    }
+
+    const TYPE_ID_META: MetadataBuffer;
+}
+
+/// Return Rust values to the foreign code
+///
+/// This is usually derived from [Lift], but we special case types like `Result<>` and `()`.
+///
+/// ## Safety
+///
+/// All traits are unsafe (implementing it requires `unsafe impl`) because we can't guarantee
+/// that it's safe to pass your type out to foreign-language code and back again. Buggy
+/// implementations of this trait might violate some assumptions made by the generated code,
+/// or might not match with the corresponding code in the generated foreign-language bindings.
+/// These traits should not be used directly, only in generated code, and the generated code should
+/// have fixture tests to test that everything works correctly together.
+pub unsafe trait LowerReturn<UT>: Sized {
+    /// The type that should be returned by scaffolding functions for this type.
+    ///
+    /// When derived, it's the same as `FfiType`.
+    type ReturnType: FfiDefault;
+
+    /// Lower this value for scaffolding function return
+    ///
+    /// This method converts values into the `Result<>` type that [rust_call] expects. For
+    /// successful calls, return `Ok(lower_return)`.  For errors that should be translated into
+    /// thrown exceptions on the foreign code, serialize the error into a RustBuffer and return
+    /// `Err(buf)`
+    fn lower_return(obj: Self) -> Result<Self::ReturnType, RustBuffer>;
+
+    /// If possible, get a serialized error for failed argument lifts
+    ///
+    /// By default, we just panic and let `rust_call` handle things.  However, for `Result<_, E>`
+    /// returns, if the anyhow error can be downcast to `E`, then serialize that and return it.
+    /// This results in the foreign code throwing a "normal" exception, rather than an unexpected
+    /// exception.
+    fn handle_failed_lift(arg_name: &str, e: anyhow::Error) -> Self {
+        panic!("Failed to convert arg '{arg_name}': {e}")
+    }
+
+    const TYPE_ID_META: MetadataBuffer;
+}
+
+/// Return foreign values to Rust
+///
+/// This is usually derived from [Lower], but we special case types like `Result<>` and `()`.
+///
+/// ## Safety
+///
+/// All traits are unsafe (implementing it requires `unsafe impl`) because we can't guarantee
+/// that it's safe to pass your type out to foreign-language code and back again. Buggy
+/// implementations of this trait might violate some assumptions made by the generated code,
+/// or might not match with the corresponding code in the generated foreign-language bindings.
+/// These traits should not be used directly, only in generated code, and the generated code should
+/// have fixture tests to test that everything works correctly together.
+pub unsafe trait LiftReturn<UT>: Sized {
+    /// Lift a Rust value for a callback interface method result
+    fn lift_callback_return(buf: RustBuffer) -> Self;
+
+    /// Lift a Rust value for a callback interface method error result
+    ///
+    /// This is called for "expected errors" -- the callback method returns a Result<> type and the
+    /// foreign code throws an exception that corresponds to the error type.
+    fn lift_callback_error(_buf: RustBuffer) -> Self {
+        panic!("Callback interface method returned unexpected error")
+    }
+
+    /// Lift a Rust value for an unexpected callback interface error
+    ///
+    /// The main reason this is called is when the callback interface throws an error type that
+    /// doesn't match the Rust trait definition.  It's also called for corner cases, like when the
+    /// foreign code doesn't follow the FFI contract.
+    ///
+    /// The default implementation panics unconditionally.  Errors used in callback interfaces
+    /// handle this using the `From<UnexpectedUniFFICallbackError>` impl that the library author
+    /// must provide.
+    fn handle_callback_unexpected_error(e: UnexpectedUniFFICallbackError) -> Self {
+        panic!("Callback interface failure: {e}")
+    }
+
+    const TYPE_ID_META: MetadataBuffer;
+}
+
+/// Lift references
+///
+/// This is usually derived from [Lift] and also implemented for the inner `T` value of smart
+/// pointers.  For example, if `Lift` is implemented for `Arc<T>`, then we implement this to lift
+///
+/// ## Safety
+///
+/// All traits are unsafe (implementing it requires `unsafe impl`) because we can't guarantee
+/// that it's safe to pass your type out to foreign-language code and back again. Buggy
+/// implementations of this trait might violate some assumptions made by the generated code,
+/// or might not match with the corresponding code in the generated foreign-language bindings.
+/// These traits should not be used directly, only in generated code, and the generated code should
+/// have fixture tests to test that everything works correctly together.
+/// `&T` using the Arc.
+pub unsafe trait LiftRef<UT> {
+    type LiftType: Lift<UT> + Borrow<Self>;
+}
+
+/// Derive FFI traits
+///
+/// This can be used to derive:
+///   * [Lower] and [Lift] from [FfiConverter]
+///   * [LowerReturn] from [Lower]
+///   * [LiftReturn] and [LiftRef] from [Lift]
+///
+/// Usage:
+/// ```ignore
+///
+/// // Derive everything from [FfiConverter] for all Uniffi tags
+/// ::uniffi::derive_ffi_traits!(blanket Foo)
+/// // Derive everything from [FfiConverter] for the local crate::UniFfiTag
+/// ::uniffi::derive_ffi_traits!(local Foo)
+/// // To derive a specific trait, write out the impl item minus the actual  block
+/// ::uniffi::derive_ffi_traits!(impl<T, UT> LowerReturn<UT> for Option<T>)
+/// ```
+#[macro_export]
+#[allow(clippy::crate_in_macro_def)]
+macro_rules! derive_ffi_traits {
+    (blanket $ty:ty) => {
+        $crate::derive_ffi_traits!(impl<UT> Lower<UT> for $ty);
+        $crate::derive_ffi_traits!(impl<UT> Lift<UT> for $ty);
+        $crate::derive_ffi_traits!(impl<UT> LowerReturn<UT> for $ty);
+        $crate::derive_ffi_traits!(impl<UT> LiftReturn<UT> for $ty);
+        $crate::derive_ffi_traits!(impl<UT> LiftRef<UT> for $ty);
+    };
+
+    (local $ty:ty) => {
+        $crate::derive_ffi_traits!(impl Lower<crate::UniFfiTag> for $ty);
+        $crate::derive_ffi_traits!(impl Lift<crate::UniFfiTag> for $ty);
+        $crate::derive_ffi_traits!(impl LowerReturn<crate::UniFfiTag> for $ty);
+        $crate::derive_ffi_traits!(impl LiftReturn<crate::UniFfiTag> for $ty);
+        $crate::derive_ffi_traits!(impl LiftRef<crate::UniFfiTag> for $ty);
+    };
+
+    (impl $(<$($generic:ident),*>)? $(::uniffi::)? Lower<$ut:path> for $ty:ty $(where $($where:tt)*)?) => {
+        unsafe impl $(<$($generic),*>)* $crate::Lower<$ut> for $ty $(where $($where)*)*
+        {
+            type FfiType = <Self as $crate::FfiConverter<$ut>>::FfiType;
+
+            fn lower(obj: Self) -> Self::FfiType {
+                <Self as $crate::FfiConverter<$ut>>::lower(obj)
+            }
+
+            fn write(obj: Self, buf: &mut ::std::vec::Vec<u8>) {
+                <Self as $crate::FfiConverter<$ut>>::write(obj, buf)
+            }
+
+            const TYPE_ID_META: $crate::MetadataBuffer = <Self as $crate::FfiConverter<$ut>>::TYPE_ID_META;
+        }
+    };
+
+    (impl $(<$($generic:ident),*>)? $(::uniffi::)? Lift<$ut:path> for $ty:ty $(where $($where:tt)*)?) => {
+        unsafe impl $(<$($generic),*>)* $crate::Lift<$ut> for $ty $(where $($where)*)*
+        {
+            type FfiType = <Self as $crate::FfiConverter<$ut>>::FfiType;
+
+            fn try_lift(v: Self::FfiType) -> $crate::deps::anyhow::Result<Self> {
+                <Self as $crate::FfiConverter<$ut>>::try_lift(v)
+            }
+
+            fn try_read(buf: &mut &[u8]) -> $crate::deps::anyhow::Result<Self> {
+                <Self as $crate::FfiConverter<$ut>>::try_read(buf)
+            }
+
+            const TYPE_ID_META: $crate::MetadataBuffer = <Self as $crate::FfiConverter<$ut>>::TYPE_ID_META;
+        }
+    };
+
+    (impl $(<$($generic:ident),*>)? $(::uniffi::)? LowerReturn<$ut:path> for $ty:ty $(where $($where:tt)*)?) => {
+        unsafe impl $(<$($generic),*>)* $crate::LowerReturn<$ut> for $ty $(where $($where)*)*
+        {
+            type ReturnType = <Self as $crate::Lower<$ut>>::FfiType;
+
+            fn lower_return(obj: Self) -> $crate::deps::anyhow::Result<Self::ReturnType, $crate::RustBuffer> {
+                Ok(<Self as $crate::Lower<$ut>>::lower(obj))
+            }
+
+            const TYPE_ID_META: $crate::MetadataBuffer =<Self as $crate::Lower<$ut>>::TYPE_ID_META;
+        }
+    };
+
+    (impl $(<$($generic:ident),*>)? $(::uniffi::)? LiftReturn<$ut:path> for $ty:ty $(where $($where:tt)*)?) => {
+        unsafe impl $(<$($generic),*>)* $crate::LiftReturn<$ut> for $ty $(where $($where)*)*
+        {
+            fn lift_callback_return(buf: $crate::RustBuffer) -> Self {
+                <Self as $crate::Lift<$ut>>::try_lift_from_rust_buffer(buf)
+                    .expect("Error reading callback interface result")
+            }
+
+            const TYPE_ID_META: $crate::MetadataBuffer = <Self as $crate::Lift<$ut>>::TYPE_ID_META;
+        }
+    };
+
+    (impl $(<$($generic:ident),*>)? $(::uniffi::)? LiftRef<$ut:path> for $ty:ty $(where $($where:tt)*)?) => {
+        unsafe impl $(<$($generic),*>)* $crate::LiftRef<$ut> for $ty $(where $($where)*)*
+        {
+            type LiftType = Self;
+        }
+    };
 }

--- a/uniffi_macros/src/custom.rs
+++ b/uniffi_macros/src/custom.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::util::{ident_to_string, mod_path, tagged_impl_header};
+use crate::util::{derive_ffi_traits, ident_to_string, mod_path, tagged_impl_header};
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use syn::Path;
@@ -15,41 +15,40 @@ pub(crate) fn expand_ffi_converter_custom_type(
     udl_mode: bool,
 ) -> syn::Result<TokenStream> {
     let impl_spec = tagged_impl_header("FfiConverter", ident, udl_mode);
-    let lift_ref_impl_spec = tagged_impl_header("LiftRef", ident, udl_mode);
+    let derive_ffi_traits = derive_ffi_traits(ident, udl_mode);
     let name = ident_to_string(ident);
     let mod_path = mod_path()?;
 
     Ok(quote! {
         #[automatically_derived]
         unsafe #impl_spec {
-            type FfiType = <#builtin as ::uniffi::FfiConverter<crate::UniFfiTag>>::FfiType;
+            // Note: the builtin type needs to implement both `Lower` and `Lift'.  We use the
+            // `Lower` trait to get the associated type `FfiType` and const `TYPE_ID_META`.  These
+            // can't differ between `Lower` and `Lift`.
+            type FfiType = <#builtin as ::uniffi::Lower<crate::UniFfiTag>>::FfiType;
             fn lower(obj: #ident ) -> Self::FfiType {
-                <#builtin as ::uniffi::FfiConverter<crate::UniFfiTag>>::lower(<#ident as crate::UniffiCustomTypeConverter>::from_custom(obj))
+                <#builtin as ::uniffi::Lower<crate::UniFfiTag>>::lower(<#ident as crate::UniffiCustomTypeConverter>::from_custom(obj))
             }
 
             fn try_lift(v: Self::FfiType) -> uniffi::Result<#ident> {
-                <#ident as crate::UniffiCustomTypeConverter>::into_custom(<#builtin as ::uniffi::FfiConverter<crate::UniFfiTag>>::try_lift(v)?)
+                <#ident as crate::UniffiCustomTypeConverter>::into_custom(<#builtin as ::uniffi::Lift<crate::UniFfiTag>>::try_lift(v)?)
             }
 
             fn write(obj: #ident, buf: &mut Vec<u8>) {
-                <#builtin as ::uniffi::FfiConverter<crate::UniFfiTag>>::write(<#ident as crate::UniffiCustomTypeConverter>::from_custom(obj), buf);
+                <#builtin as ::uniffi::Lower<crate::UniFfiTag>>::write(<#ident as crate::UniffiCustomTypeConverter>::from_custom(obj), buf);
             }
 
             fn try_read(buf: &mut &[u8]) -> uniffi::Result<#ident> {
-                <#ident as crate::UniffiCustomTypeConverter>::into_custom(<#builtin as ::uniffi::FfiConverter<crate::UniFfiTag>>::try_read(buf)?)
+                <#ident as crate::UniffiCustomTypeConverter>::into_custom(<#builtin as ::uniffi::Lift<crate::UniFfiTag>>::try_read(buf)?)
             }
-
-            ::uniffi::ffi_converter_default_return!(crate::UniFfiTag);
 
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_CUSTOM)
                 .concat_str(#mod_path)
                 .concat_str(#name)
-                .concat(<#builtin as ::uniffi::FfiConverter<crate::UniFfiTag>>::TYPE_ID_META);
+                .concat(<#builtin as ::uniffi::Lower<crate::UniFfiTag>>::TYPE_ID_META);
         }
 
-        #lift_ref_impl_spec {
-            type LiftType = Self;
-        }
+        #derive_ffi_traits
     })
 }
 

--- a/uniffi_macros/src/enum_.rs
+++ b/uniffi_macros/src/enum_.rs
@@ -3,7 +3,7 @@ use quote::quote;
 use syn::{Data, DataEnum, DeriveInput, Field, Index};
 
 use crate::util::{
-    create_metadata_items, ident_to_string, mod_path, tagged_impl_header,
+    create_metadata_items, derive_ffi_traits, ident_to_string, mod_path, tagged_impl_header,
     try_metadata_value_from_usize, try_read_field,
 };
 
@@ -39,7 +39,6 @@ pub(crate) fn enum_ffi_converter_impl(
         ident,
         enum_,
         udl_mode,
-        false,
         quote! { ::uniffi::metadata::codes::TYPE_ENUM },
     )
 }
@@ -48,13 +47,11 @@ pub(crate) fn rich_error_ffi_converter_impl(
     ident: &Ident,
     enum_: &DataEnum,
     udl_mode: bool,
-    handle_unknown_callback_error: bool,
 ) -> TokenStream {
     enum_or_error_ffi_converter_impl(
         ident,
         enum_,
         udl_mode,
-        handle_unknown_callback_error,
         quote! { ::uniffi::metadata::codes::TYPE_ENUM },
     )
 }
@@ -63,12 +60,11 @@ fn enum_or_error_ffi_converter_impl(
     ident: &Ident,
     enum_: &DataEnum,
     udl_mode: bool,
-    handle_unknown_callback_error: bool,
     metadata_type_code: TokenStream,
 ) -> TokenStream {
     let name = ident_to_string(ident);
     let impl_spec = tagged_impl_header("FfiConverter", ident, udl_mode);
-    let lift_ref_impl_spec = tagged_impl_header("LiftRef", ident, udl_mode);
+    let derive_ffi_traits = derive_ffi_traits(ident, udl_mode);
     let mod_path = match mod_path() {
         Ok(p) => p,
         Err(e) => return e.into_compile_error(),
@@ -109,14 +105,10 @@ fn enum_or_error_ffi_converter_impl(
         })
     };
 
-    let handle_callback_unexpected_error =
-        handle_callback_unexpected_error_fn(handle_unknown_callback_error);
-
     quote! {
         #[automatically_derived]
         unsafe #impl_spec {
             ::uniffi::ffi_converter_rust_buffer_lift_and_lower!(crate::UniFfiTag);
-            ::uniffi::ffi_converter_default_return!(crate::UniFfiTag);
 
             fn write(obj: Self, buf: &mut ::std::vec::Vec<u8>) {
                 #write_impl
@@ -126,16 +118,12 @@ fn enum_or_error_ffi_converter_impl(
                 #try_read_impl
             }
 
-            #handle_callback_unexpected_error
-
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(#metadata_type_code)
                 .concat_str(#mod_path)
                 .concat_str(#name);
         }
 
-        #lift_ref_impl_spec {
-            type LiftType = Self;
-        }
+        #derive_ffi_traits
     }
 }
 
@@ -144,7 +132,7 @@ fn write_field(f: &Field) -> TokenStream {
     let ty = &f.ty;
 
     quote! {
-        <#ty as ::uniffi::FfiConverter<crate::UniFfiTag>>::write(#ident, buf);
+        <#ty as ::uniffi::Lower<crate::UniFfiTag>>::write(#ident, buf);
     }
 }
 
@@ -196,7 +184,7 @@ pub fn variant_metadata(enum_: &DataEnum) -> syn::Result<Vec<TokenStream>> {
                         .concat_value(#fields_len)
                             #(
                                 .concat_str(#field_names)
-                                .concat(<#field_types as ::uniffi::FfiConverter<crate::UniFfiTag>>::TYPE_ID_META)
+                                .concat(<#field_types as ::uniffi::Lower<crate::UniFfiTag>>::TYPE_ID_META)
                                 // field defaults not yet supported for enums
                                 .concat_bool(false)
                             )*
@@ -204,21 +192,4 @@ pub fn variant_metadata(enum_: &DataEnum) -> syn::Result<Vec<TokenStream>> {
                 })
         )
         .collect()
-}
-
-/// Generate the `handle_callback_unexpected_error()` implementation
-///
-/// If handle_unknown_callback_error is true, this will use the `From<UnexpectedUniFFICallbackError>`
-/// implementation that the library author must provide.
-///
-/// If handle_unknown_callback_error is false, then we won't generate any code, falling back to the default
-/// implementation which panics.
-pub(crate) fn handle_callback_unexpected_error_fn(
-    handle_unknown_callback_error: bool,
-) -> Option<TokenStream> {
-    handle_unknown_callback_error.then(|| quote! {
-        fn handle_callback_unexpected_error(e: ::uniffi::UnexpectedUniFFICallbackError) -> Self {
-            <Self as ::std::convert::From<::uniffi::UnexpectedUniFFICallbackError>>::from(e)
-        }
-    })
 }

--- a/uniffi_macros/src/error.rs
+++ b/uniffi_macros/src/error.rs
@@ -6,7 +6,7 @@ use syn::{
 };
 
 use crate::{
-    enum_::{handle_callback_unexpected_error_fn, rich_error_ffi_converter_impl, variant_metadata},
+    enum_::{rich_error_ffi_converter_impl, variant_metadata},
     util::{
         chain, create_metadata_items, either_attribute_arg, ident_to_string, kw, mod_path,
         parse_comma_separated, tagged_impl_header, try_metadata_value_from_usize,
@@ -69,20 +69,9 @@ fn error_ffi_converter_impl(
     udl_mode: bool,
 ) -> TokenStream {
     if attr.flat.is_some() {
-        flat_error_ffi_converter_impl(
-            ident,
-            enum_,
-            udl_mode,
-            attr.with_try_read.is_some(),
-            attr.handle_unknown_callback_error.is_some(),
-        )
+        flat_error_ffi_converter_impl(ident, enum_, udl_mode, attr.with_try_read.is_some())
     } else {
-        rich_error_ffi_converter_impl(
-            ident,
-            enum_,
-            udl_mode,
-            attr.handle_unknown_callback_error.is_some(),
-        )
+        rich_error_ffi_converter_impl(ident, enum_, udl_mode)
     }
 }
 
@@ -94,18 +83,16 @@ fn flat_error_ffi_converter_impl(
     ident: &Ident,
     enum_: &DataEnum,
     udl_mode: bool,
-    implement_try_read: bool,
-    handle_unknown_callback_error: bool,
+    implement_lift: bool,
 ) -> TokenStream {
     let name = ident_to_string(ident);
-    let impl_spec = tagged_impl_header("FfiConverter", ident, udl_mode);
-    let lift_ref_impl_spec = tagged_impl_header("LiftRef", ident, udl_mode);
+    let lower_impl_spec = tagged_impl_header("Lower", ident, udl_mode);
     let mod_path = match mod_path() {
         Ok(p) => p,
         Err(e) => return e.into_compile_error(),
     };
 
-    let write_impl = {
+    let lower_impl = {
         let match_arms = enum_.variants.iter().enumerate().map(|(i, v)| {
             let v_ident = &v.ident;
             let idx = Index::from(i + 1);
@@ -113,18 +100,34 @@ fn flat_error_ffi_converter_impl(
             quote! {
                 Self::#v_ident { .. } => {
                     ::uniffi::deps::bytes::BufMut::put_i32(buf, #idx);
-                    <::std::string::String as ::uniffi::FfiConverter<crate::UniFfiTag>>::write(error_msg, buf);
+                    <::std::string::String as ::uniffi::Lower<crate::UniFfiTag>>::write(error_msg, buf);
                 }
             }
         });
 
         quote! {
-            let error_msg = ::std::string::ToString::to_string(&obj);
-            match obj { #(#match_arms)* }
+            #[automatically_derived]
+            unsafe #lower_impl_spec {
+                type FfiType = ::uniffi::RustBuffer;
+
+                fn write(obj: Self, buf: &mut ::std::vec::Vec<u8>) {
+                    let error_msg = ::std::string::ToString::to_string(&obj);
+                    match obj { #(#match_arms)* }
+                }
+
+                fn lower(obj: Self) -> ::uniffi::RustBuffer {
+                    <Self as ::uniffi::Lower<crate::UniFfiTag>>::lower_into_rust_buffer(obj)
+                }
+
+                const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_ENUM)
+                    .concat_str(#mod_path)
+                    .concat_str(#name);
+            }
         }
     };
 
-    let try_read_impl = if implement_try_read {
+    let lift_impl = implement_lift.then(|| {
+        let lift_impl_spec = tagged_impl_header("Lift", ident, udl_mode);
         let match_arms = enum_.variants.iter().enumerate().map(|(i, v)| {
             let v_ident = &v.ident;
             let idx = Index::from(i + 1);
@@ -134,42 +137,30 @@ fn flat_error_ffi_converter_impl(
             }
         });
         quote! {
-            Ok(match ::uniffi::deps::bytes::Buf::get_i32(buf) {
-                #(#match_arms)*
-                v => ::uniffi::deps::anyhow::bail!("Invalid #ident enum value: {}", v),
-            })
-        }
-    } else {
-        quote! { ::std::panic!("try_read not supported for flat errors") }
-    };
+            #[automatically_derived]
+            unsafe #lift_impl_spec {
+                type FfiType = ::uniffi::RustBuffer;
 
-    let handle_callback_unexpected_error =
-        handle_callback_unexpected_error_fn(handle_unknown_callback_error);
+                fn try_read(buf: &mut &[::std::primitive::u8]) -> ::uniffi::deps::anyhow::Result<Self> {
+                    Ok(match ::uniffi::deps::bytes::Buf::get_i32(buf) {
+                        #(#match_arms)*
+                        v => ::uniffi::deps::anyhow::bail!("Invalid #ident enum value: {}", v),
+                    })
+                }
+
+                fn try_lift(v: ::uniffi::RustBuffer) -> ::uniffi::deps::anyhow::Result<Self> {
+                    <Self as ::uniffi::Lift<crate::UniFfiTag>>::try_lift_from_rust_buffer(v)
+                }
+
+                const TYPE_ID_META: ::uniffi::MetadataBuffer = <Self as ::uniffi::Lower<crate::UniFfiTag>>::TYPE_ID_META;
+            }
+
+        }
+    });
 
     quote! {
-        #[automatically_derived]
-        unsafe #impl_spec {
-            ::uniffi::ffi_converter_rust_buffer_lift_and_lower!(crate::UniFfiTag);
-            ::uniffi::ffi_converter_default_return!(crate::UniFfiTag);
-
-            fn write(obj: Self, buf: &mut ::std::vec::Vec<u8>) {
-                #write_impl
-            }
-
-            fn try_read(buf: &mut &[::std::primitive::u8]) -> ::uniffi::deps::anyhow::Result<Self> {
-                #try_read_impl
-            }
-
-            #handle_callback_unexpected_error
-
-            const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_ENUM)
-                .concat_str(#mod_path)
-                .concat_str(#name);
-        }
-
-        #lift_ref_impl_spec {
-            type LiftType = Self;
-        }
+        #lower_impl
+        #lift_impl
     }
 }
 
@@ -211,8 +202,6 @@ pub fn flat_error_variant_metadata(enum_: &DataEnum) -> syn::Result<Vec<TokenStr
 pub struct ErrorAttr {
     flat: Option<kw::flat_error>,
     with_try_read: Option<kw::with_try_read>,
-    /// Can this error be used in a callback interface?
-    handle_unknown_callback_error: Option<kw::handle_unknown_callback_error>,
 }
 
 impl UniffiAttributeArgs for ErrorAttr {
@@ -229,10 +218,8 @@ impl UniffiAttributeArgs for ErrorAttr {
                 ..Self::default()
             })
         } else if lookahead.peek(kw::handle_unknown_callback_error) {
-            Ok(Self {
-                handle_unknown_callback_error: input.parse()?,
-                ..Self::default()
-            })
+            // Not used anymore, but still lallowed
+            Ok(Self::default())
         } else {
             Err(lookahead.error())
         }
@@ -242,10 +229,6 @@ impl UniffiAttributeArgs for ErrorAttr {
         Ok(Self {
             flat: either_attribute_arg(self.flat, other.flat)?,
             with_try_read: either_attribute_arg(self.with_try_read, other.with_try_read)?,
-            handle_unknown_callback_error: either_attribute_arg(
-                self.handle_unknown_callback_error,
-                other.handle_unknown_callback_error,
-            )?,
         })
     }
 }

--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -190,7 +190,6 @@ pub(crate) fn ffi_converter_trait_impl(trait_ident: &Ident, udl_mode: bool) -> T
 
         unsafe #impl_spec {
             type FfiType = *const ::std::os::raw::c_void;
-            type ReturnType = Self::FfiType;
 
             fn lower(obj: ::std::sync::Arc<Self>) -> Self::FfiType {
                 ::std::boxed::Box::into_raw(::std::boxed::Box::new(obj)) as *const ::std::os::raw::c_void
@@ -217,17 +216,13 @@ pub(crate) fn ffi_converter_trait_impl(trait_ident: &Ident, udl_mode: bool) -> T
                     ::uniffi::deps::bytes::Buf::get_u64(buf) as Self::FfiType)
             }
 
-            fn lower_return(v: ::std::sync::Arc<Self>) -> ::std::result::Result<Self::FfiType, ::uniffi::RustBuffer> {
-                Ok(<Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::lower(v))
-            }
-
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_INTERFACE)
                 .concat_str(#mod_path)
                 .concat_str(#name)
                 .concat_bool(true);
         }
 
-        #lift_ref_impl_spec {
+        unsafe #lift_ref_impl_spec {
             type LiftType = ::std::sync::Arc<dyn #trait_ident>;
         }
     }

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -216,7 +216,7 @@ fn gen_ffi_function(
 
     let ffi_ident = sig.scaffolding_fn_ident()?;
     let name = &sig.name;
-    let return_ffi_converter = &sig.return_ffi_converter();
+    let return_impl = &sig.return_impl();
 
     Ok(if !sig.is_async {
         quote! {
@@ -225,15 +225,15 @@ fn gen_ffi_function(
             #vis extern "C" fn #ffi_ident(
                 #(#params,)*
                 call_status: &mut ::uniffi::RustCallStatus,
-            ) -> #return_ffi_converter::ReturnType {
+            ) -> #return_impl::ReturnType {
                 ::uniffi::deps::log::debug!(#name);
                 let uniffi_lift_args = #lift_closure;
                 ::uniffi::rust_call(call_status, || {
-                    #return_ffi_converter::lower_return(
+                    #return_impl::lower_return(
                         match uniffi_lift_args() {
                             Ok(uniffi_args) => #rust_fn_call,
                             Err((arg_name, anyhow_error)) => {
-                                #return_ffi_converter::handle_failed_lift(arg_name, anyhow_error)
+                                #return_impl::handle_failed_lift(arg_name, anyhow_error)
                             },
                         }
                     )
@@ -262,7 +262,7 @@ fn gen_ffi_function(
                     Err((arg_name, anyhow_error)) => {
                         ::uniffi::rust_future_new(
                             async move {
-                                #return_ffi_converter::handle_failed_lift(arg_name, anyhow_error)
+                                #return_impl::handle_failed_lift(arg_name, anyhow_error)
                             },
                             crate::UniFfiTag,
                         )

--- a/uniffi_macros/src/object.rs
+++ b/uniffi_macros/src/object.rs
@@ -64,7 +64,6 @@ pub(crate) fn interface_impl(ident: &Ident, udl_mode: bool) -> TokenStream {
         unsafe #impl_spec {
             // Don't use a pointer to <T> as that requires a `pub <T>`
             type FfiType = *const ::std::os::raw::c_void;
-            type ReturnType = *const ::std::os::raw::c_void;
 
             /// When lowering, we have an owned `Arc` and we transfer that ownership
             /// to the foreign-language code, "leaking" it out of Rust's ownership system
@@ -116,17 +115,13 @@ pub(crate) fn interface_impl(ident: &Ident, udl_mode: bool) -> TokenStream {
                 <Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::try_lift(::uniffi::deps::bytes::Buf::get_u64(buf) as Self::FfiType)
             }
 
-            fn lower_return(v: ::std::sync::Arc<Self>) -> ::std::result::Result<Self::FfiType, ::uniffi::RustBuffer> {
-                Ok(<Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::lower(v))
-            }
-
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_INTERFACE)
                 .concat_str(#mod_path)
                 .concat_str(#name)
                 .concat_bool(false);
         }
 
-        #lift_ref_impl_spec {
+        unsafe #lift_ref_impl_spec {
             type LiftType = ::std::sync::Arc<Self>;
         }
     }

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -80,7 +80,7 @@ pub fn try_read_field(f: &syn::Field) -> TokenStream {
     let ty = &f.ty;
 
     quote! {
-        #ident: <#ty as ::uniffi::FfiConverter<crate::UniFfiTag>>::try_read(buf)?,
+        #ident: <#ty as ::uniffi::Lift<crate::UniFfiTag>>::try_read(buf)?,
     }
 }
 
@@ -216,6 +216,14 @@ pub(crate) fn tagged_impl_header(
     }
 }
 
+pub(crate) fn derive_ffi_traits(ty: &Ident, udl_mode: bool) -> TokenStream {
+    if udl_mode {
+        quote! { ::uniffi::derive_ffi_traits!(local #ty); }
+    } else {
+        quote! { ::uniffi::derive_ffi_traits!(blanket #ty); }
+    }
+}
+
 /// Custom keywords
 pub mod kw {
     syn::custom_keyword!(async_runtime);
@@ -223,9 +231,10 @@ pub mod kw {
     syn::custom_keyword!(constructor);
     syn::custom_keyword!(default);
     syn::custom_keyword!(flat_error);
-    syn::custom_keyword!(handle_unknown_callback_error);
     syn::custom_keyword!(None);
     syn::custom_keyword!(with_try_read);
+    // Not used anymore
+    syn::custom_keyword!(handle_unknown_callback_error);
 }
 
 /// Specifies a type from a dependent crate


### PR DESCRIPTION
We've been discussing this for a while, here's my attempt at it.  This makes it so the macro code stops using `FfiConverter` and starts using more specialized traits `Return`, `Lift`, etc.  The `FfiConverter` trait lives on, but just as a simple way to implement all the traits that we actually use in the generated code.

This is rebased on top of the async-cancellation branch because that one had some changes to how we handled callback returns.  Ignore all commits except the last.  If we end up not taking that branch, I think it should be pretty easy to rebase over main too.