### PR TITLE
[Kotlin] Generate open classes and methods

### DIFF
--- a/fixtures/coverall/tests/bindings/test_coverall.kts
+++ b/fixtures/coverall/tests/bindings/test_coverall.kts
@@ -7,6 +7,8 @@ import java.util.concurrent.*
 
 import uniffi.coverall.*
 
+import com.sun.jna.Pointer
+
 // TODO: use an actual test runner.
 
 // Test some_dict().
@@ -424,4 +426,28 @@ assert(d.integer == 42UL)
 // Test bytes
 Coveralls("test_bytes").use { coveralls ->
     assert(coveralls.reverse("123".toByteArray(Charsets.UTF_8)).toString(Charsets.UTF_8) == "321")
+}
+
+// Test fakes using open classes
+
+class FakePatch(private val color: Color): Patch(NoPointer) {
+    override fun `getColor`(): Color = color
+}
+
+class FakeCoveralls(private val name: String) : Coveralls(NoPointer) {
+    private val repairs = mutableListOf<Repair>()
+
+    override fun `addPatch`(patch: Patch) {
+        repairs += Repair(Instant.now(), patch)
+    }
+
+    override fun `getRepairs`(): List<Repair> {
+        return repairs
+    }
+}
+
+FakeCoveralls("using_fakes").use { coveralls ->
+    val patch = FakePatch(Color.RED)
+    coveralls.addPatch(patch)
+    assert(!coveralls.getRepairs().isEmpty())
 }

--- a/fixtures/coverall/tests/bindings/test_coverall.kts
+++ b/fixtures/coverall/tests/bindings/test_coverall.kts
@@ -7,8 +7,6 @@ import java.util.concurrent.*
 
 import uniffi.coverall.*
 
-import com.sun.jna.Pointer
-
 // TODO: use an actual test runner.
 
 // Test some_dict().
@@ -450,4 +448,25 @@ FakeCoveralls("using_fakes").use { coveralls ->
     val patch = FakePatch(Color.RED)
     coveralls.addPatch(patch)
     assert(!coveralls.getRepairs().isEmpty())
+}
+
+FakeCoveralls("using_fakes_and_calling_methods_without_override_crashes").use { coveralls ->
+    var exception: Throwable? = null
+    try {
+        coveralls.cloneMe()
+    } catch (e: Throwable) {
+        exception = e
+    }
+    assert(exception != null)
+}
+
+Coveralls("using_fakes_with_real_objects_crashes").use { coveralls ->
+    val patch = FakePatch(Color.RED)
+    var exception: Throwable? = null
+    try {
+        coveralls.addPatch(patch)
+    } catch (e: Throwable) {
+        exception = e
+    }
+    assert(exception != null)
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectRuntime.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectRuntime.kt
@@ -117,8 +117,16 @@ abstract class FFIObject: Disposable, AutoCloseable {
         this.pointer = pointer
     }
 
+    /**
+     * This constructor can be used to instantiate a fake object.
+     *
+     * **WARNING: Any object instantiated with this constructor cannot be passed to an actual Rust-backed object.**
+     * Since there isn't a backing [Pointer] the FFI lower functions will crash.
+     * @param noPointer Placeholder value so we can have a constructor separate from the default empty one that may be
+     *   implemented for classes extending [FFIObject].
+     */
     @Suppress("UNUSED_PARAMETER")
-    protected constructor(noPointer: NoPointer) {
+    constructor(noPointer: NoPointer) {
         this.pointer = null
     }
 
@@ -171,4 +179,5 @@ abstract class FFIObject: Disposable, AutoCloseable {
     }
 }
 
+/** Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly. */
 object NoPointer

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -7,7 +7,15 @@ open class {{ impl_class_name }} : FFIObject{% if obj.is_trait_interface() %}, {
 
     constructor(pointer: Pointer): super(pointer)
 
-    protected constructor(noPointer: NoPointer): super(noPointer)
+    /**
+     * This constructor can be used to instantiate a fake object.
+     *
+     * **WARNING: Any object instantiated with this constructor cannot be passed to an actual Rust-backed object.**
+     * Since there isn't a backing [Pointer] the FFI lower functions will crash.
+     * @param noPointer Placeholder value so we can have a constructor separate from the default empty one that may be
+     *   implemented for classes extending [FFIObject].
+     */
+    constructor(noPointer: NoPointer): super(noPointer)
 
     {%- match obj.primary_constructor() %}
     {%- when Some with (cons) %}


### PR DESCRIPTION
This PR is an alternative implementation of #1782 , with the 1st approach @bendk proposed [here](https://github.com/mozilla/uniffi-rs/pull/1782#issuecomment-1771432020):

> We could make the concrete type open. It's slightly risky because if you don't have an actual handle to a Rust object, then calling a UniFFI function will fail. But I would be okay with saying that users accept that risk if they extend the generated class. For your use case of only creating the objects if the native library isn't available, it seems like it should work fine.

The implementation changes are:

- `FFIObject.pointer` is now nullable. I know it's not great, but it's necessary as far as I can tell and I haven't seen any issues with it so far.
- `FFIObject` now has an alternate `constructor(noPointer: NoPointer)`. I tried using an empty constructor or one with `pointer: Pointer?` as the only parameter, but it clashed with the code in generated classes.
- `FFIObject.freeRustArcPtr` implementation in the different classes now does a null check before trying to free the pointer, so you don't need to override it in the fakes, and methods using `callWithPointer` will unwrap the nullable value and throw a `NullPointerException` if it doesn't exist.
- I removed the interfaces for concrete types because they don't seem to have any use, since you can't implement some `FooInterface` and just pass it to a `fn bar(foo: Foo)` function without a `ClassCastException`, and the open class can now act as a kind of interface (again, I might be wrong about this, they could be restored). I did keep the interface for the trait interfaces and their impls.

I added a few tests displaying how these open classes can be extended, used and **not used** in a real project.

I feel like this approach isn't as correct as the one in #1782 where you'd be forced to provide an alternative implementation for the interfaces that doesn't crash, but it's way simpler to maintain and the drawbacks I see as a lib user aren't that bad.