### PR TITLE
Update docs re uniffi.toml and tweaks to a couple of examples

### DIFF
--- a/docs/manual/src/SUMMARY.md
+++ b/docs/manual/src/SUMMARY.md
@@ -22,17 +22,26 @@
 - [Procedural Macros: Attributes and Derives](./proc_macro/index.md)
 - [Futures and async support](./futures.md)
 
-# Kotlin
+# Bindings
 
+- [Generating bindings](./bindings)
+- [Customizing binding generation](./bindings#customizing-the-binding-generation)
+
+## Kotlin
+
+- [Configuration](./kotlin/configuration)
 - [Integrating with Gradle](./kotlin/gradle.md)
 - [Kotlin Lifetimes](./kotlin/lifetimes.md)
 
-# Swift
+## Swift
 
 - [Overview](./swift/overview.md)
 - [Configuration](./swift/configuration.md)
 - [Building a Swift module](./swift/module.md)
 - [Integrating with Xcode](./swift/xcode.md)
+
+## Python
+- [Configuration](./python/configuration)
 
 # Internals
 - [Design Principles](./internals/design_principles.md)

--- a/docs/manual/src/bindings.md
+++ b/docs/manual/src/bindings.md
@@ -1,0 +1,16 @@
+# Generating bindings
+
+Bindings is the term used for the code generates for foreign languages which integrate
+with Rust crates - that is, the generated Python, Swift or Kotlin code which drives the
+examples.
+
+UniFFI comes with a `uniffi_bindgen` which generates these bindings. For introductory
+information, see [Foreign Language Bindings in the tutorial](./tutorial/foreign_language_bindings.md)
+
+# Customizing the binding generation.
+
+Each of the bindings reads a file `uniffi.toml` in the root of a crate which supports
+various options which influence how the bindings are generated. Default options will be used
+if this file is missing.
+
+Each binding supports different options, so please see the documentation for each binding language.

--- a/docs/manual/src/kotlin/configuration.md
+++ b/docs/manual/src/kotlin/configuration.md
@@ -1,0 +1,36 @@
+# Configuration
+
+The generated Kotlin modules can be configured using a `uniffi.toml` configuration file.
+
+## Available options
+
+| Configuration name | Default  | Description |
+| ------------------ | -------  |------------ |
+| `package_name`     |  `uniffi` | The Kotlin package name - ie, the value used in the `package` statement at the top of generated files. |
+| `cdylib_name`      | `uniffi_{namespace}`[^1] | The name of the compiled Rust library containing the FFI implementation (not needed when using `generate --library`). |
+| `custom_types`      | | A map which controls how custom types are exposed to Kotlin. See the [custom types section of the manual](../udl/custom_types#custom-types-in-the-bindings-code)|
+| `external_packages` | | A map of packages to be used for the specified external crates. The key is the Rust crate name, the value is the Kotlin package which will be used referring to types in that crate. See the [external types section of the manual](../udl/ext_types_external#kotlin)
+
+
+## Example
+
+Custom types
+```toml
+# Assuming a Custom Type named URL using a String as the builtin.
+[bindings.kotlin.custom_types.Url]
+# Name of the type in the Kotlin code
+type_name = "URL"
+# Classes that need to be imported
+imports = [ "java.net.URI", "java.net.URL" ]
+# Functions to convert between strings and URLs
+into_custom = "URI({}).toURL()"
+from_custom = "{}.toString()"
+```
+
+External types
+```toml
+[bindings.kotlin.external_packages]
+# This specifies that external types from the crate `rust-crate-name` will be referred by by the package `"kotlin.package.name`.
+rust-crate-name = "kotlin.package.name"
+```
+

--- a/docs/manual/src/python/configuration.md
+++ b/docs/manual/src/python/configuration.md
@@ -1,0 +1,22 @@
+# Configuration
+
+The generated Python modules can be configured using a `uniffi.toml` configuration file.
+
+## Available options
+
+| Configuration name | Default  | Description |
+| ------------------ | -------  |------------ |
+| `cdylib_name`      | `uniffi_{namespace}`[^1] | The name of the compiled Rust library containing the FFI implementation (not needed when using `generate --library`). |
+| `custom_types`      | | A map which controls how custom types are exposed to Python. See the [custom types section of the manual](../udl/custom_types#custom-types-in-the-bindings-code)|
+
+
+## Example
+
+```toml
+# Assuming a Custom Type named URL using a String as the builtin.
+[bindings.python.custom_types.Url]
+imports = ["urllib.parse"]
+# Functions to convert between strings and the ParsedUrl class
+into_custom = "urllib.parse.urlparse({})"
+from_custom = "urllib.parse.urlunparse({})"
+```

--- a/docs/manual/src/swift/configuration.md
+++ b/docs/manual/src/swift/configuration.md
@@ -12,6 +12,8 @@ The generated Swift module can be configured using a `uniffi.toml` configuration
 | `ffi_module_filename` | `{ffi_module_name}` | The filename stem for the lower-level C module containing the FFI declarations. |
 | `generate_module_map` | `true` | Whether to generate a `.modulemap` file for the lower-level C module with FFI declarations. |
 | `omit_argument_labels` | `false` | Whether to omit argument labels in Swift function definitions. |
+| `custom_types`      | | A map which controls how custom types are exposed to Swift. See the [custom types section of the manual](../udl/custom_types#custom-types-in-the-bindings-code)|
+
 
 [^1]: `namespace` is the top-level namespace from your UDL file.
 

--- a/docs/manual/src/udl/ext_types_external.md
+++ b/docs/manual/src/udl/ext_types_external.md
@@ -80,9 +80,6 @@ By default, UniFFI assumes that the Kotlin module name matches the Rust crate na
 rust-crate-name = "kotlin.package.name"
 ```
 
-See the [`ext-types` fixture](https://github.com/mozilla/uniffi-rs/blob/main/fixtures/ext-types/lib/uniffi.toml)
-for an example
-
 ### Swift
 
 For Swift, you must compile all generated `.swift` files together in a single

--- a/examples/custom-types/src/lib.rs
+++ b/examples/custom-types/src/lib.rs
@@ -1,5 +1,10 @@
 use url::Url;
 
+// A custom guid defined via a proc-macro (ie, not referenced in the UDL)
+// By far the easiest way to define custom types.
+pub struct ExampleCustomType(String);
+uniffi::custom_newtype!(ExampleCustomType, String);
+
 // Custom Handle type which trivially wraps an i64.
 pub struct Handle(pub i64);
 
@@ -106,6 +111,11 @@ pub fn get_custom_types_demo(v: Option<CustomTypesDemo>) -> CustomTypesDemo {
         time_interval_sec_dbl: TimeIntervalSecDbl(456.0),
         time_interval_sec_flt: TimeIntervalSecFlt(777.0),
     })
+}
+
+#[uniffi::export]
+pub fn get_example_custom_type() -> ExampleCustomType {
+    ExampleCustomType("abadidea".to_string())
 }
 
 uniffi::include_scaffolding!("custom-types");

--- a/examples/fxa-client/README.md
+++ b/examples/fxa-client/README.md
@@ -1,0 +1,4 @@
+# Firefox Account Example.
+
+An old version of the UDL for a Firefox Account, as the very first UniFFI consumer.
+See also [the current implementation](https://github.com/mozilla/application-services/tree/main/components/fxa-client)


### PR DESCRIPTION
Better docs for `uniffi.toml`, in preparation for a Python enhancement.