### PR TITLE
Fix (possibly) inconsistent example code in proc-macro docs

### DIFF
--- a/docs/manual/src/proc_macro/index.md
+++ b/docs/manual/src/proc_macro/index.md
@@ -231,8 +231,8 @@ pub struct Uuid {
     val: String,
 }
 
-// Use `url::Url` as a custom type, with `String` as the Builtin
-uniffi::custom_type!(Url, String);
+// Use `Uuid` as a custom type, with `String` as the Builtin
+uniffi::custom_type!(Uuid, String);
 
 impl UniffiCustomTypeConverter for Uuid {
     type Builtin = String;


### PR DESCRIPTION
This pull request fixes a minor bug in the proc-macro documentation's [custom type macro section](https://mozilla.github.io/uniffi-rs/proc_macro/index.html#the-unifficustom_type-and-unifficustom_newtype-macros).

The current example code for the custom_type macro uses url::Url as "custom type" in the macro, even though the rest of the code features a custom Uuid type. As I understand the example, it is intended to use the Uuid type as "custom type" here.