### PR TITLE
Add an example of and better docs for foreign traits.

### DIFF
--- a/docs/manual/src/SUMMARY.md
+++ b/docs/manual/src/SUMMARY.md
@@ -26,6 +26,7 @@
 
 - [Generating bindings](./bindings)
 - [Customizing binding generation](./bindings#customizing-the-binding-generation)
+- [Implementing Rust traits in foreign bindings](./foreign_traits)
 
 ## Kotlin
 

--- a/docs/manual/src/foreign_traits.md
+++ b/docs/manual/src/foreign_traits.md
@@ -1,0 +1,146 @@
+# Foreign traits
+
+UniFFI traits can be implemented by foreign code.
+This means traits implemented in Python/Swift/Kotlin etc can provide Rust code with capabilities not easily implemented in Rust, such as:
+
+ * device APIs not directly available to Rust.
+ * provide glue to clip together Rust components at runtime.
+ * access shared resources and assets bundled with the app.
+
+# Example
+
+To implement a Rust trait in a foreign language, you might:
+
+## 1. Define a Rust trait
+
+This toy example defines a way of Rust accessing a key-value store exposed
+by the host operating system (e.g. the key chain).
+
+All methods of the Rust trait should return a `Result<>` with the error half being
+a [compatible error type](./udl/errors.md) - see below for more on error handling.
+
+For example:
+
+```rust,no_run
+pub trait Keychain: Send + Sync + Debug {
+  fn get(&self, key: String) -> Result<Option<String>, KeyChainError>;
+  fn put(&self, key: String, value: String) -> Result<(), KeyChainError>;
+}
+```
+
+If you are using macros add `#[uniffi::export]` above the trait.
+Otherwise define this trait in your UDL file:
+
+```webidl
+[Trait]
+interface Keychain {
+    [Throws=KeyChainError]
+    string? get(string key);
+
+    [Throws=KeyChainError]
+    void put(string key, string data);
+};
+```
+
+## 2. Allow it to be passed into Rust
+
+Here, we define a new object with a constructor which takes a keychain.
+
+```webidl
+interface Authenticator {
+    constructor(Keychain keychain);
+    void login();
+};
+```
+
+In Rust we'd write:
+
+```rust,no_run
+struct Authenticator {
+  keychain: Arc<dyn Keychain>,
+}
+
+impl Authenticator {
+  pub fn new(keychain: Arc<dyn Keychain>) -> Self {
+    Self { keychain }
+  }
+
+  pub fn login(&self) {
+    let username = self.keychain.get("username".into());
+    let password = self.keychain.get("password".into());
+  }
+}
+```
+
+## 3. Create a foreign language implementation of the trait
+
+Here's a Kotlin implementation:
+
+```kotlin
+class KotlinKeychain: Keychain {
+    override fun get(key: String): String? {
+        // … elide the implementation.
+        return value
+    }
+    override fun put(key: String) {
+        // … elide the implementation.
+    }
+}
+```
+
+…and Swift:
+
+```swift
+class SwiftKeychain: Keychain {
+    func get(key: String) -> String? {
+        // … elide the implementation.
+        return value
+    }
+    func put(key: String) {
+        // … elide the implementation.
+    }
+}
+```
+
+## 4. Pass the implementation to Rust
+
+Again, in Kotlin
+
+```kt
+val authenticator = Authenticator(KotlinKeychain())
+// later on:
+authenticator.login()
+```
+
+and in Swift:
+
+```swift
+let authenticator = Authenticator(SwiftKeychain())
+// later on:
+authenticator.login()
+```
+
+Care is taken to ensure that things are cleaned up in the foreign language once all Rust references drop.
+
+## ⚠️  Avoid cycles
+
+Foreign trait implementations make it easy to create cycles between Rust and foreign objects causing memory leaks.
+For example a foreign implementation holding a reference to a Rust object which also holds a reference to the same foreign implementation.
+
+UniFFI doesn't try to help here and there's no universal advice; take the usual precautions.
+
+# Error handling
+
+We must handle foreign code failing, so all methods of the Rust trait should return a `Result<>` with a [compatible error type](./udl/errors.md) otherwise these errors will panic.
+
+## Unexpected Error handling.
+
+So long as your function returns a `Result<>`, it's possible for you to define how "unexpected" errors
+(ie, errors not directly covered by your `Result<>` type, panics, etc) are converted to your `Result<>`'s `Err`.
+
+If your code defines a `From<uniffi::UnexpectedUniFFICallbackError>` impl for your error type, then those errors will be converted into your error type which will be returned to the Rust caller.
+If your code does not define this implementation the generated code will panic.
+In other words, you really should implement this!
+
+See our [callbacks example](https://github.com/mozilla/uniffi-rs/tree/main/examples/callbacks) for more.
+

--- a/docs/manual/src/udl/callback_interfaces.md
+++ b/docs/manual/src/udl/callback_interfaces.md
@@ -1,176 +1,36 @@
 # Callback interfaces
 
-Callback interfaces are traits specified in UDL which can be implemented by foreign languages.
+Callback interfaces are a special implementation of
+[Rust traits implemented by foreign languages](../foreign_traits).
 
-They can provide Rust code access available to the host language, but not easily replicated
-in Rust.
+These are described in both UDL and proc-macros as an explict "callback interface".
+They are (soft) deprecated, remain now for backwards compatibility, but probably
+should be avoided.
 
- * accessing device APIs.
- * provide glue to clip together Rust components at runtime.
- * access shared resources and assets bundled with the app.
+This document describes the differences from regular traits.
 
-# Using callback interfaces
-
-## 1. Define a Rust trait
-
-This toy example defines a way of Rust accessing a key-value store exposed
-by the host operating system (e.g. the key chain).
-
-```rust,no_run
-pub trait Keychain: Send + Sync + Debug {
-  fn get(&self, key: String) -> Result<Option<String>, KeyChainError>;
-  fn put(&self, key: String, value: String) -> Result<(), KeyChainError>;
-}
-```
-
-### Send + Sync?
-
-The concrete types that UniFFI generates for callback interfaces implement `Send`, `Sync`, and `Debug`, so it's legal to
-include these as supertraits of your callback interface trait.  This isn't strictly necessary, but it's often useful.  In
-particular, `Send + Sync` is useful when:
-  - Storing `Box<dyn CallbackInterfaceTrait>` types inside a type that needs to be `Send + Sync` (for example a UniFFI
-    interface type)
-  - Storing `Box<dyn CallbackInterfaceTrait>` inside a global `Mutex` or `RwLock`
-
-**⚠ Warning ⚠**: this comes with a caveat: the methods of the foreign class must be safe to call
-from multiple threads at once, for example because they are synchronized with a mutex, or use
-thread-safe data structures.  However, Rust can not enforce this in the foreign code.  If you add
-`Send + Sync` to your callback interface, you must make sure to inform your library consumers that
-their implementations must logically be Send + Sync.
-
-## 2. Setup error handling
-
-All methods of the Rust trait should return a Result.  The error half of that result must
-be an [error type defined in the UDL](./errors.md).
-
-It's currently allowed for callback interface methods to return a regular value
-rather than a `Result<>`.  However, this is means that any exception from the
-foreign bindings will lead to a panic.
-
-### Errors used in callback interfaces
-
-In order to support errors in callback interfaces, UniFFI must be able to
-properly [lift the error](../internals/lifting_and_lowering.md).  This means
-that the if the error is described by an `enum` rather than an `interface` in
-the UDL (see [Errors](./errors.md)) then all variants of the Rust enum must be unit variants.
-
-### Unexpected errors
-
-When Rust code invokes a callback interface method, that call may result in all kinds of unexpected errors.
-Some examples are the foreign code throws an exception that's not part of the exception type or there was a problem marshalling the data for the call.
-UniFFI creates an `uniffi::UnexpectedUniFFICallbackError` for these cases.
-If your code defines a `From<uniffi::UnexpectedUniFFICallbackError>` impl for your error type, then those errors will be converted into your error type which will be returned to the Rust caller.
-If not, then any unexpected errors will result in a panic.
-See `example/callbacks` for an example of this.
-
-## 3. Define a callback interface in the UDL
-
+## Defining a callback
+If you must define a callback in UDL it would look like:
 ```webidl
 callback interface Keychain {
-    [Throws=KeyChainError]
-    string? get(string key);
-
-    [Throws=KeyChainError]
-    void put(string key, string data);
+  // as described in the foreign traits docs...
 };
 ```
 
-## 4. And allow it to be passed into Rust
+procmacros support it too, but just don't use it :)
 
-Here, we define a constructor to pass the keychain to rust, and then another method
-which may use it.
+### Box and Send + Sync?
 
-In UDL:
+Traits defined purely for callbacks probably don't technically need to be `Sync` in Rust, but
+they conceptually are, just outside of Rust's view.
 
-```webidl
-interface Authenticator {
-    constructor(Keychain keychain);
-    void login();
-};
-```
+That is, the methods of the foreign class must be safe to call
+from multiple threads at once, but Rust can not enforce this in the foreign code.
 
-In Rust:
+## Rust signature differences
 
-```rust,no_run
-struct Authenticator {
-  keychain: Box<dyn Keychain>,
-}
+Consider the examples in [Rust traits implemented by foreign languages](../foreign_traits).
 
-impl Authenticator {
-  pub fn new(keychain: Box<dyn Keychain>) -> Self {
-    Self { keychain }
-  }
-  pub fn login(&self) {
-    let username = self.keychain.get("username".into());
-    let password = self.keychain.get("password".into());
-  }
-}
-```
-
-## 5. Create an foreign language implementation of the callback interface
-
-In this example, here's a Kotlin implementation.
-
-```kotlin
-class KotlinKeychain: Keychain {
-    override fun get(key: String): String? {
-        // … elide the implementation.
-        return value
-    }
-    override fun put(key: String) {
-        // … elide the implementation.
-    }
-}
-```
-
-…and Swift:
-
-```swift
-class SwiftKeychain: Keychain {
-    func get(key: String) -> String? {
-        // … elide the implementation.
-        return value
-    }
-    func put(key: String) {
-        // … elide the implementation.
-    }
-}
-```
-
-Note: in Swift, this must be a `class`.
-
-## 6. Pass the implementation to Rust
-
-Again, in Kotlin
-
-```kt
-val authenticator = Authenticator(KotlinKeychain())
-// later on:
-authenticator.login()
-```
-
-and in Swift:
-
-```swift
-let authenticator = Authenticator(SwiftKeychain())
-// later on:
-authenticator.login()
-```
-
-Care is taken to ensure that once `Box<dyn Keychain>` is dropped in Rust, then it is cleaned up in the foreign language.
-
-Also note, that storing the `Box<dyn Keychain>` in the `Authenticator` required that all implementations
-*must* implement `Send`.
-
-## ⚠️  Avoid callback interfaces cycles
-
-Callback interfaces can create cycles between Rust and foreign objects and lead to memory leaks.  For example a callback
-interface object holds a reference to a Rust object which also holds a reference to the same callback interface object.
-Take care to avoid this by following guidelines:
-
-1. Avoid references to UniFFI objects in callback objects, including direct references and transitive
-   references through intermediate objects.
-2. Avoid references to callback objects from UniFFI objects, including direct references and transitive
-   references through intermediate objects.
-3. If you need to break the first 2 guidelines, then take steps to manually break the cycles to avoid memory leaks.
-   Alternatively, ensure that the number of objects that can ever be created is bounded below some acceptable level.
+If the traits in question are defined as a "callback" interface, the `Arc<dyn Keychain>` types
+would actually be `Box<dyn Keychain>` - eg, the Rust implementation of the `Authenticator`
+constructor would be ```fn new(keychain: Box<dyn Keychain>) -> Self``` instead of the `Arc<>`.

--- a/examples/callbacks/README.md
+++ b/examples/callbacks/README.md
@@ -1,0 +1,5 @@
+This is an example of UniFFI "callbacks".
+
+Callbacks are the ability to implement Rust traits in foreign languges. These are defined by
+[normal UniFFI traits](../../docs/manual/src/foreign_traits) or via  ["callback" definitions](../../docs/manual/src/udl/callback_interfaces).
+

--- a/examples/callbacks/src/callbacks.udl
+++ b/examples/callbacks/src/callbacks.udl
@@ -1,4 +1,12 @@
-namespace callbacks {};
+namespace callbacks {
+  // `get_sim_cards` is defined via a procmacro.
+};
+
+// This trait is implemented in Rust and in foreign bindings.
+[Trait]
+interface SimCard {
+  string name(); // The name of the carrier/provider.
+};
 
 [Error]
 enum TelephoneError {
@@ -9,9 +17,11 @@ enum TelephoneError {
 interface Telephone {
   constructor();
   [Throws=TelephoneError]
-  string call(CallAnswerer answerer);
+  string call(SimCard sim, CallAnswerer answerer);
 };
 
+// callback interfaces are discouraged now that foreign code can
+// implement traits, but here's one!
 callback interface CallAnswerer {
   [Throws=TelephoneError]
   string answer();

--- a/examples/callbacks/src/lib.rs
+++ b/examples/callbacks/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 #[derive(Debug, thiserror::Error)]
 pub enum TelephoneError {
     #[error("Busy")]
@@ -18,6 +20,25 @@ impl From<uniffi::UnexpectedUniFFICallbackError> for TelephoneError {
     }
 }
 
+// SIM cards.
+pub trait SimCard: Send + Sync {
+    fn name(&self) -> String;
+}
+
+struct RustySim;
+impl SimCard for RustySim {
+    fn name(&self) -> String {
+        "rusty!".to_string()
+    }
+}
+
+// namespace functions.
+#[uniffi::export]
+fn get_sim_cards() -> Vec<Arc<dyn SimCard>> {
+    vec![Arc::new(RustySim {})]
+}
+
+// The call-answer, callback interface.
 pub trait CallAnswerer {
     fn answer(&self) -> Result<String, TelephoneError>;
 }
@@ -29,8 +50,42 @@ impl Telephone {
         Self {}
     }
 
-    pub fn call(&self, answerer: Box<dyn CallAnswerer>) -> Result<String, TelephoneError> {
-        answerer.answer()
+    pub fn call(
+        &self,
+        // Traits are Arc<>, callbacks Box<>.
+        sim: Arc<dyn SimCard>,
+        answerer: Box<dyn CallAnswerer>,
+    ) -> Result<String, TelephoneError> {
+        if sim.name() != "rusty!" {
+            Ok(format!("{} est bon marché", sim.name()))
+        } else {
+            answerer.answer()
+        }
+    }
+}
+
+// Some proc-macro definitions of the same thing.
+#[derive(uniffi::Object, Debug, Default, Clone)]
+pub struct FancyTelephone;
+
+#[uniffi::export]
+impl FancyTelephone {
+    #[uniffi::constructor]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self)
+    }
+
+    // Exact same signature as the UDL version.
+    pub fn call(
+        &self,
+        sim: Arc<dyn SimCard>,
+        answerer: Box<dyn CallAnswerer>,
+    ) -> Result<String, TelephoneError> {
+        if sim.name() != "rusty!" {
+            Ok(format!("{} est bon marché", sim.name()))
+        } else {
+            answerer.answer()
+        }
     }
 }
 

--- a/examples/callbacks/tests/bindings/test_callbacks.kts
+++ b/examples/callbacks/tests/bindings/test_callbacks.kts
@@ -22,18 +22,27 @@ class CallAnswererImpl(val mode: String) : CallAnswerer {
 }
 
 val telephone = Telephone()
+val sim = getSimCards()[0]
 
-assert(telephone.call(CallAnswererImpl("normal")) == "Bonjour")
+assert(telephone.call(sim, CallAnswererImpl("normal")) == "Bonjour")
+
+// Our own sim.
+class Sim() : SimCard {
+    override fun name(): String {
+        return "kotlin"
+    }
+}
+assert(telephone.call(Sim(), CallAnswererImpl("normal")) == "kotlin est bon marché")
 
 try {
-    telephone.call(CallAnswererImpl("busy"))
+    telephone.call(sim, CallAnswererImpl("busy"))
     throw RuntimeException("Should have thrown a Busy exception!")
 } catch(e: TelephoneException.Busy) {
     // It's okay
 }
 
 try {
-    telephone.call(CallAnswererImpl("something-else"))
+    telephone.call(sim, CallAnswererImpl("something-else"))
     throw RuntimeException("Should have thrown an internal exception!")
 } catch(e: TelephoneException.InternalTelephoneException) {
     // It's okay

--- a/examples/callbacks/tests/bindings/test_callbacks.py
+++ b/examples/callbacks/tests/bindings/test_callbacks.py
@@ -1,6 +1,8 @@
 import unittest
 from callbacks import *
 
+# This is defined in UDL as a "callback". It's not possible to have a Rust
+# implementation of a callback, they only exist on the foreign side.
 class CallAnswererImpl(CallAnswerer):
     def __init__(self, mode):
         self.mode = mode
@@ -13,22 +15,39 @@ class CallAnswererImpl(CallAnswerer):
         else:
             raise ValueError("Testing an unexpected error")
 
+# This is a normal Rust trait - very much like a callback but can be implemented
+# in Rust or in foreign code and is generally more consistent with the uniffi
+# Arc<>-based object model.
+class DiscountSim(SimCard):
+    def name(self):
+        return "python"
+
 class CallbacksTest(unittest.TestCase):
+    TelephoneImpl = Telephone
     def test_answer(self):
         cb_object = CallAnswererImpl("ready")
-        telephone = Telephone()
-        self.assertEqual("Bonjour", telephone.call(cb_object))
+        telephone = self.TelephoneImpl()
+        self.assertEqual("Bonjour", telephone.call(get_sim_cards()[0], cb_object))
 
     def test_busy(self):
         cb_object = CallAnswererImpl("busy")
-        telephone = Telephone()
+        telephone = self.TelephoneImpl()
         with self.assertRaises(TelephoneError.Busy):
-            telephone.call(cb_object)
+            telephone.call(get_sim_cards()[0], cb_object)
 
     def test_unexpected_error(self):
         cb_object = CallAnswererImpl("something-else")
-        telephone = Telephone()
+        telephone = self.TelephoneImpl()
         with self.assertRaises(TelephoneError.InternalTelephoneError):
-            telephone.call(cb_object)
+            telephone.call(get_sim_cards()[0], cb_object)
+
+    def test_sims(self):
+        cb_object = CallAnswererImpl("ready")
+        telephone = self.TelephoneImpl()
+        sim = DiscountSim()
+        self.assertEqual("python est bon marché", telephone.call(sim, cb_object))
+
+class FancyCallbacksTest(CallbacksTest):
+    TelephoneImpl = FancyTelephone
 
 unittest.main()

--- a/examples/callbacks/tests/bindings/test_callbacks.swift
+++ b/examples/callbacks/tests/bindings/test_callbacks.swift
@@ -33,17 +33,28 @@ class OnCallAnsweredImpl : CallAnswerer {
 }
 
 let telephone = Telephone()
+let sim = getSimCards()[0];
 
-assert(try! telephone.call(answerer: OnCallAnsweredImpl(withMode: "ready")) == "Bonjour")
+assert(try! telephone.call(sim: sim, answerer: OnCallAnsweredImpl(withMode: "ready")) == "Bonjour")
 
+// We can implement our own sim cards.
+class Sim : SimCard {
+    func name() -> String {
+        return "swift"
+    }
+}
+
+assert(try! telephone.call(sim: Sim(), answerer: OnCallAnsweredImpl(withMode: "ready")) == "swift est bon marché")
+
+// Error cases.
 do {
-    _ = try telephone.call(answerer: OnCallAnsweredImpl(withMode: "busy"))
+    _ = try telephone.call(sim: sim, answerer: OnCallAnsweredImpl(withMode: "busy"))
 } catch TelephoneError.Busy {
     // Expected error
 }
 
 do {
-    _ = try telephone.call(answerer: OnCallAnsweredImpl(withMode: "unexpected-value"))
+    _ = try telephone.call(sim: sim, answerer: OnCallAnsweredImpl(withMode: "unexpected-value"))
 } catch TelephoneError.InternalTelephoneError {
     // Expected error
 }


### PR DESCRIPTION
The main point of that is to somewhat de-emphasize callbacks and put them on an even keel with foreign traits. It doesn't go so far as to deprecate callbacks, but I think ultimately that's where we are likely to end up.