### PR TITLE
Merge override config with `uniffi.toml`

### DIFF
--- a/docs/manual/src/bindings.md
+++ b/docs/manual/src/bindings.md
@@ -13,4 +13,7 @@ Each of the bindings reads a file `uniffi.toml` in the root of a crate which sup
 various options which influence how the bindings are generated. Default options will be used
 if this file is missing.
 
+`--config` option can be used to specify additional uniffi config file. This config is merged with
+the `uniffi.toml` config present in each crate, with its values taking precedence.
+
 Each binding supports different options, so please see the documentation for each binding language.

--- a/uniffi/src/cli.rs
+++ b/uniffi/src/cli.rs
@@ -35,7 +35,9 @@ enum Commands {
         #[clap(long, short)]
         no_format: bool,
 
-        /// Path to the optional uniffi config file. If not provided, uniffi-bindgen will try to guess it from the UDL's file location.
+        /// Path to optional uniffi config file. This config will be merged on top of default
+        /// `uniffi.toml` config in crate root. The merge recursively upserts TOML keys into
+        /// the default config.
         #[clap(long, short)]
         config: Option<Utf8PathBuf>,
 
@@ -95,15 +97,17 @@ pub fn run_main() -> anyhow::Result<()> {
                 if lib_file.is_some() {
                     panic!("--lib-file is not compatible with --library.")
                 }
-                if config.is_some() {
-                    panic!("--config is not compatible with --library.  The config file(s) will be found automatically.")
-                }
                 let out_dir = out_dir.expect("--out-dir is required when using --library");
                 if language.is_empty() {
                     panic!("please specify at least one language with --language")
                 }
                 uniffi_bindgen::library_mode::generate_bindings(
-                    &source, crate_name, &language, &out_dir, !no_format,
+                    &source,
+                    crate_name,
+                    &language,
+                    config.as_deref(),
+                    &out_dir,
+                    !no_format,
                 )?;
             } else {
                 uniffi_bindgen::generate_bindings(

--- a/uniffi/src/cli.rs
+++ b/uniffi/src/cli.rs
@@ -35,9 +35,7 @@ enum Commands {
         #[clap(long, short)]
         no_format: bool,
 
-        /// Path to optional uniffi config file. This config will be merged on top of default
-        /// `uniffi.toml` config in crate root. The merge recursively upserts TOML keys into
-        /// the default config.
+        /// Path to optional uniffi config file. This config is merged with the `uniffi.toml` config present in each crate, with its values taking precedence.
         #[clap(long, short)]
         config: Option<Utf8PathBuf>,
 

--- a/uniffi_bindgen/src/bindings/kotlin/test.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/test.rs
@@ -41,6 +41,7 @@ pub fn run_script(
         &cdylib_path,
         None,
         &[TargetLanguage::Kotlin],
+        None,
         &out_dir,
         false,
     )?;

--- a/uniffi_bindgen/src/bindings/python/test.rs
+++ b/uniffi_bindgen/src/bindings/python/test.rs
@@ -42,6 +42,7 @@ pub fn run_script(
         &cdylib_path,
         None,
         &[TargetLanguage::Python],
+        None,
         &out_dir,
         false,
     )?;

--- a/uniffi_bindgen/src/bindings/ruby/test.rs
+++ b/uniffi_bindgen/src/bindings/ruby/test.rs
@@ -34,7 +34,14 @@ pub fn test_script_command(
     let test_helper = UniFFITestHelper::new(fixture_name)?;
     let out_dir = test_helper.create_out_dir(tmp_dir, &script_path)?;
     let cdylib_path = test_helper.copy_cdylib_to_out_dir(&out_dir)?;
-    generate_bindings(&cdylib_path, None, &[TargetLanguage::Ruby], &out_dir, false)?;
+    generate_bindings(
+        &cdylib_path,
+        None,
+        &[TargetLanguage::Ruby],
+        None,
+        &out_dir,
+        false,
+    )?;
 
     let rubypath = env::var_os("RUBYLIB").unwrap_or_else(|| OsString::from(""));
     let rubypath = env::join_paths(

--- a/uniffi_bindgen/src/bindings/swift/test.rs
+++ b/uniffi_bindgen/src/bindings/swift/test.rs
@@ -126,8 +126,14 @@ struct GeneratedSources {
 
 impl GeneratedSources {
     fn new(crate_name: &str, cdylib_path: &Utf8Path, out_dir: &Utf8Path) -> Result<Self> {
-        let sources =
-            generate_bindings(cdylib_path, None, &[TargetLanguage::Swift], out_dir, false)?;
+        let sources = generate_bindings(
+            cdylib_path,
+            None,
+            &[TargetLanguage::Swift],
+            None,
+            out_dir,
+            false,
+        )?;
         let main_source = sources
             .iter()
             .find(|s| s.package.name == crate_name)

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -417,22 +417,53 @@ fn format_code_with_rustfmt(path: &Utf8Path) -> Result<()> {
     Ok(())
 }
 
+/// Load TOML from file if the file exists.
+fn load_toml_file(source: Option<&Utf8Path>) -> Result<Option<toml::value::Table>> {
+    if let Some(source) = source {
+        if source.exists() {
+            let contents =
+                fs::read_to_string(source).with_context(|| format!("read file: {:?}", source))?;
+            return Ok(Some(
+                toml::de::from_str(&contents)
+                    .with_context(|| format!("parse toml: {:?}", source))?,
+            ));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Load the default `uniffi.toml` config, merge TOML trees with `config_file_override` if specified.
 fn load_initial_config<Config: DeserializeOwned>(
     crate_root: &Utf8Path,
     config_file_override: Option<&Utf8Path>,
 ) -> Result<Config> {
-    let path = match config_file_override {
-        Some(cfg) => Some(cfg.to_owned()),
-        None => crate_root.join("uniffi.toml").canonicalize_utf8().ok(),
-    };
-    let toml_config = match path {
-        Some(path) => {
-            let contents = fs::read_to_string(path).context("Failed to read config file")?;
-            toml::de::from_str(&contents)?
+    let mut config = load_toml_file(Some(crate_root.join("uniffi.toml").as_path()))
+        .context("default config")?
+        .unwrap_or(toml::value::Table::default());
+
+    let override_config = load_toml_file(config_file_override).context("override config")?;
+    if let Some(override_config) = override_config {
+        merge_toml(&mut config, override_config);
+    }
+
+    Ok(toml::Value::from(config).try_into()?)
+}
+
+fn merge_toml(a: &mut toml::value::Table, b: toml::value::Table) {
+    for (key, value) in b.into_iter() {
+        match a.get_mut(&key) {
+            Some(existing_value) => match (existing_value, value) {
+                (toml::Value::Table(ref mut t0), toml::Value::Table(t1)) => {
+                    merge_toml(t0, t1);
+                }
+                (v, value) => *v = value,
+            },
+            None => {
+                a.insert(key, value);
+            }
         }
-        None => toml::Value::from(toml::value::Table::default()),
-    };
-    Ok(toml_config.try_into()?)
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]


### PR DESCRIPTION
Instead of replacing `uniffi.toml` with override config entirely, merge the override config into `uniffi.toml`. The merge recursively upserts TOML keys.

This strategy seems pretty standard everywhere when it comes to configuration. Merging allows the configuration to be selectively changed, without having to duplicate the entire default configuration.

The main use case for this would be to allow "global" configuration across multiple crates in a library. Some configuration options should be the same for all crates in a library, without having to duplicate these options across all crates. Right now I can think of a few use cases of such configuration:

- In Swift generator, `omit_argument_labels`. I'm not entirely sure if anyone is actually using this, but it seems like an option that someone might potentially want to configure for all crates in a library.

- In `uniffi-bindgen-go`, `go_mod` configuration key is used to control the prefix for external type imports. Multiple crates in a library using external types share a common prefix when it comes to importing the external types, e.g. `com.example.uniffi.*`. This should configured as a single property for all crates.

- In `uniffi-bindgen-cs`, `visibility_modifier` configuration key is used to control the visibility modifier for "public" types. In C# visibility is applied to "assembly" level, not "file" level. So if bindings consumers wishes to package the bindings into his own "assembly" (library?), then "public" fields would be public for the consumers of the wrapper aswell https://github.com/NordSecurity/uniffi-bindgen-go/pull/13. This option would also benefit from a global config, since you would expect this value to remain the same for all crates in Rust library.

- External binding generators can use the merge option to inject additional configuration into `custom_types` fixture. This one is a bit sketchy, because external binding generators might want to modify the configuration for specific fixture/example crates in upstream, instead of doing global configuration for all crates. Still, global configuration solves the immediate issue of configuring `custom_types` crate to including `Url` custom type for external bindings.