### PR TITLE
Replaced CancellationError with fatalError

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/Helpers.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Helpers.swift
@@ -93,7 +93,7 @@ private func uniffiCheckCallStatus(
             }
 
         case CALL_CANCELLED:
-                throw CancellationError()
+                throw fatalError("Cancellation not supported yet")
 
         default:
             throw UniffiInternalError.unexpectedRustCallStatusCode


### PR DESCRIPTION
Closes #1824.

This fix was discussed in briefly in matrix. https://github.com/mozilla/uniffi-rs/pull/1768 has some related work.

I've tested this work fix in https://github.com/liveview-native/liveview-native-core/pull/43

Is there a CI check I should add to prevent this in the future?