### PR TITLE
Adding `FfiType::Callback`

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/Async.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Async.kt
@@ -1,20 +1,20 @@
 // Async return type handlers
 
-internal const val UNIFFI_RUST_FUTURE_POLL_READY = 0.toShort()
-internal const val UNIFFI_RUST_FUTURE_POLL_MAYBE_READY = 1.toShort()
+internal const val UNIFFI_RUST_FUTURE_POLL_READY = 0.toByte()
+internal const val UNIFFI_RUST_FUTURE_POLL_MAYBE_READY = 1.toByte()
 
-internal val uniffiContinuationHandleMap = UniFfiHandleMap<CancellableContinuation<Short>>()
+internal val uniffiContinuationHandleMap = UniFfiHandleMap<CancellableContinuation<Byte>>()
 
 // FFI type for Rust future continuations
-internal object uniffiRustFutureContinuationCallback: UniFffiRustFutureContinuationCallbackType {
-    override fun callback(continuationHandle: USize, pollResult: Short) {
-        uniffiContinuationHandleMap.remove(continuationHandle)?.resume(pollResult)
+internal object uniffiRustFutureContinuationCallback: UniffiRustFutureContinuationCallback {
+    override fun callback(data: USize, pollResult: Byte) {
+        uniffiContinuationHandleMap.remove(data)?.resume(pollResult)
     }
 }
 
 internal suspend fun<T, F, E: Exception> uniffiRustCallAsync(
     rustFuture: Pointer,
-    pollFunc: (Pointer, UniFffiRustFutureContinuationCallbackType, USize) -> Unit,
+    pollFunc: (Pointer, UniffiRustFutureContinuationCallback, USize) -> Unit,
     completeFunc: (Pointer, RustCallStatus) -> F,
     freeFunc: (Pointer) -> Unit,
     liftFunc: (F) -> T,
@@ -22,7 +22,7 @@ internal suspend fun<T, F, E: Exception> uniffiRustCallAsync(
 ): T {
     try {
         do {
-            val pollResult = suspendCancellableCoroutine<Short> { continuation ->
+            val pollResult = suspendCancellableCoroutine<Byte> { continuation ->
                 pollFunc(
                     rustFuture,
                     uniffiRustFutureContinuationCallback,

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
@@ -154,8 +154,3 @@ internal class UniFfiHandleMap<T: Any> {
         return map.remove(handle)
     }
 }
-
-// FFI type for Rust future continuations
-internal interface UniFffiRustFutureContinuationCallbackType : com.sun.jna.Callback {
-    fun callback(continuationHandle: USize, pollResult: Short);
-}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
@@ -13,6 +13,22 @@ private inline fun <reified Lib : Library> loadIndirect(
     return Native.load<Lib>(findLibraryName(componentName), Lib::class.java)
 }
 
+// Define FFI callback types
+{%- for callback in ci.ffi_callback_definitions() %}
+internal interface {{ callback.name()|ffi_callback_name }} : com.sun.jna.Callback {
+    fun callback(
+        {%- for arg in callback.arguments() -%}
+        {{ arg.name().borrow()|var_name }}: {{ arg.type_().borrow()|ffi_type_name }},
+        {%- endfor -%}
+    )
+    {%- match callback.return_type() %}
+    {%- when Some(return_type) %}: {{ return_type|ffi_type_name }},
+    {%- when None %}
+    {%- endmatch %}
+}
+
+{%- endfor %}
+
 // A JNA Library to expose the extern-C FFI definitions.
 // This is an implementation detail which will be called internally by the public API.
 

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -299,7 +299,12 @@ impl PythonCodeOracle {
         fixup_keyword(nm.to_string().to_shouty_snake_case())
     }
 
-    fn ffi_type_label(ffi_type: &FfiType) -> String {
+    /// Get the idiomatic Python rendering of an FFI callback function
+    fn ffi_callback_name(&self, nm: &str) -> String {
+        format!("UNIFFI_{}", nm.to_shouty_snake_case())
+    }
+
+    fn ffi_type_label(&self, ffi_type: &FfiType) -> String {
         match ffi_type {
             FfiType::Int8 => "ctypes.c_int8".to_string(),
             FfiType::UInt8 => "ctypes.c_uint8".to_string(),
@@ -317,12 +322,12 @@ impl PythonCodeOracle {
                 None => "_UniffiRustBuffer".to_string(),
             },
             FfiType::ForeignBytes => "_UniffiForeignBytes".to_string(),
+            FfiType::Callback(name) => self.ffi_callback_name(name),
             FfiType::ForeignCallback => "_UNIFFI_FOREIGN_CALLBACK_T".to_string(),
             // Pointer to an `asyncio.EventLoop` instance
             FfiType::ForeignExecutorHandle => "ctypes.c_size_t".to_string(),
             FfiType::ForeignExecutorCallback => "_UNIFFI_FOREIGN_EXECUTOR_CALLBACK_T".to_string(),
             FfiType::RustFutureHandle => "ctypes.c_void_p".to_string(),
-            FfiType::RustFutureContinuationCallback => "_UNIFFI_FUTURE_CONTINUATION_T".to_string(),
             FfiType::RustFutureContinuationData => "ctypes.c_size_t".to_string(),
         }
     }
@@ -439,7 +444,7 @@ pub mod filters {
 
     /// Get the Python syntax for representing a given low-level `FfiType`.
     pub fn ffi_type_name(type_: &FfiType) -> Result<String, askama::Error> {
-        Ok(PythonCodeOracle::ffi_type_label(type_))
+        Ok(PythonCodeOracle.ffi_type_label(type_))
     }
 
     /// Get the idiomatic Python rendering of a class name (for enums, records, errors, etc).
@@ -460,6 +465,11 @@ pub mod filters {
     /// Get the idiomatic Python rendering of an individual enum variant.
     pub fn enum_variant_py(nm: &str) -> Result<String, askama::Error> {
         Ok(PythonCodeOracle.enum_variant_name(nm))
+    }
+
+    /// Get the idiomatic Python rendering of a FFI callback function name
+    pub fn ffi_callback_name(nm: &str) -> Result<String, askama::Error> {
+        Ok(PythonCodeOracle.ffi_callback_name(nm))
     }
 
     /// Get the idiomatic Python rendering of an individual enum variant.

--- a/uniffi_bindgen/src/bindings/python/templates/Async.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Async.py
@@ -7,7 +7,7 @@ _UniffiContinuationPointerManager = _UniffiPointerManager()
 
 # Continuation callback for async functions
 # lift the return value or error and resolve the future, causing the async function to resume.
-@_UNIFFI_FUTURE_CONTINUATION_T
+@UNIFFI_RUST_FUTURE_CONTINUATION_CALLBACK
 def _uniffi_continuation_callback(future_ptr, poll_code):
     (eventloop, future) = _UniffiContinuationPointerManager.release_pointer(future_ptr)
     eventloop.call_soon_threadsafe(_uniffi_set_future_result, future, poll_code)

--- a/uniffi_bindgen/src/bindings/python/templates/Helpers.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Helpers.py
@@ -70,6 +70,3 @@ def _uniffi_check_call_status(error_ffi_converter, call_status):
 # Rust definition `fn(handle: u64, method: u32, args: _UniffiRustBuffer, buf_ptr: *mut _UniffiRustBuffer) -> int`
 _UNIFFI_FOREIGN_CALLBACK_T = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_ulonglong, ctypes.c_ulong, ctypes.POINTER(ctypes.c_char), ctypes.c_int, ctypes.POINTER(_UniffiRustBuffer))
 
-# UniFFI future continuation
-_UNIFFI_FUTURE_CONTINUATION_T = ctypes.CFUNCTYPE(None, ctypes.c_size_t, ctypes.c_int8)
-

--- a/uniffi_bindgen/src/bindings/python/templates/NamespaceLibraryTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/NamespaceLibraryTemplate.py
@@ -68,6 +68,20 @@ def _uniffi_check_api_checksums(lib):
     pass
     {%- endfor %}
 
+
+# Define FFI callback types
+{%- for callback in ci.ffi_callback_definitions() %}
+{{ callback.name()|ffi_callback_name }} = ctypes.CFUNCTYPE(
+    {%- match callback.return_type() %}
+    {%- when Some(return_type) %}{{ return_type|ffi_type_name }},
+    {%- when None %}None,
+    {%- endmatch %}
+    {%- for arg in callback.arguments() -%}
+    {{ arg.type_().borrow()|ffi_type_name }},
+    {%- endfor -%}
+)
+{%- endfor %}
+
 # A ctypes library to expose the extern-C FFI definitions.
 # This is an implementation detail which will be called internally by the public API.
 

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -153,6 +153,7 @@ mod filters {
             FfiType::RustArcPtr(_) => ":pointer".to_string(),
             FfiType::RustBuffer(_) => "RustBuffer.by_value".to_string(),
             FfiType::ForeignBytes => "ForeignBytes".to_string(),
+            FfiType::Callback(_) => unimplemented!("FFI Callbacks not implemented"),
             // Callback interfaces are not yet implemented, but this needs to return something in
             // order for the coverall tests to pass.
             FfiType::ForeignCallback => ":pointer".to_string(),
@@ -162,9 +163,7 @@ mod filters {
             FfiType::ForeignExecutorHandle => {
                 unimplemented!("Foreign executors are not implemented")
             }
-            FfiType::RustFutureHandle
-            | FfiType::RustFutureContinuationCallback
-            | FfiType::RustFutureContinuationData => {
+            FfiType::RustFutureHandle | FfiType::RustFutureContinuationData => {
                 unimplemented!("Async functions are not implemented")
             }
         })

--- a/uniffi_bindgen/src/bindings/swift/templates/Async.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Async.swift
@@ -3,7 +3,7 @@ private let UNIFFI_RUST_FUTURE_POLL_MAYBE_READY: Int8 = 1
 
 fileprivate func uniffiRustCallAsync<F, T>(
     rustFutureFunc: () -> UnsafeMutableRawPointer,
-    pollFunc: (UnsafeMutableRawPointer, @escaping UniFfiRustFutureContinuation, UnsafeMutableRawPointer) -> (),
+    pollFunc: (UnsafeMutableRawPointer, @escaping UniffiRustFutureContinuationCallback, UnsafeMutableRawPointer) -> (),
     completeFunc: (UnsafeMutableRawPointer, UnsafeMutablePointer<RustCallStatus>) -> F,
     freeFunc: (UnsafeMutableRawPointer) -> (),
     liftFunc: (F) throws -> T,

--- a/uniffi_bindgen/src/bindings/swift/templates/BridgingHeaderTemplate.h
+++ b/uniffi_bindgen/src/bindings/swift/templates/BridgingHeaderTemplate.h
@@ -59,8 +59,17 @@ typedef struct RustCallStatus {
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
 
-// Continuation callback for UniFFI Futures
-typedef void (*UniFfiRustFutureContinuation)(void * _Nonnull, int8_t);
+// Define FFI callback types
+{%- for callback in ci.ffi_callback_definitions() %}
+typedef
+    {%- match callback.return_type() %}{% when Some(return_type) %} {{ return_type|ffi_type_name }} {% when None %} void {% endmatch -%}
+    (*{{ callback.name()|ffi_callback_name }})(
+        {%- for arg in callback.arguments() -%}
+        {{ arg.type_().borrow()|header_ffi_type_name }}
+        {%- if !loop.last %}, {% endif %}
+        {%- endfor -%}
+    );
+{%- endfor %}
 
 // Scaffolding functions
 {%- for func in ci.iter_ffi_function_definitions() %}

--- a/uniffi_bindgen/src/interface/ffi.rs
+++ b/uniffi_bindgen/src/interface/ffi.rs
@@ -47,6 +47,9 @@ pub enum FfiType {
     /// A borrowed reference to some raw bytes owned by foreign language code.
     /// The provider of this reference must keep it alive for the duration of the receiving call.
     ForeignBytes,
+    /// Pointer to a callback function.  The inner type is the name of the callback, which matches
+    /// one of the items in [crate::ComponentInterface::ffi_callback_definitions].
+    Callback(String),
     /// Pointer to a callback function that handles all callbacks on the foreign language side.
     ForeignCallback,
     /// Pointer-sized opaque handle that represents a foreign executor.  Foreign bindings can
@@ -56,8 +59,6 @@ pub enum FfiType {
     ForeignExecutorCallback,
     /// Pointer to a Rust future
     RustFutureHandle,
-    /// Continuation function for a Rust future
-    RustFutureContinuationCallback,
     RustFutureContinuationData,
     // TODO: you can imagine a richer structural typesystem here, e.g. `Ref<String>` or something.
     // We don't need that yet and it's possible we never will, so it isn't here for now.
@@ -225,11 +226,49 @@ pub struct FfiArgument {
 }
 
 impl FfiArgument {
+    pub fn new(name: impl Into<String>, type_: FfiType) -> Self {
+        Self {
+            name: name.into(),
+            type_,
+        }
+    }
+
     pub fn name(&self) -> &str {
         &self.name
     }
+
     pub fn type_(&self) -> FfiType {
         self.type_.clone()
+    }
+}
+
+/// Represents an "extern C"-style callback function
+///
+/// These are defined in the foreign code and passed to Rust as a function pointer.
+#[derive(Debug, Default, Clone)]
+pub struct FfiCallbackFunction {
+    // Name for this function type. This matches the value inside `FfiType::Callback`
+    pub(super) name: String,
+    pub(super) arguments: Vec<FfiArgument>,
+    pub(super) return_type: Option<FfiType>,
+    pub(super) has_rust_call_status_arg: bool,
+}
+
+impl FfiCallbackFunction {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn arguments(&self) -> Vec<&FfiArgument> {
+        self.arguments.iter().collect()
+    }
+
+    pub fn return_type(&self) -> Option<&FfiType> {
+        self.return_type.as_ref()
+    }
+
+    pub fn has_rust_call_status_arg(&self) -> bool {
+        self.has_rust_call_status_arg
     }
 }
 

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -67,7 +67,7 @@ mod record;
 pub use record::{Field, Record};
 
 pub mod ffi;
-pub use ffi::{FfiArgument, FfiFunction, FfiType};
+pub use ffi::{FfiArgument, FfiCallbackFunction, FfiFunction, FfiType};
 pub use uniffi_meta::Radix;
 use uniffi_meta::{
     ConstructorMetadata, LiteralMetadata, NamespaceMetadata, ObjectMetadata, TraitMethodMetadata,
@@ -202,6 +202,21 @@ impl ComponentInterface {
     pub fn get_object_definition(&self, name: &str) -> Option<&Object> {
         // TODO: probably we could store these internally in a HashMap to make this easier?
         self.objects.iter().find(|o| o.name == name)
+    }
+
+    /// Get the definitions for callback FFI functions
+    ///
+    /// These are defined by the foreign code and invoked by Rust.
+    pub fn ffi_callback_definitions(&self) -> impl IntoIterator<Item = FfiCallbackFunction> {
+        [FfiCallbackFunction {
+            name: "RustFutureContinuationCallback".to_owned(),
+            arguments: vec![
+                FfiArgument::new("data", FfiType::RustFutureContinuationData),
+                FfiArgument::new("poll_result", FfiType::Int8),
+            ],
+            return_type: None,
+            has_rust_call_status_arg: false,
+        }]
     }
 
     /// Get the definitions for every Callback Interface type in the interface.
@@ -447,7 +462,7 @@ impl ComponentInterface {
                 },
                 FfiArgument {
                     name: "callback".to_owned(),
-                    type_: FfiType::RustFutureContinuationCallback,
+                    type_: FfiType::Callback("RustFutureContinuationCallback".to_owned()),
                 },
                 FfiArgument {
                     name: "callback_data".to_owned(),


### PR DESCRIPTION
This is sort-of in the same sprit as #1808, but just focused on foreign callback functions.  The goal is to have a single `FfiType` that we can reuse whenever we want to add a new callback function type.

With this change, if you want to add a new callback function type you just add an item in `ffi_callback_definitions()`.  I think this should make the process much easier.  It  can help avoid FFI type mismatches, like how I made the Kotlin signature input a i16 instead of an i8.

Use the new type for the future continuation callback.  I have another plan for callback interface callbacks.  I didn't touch the foreign executor callback, I hope to work on that very soon.