### PR TITLE
Update docs and tests for HashMap<>/record<>

### DIFF
--- a/docs/manual/src/udl/builtin_types.md
+++ b/docs/manual/src/udl/builtin_types.md
@@ -15,7 +15,7 @@ The following built-in types can be passed as arguments/returned by Rust methods
 | `&T`                 | `[ByRef] T`            | This works for `&str` and `&[T]`                                |
 | `Option<T>`          | `T?`                   |                                                                 |
 | `Vec<T>`             | `sequence<T>`          |                                                                 |
-| `HashMap<String, T>` | `record<string, T>`    | Only string keys are supported                                  |
+| `HashMap<K, V>`      | `record<K, T>`         |                                                                 |
 | `()`                 | `void`                 | Empty return                                                    |
 | `Result<T, E>`       | N/A                    | See [Errors](./errors.md) section                               |
 

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 mod callback_interface;
 
@@ -114,6 +114,17 @@ fn make_one(inner: i32) -> One {
 #[uniffi::export]
 fn take_two(two: Two) -> String {
     two.a
+}
+
+#[uniffi::export]
+fn make_hashmap(k: i8, v: u64) -> HashMap<i8, u64> {
+    HashMap::from([(k, v)])
+}
+
+// XXX - fails to call this from python - https://github.com/mozilla/uniffi-rs/issues/1774
+#[uniffi::export]
+fn return_hashmap(h: HashMap<i8, u64>) -> HashMap<i8, u64> {
+    h
 }
 
 #[uniffi::export]

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -33,6 +33,11 @@ three = Three(obj)
 assert(make_zero().inner == "ZERO")
 assert(make_record_with_bytes().some_bytes == bytes([0, 1, 2, 3, 4]))
 
+assert(make_hashmap(1, 2) == {1: 2})
+# fails with AttributeError!? - https://github.com/mozilla/uniffi-rs/issues/1774
+# d = {1, 2}
+# assert(return_hashmap(d) == d)
+
 try:
     always_fails()
 except BasicError.OsError:

--- a/uniffi_core/src/ffi_converter_impls.rs
+++ b/uniffi_core/src/ffi_converter_impls.rs
@@ -385,10 +385,7 @@ unsafe impl<UT, T: FfiConverter<UT>> FfiConverter<UT> for Vec<T> {
         MetadataBuffer::from_code(metadata::codes::TYPE_VEC).concat(T::TYPE_ID_META);
 }
 
-/// Support for associative arrays via the FFI.
-/// Note that because of webidl limitations,
-/// the key must always be of the String type.
-///
+/// Support for associative arrays via the FFI - `record<u32, u64>` in UDL.
 /// HashMaps are currently always passed by serializing to a buffer.
 /// We write a `i32` entries count followed by each entry (string
 /// key followed by the value) in turn.


### PR DESCRIPTION
[Non-string keys already have tests](https://github.com/mozilla/uniffi-rs/blob/7acfce022c1c394d9f91c390874557e611b47385/fixtures/coverall/src/coverall.udl#L156-L157), added almost-passing procmacro tests.