### PR TITLE
Backporting fix for trait methods that throw exceptions

### DIFF
--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -21,9 +21,11 @@ pub trait r#{{ obj.name() }} {
         {{ arg.name() }}: {% if arg.by_ref() %}&{% endif %}{{ arg.as_type().borrow()|type_rs }},
         {%- endfor %}
     )
-    {%- match meth.return_type() %}
-    {%- when Some(return_type) %} -> {{ return_type|type_rs }};
-    {%- when None %};
+    {%- match (meth.return_type(), meth.throws_type()) %}
+    {%- when (Some(return_type), None) %} -> {{ return_type|type_rs }};
+    {%- when (Some(return_type), Some(error_type)) %} -> ::std::result::Result::<{{ return_type|type_rs }}, {{ error_type|type_rs }}>;
+    {%- when (None, Some(error_type)) %} -> ::std::result::Result::<(), {{ error_type|type_rs }}>;
+    {%- when (None, None) %};
     {%- endmatch %}
     {% endfor %}
 }


### PR DESCRIPTION
This is part of #1791, which was merged just after the `0.25.0` release was made.  We wanted to give that code a bit of time in main before releasing it.  However, this part is useful for traits implemented in Rust.