### PR TITLE
Allow library mode to be used by external generators

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -66,8 +66,6 @@ impl Config {
 }
 
 impl BindingsConfig for Config {
-    const TOML_KEY: &'static str = "kotlin";
-
     fn update_from_ci(&mut self, ci: &ComponentInterface) {
         self.package_name
             .get_or_insert_with(|| format!("uniffi.{}", ci.namespace()));

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -97,8 +97,6 @@ impl Config {
 }
 
 impl BindingsConfig for Config {
-    const TOML_KEY: &'static str = "python";
-
     fn update_from_ci(&mut self, ci: &ComponentInterface) {
         self.cdylib_name
             .get_or_insert_with(|| format!("uniffi_{}", ci.namespace()));

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -104,8 +104,6 @@ impl Config {
 }
 
 impl BindingsConfig for Config {
-    const TOML_KEY: &'static str = "ruby";
-
     fn update_from_ci(&mut self, ci: &ComponentInterface) {
         self.cdylib_name
             .get_or_insert_with(|| format!("uniffi_{}", ci.namespace()));

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -204,8 +204,6 @@ impl Config {
 }
 
 impl BindingsConfig for Config {
-    const TOML_KEY: &'static str = "swift";
-
     fn update_from_ci(&mut self, ci: &ComponentInterface) {
         self.module_name
             .get_or_insert_with(|| ci.namespace().into());


### PR DESCRIPTION
The dependency between `lib.rs` and `library_mode.rs` is a bit convoluted, but I think this turned out quite elegant.