### PR TITLE
Rust traits `Display`, `Hash` and `Eq` exposed to Kotlin and Swift.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 - The `rust_future_continuation_callback_set` FFI function was removed.  `rust_future_poll` now
   inputs the callback pointer.  External bindings authors will need to update their code.
 
+### What's new?
+
+- Rust traits `Display`, `Hash` and `Eq` exposed to Kotlin and Swift.
+
 ## v0.25.0 (backend crates: v0.25.0) - (_2023-10-18_)
 
 [All changes in v0.25.0](https://github.com/mozilla/uniffi-rs/compare/v0.24.3...v0.25.0).

--- a/fixtures/trait-methods/tests/bindings/test.kts
+++ b/fixtures/trait-methods/tests/bindings/test.kts
@@ -1,0 +1,11 @@
+import uniffi.trait_methods.*
+
+val m = TraitMethods("yo")
+assert(m.toString() == "TraitMethods(yo)")
+
+assert(m == TraitMethods("yo"))
+assert(m != TraitMethods("yoyo"))
+
+val map = mapOf(m to 1, TraitMethods("yoyo") to 2)
+assert(map[m] == 1)
+assert(map[TraitMethods("yoyo")] == 2)

--- a/fixtures/trait-methods/tests/bindings/test.swift
+++ b/fixtures/trait-methods/tests/bindings/test.swift
@@ -1,0 +1,12 @@
+import trait_methods
+
+let m = TraitMethods(name: "yo")
+assert(String(describing: m) == "TraitMethods(yo)")
+assert(String(reflecting: m) == "TraitMethods { val: \"yo\" }")
+
+// eq
+assert(m == TraitMethods(name: "yo"))
+
+// hash
+var set: Set = [TraitMethods(name: "yo")]
+assert(set.contains(TraitMethods(name: "yo")))

--- a/fixtures/trait-methods/tests/test_generated_bindings.rs
+++ b/fixtures/trait-methods/tests/test_generated_bindings.rs
@@ -1,1 +1,5 @@
-uniffi::build_foreign_language_testcases!("tests/bindings/test.py",);
+uniffi::build_foreign_language_testcases!(
+    "tests/bindings/test.py",
+    "tests/bindings/test.kts",
+    "tests/bindings/test.swift"
+);

--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -4,7 +4,21 @@
 
 {% include "Protocol.swift" %}
 
-public class {{ impl_class_name }}: {{ protocol_name }} {
+public class {{ impl_class_name }}:
+    {%- for tm in obj.uniffi_traits() %}
+    {%-     match tm %}
+    {%-         when UniffiTrait::Display { fmt } %}
+    CustomStringConvertible,
+    {%-         when UniffiTrait::Debug { fmt } %}
+    CustomDebugStringConvertible,
+    {%-         when UniffiTrait::Eq { eq, ne } %}
+    Equatable,
+    {%-         when UniffiTrait::Hash { hash } %}
+    Hashable,
+    {%-         else %}
+    {%-    endmatch %}
+    {%- endfor %}
+    {{ protocol_name }} {
     fileprivate let pointer: UnsafeMutableRawPointer
 
     // TODO: We'd like this to be `private` but for Swifty reasons,
@@ -88,6 +102,38 @@ public class {{ impl_class_name }}: {{ protocol_name }} {
     {%- endmatch -%}
     {%- endif -%}
     {% endfor %}
+
+    {%- for tm in obj.uniffi_traits() %}
+    {%-     match tm %}
+    {%-         when UniffiTrait::Display { fmt } %}
+    public var description: String {
+        return {% call swift::try(fmt) %} {{ fmt.return_type().unwrap()|lift_fn }}(
+            {% call swift::to_ffi_call_with_prefix("self.pointer", fmt) %}
+        )
+    }
+    {%-         when UniffiTrait::Debug { fmt } %}
+    public var debugDescription: String {
+        return {% call swift::try(fmt) %} {{ fmt.return_type().unwrap()|lift_fn }}(
+            {% call swift::to_ffi_call_with_prefix("self.pointer", fmt) %}
+        )
+    }
+    {%-         when UniffiTrait::Eq { eq, ne } %}
+    public static func == (lhs: {{ impl_class_name }}, other: {{ impl_class_name }}) -> Bool {
+        return {% call swift::try(eq) %} {{ eq.return_type().unwrap()|lift_fn }}(
+            {% call swift::to_ffi_call_with_prefix("lhs.pointer", eq) %}
+        )
+    }
+    {%-         when UniffiTrait::Hash { hash } %}
+    public func hash(into hasher: inout Hasher) {
+        let val = {% call swift::try(hash) %} {{ hash.return_type().unwrap()|lift_fn }}(
+            {% call swift::to_ffi_call_with_prefix("self.pointer", hash) %}
+        )
+        hasher.combine(val)
+    }
+    {%-         else %}
+    {%-    endmatch %}
+    {%- endfor %}
+
 }
 
 {%- if obj.is_trait_interface() %}


### PR DESCRIPTION
This brings those language to parity with Python.

Note that Kotin is using `Display` for `toString()` and there's no obvious way to expose `Debug`, so it isn't. Swift does seem to have a sensible way of exposing both `Debug` and `Display`.

Neither language seems to need `ne` so that's unused.
