### PR TITLE
Add support for `external_packages` to Python so Python packages can …

### DIFF
--- a/docs/manual/src/python/configuration.md
+++ b/docs/manual/src/python/configuration.md
@@ -8,10 +8,41 @@ The generated Python modules can be configured using a `uniffi.toml` configurati
 | ------------------ | -------  |------------ |
 | `cdylib_name`      | `uniffi_{namespace}`[^1] | The name of the compiled Rust library containing the FFI implementation (not needed when using `generate --library`). |
 | `custom_types`      | | A map which controls how custom types are exposed to Python. See the [custom types section of the manual](../udl/custom_types#custom-types-in-the-bindings-code)|
+| `external_packages` | | A map which controls the package name used by external packages. See below for more.
 
+## External Packages
 
-## Example
+When you reference external modules, uniffi will generate statements like `from module import Type`
+in the referencing module. The `external_packages` configuration value allows you to specify how `module`
+is formed in such statements.
 
+The value is a map, keyed by the crate-name and the value is the package name which will be used by
+Python for that crate. The default value is an empty map.
+
+When looking up crate-name, the following behavior is implemented.
+
+### Default value
+If no value for the crate is found, it is assumed that you will be packaging up your library
+as a simple Python package, so the statement will be of the form `from .module import Type`,
+where `module` is the namespace specified in that crate.
+
+Note that this is invalid syntax unless the module lives in a package - attempting to
+use the module as a stand-alone module will fail. UniFFI just generates flat .py files; the
+packaging is up to you. Eg, a build process might create a directory, create an `__init__.py`
+file in that directory (maybe including `from subpackage import *`) and have `uniffi-bindgen`
+generate the bindings into this directory.
+
+### Specified value
+If the crate-name is found in the map, the specified entry used as a package name, so the statement will be of the form
+`from package.module import Type` (again, where `module` is the namespace specified in that crate)
+
+An exception is when the specified value is an empty string, in which case you will see
+`from module import Type`, so each generated module functions outside a package.
+This is used by some UniFFI tests to avoid the test code needing to create a Python package.
+
+## Examples
+
+Custom Types
 ```toml
 # Assuming a Custom Type named URL using a String as the builtin.
 [bindings.python.custom_types.Url]
@@ -19,4 +50,11 @@ imports = ["urllib.parse"]
 # Functions to convert between strings and the ParsedUrl class
 into_custom = "urllib.parse.urlparse({})"
 from_custom = "urllib.parse.urlunparse({})"
+```
+
+External Packages
+```toml
+[bindings.python.external_packages]
+# An external type `Foo` in `crate-name` (which specifies a namespace of `my_module`) will be referenced via `from MyPackageName.my_module import Foo`
+crate-name = "MyPackageName"
 ```

--- a/fixtures/ext-types/lib/uniffi.toml
+++ b/fixtures/ext-types/lib/uniffi.toml
@@ -1,0 +1,5 @@
+[bindings.python.external_packages]
+# This fixture does not create a Python package, so we want all modules to be top-level modules.
+custom_types = ""
+ext_types_guid = ""
+uniffi_one_ns = ""

--- a/fixtures/ext-types/proc-macro-lib/uniffi.toml
+++ b/fixtures/ext-types/proc-macro-lib/uniffi.toml
@@ -1,0 +1,5 @@
+[bindings.python.external_packages]
+# This fixture does not create a Python package, so we want all modules to be top-level modules.
+custom_types = ""
+ext_types_guid = ""
+uniffi_one_ns = ""

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -75,6 +75,8 @@ pub struct Config {
     cdylib_name: Option<String>,
     #[serde(default)]
     custom_types: HashMap<String, CustomTypeConfig>,
+    #[serde(default)]
+    external_packages: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -92,6 +94,16 @@ impl Config {
             cdylib_name.clone()
         } else {
             "uniffi".into()
+        }
+    }
+
+    /// Get the package name for a given external namespace.
+    pub fn module_for_namespace(&self, ns: &str) -> String {
+        let ns = ns.to_string().to_snake_case();
+        match self.external_packages.get(&ns) {
+            None => format!(".{ns}"),
+            Some(value) if value.is_empty() => ns,
+            Some(value) => format!("{value}.{ns}"),
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/python/templates/ExternalTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ExternalTemplate.py
@@ -1,9 +1,9 @@
-{%- let ns = namespace|fn_name %}
+{%- let module = python_config.module_for_namespace(namespace) -%}
 
 # External type {{name}} is in namespace "{{namespace}}", crate {{module_path}}
 {%- let ffi_converter_name = "_UniffiConverterType{}"|format(name) %}
-{{ self.add_import_of(ns, ffi_converter_name) }}
-{{ self.add_import_of(ns, name) }} {#- import the type alias itself -#}
+{{ self.add_import_of(module, ffi_converter_name) }}
+{{ self.add_import_of(module, name) }} {#- import the type alias itself -#}
 
 {%- let rustbuffer_local_name = "_UniffiRustBuffer{}"|format(name) %}
-{{ self.add_import_of_as(ns, "_UniffiRustBuffer", rustbuffer_local_name) }}
+{{ self.add_import_of_as(module, "_UniffiRustBuffer", rustbuffer_local_name) }}


### PR DESCRIPTION
…be used.

When using external types, the expectation is that most consumers will want to use a Python package which holds all the modules - therefore, imports for external types defaults to `from .module import name`. This behaviour can be changed to support any package name, including just doing a regular top-level module import - which we leverage for some tests.

Fixes #1776

(While this seems sensible to me, feel free to push back on either the implementation or the default)