### PR TITLE
Add Dart to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Other tools we know of which try and solve a similarly shaped problem are:
 * [Kotlin Multiplatform support](https://gitlab.com/trixnity/uniffi-kotlin-multiplatform-bindings). The repository contains Kotlin Multiplatform bindings generation for UniFFI, letting you target both JVM and Native.
 * [Go bindings](https://github.com/NordSecurity/uniffi-bindgen-go)
 * [C# bindings](https://github.com/NordSecurity/uniffi-bindgen-cs)
+* [Dart bindings](https://github.com/NiallBunting/uniffi-rs-dart)
 
 ### External resources
 


### PR DESCRIPTION
Add a 3rd party language "Dart".

This creates valid dart and I am using this this to generate the bindings for `matrix-rust-sdk` for use in my project.