### PR TITLE
Kotlin: allow exporting empty records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 
 - Updated the async functionality to correctly handle cancellation (#1669)
 - Kotlin: Fixed low-level issue with exported async APIs
+- Kotlin: Fixed empty records being exported as empty data classes in Kotlin. A class with a proper `equals` function should be used instead.
 
 ### What's changed?
 

--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -172,6 +172,8 @@ interface Coveralls {
 
     /// Reverses the bytes.
     bytes reverse(bytes value);
+
+    EmptyStruct set_and_get_empty_struct(EmptyStruct empty_struct);
 };
 
 // coveralls keep track of their repairs (an interface in a dict)
@@ -245,3 +247,5 @@ interface ISecond {
   // Default only
   boolean compare(IFirst? other);
 };
+
+dictionary EmptyStruct {};

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -386,6 +386,10 @@ impl Coveralls {
         value.reverse();
         value
     }
+
+    fn set_and_get_empty_struct(&self, empty_struct: EmptyStruct) -> EmptyStruct {
+        empty_struct
+    }
 }
 
 impl Drop for Coveralls {
@@ -479,5 +483,7 @@ impl ISecond {
         false
     }
 }
+
+pub struct EmptyStruct;
 
 uniffi::include_scaffolding!("coverall");

--- a/fixtures/coverall/tests/bindings/test_coverall.kts
+++ b/fixtures/coverall/tests/bindings/test_coverall.kts
@@ -214,6 +214,11 @@ Coveralls("test_regressions").use { coveralls ->
     assert(coveralls.getStatus("success") == "status: success")
 }
 
+Coveralls("test_empty_records").use { coveralls ->
+    assert(coveralls.setAndGetEmptyStruct(EmptyStruct()) == EmptyStruct())
+    assert(EmptyStruct() !== EmptyStruct())
+}
+
 class KotlinGetters : Getters {
     override fun getBool(v: Boolean, arg2: Boolean) : Boolean {
         return v != arg2

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
@@ -1,5 +1,6 @@
 {%- let rec = ci|get_record_definition(name) %}
 
+{%- if rec.has_fields() %}
 data class {{ type_name }} (
     {%- for field in rec.fields() %}
     var {{ field.name()|var_name }}: {{ field|type_name -}}
@@ -18,21 +19,38 @@ data class {{ type_name }} (
     {% endif %}
     companion object
 }
+{%- else -%}
+class {{ type_name }} {
+    override fun equals(other: Any?): Boolean {
+        return other is {{ type_name }}
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
+    }
+
+    companion object
+}
+{%- endif %}
 
 public object {{ rec|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
     override fun read(buf: ByteBuffer): {{ type_name }} {
+        {%- if rec.has_fields() %}
         return {{ type_name }}(
         {%- for field in rec.fields() %}
             {{ field|read_fn }}(buf),
         {%- endfor %}
         )
+        {%- else %}
+        return {{ type_name }}()
+        {%- endif %}
     }
 
-    override fun allocationSize(value: {{ type_name }}) = (
+    override fun allocationSize(value: {{ type_name }}) = {%- if rec.has_fields() %} (
         {%- for field in rec.fields() %}
-            {{ field|allocation_size_fn }}(value.{{ field.name()|var_name }}){% if !loop.last %} +{% endif%}
+            {{ field|allocation_size_fn }}(value.{{ field.name()|var_name }}){% if !loop.last %} +{% endif %}
         {%- endfor %}
-    )
+    ) {%- else %} 0 {%- endif %}
 
     override fun write(value: {{ type_name }}, buf: ByteBuffer) {
         {%- for field in rec.fields() %}

--- a/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
@@ -4,6 +4,7 @@ class {{ type_name }}:
         {{- field.name()|var_name }}: "{{- field|type_name }}";
     {%- endfor %}
 
+    {%- if rec.has_fields() %}
     @typing.no_type_check
     def __init__(self, {% for field in rec.fields() %}
     {{- field.name()|var_name }}: "{{- field|type_name }}"
@@ -22,6 +23,7 @@ class {{ type_name }}:
             self.{{ field_name }} = {{ field_name }}
         {%- endmatch %}
         {%- endfor %}
+    {%- endif %}
 
     def __str__(self):
         return "{{ type_name }}({% for field in rec.fields() %}{{ field.name()|var_name }}={}{% if loop.last %}{% else %}, {% endif %}{% endfor %})".format({% for field in rec.fields() %}self.{{ field.name()|var_name }}{% if loop.last %}{% else %}, {% endif %}{% endfor %})
@@ -44,6 +46,10 @@ class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
 
     @staticmethod
     def write(value, buf):
+        {%- if rec.has_fields() %}
         {%- for field in rec.fields() %}
         {{ field|write_fn }}(value.{{ field.name()|var_name }}, buf)
         {%- endfor %}
+        {%- else %}
+        pass
+        {%- endif %}

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -34,12 +34,16 @@ extension {{ type_name }}: Equatable, Hashable {
 
 public struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> {{ type_name }} {
-        return try {{ type_name }}(
+        return {%- if rec.has_fields() %}
+            try {{ type_name }}(
             {%- for field in rec.fields() %}
-            {{ field.name()|arg_name }}: {{ field|read_fn }}(from: &buf)
-            {%- if !loop.last %}, {% endif %}
+                {{ field.name()|arg_name }}: {{ field|read_fn }}(from: &buf)
+                {%- if !loop.last %}, {% endif %}
             {%- endfor %}
         )
+        {%- else %}
+            {{ type_name }}()
+        {%- endif %}
     }
 
     public static func write(_ value: {{ type_name }}, into buf: inout [UInt8]) {

--- a/uniffi_bindgen/src/interface/record.rs
+++ b/uniffi_bindgen/src/interface/record.rs
@@ -74,6 +74,10 @@ impl Record {
     pub fn iter_types(&self) -> TypeIterator<'_> {
         Box::new(self.fields.iter().flat_map(Field::iter_types))
     }
+
+    pub fn has_fields(&self) -> bool {
+        !self.fields.is_empty()
+    }
 }
 
 impl AsType for Record {


### PR DESCRIPTION
As seen in #1760, Kotlin can't have empty data classes, `object`s are used instead. In this PR, I modified the `RecordTemplate.kt` to produce objects for records with no fields, which should take care of that issue. Also, I had to fix some unknown issues when using empty records in other languages  (Swift, Python).

This means something like:
```rust
#[derive(uniffi::Record)]
pub struct MyEmptyRecord {}
```

Will produce:
```kotlin
object MyEmptyRecord {}
```

To be honest, I'm not 100% sure my changes to the `TypeConverters` for these record types make sense.

Also, being able to use `data object` instead of `object` would be nice, but it's only compatible with Kotlin 1.9+, and I'm not sure how to create a flag for that, or if it's possible at all.