### PR TITLE
Fix for multiple crates defining async functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.25.0...HEAD).
 
+### What's changed?
+
+- The `rust_future_continuation_callback_set` FFI function was removed.  `rust_future_poll` now
+  inputs the callback pointer.  External bindings authors will need to update their code.
+
 ## v0.25.0 (backend crates: v0.25.0) - (_2023-10-18_)
 
 [All changes in v0.25.0](https://github.com/mozilla/uniffi-rs/compare/v0.24.3...v0.25.0).

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.kts
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.kts
@@ -29,6 +29,9 @@ assert(getUniffiOneTypes(listOf(uot)) == listOf(uot))
 assert(getMaybeUniffiOneTypes(listOf(uot, null)) == listOf(uot, null))
 
 runBlocking {
+    // This async function comes from the `uniffi-one` crate
+    assert(getUniffiOneAsync() == UniffiOneEnum.ONE)
+    // This async function comes from the `proc-macro-lib` crate
     assert(getUniffiOneTypeAsync(uot) == uot)
 }
 

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.py
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.py
@@ -36,9 +36,15 @@ class TestIt(unittest.TestCase):
         self.assertEqual(None, get_maybe_uniffi_one_type(None))
         self.assertEqual([t1], get_uniffi_one_types([t1]))
         self.assertEqual([t1, None], get_maybe_uniffi_one_types([t1, None]))
-        async def test_async():
+
+    def test_async(self):
+        async def test():
+            t1 = UniffiOneType("hello")
+            # This async function comes from the `uniffi-one` crate
+            self.assertEqual(await get_uniffi_one_async(), UniffiOneEnum.ONE)
+            # This async function comes from the `proc-macro-lib` crate
             self.assertEqual(t1, await get_uniffi_one_type_async(t1))
-        asyncio.run(test_async())
+        asyncio.run(test())
 
     def test_get_uniffi_one_proc_macro_type(self):
         t1 = UniffiOneProcMacroType("hello")

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.swift
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.swift
@@ -29,8 +29,14 @@ assert(getMaybeUniffiOneTypes(ts: [UniffiOneType(sval: "hello"), nil]) == [Uniff
 var counter = DispatchGroup()
 counter.enter()
 Task {
-    let t = await getUniffiOneTypeAsync(t: UniffiOneType(sval: "hello"))
-    assert(t.sval == "hello")
+    // This async function comes from the `uniffi-one` crate
+    let uniffiOneEnum = await getUniffiOneAsync()
+    assert(uniffiOneEnum == UniffiOneEnum.one)
+
+    // This async function comes from the `proc-macro-lib` crate
+    let uniffiOneType = await getUniffiOneTypeAsync(t: UniffiOneType(sval: "hello"))
+    assert(uniffiOneType.sval == "hello")
+
     counter.leave()
 }
 counter.wait()

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -196,7 +196,6 @@ pub struct KotlinWrapper<'a> {
     ci: &'a ComponentInterface,
     type_helper_code: String,
     type_imports: BTreeSet<ImportRequirement>,
-    has_async_fns: bool,
 }
 
 impl<'a> KotlinWrapper<'a> {
@@ -209,7 +208,6 @@ impl<'a> KotlinWrapper<'a> {
             ci,
             type_helper_code,
             type_imports,
-            has_async_fns: ci.has_async_fns(),
         }
     }
 
@@ -218,10 +216,6 @@ impl<'a> KotlinWrapper<'a> {
             .iter_types()
             .map(|t| KotlinCodeOracle.find(t))
             .filter_map(|ct| ct.initialization_fn())
-            .chain(
-                self.has_async_fns
-                    .then(|| "uniffiRustFutureContinuationCallback.register".into()),
-            )
             .collect()
     }
 
@@ -551,7 +545,7 @@ pub mod filters {
     ) -> Result<String, askama::Error> {
         let ffi_func = callable.ffi_rust_future_poll(ci);
         Ok(format!(
-            "{{ future, continuation -> _UniFFILib.INSTANCE.{ffi_func}(future, continuation) }}"
+            "{{ future, callback, continuation -> _UniFFILib.INSTANCE.{ffi_func}(future, callback, continuation) }}"
         ))
     }
 

--- a/uniffi_bindgen/src/bindings/python/templates/Async.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Async.py
@@ -25,6 +25,7 @@ async def _uniffi_rust_call_async(rust_future, ffi_poll, ffi_complete, ffi_free,
             future = eventloop.create_future()
             ffi_poll(
                 rust_future,
+                _uniffi_continuation_callback,
                 _UniffiContinuationPointerManager.new_pointer((eventloop, future)),
             )
             poll_code = await future
@@ -36,5 +37,3 @@ async def _uniffi_rust_call_async(rust_future, ffi_poll, ffi_complete, ffi_free,
         )
     finally:
         ffi_free(rust_future)
-
-_UniffiLib.{{ ci.ffi_rust_future_continuation_callback_set().name() }}(_uniffi_continuation_callback)

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -340,7 +340,6 @@ pub struct SwiftWrapper<'a> {
     ci: &'a ComponentInterface,
     type_helper_code: String,
     type_imports: BTreeSet<String>,
-    has_async_fns: bool,
 }
 impl<'a> SwiftWrapper<'a> {
     pub fn new(config: Config, ci: &'a ComponentInterface) -> Self {
@@ -352,7 +351,6 @@ impl<'a> SwiftWrapper<'a> {
             ci,
             type_helper_code,
             type_imports,
-            has_async_fns: ci.has_async_fns(),
         }
     }
 
@@ -365,10 +363,6 @@ impl<'a> SwiftWrapper<'a> {
             .iter_types()
             .map(|t| SwiftCodeOracle.find(t))
             .filter_map(|ct| ct.initialization_fn())
-            .chain(
-                self.has_async_fns
-                    .then(|| "uniffiInitContinuationCallback".into()),
-            )
             .collect()
     }
 }

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -435,24 +435,6 @@ impl ComponentInterface {
         }
     }
 
-    /// Builtin FFI function to set the Rust Future continuation callback
-    pub fn ffi_rust_future_continuation_callback_set(&self) -> FfiFunction {
-        FfiFunction {
-            name: format!(
-                "ffi_{}_rust_future_continuation_callback_set",
-                self.ffi_namespace()
-            ),
-            arguments: vec![FfiArgument {
-                name: "callback".to_owned(),
-                type_: FfiType::RustFutureContinuationCallback,
-            }],
-            return_type: None,
-            is_async: false,
-            has_rust_call_status_arg: false,
-            is_object_free_function: false,
-        }
-    }
-
     /// Builtin FFI function to poll a Rust future.
     pub fn ffi_rust_future_poll(&self, return_ffi_type: Option<FfiType>) -> FfiFunction {
         FfiFunction {
@@ -463,9 +445,12 @@ impl ComponentInterface {
                     name: "handle".to_owned(),
                     type_: FfiType::RustFutureHandle,
                 },
-                // Data to pass to the continuation
                 FfiArgument {
-                    name: "uniffi_callback".to_owned(),
+                    name: "callback".to_owned(),
+                    type_: FfiType::RustFutureContinuationCallback,
+                },
+                FfiArgument {
+                    name: "callback_data".to_owned(),
                     type_: FfiType::RustFutureContinuationData,
                 },
             ],
@@ -644,18 +629,16 @@ impl ComponentInterface {
             None,
         ];
 
-        iter::once(self.ffi_rust_future_continuation_callback_set()).chain(
-            all_possible_return_ffi_types
-                .into_iter()
-                .flat_map(|return_type| {
-                    [
-                        self.ffi_rust_future_poll(return_type.clone()),
-                        self.ffi_rust_future_cancel(return_type.clone()),
-                        self.ffi_rust_future_free(return_type.clone()),
-                        self.ffi_rust_future_complete(return_type),
-                    ]
-                }),
-        )
+        all_possible_return_ffi_types
+            .into_iter()
+            .flat_map(|return_type| {
+                [
+                    self.ffi_rust_future_poll(return_type.clone()),
+                    self.ffi_rust_future_cancel(return_type.clone()),
+                    self.ffi_rust_future_free(return_type.clone()),
+                    self.ffi_rust_future_complete(return_type),
+                ]
+            })
     }
 
     /// The ffi_foreign_executor_callback_set FFI function

--- a/uniffi_macros/src/setup_scaffolding.rs
+++ b/uniffi_macros/src/setup_scaffolding.rs
@@ -22,8 +22,6 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
     let reexport_hack_ident = format_ident!("{module_path}_uniffi_reexport_hack");
     let ffi_foreign_executor_callback_set_ident =
         format_ident!("ffi_{module_path}_foreign_executor_callback_set");
-    let ffi_rust_future_continuation_callback_set =
-        format_ident!("ffi_{module_path}_rust_future_continuation_callback_set");
     let ffi_rust_future_scaffolding_fns = rust_future_scaffolding_fns(&module_path);
 
     Ok(quote! {
@@ -94,13 +92,6 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
         #[no_mangle]
         pub extern "C" fn #ffi_foreign_executor_callback_set_ident(callback: uniffi::ffi::ForeignExecutorCallback) {
             uniffi::ffi::foreign_executor_callback_set(callback)
-        }
-
-        #[allow(clippy::missing_safety_doc, missing_docs)]
-        #[doc(hidden)]
-        #[no_mangle]
-        pub unsafe extern "C" fn #ffi_rust_future_continuation_callback_set(callback: ::uniffi::RustFutureContinuationCallback) {
-            ::uniffi::ffi::rust_future_continuation_callback_set(callback);
         }
 
         #ffi_rust_future_scaffolding_fns
@@ -184,8 +175,8 @@ fn rust_future_scaffolding_fns(module_path: &str) -> TokenStream {
             #[allow(clippy::missing_safety_doc, missing_docs)]
             #[doc(hidden)]
             #[no_mangle]
-            pub unsafe extern "C" fn #ffi_rust_future_poll(handle: ::uniffi::RustFutureHandle, data: *const ()) {
-                ::uniffi::ffi::rust_future_poll::<#return_type>(handle, data);
+            pub unsafe extern "C" fn #ffi_rust_future_poll(handle: ::uniffi::RustFutureHandle, callback: ::uniffi::RustFutureContinuationCallback, data: *const ()) {
+                ::uniffi::ffi::rust_future_poll::<#return_type>(handle, callback, data);
             }
 
             #[allow(clippy::missing_safety_doc, missing_docs)]

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -23,7 +23,7 @@ mod metadata;
 // `docs/uniffi-versioning.md` for details.
 //
 // Once we get to 1.0, then we'll need to update the scheme to something like 100 + major_version
-pub const UNIFFI_CONTRACT_VERSION: u32 = 24;
+pub const UNIFFI_CONTRACT_VERSION: u32 = 25;
 
 /// Similar to std::hash::Hash.
 ///


### PR DESCRIPTION
A single global callback won't work if there are multiple foreign modules.  Instead, input the callback in `poll()`.

Added some tests for this in `fixtures/ext-types/proc-macro-lib`. Things worked on Swift and Python for me because that code was based on leaking a pointer and it happened to work if the pointer came from another module.  It just halted on Kotlin though and I think the same would happen if I wasn't on CPython and the alternate PointerMangager was used.