### PR TITLE
Removing redundant `throw` in `Helpers.swift`

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/Helpers.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Helpers.swift
@@ -93,7 +93,7 @@ private func uniffiCheckCallStatus(
             }
 
         case CALL_CANCELLED:
-                throw fatalError("Cancellation not supported yet")
+            fatalError("Cancellation not supported yet")
 
         default:
             throw UniffiInternalError.unexpectedRustCallStatusCode


### PR DESCRIPTION
`fatalError()` just causes a crash, there's no need to throw it.  This removes some warnings when building the swift code.