### PR TITLE
Adding UDL async support

### DIFF
--- a/docs/manual/src/futures.md
+++ b/docs/manual/src/futures.md
@@ -4,8 +4,6 @@ UniFFI supports exposing async Rust functions over the FFI. It can convert a Rus
 
 Check out the [examples](https://github.com/mozilla/uniffi-rs/tree/main/examples/futures) or the more terse and thorough [fixtures](https://github.com/mozilla/uniffi-rs/tree/main/fixtures/futures).
 
-Note that currently async functions are only supported by proc-macros, UDL support is being planned in https://github.com/mozilla/uniffi-rs/issues/1716.
-
 ## Example
 
 This is a short "async sleep()" example:
@@ -32,6 +30,14 @@ async def main():
 
 if __name__ == '__main__':
     asyncio.run(main())
+```
+
+Async functions can also be defined in UDL:
+```idl
+namespace example {
+    [Async]
+    string say_after(u64 ms, string who);
+}
 ```
 
 This code uses `asyncio` to drive the future to completion, while our exposed function is used with `await`.

--- a/docs/manual/src/udl/functions.md
+++ b/docs/manual/src/udl/functions.md
@@ -47,3 +47,16 @@ fun helloName(name: String = "world" ): String {
     // ...
 }
 ```
+
+## Async
+
+Async functions can be exposed using the `[Async]` attribute:
+
+```idl
+namespace Example {
+    [Async]
+    string async_hello();
+}
+```
+
+See the [Async/Future support section](../futures.md) for details.

--- a/fixtures/futures/src/futures.udl
+++ b/fixtures/futures/src/futures.udl
@@ -1,1 +1,4 @@
-namespace futures {};
+namespace futures {
+    [Async]
+    boolean always_ready();
+};

--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -67,8 +67,9 @@ pub fn greet(who: String) -> String {
     format!("Hello, {who}")
 }
 
-/// Async function that is immediatly ready.
-#[uniffi::export]
+/// Async function that is immediately ready.
+///
+/// (This one is defined in the UDL to test UDL support)
 pub async fn always_ready() -> bool {
     true
 }

--- a/fixtures/futures/src/uniffi_futures.udl
+++ b/fixtures/futures/src/uniffi_futures.udl
@@ -1,1 +1,0 @@
-namespace uniffi_futures {};

--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -15,7 +15,7 @@
 #[::uniffi::export_for_udl]
 pub trait r#{{ obj.name() }} {
     {%- for meth in obj.methods() %}
-    fn {{ meth.name() }}(
+    fn {% if meth.is_async() %}async {% endif %}{{ meth.name() }}(
         {% if meth.takes_self_by_arc()%}self: Arc<Self>{% else %}&self{% endif %},
         {%- for arg in meth.arguments() %}
         {{ arg.name() }}: {% if arg.by_ref() %}&{% endif %}{{ arg.as_type().borrow()|type_rs }},
@@ -68,7 +68,7 @@ impl {{ obj.rust_name() }} {
 {%- for meth in obj.methods() %}
 #[::uniffi::export_for_udl]
 impl {{ obj.rust_name() }} {
-    pub fn r#{{ meth.name() }}(
+    pub {% if meth.is_async() %}async {% endif %}fn r#{{ meth.name() }}(
         {% if meth.takes_self_by_arc()%}self: Arc<Self>{% else %}&self{% endif %},
         {%- for arg in meth.arguments() %}
         r#{{ arg.name() }}: {% if arg.by_ref() %}&{% endif %}{{ arg.as_type().borrow()|type_rs }},

--- a/uniffi_bindgen/src/scaffolding/templates/TopLevelFunctionTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/TopLevelFunctionTemplate.rs
@@ -1,5 +1,5 @@
 #[::uniffi::export_for_udl]
-pub fn r#{{ func.name() }}(
+pub {% if func.is_async() %}async {% endif %}fn r#{{ func.name() }}(
     {%- for arg in func.arguments() %}
     r#{{ arg.name() }}: {% if arg.by_ref() %}&{% endif %}{{ arg.as_type().borrow()|type_rs }},
     {%- endfor %}

--- a/uniffi_udl/src/converters/callables.rs
+++ b/uniffi_udl/src/converters/callables.rs
@@ -89,6 +89,7 @@ impl APIConverter<FnMetadata> for weedle::namespace::OperationNamespaceMember<'_
             Some(id) => id.0.to_string(),
         };
         let attrs = FunctionAttributes::try_from(self.attributes.as_ref())?;
+        let is_async = attrs.is_async();
         let throws = match attrs.get_throws_err() {
             None => None,
             Some(name) => match ci.get_type(name) {
@@ -99,7 +100,7 @@ impl APIConverter<FnMetadata> for weedle::namespace::OperationNamespaceMember<'_
         Ok(FnMetadata {
             module_path: ci.module_path(),
             name,
-            is_async: false,
+            is_async,
             return_type,
             inputs: self.args.body.list.convert(ci)?,
             throws,
@@ -140,6 +141,7 @@ impl APIConverter<MethodMetadata> for weedle::interface::OperationInterfaceMembe
         }
         let return_type = ci.resolve_return_type_expression(&self.return_type)?;
         let attributes = MethodAttributes::try_from(self.attributes.as_ref())?;
+        let is_async = attributes.is_async();
 
         let throws = match attributes.get_throws_err() {
             Some(name) => match ci.get_type(name) {
@@ -164,7 +166,7 @@ impl APIConverter<MethodMetadata> for weedle::interface::OperationInterfaceMembe
             },
             // We don't know the name of the containing `Object` at this point, fill it in later.
             self_name: Default::default(),
-            is_async: false, // not supported in UDL
+            is_async,
             inputs: self.args.body.list.convert(ci)?,
             return_type,
             throws,
@@ -184,6 +186,7 @@ impl APIConverter<TraitMethodMetadata> for weedle::interface::OperationInterface
         }
         let return_type = ci.resolve_return_type_expression(&self.return_type)?;
         let attributes = MethodAttributes::try_from(self.attributes.as_ref())?;
+        let is_async = attributes.is_async();
 
         let throws = match attributes.get_throws_err() {
             Some(name) => match ci.get_type(name) {
@@ -208,7 +211,7 @@ impl APIConverter<TraitMethodMetadata> for weedle::interface::OperationInterface
                     name
                 }
             },
-            is_async: false, // not supported in udl
+            is_async,
             inputs: self.args.body.list.convert(ci)?,
             return_type,
             throws,


### PR DESCRIPTION
If I realized it was this easy, I would have done this before.  `uniffi_udl` is great. Fixes #1716.