### PR TITLE
procmacro implemented types can be used in UDL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 - Foreign types can now implement trait interfaces [#1791](https://github.com/mozilla/uniffi-rs/pull/1791)
 - Generated Python code is able to specify a package name for the module [#1784](https://github.com/mozilla/uniffi-rs/pull/1784)
 - UDL can describe async function [#1834](https://github.com/mozilla/uniffi-rs/pull/1834)
+- UDL files can reference types defined in procmacros in this crate - see
+  [the external types docs](https://mozilla.github.io/uniffi-rs/udl/ext_types.html)
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.25.1...HEAD).
 

--- a/docs/manual/src/udl/ext_types.md
+++ b/docs/manual/src/udl/ext_types.md
@@ -1,16 +1,42 @@
 # External types
 
-*Note: The facility described in this document is not yet available for all foreign language
-bindings.*
+External types are types implemented by UniFFI but outside of this UDL file.
 
-UniFFI supports referring to types defined outside of the UDL file. These types must be
-either:
+They are similar to, but different from [custom types](./custom_types.md) which wrap UniFFI primitive types.
 
-1) A locally defined type which [wraps a UniFFI primitive type](./custom_types.md).
-2) A "UniFFI compatible" type [in another crate](./ext_types_external.md).
+But like custom types, external types are all declared using a `typedef` with attributes
+giving more detail.
 
-Specifically, "UniFFI compatible" means either a type defined in `udl` in an external crate, or
-a type defined in another crate that satisfies (1).
+## Types in another crate
 
-These types are all declared using a `typedef`, with attributes specifying how the type is
-handled. See the links for details.
+[There's a whole page about that!](./ext_types_external.md)
+
+## Types from procmacros in this crate.
+
+If your crate has types defined via `#[uniffi::export]` etc you can make them available
+to the UDL file in your own crate via a `typedef` with a `[Rust=]` attribute. Eg, your Rust
+might have:
+
+```rust
+#[derive(uniffi::Record)]
+pub struct One {
+    inner: i32,
+}
+```
+you can use it in your UDL:
+
+```idl
+[Rust="record"]
+typedef extern One;
+
+namespace app {
+    // use the procmacro type.
+    One get_one(One? one);
+}
+
+```
+
+Supported values:
+*  "enum", "trait", "callback"
+* For records, either "record" or "dictionary"
+* For objects, either "object" or "interface"

--- a/docs/manual/src/udl/ext_types_external.md
+++ b/docs/manual/src/udl/ext_types_external.md
@@ -1,8 +1,5 @@
 # Declaring External Types
 
-*Note: The facility described in this document is not yet available for all foreign language
-bindings.*
-
 It is possible to use types defined by UniFFI in an external crate. For example, let's assume
 that you have an existing crate named `demo_crate` with the following UDL:
 
@@ -13,8 +10,8 @@ dictionary DemoDict {
 };
 ```
 
-And further, assume that you have another crate called `consuming_crate` which would like to use
-this dictionary. Inside `consuming_crate`'s UDL file you can reference `DemoDict` by using a
+Inside another crate,  `consuming_crate`, you'd like to use this dictionary.
+Inside `consuming_crate`'s UDL file you can reference `DemoDict` by using a
 `typedef` with an `External` attribute, as shown below.
 
 ```idl
@@ -28,12 +25,6 @@ dictionary ConsumingDict {
 };
 
 ```
-
-If in the above example, `DemoDict` was actually "exported" via a procmacro
-you should instead use `ExternExport`
-
-(Note the special type `extern` used on the `typedef`. It is not currently enforced that the
-literal `extern` is used, but we hope to enforce this later, so please use it!)
 
 Inside `consuming_crate`'s Rust code you must `use` that struct as normal - for example,
 `consuming_crate`'s `lib.rs` might look like:
@@ -51,7 +42,7 @@ uniffi::include_scaffolding!("consuming_crate");
 
 Your `Cargo.toml` must reference the external crate as normal.
 
-The `External` attribute can be specified on dictionaries, enums and errors.
+The `External` attribute can be specified on dictionaries, enums, errors.
 
 ## External interface types
 
@@ -61,6 +52,15 @@ If the external type is an [Interface](./interfaces.md), then use the `[External
 [ExternalInterface="demo_crate"]
 typedef extern DemoInterface;
 ```
+
+## External procmacro types
+
+The above examples assume the external types were defined via UDL.
+If they were defined by procmacros, you need different attribute names:
+* if `DemoDict` is implemented by a procmacro in `demo_crate`, you'd use `[ExternalExport=...]`
+* for `DemoInterface` you'd use `[ExternalInterfaceExport=...]`
+
+For types defined by procmacros in *this* crate, see the []`[Rust=...]` attribute](../ext_types.md)
 
 ## Foreign bindings
 

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -234,4 +234,31 @@ impl Object {
     }
 }
 
+// defined in UDL.
+fn get_one(one: Option<One>) -> One {
+    one.unwrap_or(One { inner: 0 })
+}
+
+fn get_bool(b: Option<MaybeBool>) -> MaybeBool {
+    b.unwrap_or(MaybeBool::Uncertain)
+}
+
+fn get_object(o: Option<Arc<Object>>) -> Arc<Object> {
+    o.unwrap_or_else(Object::new)
+}
+
+fn get_trait(o: Option<Arc<dyn Trait>>) -> Arc<dyn Trait> {
+    o.unwrap_or_else(|| Arc::new(TraitImpl {}))
+}
+
+#[derive(Default)]
+struct Externals {
+    one: Option<One>,
+    bool: Option<MaybeBool>,
+}
+
+fn get_externals(e: Option<Externals>) -> Externals {
+    e.unwrap_or_default()
+}
+
 uniffi::include_scaffolding!("proc-macro");

--- a/fixtures/proc-macro/src/proc-macro.udl
+++ b/fixtures/proc-macro/src/proc-macro.udl
@@ -1,7 +1,32 @@
-// Namespace different from crate name.
-namespace proc_macro { };
-
 // Use this to test that types defined in the UDL can be used in the proc-macros
 dictionary Zero {
     string inner;
+};
+
+// And all of these for the opposite - proc-macro types used in UDL.
+[Rust="record"]
+typedef extern One;
+
+[Rust="enum"]
+typedef extern MaybeBool;
+
+[Rust="interface"]
+typedef extern Object;
+
+[Rust="trait"]
+typedef extern Trait;
+
+// Then stuff defined here but referencing the imported types.
+dictionary Externals {
+    One? one;
+    MaybeBool? bool;
+};
+
+// Namespace different from crate name.
+namespace proc_macro {
+    One get_one(One? one);
+    MaybeBool get_bool(MaybeBool? b);
+    Object get_object(Object? o);
+    Trait get_trait(Trait? t);
+    Externals get_externals(Externals? e);
 };

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -83,3 +83,10 @@ class PyTestCallbackInterface(TestCallbackInterface):
         return v
 
 call_callback_interface(PyTestCallbackInterface())
+
+# udl exposed functions with procmacro types.
+assert get_one(None).inner == 0
+assert get_bool(None) == MaybeBool.UNCERTAIN
+assert get_object(None).is_heavy() == MaybeBool.UNCERTAIN
+assert get_trait(None).name() == "TraitImpl"
+assert get_externals(None).one is None

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -869,31 +869,6 @@ impl ComponentInterface {
                 bail!("Conflicting type definition for \"{}\"", f.name());
             }
         }
-
-        for ty in self.iter_types() {
-            match ty {
-                Type::Object { name, .. } => {
-                    ensure!(
-                        self.objects.iter().any(|o| o.name == *name),
-                        "Object `{name}` has no definition"
-                    );
-                }
-                Type::Record { name, .. } => {
-                    ensure!(
-                        self.records.contains_key(name),
-                        "Record `{name}` has no definition",
-                    );
-                }
-                Type::Enum { name, .. } => {
-                    ensure!(
-                        self.enums.contains_key(name),
-                        "Enum `{name}` has no definition",
-                    );
-                }
-                _ => {}
-            }
-        }
-
         Ok(())
     }
 

--- a/uniffi_udl/src/finder.rs
+++ b/uniffi_udl/src/finder.rs
@@ -22,8 +22,8 @@ use std::convert::TryFrom;
 use anyhow::{bail, Result};
 
 use super::TypeCollector;
-use crate::attributes::{InterfaceAttributes, TypedefAttributes};
-use uniffi_meta::Type;
+use crate::attributes::{InterfaceAttributes, RustKind, TypedefAttributes};
+use uniffi_meta::{ObjectImpl, Type};
 
 /// Trait to help with an early "type discovery" phase when processing the UDL.
 ///
@@ -111,7 +111,6 @@ impl TypeFinder for weedle::EnumDefinition<'_> {
 
 impl TypeFinder for weedle::TypedefDefinition<'_> {
     fn add_type_definitions_to(&self, types: &mut TypeCollector) -> Result<()> {
-        let name = self.identifier.0;
         let attrs = TypedefAttributes::try_from(self.attributes.as_ref())?;
         // If we wanted simple `typedef`s, it would be as easy as:
         // > let t = types.resolve_type_expression(&self.type_)?;
@@ -122,29 +121,47 @@ impl TypeFinder for weedle::TypedefDefinition<'_> {
             // `FfiConverter` implementation.
             let builtin = types.resolve_type_expression(&self.type_)?;
             types.add_type_definition(
-                name,
+                self.identifier.0,
                 Type::Custom {
                     module_path: types.module_path(),
-                    name: name.to_string(),
+                    name: self.identifier.0.to_string(),
                     builtin: builtin.into(),
                 },
             )
         } else {
-            let kind = attrs.external_kind().expect("External missing");
-            let tagged = attrs.external_tagged().expect("External missing");
+            let module_path = types.module_path();
+            let name = self.identifier.0.to_string();
+            let ty = match attrs.rust_kind() {
+                Some(RustKind::Object) => Type::Object {
+                    module_path,
+                    name,
+                    imp: ObjectImpl::Struct,
+                },
+                Some(RustKind::Trait) => Type::Object {
+                    module_path,
+                    name,
+                    imp: ObjectImpl::Trait,
+                },
+                Some(RustKind::Record) => Type::Record { module_path, name },
+                Some(RustKind::Enum) => Type::Enum { module_path, name },
+                Some(RustKind::CallbackInterface) => Type::CallbackInterface { module_path, name },
+                // must be external
+                None => {
+                    let kind = attrs.external_kind().expect("External missing kind");
+                    let tagged = attrs.external_tagged().expect("External missing tagged");
+                    Type::External {
+                        name,
+                        namespace: "".to_string(), // we don't know this yet
+                        module_path: attrs.get_crate_name(),
+                        kind,
+                        tagged,
+                    }
+                }
+            };
             // A crate which can supply an `FfiConverter`.
             // We don't reference `self._type`, so ideally we could insist on it being
             // the literal 'extern' but that's tricky
-            types.add_type_definition(
-                name,
-                Type::External {
-                    name: name.to_string(),
-                    namespace: "".to_string(), // we don't know this yet
-                    module_path: attrs.get_crate_name(),
-                    kind,
-                    tagged,
-                },
-            )
+            types.add_type_definition(self.identifier.0, ty)
         }
     }
 }


### PR DESCRIPTION
People who want to slowly move away from UDL, or wish to stick with UDL but use some features available only to procmacros are a little stuck as currently it's impossible for UDL to reference types defined by procmacros in this crate. This PR makes that possible.