### PR TITLE
Allow uniffi_traits to be used with procmacros.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.24.3...HEAD).
 
 ### What's new
+- Proc-macros can now expose standard Rust traits (eg, `Display`, `Eq`, etc)
 - Fixed issues when trying to combine UDL and procmacros in the same crate when the "namespace" is
   different from the crate name. This meant that the "ffi namespace" has changed to consistently be
   the crate name, rather than either the crate name or the namespace name depending on whether the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,6 +1787,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-fixture-metadata"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+ "uniffi",
+ "uniffi_core",
+ "uniffi_meta",
+]
+
+[[package]]
 name = "uniffi-fixture-proc-macro"
 version = "0.22.0"
 dependencies = [
@@ -1975,16 +1985,6 @@ dependencies = [
  "oneshot",
  "paste",
  "static_assertions",
-]
-
-[[package]]
-name = "uniffi_fixture_metadata"
-version = "0.1.0"
-dependencies = [
- "thiserror",
- "uniffi",
- "uniffi_core",
- "uniffi_meta",
 ]
 
 [[package]]

--- a/docs/manual/src/udl/interfaces.md
+++ b/docs/manual/src/udl/interfaces.md
@@ -169,6 +169,14 @@ struct TodoList {
    ...
 }
 ```
+(or using proc-macros)
+```rust
+#[derive(Debug, uniffi::Object)]
+#[uniffi::export(Debug)]
+struct TodoList {
+   ...
+}
+```
 
 This will cause the Python bindings to generate a `__repr__` method that returns the value implemented by the `Debug` trait.
 Not all bindings support generating special methods, so they may be ignored.

--- a/fixtures/metadata/Cargo.toml
+++ b/fixtures/metadata/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "uniffi_fixture_metadata"
+name = "uniffi-fixture-metadata"
 version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"

--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -66,6 +66,12 @@ mod calc {
     pub struct Calculator {}
 }
 
+mod uniffi_traits {
+    #[derive(Debug, PartialEq, Eq, uniffi::Object)]
+    #[uniffi::export(Debug, Eq)]
+    pub struct Special {}
+}
+
 #[uniffi::export(callback_interface)]
 pub trait Logger {
     fn log(&self, message: String);
@@ -75,6 +81,7 @@ pub use calc::Calculator;
 pub use error::{ComplexError, FlatError};
 pub use person::Person;
 pub use state::State;
+pub use uniffi_traits::Special;
 pub use weapon::Weapon;
 
 mod test_type_ids {
@@ -308,9 +315,26 @@ mod test_metadata {
                 module_path: "uniffi_fixture_metadata".into(),
                 name: "Calculator".into(),
                 imp: ObjectImpl::Struct,
-                uniffi_traits: vec![],
             },
         );
+    }
+
+    #[test]
+    fn test_uniffi_traits() {
+        assert!(matches!(
+            uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIAL_DEBUG).unwrap(),
+            Metadata::UniffiTrait(UniffiTraitMetadata::Debug { fmt })
+                if fmt.module_path == "uniffi_fixture_metadata"
+                   && fmt.self_name == "Special"
+        ));
+        assert!(matches!(
+            uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIAL_EQ).unwrap(),
+            Metadata::UniffiTrait(UniffiTraitMetadata::Eq { eq, ne })
+                if eq.module_path == "uniffi_fixture_metadata"
+                   && ne.module_path == "uniffi_fixture_metadata"
+                   && eq.self_name == "Special"
+                   && ne.self_name == "Special"
+        ));
     }
 }
 

--- a/fixtures/trait-methods/src/lib.rs
+++ b/fixtures/trait-methods/src/lib.rs
@@ -1,8 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::sync::Arc;
+
 #[derive(Debug, PartialEq, Eq, Hash)]
-struct TraitMethods {
+pub struct TraitMethods {
     val: String,
 }
 
@@ -15,6 +18,26 @@ impl TraitMethods {
 impl std::fmt::Display for TraitMethods {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "TraitMethods({})", self.val)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, uniffi::Object)]
+#[uniffi::export(Debug, Display, Eq, Hash)]
+pub struct ProcTraitMethods {
+    val: String,
+}
+
+#[uniffi::export]
+impl ProcTraitMethods {
+    #[uniffi::constructor]
+    fn new(val: String) -> Arc<Self> {
+        Arc::new(Self { val })
+    }
+}
+
+impl std::fmt::Display for ProcTraitMethods {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ProcTraitMethods({})", self.val)
     }
 }
 

--- a/fixtures/trait-methods/tests/bindings/test.py
+++ b/fixtures/trait-methods/tests/bindings/test.py
@@ -29,5 +29,29 @@ class TestTraitMethods(unittest.TestCase):
         d[m] = "m"
         self.assertTrue(m in d)
 
+class TestProcmacroTraitMethods(unittest.TestCase):
+    def test_str(self):
+        m = ProcTraitMethods("yo")
+        self.assertEqual(str(m), "ProcTraitMethods(yo)")
+
+    def test_repr(self):
+        m = ProcTraitMethods("yo")
+        self.assertEqual(repr(m), 'ProcTraitMethods { val: "yo" }')
+
+    def test_eq(self):
+        m = ProcTraitMethods("yo")
+        self.assertEqual(m, ProcTraitMethods("yo"))
+        self.assertNotEqual(m, ProcTraitMethods("yoyo"))
+
+    def test_eq(self):
+        m = ProcTraitMethods("yo")
+        self.assertNotEqual(m, 17)
+
+    def test_hash(self):
+        d = {}
+        m = ProcTraitMethods("m")
+        d[m] = "m"
+        self.assertTrue(m in d)
+
 if __name__=='__main__':
     unittest.main()

--- a/fixtures/uitests/tests/ui/trait_methods_no_trait.stderr
+++ b/fixtures/uitests/tests/ui/trait_methods_no_trait.stderr
@@ -1,28 +1,24 @@
 error[E0277]: `TraitMethods` doesn't implement `std::fmt::Display`
  --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
   |
-  | ...   uniffi::deps::static_assertions::assert_impl_all!(r#TraitMethods: std::fmt::Display); // This object has a trait method which requi...
-  |                                                         ^^^^^^^^^^^^^^ `TraitMethods` cannot be formatted with the default formatter
+  | struct r#TraitMethods { }
+  |        ^^^^^^^^^^^^^^ `TraitMethods` cannot be formatted with the default formatter
   |
   = help: the trait `std::fmt::Display` is not implemented for `TraitMethods`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-note: required by a bound in `uniffi_uniffi_trait_methods_fn_method_traitmethods_uniffi_trait_display::{closure#0}::_::{closure#0}::assert_impl_all`
+note: required by a bound in `TraitMethods::uniffi_trait_display::_::{closure#0}::assert_impl_all`
  --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
   |
-  | ...   uniffi::deps::static_assertions::assert_impl_all!(r#TraitMethods: std::fmt::Display); // This object has a trait method which requi...
-  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
-  = note: this error originates in the macro `uniffi::deps::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+  | #[uniffi::export(Display)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+  = note: this error originates in the macro `::uniffi::deps::static_assertions::assert_impl_all` which comes from the expansion of the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `TraitMethods` doesn't implement `std::fmt::Display`
  --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
   |
-  | /                 match<std::sync::Arc<r#TraitMethods> as ::uniffi::Lift<crate::UniFfiTag>>::try_lift(r#ptr) {
-  | |                     Ok(ref val) => val,
-  | |                     Err(err) => panic!("Failed to convert arg '{}': {}", "ptr", err),
-  | |                 }
-  | |_________________^ `TraitMethods` cannot be formatted with the default formatter
+  | #[uniffi::export(Display)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `TraitMethods` cannot be formatted with the default formatter
   |
   = help: the trait `std::fmt::Display` is not implemented for `TraitMethods`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-  = help: the trait `std::fmt::Display` is implemented for `Arc<T>`
-  = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -71,7 +71,7 @@ pub use ffi::{FfiArgument, FfiFunction, FfiType};
 pub use uniffi_meta::Radix;
 use uniffi_meta::{
     ConstructorMetadata, LiteralMetadata, NamespaceMetadata, ObjectMetadata, TraitMethodMetadata,
-    UNIFFI_CONTRACT_VERSION,
+    UniffiTraitMetadata, UNIFFI_CONTRACT_VERSION,
 };
 pub type Literal = LiteralMetadata;
 
@@ -802,7 +802,15 @@ impl ComponentInterface {
         self.types.add_known_types(method.iter_types())?;
         method.object_impl = object.imp;
         object.methods.push(method);
+        Ok(())
+    }
 
+    pub(super) fn add_uniffitrait_meta(&mut self, meta: UniffiTraitMetadata) -> Result<()> {
+        let object = get_object(&mut self.objects, meta.self_name())
+            .ok_or_else(|| anyhow!("add_uniffitrait_meta: object not found"))?;
+        let ut: UniffiTrait = meta.into();
+        self.types.add_known_types(ut.iter_types())?;
+        object.uniffi_traits.push(ut);
         Ok(())
     }
 

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -225,7 +225,7 @@ impl From<uniffi_meta::ObjectMetadata> for Object {
             imp: meta.imp,
             constructors: Default::default(),
             methods: Default::default(),
-            uniffi_traits: meta.uniffi_traits.into_iter().map(Into::into).collect(),
+            uniffi_traits: Default::default(),
             ffi_func_free: FfiFunction {
                 name: ffi_free_name,
                 ..Default::default()

--- a/uniffi_bindgen/src/library_mode.rs
+++ b/uniffi_bindgen/src/library_mode.rs
@@ -26,7 +26,9 @@ use std::{
     collections::{HashMap, HashSet},
     fs,
 };
-use uniffi_meta::{create_metadata_groups, fixup_external_type, group_metadata, MetadataGroup};
+use uniffi_meta::{
+    create_metadata_groups, fixup_external_type, group_metadata, Metadata, MetadataGroup,
+};
 
 /// Generate foreign bindings
 ///
@@ -142,6 +144,10 @@ fn find_sources(
                 .items
                 .into_iter()
                 .map(|item| fixup_external_type(item, &metadata_groups))
+                // some items are both in UDL and library metadata. For many that's fine but
+                // uniffi-traits aren't trivial to compare meaning we end up with dupes.
+                // We filter out such problematic items here.
+                .filter(|item| !matches!(item, Metadata::UniffiTrait { .. }))
                 .collect();
             udl_items.insert(crate_name, metadata_group);
         };

--- a/uniffi_bindgen/src/macro_metadata/ci.rs
+++ b/uniffi_bindgen/src/macro_metadata/ci.rs
@@ -109,6 +109,9 @@ fn add_item_to_ci(iface: &mut ComponentInterface, item: Metadata) -> anyhow::Res
             })?;
             iface.add_object_meta(meta)?;
         }
+        Metadata::UniffiTrait(meta) => {
+            iface.add_uniffitrait_meta(meta)?;
+        }
         Metadata::CallbackInterface(meta) => {
             iface.types.add_known_type(&Type::CallbackInterface {
                 module_path: meta.module_path.clone(),

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -68,31 +68,7 @@ mod filters {
         })
     }
 
-    pub fn type_ffi(type_: &FfiType) -> Result<String, askama::Error> {
-        Ok(match type_ {
-            FfiType::Int8 => "i8".into(),
-            FfiType::UInt8 => "u8".into(),
-            FfiType::Int16 => "i16".into(),
-            FfiType::UInt16 => "u16".into(),
-            FfiType::Int32 => "i32".into(),
-            FfiType::UInt32 => "u32".into(),
-            FfiType::Int64 => "i64".into(),
-            FfiType::UInt64 => "u64".into(),
-            FfiType::Float32 => "f32".into(),
-            FfiType::Float64 => "f64".into(),
-            FfiType::RustArcPtr(_) => "*const std::os::raw::c_void".into(),
-            FfiType::RustBuffer(_) => "::uniffi::RustBuffer".into(),
-            FfiType::ForeignBytes => "::uniffi::ForeignBytes".into(),
-            FfiType::ForeignCallback => "::uniffi::ForeignCallback".into(),
-            FfiType::RustFutureHandle => "::uniffi::RustFutureHandle".into(),
-            FfiType::RustFutureContinuationCallback => "::uniffi::RustFutureContinuation".into(),
-            FfiType::RustFutureContinuationData => "*const ()".into(),
-            FfiType::ForeignExecutorHandle => "::uniffi::ForeignExecutorHandle".into(),
-            FfiType::ForeignExecutorCallback => "::uniffi::ForeignExecutorCallback".into(),
-        })
-    }
-
-    // Map a type a ffi converter trait impl
+    // Map a type to Rust code that specifies the FfiConverter implementation.
     //
     // This outputs something like `<MyStruct as Lift<crate::UniFfiTag>>`
     pub fn ffi_trait(type_: &Type, trait_name: &str) -> Result<String, askama::Error> {

--- a/uniffi_bindgen/src/scaffolding/templates/macros.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/macros.rs
@@ -1,42 +1,6 @@
 {#
 // Template to receive calls into rust.
-#}
 
-{%- macro to_rs_call(func) -%}
-r#{{ func.name() }}({% call _arg_list_rs_call(func) -%})
-{%- endmacro -%}
-
-{%- macro _arg_list_rs_call(func) %}
-    {%- for arg in func.full_arguments() %}
-        match {{- arg.as_type().borrow()|ffi_trait("Lift") }}::try_lift(r#{{ arg.name() }}) {
-        {%- if arg.by_ref() %}
-        {#  args passed by reference get special treatment for traits and their Box<> #}
-        {%-     if arg.is_trait_ref() %}
-            Ok(ref val) => &**val,
-        {%-     else %}
-            Ok(ref val) => val,
-        {%-     endif %}
-        {%- else %}
-        {#  args not passed by reference get passed directly #}
-            Ok(val) => val,
-        {%- endif %}
-
-        {#- If this function returns an error, we attempt to downcast errors doing arg
-            conversions to this error. If the downcast fails or the function doesn't
-            return an error, we just panic.
-        -#}
-        {%- match func.throws_type() -%}
-        {%- when Some with (e) %}
-            Err(err) => return Err(uniffi::lower_anyhow_error_or_panic::<crate::UniFfiTag, {{ e|type_rs }}>(err, "{{ arg.name() }}")),
-        {%- else %}
-            Err(err) => panic!("Failed to convert arg '{}': {}", "{{ arg.name() }}", err),
-        {%- endmatch %}
-        }
-        {%- if !loop.last %},{% endif %}
-    {%- endfor %}
-{%- endmacro -%}
-
-{#-
 // Arglist as used in the _UniFFILib function declarations.
 // Note unfiltered name but type_ffi filters.
 -#}
@@ -62,22 +26,3 @@ r#{{ func.name() }}({% call _arg_list_rs_call(func) -%})
 {%- else -%}
 {%- endmatch -%}
 {%- endmacro -%}
-
-{%- macro method_decl_prelude(meth) %}
-#[doc(hidden)]
-#[no_mangle]
-#[allow(clippy::let_unit_value,clippy::unit_arg)] // The generated code uses the unit type like other types to keep things uniform
-pub extern "C" fn r#{{ meth.ffi_func().name() }}(
-    {%- call arg_list_ffi_decl(meth.ffi_func()) %}
-) {% call return_signature(meth) %} {
-    uniffi::deps::log::debug!("{{ meth.ffi_func().name() }}");
-    uniffi::rust_call(call_status, || {
-        <{{ meth|return_type }} as ::uniffi::LowerReturn<crate::UniFfiTag>>::lower_return(
-{%- endmacro %}
-
-{%- macro method_decl_postscript(meth) %}
-            {% if meth.throws() %}.map_err(Into::into){% endif %}
-        )
-    })
-}
-{% endmacro %}

--- a/uniffi_core/src/metadata.rs
+++ b/uniffi_core/src/metadata.rs
@@ -38,6 +38,7 @@ pub mod codes {
     pub const UDL_FILE: u8 = 8;
     pub const CALLBACK_INTERFACE: u8 = 9;
     pub const TRAIT_METHOD: u8 = 10;
+    pub const UNIFFI_TRAIT: u8 = 11;
     pub const UNKNOWN: u8 = 255;
 
     // Type codes

--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -10,10 +10,13 @@ mod attributes;
 mod callback_interface;
 mod item;
 mod scaffolding;
+mod utrait;
 
 use self::{
     item::{ExportItem, ImplItem},
-    scaffolding::{gen_constructor_scaffolding, gen_fn_scaffolding, gen_method_scaffolding},
+    scaffolding::{
+        gen_constructor_scaffolding, gen_ffi_function, gen_fn_scaffolding, gen_method_scaffolding,
+    },
 };
 use crate::{
     object::interface_meta_static_var,
@@ -168,6 +171,13 @@ pub(crate) fn expand_export(
 
                 #(#metadata_items)*
             })
+        }
+        ExportItem::Struct {
+            self_ident,
+            uniffi_traits,
+        } => {
+            assert!(!udl_mode);
+            utrait::expand_uniffi_trait_export(self_ident, uniffi_traits)
         }
     }
 }

--- a/uniffi_macros/src/export/attributes.rs
+++ b/uniffi_macros/src/export/attributes.rs
@@ -12,6 +12,11 @@ pub struct ExportAttributeArguments {
     pub(crate) async_runtime: Option<AsyncRuntime>,
     pub(crate) callback_interface: Option<kw::callback_interface>,
     pub(crate) constructor: Option<kw::constructor>,
+    // tried to make this a vec but that got messy quickly...
+    pub(crate) trait_debug: Option<kw::Debug>,
+    pub(crate) trait_display: Option<kw::Display>,
+    pub(crate) trait_hash: Option<kw::Hash>,
+    pub(crate) trait_eq: Option<kw::Eq>,
 }
 
 impl Parse for ExportAttributeArguments {
@@ -40,6 +45,26 @@ impl UniffiAttributeArgs for ExportAttributeArguments {
                 constructor: input.parse()?,
                 ..Self::default()
             })
+        } else if lookahead.peek(kw::Debug) {
+            Ok(Self {
+                trait_debug: input.parse()?,
+                ..Self::default()
+            })
+        } else if lookahead.peek(kw::Display) {
+            Ok(Self {
+                trait_display: input.parse()?,
+                ..Self::default()
+            })
+        } else if lookahead.peek(kw::Hash) {
+            Ok(Self {
+                trait_hash: input.parse()?,
+                ..Self::default()
+            })
+        } else if lookahead.peek(kw::Eq) {
+            Ok(Self {
+                trait_eq: input.parse()?,
+                ..Self::default()
+            })
         } else {
             Ok(Self::default())
         }
@@ -53,6 +78,10 @@ impl UniffiAttributeArgs for ExportAttributeArguments {
                 other.callback_interface,
             )?,
             constructor: either_attribute_arg(self.constructor, other.constructor)?,
+            trait_debug: either_attribute_arg(self.trait_debug, other.trait_debug)?,
+            trait_display: either_attribute_arg(self.trait_display, other.trait_display)?,
+            trait_hash: either_attribute_arg(self.trait_hash, other.trait_hash)?,
+            trait_eq: either_attribute_arg(self.trait_eq, other.trait_eq)?,
         })
     }
 }

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -186,7 +186,7 @@ impl ScaffoldingBits {
 ///
 /// `pre_fn_call` is the statements that we should execute before the rust call
 /// `rust_fn` is the Rust function to call.
-fn gen_ffi_function(
+pub(super) fn gen_ffi_function(
     sig: &FnSignature,
     arguments: &ExportAttributeArguments,
     udl_mode: bool,

--- a/uniffi_macros/src/export/utrait.rs
+++ b/uniffi_macros/src/export/utrait.rs
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
+use syn::ext::IdentExt;
+
+use super::{attributes::ExportAttributeArguments, gen_ffi_function};
+use crate::fnsig::FnSignature;
+use uniffi_meta::UniffiTraitDiscriminants;
+
+pub(crate) fn expand_uniffi_trait_export(
+    self_ident: Ident,
+    uniffi_traits: Vec<UniffiTraitDiscriminants>,
+) -> syn::Result<TokenStream> {
+    let udl_mode = false;
+    let mut impl_items = Vec::new();
+    let mut global_items = Vec::new();
+    for trait_id in uniffi_traits {
+        match trait_id {
+            UniffiTraitDiscriminants::Debug => {
+                let method = quote! {
+                    fn uniffi_trait_debug(&self) -> String {
+                        ::uniffi::deps::static_assertions::assert_impl_all!(#self_ident: ::std::fmt::Debug);
+                        format!("{:?}", self)
+                    }
+                };
+                let (ffi_func, method_meta) =
+                    process_uniffi_trait_method(&method, &self_ident, udl_mode)?;
+                // metadata for the trait - which includes metadata for the method.
+                let discr = UniffiTraitDiscriminants::Debug as u8;
+                let trait_meta = crate::util::create_metadata_items(
+                    "uniffi_trait",
+                    &format!("{}_Debug", self_ident.unraw()),
+                    quote! {
+                        ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::UNIFFI_TRAIT)
+                        .concat_value(#discr)
+                        .concat(#method_meta)
+                    },
+                    None,
+                );
+                impl_items.push(method);
+                global_items.push(ffi_func);
+                global_items.push(trait_meta);
+            }
+            UniffiTraitDiscriminants::Display => {
+                let method = quote! {
+                    fn uniffi_trait_display(&self) -> String {
+                        ::uniffi::deps::static_assertions::assert_impl_all!(#self_ident: ::std::fmt::Display);
+                        format!("{}", self)
+                    }
+                };
+                let (ffi_func, method_meta) =
+                    process_uniffi_trait_method(&method, &self_ident, udl_mode)?;
+                // metadata for the trait - which includes metadata for the method.
+                let discr = UniffiTraitDiscriminants::Display as u8;
+                let trait_meta = crate::util::create_metadata_items(
+                    "uniffi_trait",
+                    &format!("{}_Display", self_ident.unraw()),
+                    quote! {
+                        ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::UNIFFI_TRAIT)
+                        .concat_value(#discr)
+                        .concat(#method_meta)
+                    },
+                    None,
+                );
+                impl_items.push(method);
+                global_items.push(ffi_func);
+                global_items.push(trait_meta);
+            }
+            UniffiTraitDiscriminants::Hash => {
+                let method = quote! {
+                    fn uniffi_trait_hash(&self) -> u64 {
+                        use ::std::hash::{Hash, Hasher};
+                        ::uniffi::deps::static_assertions::assert_impl_all!(#self_ident: Hash);
+                        let mut s = ::std::collections::hash_map::DefaultHasher::new();
+                        Hash::hash(self, &mut s);
+                        s.finish()
+                    }
+                };
+                let (ffi_func, method_meta) =
+                    process_uniffi_trait_method(&method, &self_ident, udl_mode)?;
+                // metadata for the trait - which includes metadata for the hash method.
+                let discr = UniffiTraitDiscriminants::Hash as u8;
+                let trait_meta = crate::util::create_metadata_items(
+                    "uniffi_trait",
+                    &format!("{}_Hash", self_ident.unraw()),
+                    quote! {
+                        ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::UNIFFI_TRAIT)
+                        .concat_value(#discr)
+                        .concat(#method_meta)
+                    },
+                    None,
+                );
+                impl_items.push(method);
+                global_items.push(ffi_func);
+                global_items.push(trait_meta);
+            }
+            UniffiTraitDiscriminants::Eq => {
+                let method_eq = quote! {
+                    fn uniffi_trait_eq_eq(&self, other: &#self_ident) -> bool {
+                        use ::std::cmp::PartialEq;
+                        uniffi::deps::static_assertions::assert_impl_all!(#self_ident: PartialEq); // This object has a trait method which requires `PartialEq` be implemented.
+                        PartialEq::eq(self, other)
+                    }
+                };
+                let method_ne = quote! {
+                    fn uniffi_trait_eq_ne(&self, other: &#self_ident) -> bool {
+                        use ::std::cmp::PartialEq;
+                        uniffi::deps::static_assertions::assert_impl_all!(#self_ident: PartialEq); // This object has a trait method which requires `PartialEq` be implemented.
+                        PartialEq::ne(self, other)
+                    }
+                };
+                let (ffi_func_eq, method_meta_eq) =
+                    process_uniffi_trait_method(&method_eq, &self_ident, udl_mode)?;
+                let (ffi_func_ne, method_meta_ne) =
+                    process_uniffi_trait_method(&method_ne, &self_ident, udl_mode)?;
+                // metadata for the trait itself.
+                let discr = UniffiTraitDiscriminants::Eq as u8;
+                let trait_meta = crate::util::create_metadata_items(
+                    "uniffi_trait",
+                    &format!("{}_Eq", self_ident.unraw()),
+                    quote! {
+                        ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::UNIFFI_TRAIT)
+                        .concat_value(#discr)
+                        .concat(#method_meta_eq)
+                        .concat(#method_meta_ne)
+                    },
+                    None,
+                );
+                impl_items.push(method_eq);
+                impl_items.push(method_ne);
+                global_items.push(ffi_func_eq);
+                global_items.push(ffi_func_ne);
+                global_items.push(trait_meta);
+            }
+        }
+    }
+    Ok(quote! {
+        #[doc(hidden)]
+        impl #self_ident {
+            #(#impl_items)*
+        }
+        #(#global_items)*
+    })
+}
+
+fn process_uniffi_trait_method(
+    method: &TokenStream,
+    self_ident: &Ident,
+    udl_mode: bool,
+) -> syn::Result<(TokenStream, TokenStream)> {
+    let item = syn::parse(method.clone().into())?;
+
+    let syn::Item::Fn(item) = item else {
+        unreachable!()
+    };
+
+    let ffi_func = gen_ffi_function(
+        &FnSignature::new_method(self_ident.clone(), item.sig.clone())?,
+        &ExportAttributeArguments::default(),
+        udl_mode,
+    )?;
+    // metadata for the method, which will be packed inside metadata for the trait.
+    let method_meta = FnSignature::new_method(self_ident.clone(), item.sig)?.metadata_expr()?;
+    Ok((ffi_func, method_meta))
+}

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -233,6 +233,10 @@ pub mod kw {
     syn::custom_keyword!(flat_error);
     syn::custom_keyword!(None);
     syn::custom_keyword!(with_try_read);
+    syn::custom_keyword!(Debug);
+    syn::custom_keyword!(Display);
+    syn::custom_keyword!(Eq);
+    syn::custom_keyword!(Hash);
     // Not used anymore
     syn::custom_keyword!(handle_unknown_callback_error);
 }

--- a/uniffi_meta/src/metadata.rs
+++ b/uniffi_meta/src/metadata.rs
@@ -21,6 +21,7 @@ pub mod codes {
     pub const UDL_FILE: u8 = 8;
     pub const CALLBACK_INTERFACE: u8 = 9;
     pub const TRAIT_METHOD: u8 = 10;
+    pub const UNIFFI_TRAIT: u8 = 11;
     //pub const UNKNOWN: u8 = 255;
 
     // Type codes

--- a/uniffi_udl/src/converters/interface.rs
+++ b/uniffi_udl/src/converters/interface.rs
@@ -123,11 +123,13 @@ impl APIConverter<ObjectMetadata> for weedle::InterfaceDefinition<'_> {
                 })
             })
             .collect::<Result<Vec<_>>>()?;
+        for ut in uniffi_traits {
+            ci.items.insert(ut.into());
+        }
         Ok(ObjectMetadata {
             module_path: ci.module_path(),
             name: object_name.to_string(),
             imp: object_impl,
-            uniffi_traits,
         })
     }
 }


### PR DESCRIPTION
The proc-macro mechanism is also used for UDL which allows a lot of scaffolding to be removed.

Fixes #1750, fixes #1548.