### PR TITLE
Fully qualify Send and Sync trait in generated code

### DIFF
--- a/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
@@ -46,7 +46,7 @@ impl Drop for {{ trait_impl }} {
     }
 }
 
-uniffi::deps::static_assertions::assert_impl_all!({{ trait_impl }}: Send);
+uniffi::deps::static_assertions::assert_impl_all!({{ trait_impl }}: ::core::marker::Send);
 
 impl r#{{ trait_name }} for {{ trait_impl }} {
     {%- for meth in cbi.methods() %}

--- a/uniffi_macros/src/export/callback_interface.rs
+++ b/uniffi_macros/src/export/callback_interface.rs
@@ -62,7 +62,7 @@ pub(super) fn trait_impl(
             }
         }
 
-        ::uniffi::deps::static_assertions::assert_impl_all!(#trait_impl_ident: Send);
+        ::uniffi::deps::static_assertions::assert_impl_all!(#trait_impl_ident: ::core::marker::Send);
 
         impl #trait_ident for #trait_impl_ident {
             #trait_impl_methods

--- a/uniffi_macros/src/export/trait_interface.rs
+++ b/uniffi_macros/src/export/trait_interface.rs
@@ -91,7 +91,7 @@ pub(crate) fn ffi_converter(mod_path: &str, trait_ident: &Ident, udl_mode: bool)
         // if they are not, but unfortunately it fails with an unactionably obscure error message.
         // By asserting the requirement explicitly, we help Rust produce a more scrutable error message
         // and thus help the user debug why the requirement isn't being met.
-        uniffi::deps::static_assertions::assert_impl_all!(dyn #trait_ident: Sync, Send);
+        uniffi::deps::static_assertions::assert_impl_all!(dyn #trait_ident: ::core::marker::Sync, ::core::marker::Send);
 
         unsafe #impl_spec {
             type FfiType = *const ::std::os::raw::c_void;

--- a/uniffi_macros/src/object.rs
+++ b/uniffi_macros/src/object.rs
@@ -52,7 +52,7 @@ pub(crate) fn interface_impl(ident: &Ident, udl_mode: bool) -> TokenStream {
         // if they are not, but unfortunately it fails with an unactionably obscure error message.
         // By asserting the requirement explicitly, we help Rust produce a more scrutable error message
         // and thus help the user debug why the requirement isn't being met.
-        uniffi::deps::static_assertions::assert_impl_all!(#ident: Sync, Send);
+        uniffi::deps::static_assertions::assert_impl_all!(#ident: ::core::marker::Sync, ::core::marker::Send);
 
         #[doc(hidden)]
         #[automatically_derived]


### PR DESCRIPTION
Other standard library types were already using a fully qualified name, but that wasn't the case for the `Send` and `Sync` bounds, which will cause issues in any code that has types named `Send` or `Sync` and is using the `uniffi` proc macros.