### PR TITLE
Multi crate async 0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.25.0...HEAD).
 
+### What's fixed?
+
+- Fixed several bugs with async functions were defined in multiple crates that get built together.
+
 ## v0.25.0 (backend crates: v0.25.0) - (_2023-10-18_)
 
 [All changes in v0.25.0](https://github.com/mozilla/uniffi-rs/compare/v0.24.3...v0.25.0).

--- a/fixtures/ext-types/proc-macro-lib/src/lib.rs
+++ b/fixtures/ext-types/proc-macro-lib/src/lib.rs
@@ -89,6 +89,11 @@ fn get_uniffi_one_type(t: UniffiOneType) -> UniffiOneType {
     t
 }
 
+#[uniffi::export]
+async fn get_uniffi_one_type_async(t: UniffiOneType) -> UniffiOneType {
+    t
+}
+
 // Test using a type defined in a proc-macro in another crate
 #[uniffi::export]
 fn get_uniffi_one_proc_macro_type(t: UniffiOneProcMacroType) -> UniffiOneProcMacroType {

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.kts
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.kts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import kotlinx.coroutines.runBlocking
 import uniffi.imported_types_lib.*
 import uniffi.uniffi_one_ns.*
 
@@ -26,6 +27,10 @@ assert(getMaybeUniffiOneType(uot)!! == uot)
 assert(getMaybeUniffiOneType(null) == null)
 assert(getUniffiOneTypes(listOf(uot)) == listOf(uot))
 assert(getMaybeUniffiOneTypes(listOf(uot, null)) == listOf(uot, null))
+
+runBlocking {
+    assert(getUniffiOneTypeAsync(uot) == uot)
+}
 
 val uopmt = UniffiOneProcMacroType("hello from proc-macro world")
 assert(getUniffiOneProcMacroType(uopmt) == uopmt)

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.kts
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.kts
@@ -29,6 +29,9 @@ assert(getUniffiOneTypes(listOf(uot)) == listOf(uot))
 assert(getMaybeUniffiOneTypes(listOf(uot, null)) == listOf(uot, null))
 
 runBlocking {
+    // This async function comes from the `uniffi-one` crate
+    assert(getUniffiOneAsync() == UniffiOneEnum.ONE)
+    // This async function comes from the `proc-macro-lib` crate
     assert(getUniffiOneTypeAsync(uot) == uot)
 }
 

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.py
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.py
@@ -36,9 +36,15 @@ class TestIt(unittest.TestCase):
         self.assertEqual(None, get_maybe_uniffi_one_type(None))
         self.assertEqual([t1], get_uniffi_one_types([t1]))
         self.assertEqual([t1, None], get_maybe_uniffi_one_types([t1, None]))
-        async def test_async():
+
+    def test_async(self):
+        async def test():
+            t1 = UniffiOneType("hello")
+            # This async function comes from the `uniffi-one` crate
+            self.assertEqual(await get_uniffi_one_async(), UniffiOneEnum.ONE)
+            # This async function comes from the `proc-macro-lib` crate
             self.assertEqual(t1, await get_uniffi_one_type_async(t1))
-        asyncio.run(test_async())
+        asyncio.run(test())
 
     def test_get_uniffi_one_proc_macro_type(self):
         t1 = UniffiOneProcMacroType("hello")

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.py
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import asyncio
 import unittest
 import urllib
 from ext_types_guid import *
@@ -35,6 +36,9 @@ class TestIt(unittest.TestCase):
         self.assertEqual(None, get_maybe_uniffi_one_type(None))
         self.assertEqual([t1], get_uniffi_one_types([t1]))
         self.assertEqual([t1, None], get_maybe_uniffi_one_types([t1, None]))
+        async def test_async():
+            self.assertEqual(t1, await get_uniffi_one_type_async(t1))
+        asyncio.run(test_async())
 
     def test_get_uniffi_one_proc_macro_type(self):
         t1 = UniffiOneProcMacroType("hello")

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.swift
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.swift
@@ -26,6 +26,16 @@ assert(getMaybeUniffiOneType(t: nil) == nil)
 assert(getUniffiOneTypes(ts: [UniffiOneType(sval: "hello")]) == [UniffiOneType(sval: "hello")])
 assert(getMaybeUniffiOneTypes(ts: [UniffiOneType(sval: "hello"), nil]) == [UniffiOneType(sval: "hello"), nil])
 
+var counter = DispatchGroup()
+counter.enter()
+Task {
+    let t = await getUniffiOneTypeAsync(t: UniffiOneType(sval: "hello"))
+    assert(t.sval == "hello")
+    counter.leave()
+}
+counter.wait()
+
+
 assert(getUniffiOneProcMacroType(t: UniffiOneProcMacroType(sval: "hello from proc-macro world")).sval == "hello from proc-macro world")
 assert(getMyProcMacroType(t: UniffiOneProcMacroType(sval: "proc-macros all the way down")).sval == "proc-macros all the way down")
 

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.swift
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.swift
@@ -29,8 +29,14 @@ assert(getMaybeUniffiOneTypes(ts: [UniffiOneType(sval: "hello"), nil]) == [Uniff
 var counter = DispatchGroup()
 counter.enter()
 Task {
-    let t = await getUniffiOneTypeAsync(t: UniffiOneType(sval: "hello"))
-    assert(t.sval == "hello")
+    // This async function comes from the `uniffi-one` crate
+    let uniffiOneEnum = await getUniffiOneAsync()
+    assert(uniffiOneEnum == UniffiOneEnum.one)
+
+    // This async function comes from the `proc-macro-lib` crate
+    let uniffiOneType = await getUniffiOneTypeAsync(t: UniffiOneType(sval: "hello"))
+    assert(uniffiOneType.sval == "hello")
+
     counter.leave()
 }
 counter.wait()

--- a/fixtures/ext-types/uniffi-one/src/lib.rs
+++ b/fixtures/ext-types/uniffi-one/src/lib.rs
@@ -34,4 +34,9 @@ fn get_my_proc_macro_type(t: UniffiOneProcMacroType) -> UniffiOneProcMacroType {
     t
 }
 
+#[uniffi::export]
+async fn get_uniffi_one_async() -> UniffiOneEnum {
+    UniffiOneEnum::One
+}
+
 uniffi::include_scaffolding!("uniffi-one");

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -65,9 +65,9 @@ class {{ type_name }}(
                     {% call kt::arg_list_lowered(meth) %}
                 )
             },
-            { future, continuation -> _UniFFILib.INSTANCE.{{ meth.ffi_rust_future_poll(ci) }}(future, continuation) },
-            { future, status -> _UniFFILib.INSTANCE.{{ meth.ffi_rust_future_complete(ci) }}(future, status) },
-            { future -> _UniFFILib.INSTANCE.{{ meth.ffi_rust_future_free(ci) }}(future) },
+            {{ meth|async_poll(ci) }},
+            {{ meth|async_complete(ci) }},
+            {{ meth|async_free(ci) }},
             // lift function
             {%- match meth.return_type() %}
             {%- when Some(return_type) %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
@@ -20,6 +20,14 @@ open class RustBuffer : Structure() {
            }
         }
 
+        internal fun create(capacity: Int, len: Int, data: Pointer?): RustBuffer.ByValue {
+            var buf = RustBuffer.ByValue()
+            buf.capacity = capacity
+            buf.len = len
+            buf.data = data
+            return buf
+        }
+
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
             _UniFFILib.INSTANCE.{{ ci.ffi_rustbuffer_free().name() }}(buf, status)
         }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
@@ -9,9 +9,9 @@
 suspend fun {{ func.name()|fn_name }}({%- call kt::arg_list_decl(func) -%}){% match func.return_type() %}{% when Some with (return_type) %} : {{ return_type|type_name }}{% when None %}{%- endmatch %} {
     return uniffiRustCallAsync(
         _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call kt::arg_list_lowered(func) %}),
-        { future, continuation -> _UniFFILib.INSTANCE.{{ func.ffi_rust_future_poll(ci) }}(future, continuation) },
-        { future, status -> _UniFFILib.INSTANCE.{{ func.ffi_rust_future_complete(ci) }}(future, status) },
-        { future -> _UniFFILib.INSTANCE.{{ func.ffi_rust_future_free(ci) }}(future) },
+        {{ func|async_poll(ci) }},
+        {{ func|async_complete(ci) }},
+        {{ func|async_free(ci) }},
         // lift function
         {%- match func.return_type() %}
         {%- when Some(return_type) %}

--- a/uniffi_bindgen/src/bindings/swift/templates/Async.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Async.swift
@@ -1,7 +1,7 @@
 private let UNIFFI_RUST_FUTURE_POLL_READY: Int8 = 0
 private let UNIFFI_RUST_FUTURE_POLL_MAYBE_READY: Int8 = 1
 
-internal func uniffiRustCallAsync<F, T>(
+fileprivate func uniffiRustCallAsync<F, T>(
     rustFutureFunc: () -> UnsafeMutableRawPointer,
     pollFunc: (UnsafeMutableRawPointer, UnsafeMutableRawPointer) -> (),
     completeFunc: (UnsafeMutableRawPointer, UnsafeMutablePointer<RustCallStatus>) -> F,
@@ -37,7 +37,7 @@ fileprivate func uniffiFutureContinuationCallback(ptr: UnsafeMutableRawPointer, 
 
 // Wraps UnsafeContinuation in a class so that we can use reference counting when passing it across
 // the FFI
-class ContinuationHolder {
+fileprivate class ContinuationHolder {
     let continuation: UnsafeContinuation<Int8, Never>
 
     init(_ continuation: UnsafeContinuation<Int8, Never>) {

--- a/uniffi_core/src/lib.rs
+++ b/uniffi_core/src/lib.rs
@@ -58,6 +58,8 @@ pub mod deps {
     pub use bytes;
     pub use log;
     pub use static_assertions;
+    // Export this dependency for the 0.25 branch so that we can use it in `setup_scaffolding.rs`
+    pub use once_cell;
 }
 
 mod panichook;


### PR DESCRIPTION
Backporting a couple async fixes to the `0.25` release branch.

The tricky part here was the second commit.  In `main` this is handled with a breaking FFI change which we can't take in the release branch.  However, we can still fix the issue by adding a workaround in the scaffolding code.