### PR TITLE
Fix Swift codegen for async object methods without extra parameters

### DIFF
--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -168,7 +168,12 @@ impl Megaphone {
         say_after(ms, who).await.to_uppercase()
     }
 
-    // An async method that can throw.
+    /// An async method without any extra arguments.
+    pub async fn silence(&self) -> String {
+        String::new()
+    }
+
+    /// An async method that can throw.
     pub async fn fallible_me(self: Arc<Self>, do_fail: bool) -> Result<u8, MyError> {
         if do_fail {
             Err(MyError::Foo)

--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -47,9 +47,10 @@ public class {{ type_name }}: {{ obj.name() }}Protocol {
         return {% call swift::try(meth) %} await uniffiRustCallAsync(
             rustFutureFunc: {
                 {{ meth.ffi_func().name() }}(
-                    self.pointer,
-                    {%- for arg in meth.arguments() %}
-                    {{ arg|lower_fn }}({{ arg.name()|var_name }}){% if !loop.last %},{% endif %}
+                    self.pointer
+                    {%- for arg in meth.arguments() -%}
+                    ,
+                    {{ arg|lower_fn }}({{ arg.name()|var_name }})
                     {%- endfor %}
                 )
             },


### PR DESCRIPTION
`async fn` methods without extra parameters (other than `self`) worked previously, regressed in #1767.

New test previously failed Swift compilation with

```
<dir>/uniffi/target/tmp/uniffi-fixture-futures-dba82f227cc858a5/futures.swift:502:17: error: unexpected ',' separator
                )
                ^
```

because `self.pointer` as the only argument had a comma after it in the argument list, which is not allowed in Swift.