### PR TITLE
Implement `Lift` for flat errors

### DIFF
--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -22,6 +22,11 @@ namespace coverall {
     void test_getters(Getters g);
 
     sequence<string> ancestor_names(NodeTrait node);
+
+    ReturnOnlyDict output_return_only_dict();
+    ReturnOnlyEnum output_return_only_enum();
+
+    void try_input_return_only_dict(ReturnOnlyDict d);
 };
 
 dictionary SimpleDict {
@@ -47,6 +52,21 @@ dictionary SimpleDict {
     double? maybe_float64;
     Coveralls? coveralls;
     NodeTrait? test_trait;
+};
+
+// Create a type that stores `CoverallFlatError` and therefore can only be lowered but not lifted.
+// UniFFI should define a `Lower` implemenation but not try to define `Lift`.
+dictionary ReturnOnlyDict {
+    CoverallFlatError e;
+};
+
+// More complicated version of the above, each variant is return-only for different reasons
+[Enum]
+interface ReturnOnlyEnum {
+    One(CoverallFlatError e);
+    Two(ReturnOnlyDict d);
+    Three(sequence<CoverallFlatError> l);
+    Four(record<string, CoverallFlatError> m);
 };
 
 dictionary DictWithDefaults {

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -191,6 +191,44 @@ pub struct SimpleDict {
     test_trait: Option<Arc<dyn NodeTrait>>,
 }
 
+pub struct ReturnOnlyDict {
+    e: CoverallFlatError,
+}
+
+pub enum ReturnOnlyEnum {
+    One {
+        e: CoverallFlatError,
+    },
+    Two {
+        d: ReturnOnlyDict,
+    },
+    Three {
+        l: Vec<CoverallFlatError>,
+    },
+    Four {
+        m: HashMap<String, CoverallFlatError>,
+    },
+}
+
+fn output_return_only_dict() -> ReturnOnlyDict {
+    ReturnOnlyDict {
+        e: CoverallFlatError::TooManyVariants { num: 1 },
+    }
+}
+
+fn output_return_only_enum() -> ReturnOnlyEnum {
+    ReturnOnlyEnum::One {
+        e: CoverallFlatError::TooManyVariants { num: 2 },
+    }
+}
+
+fn try_input_return_only_dict(_d: ReturnOnlyDict) {
+    // This function can't work because ReturnOnlyDict contains a flat error and therefore
+    // can't be lifted by Rust.  There's a Python test that the UniFFI code panics before we get here.
+    //
+    // FIXME: should be a compile-time error rather than a runtime error (#1850)
+}
+
 #[derive(Debug, Clone)]
 pub struct DictWithDefaults {
     name: String,

--- a/fixtures/coverall/tests/bindings/test_coverall.py
+++ b/fixtures/coverall/tests/bindings/test_coverall.py
@@ -4,6 +4,7 @@
 
 import unittest
 from datetime import datetime, timezone
+
 from coverall import *
 
 class TestCoverall(unittest.TestCase):
@@ -288,6 +289,13 @@ class TestCoverall(unittest.TestCase):
     def test_bytes(self):
         coveralls = Coveralls("test_bytes")
         self.assertEqual(coveralls.reverse(b"123"), b"321")
+
+    def test_return_only_dict(self):
+        # try_input_return_only_dict can never work, since ReturnOnlyDict should only be returned
+        # from Rust not inputted.  Test that an attempt raises an internal error rather than tries
+        # to use an invalid value.
+        with self.assertRaises(InternalError):
+            try_input_return_only_dict(ReturnOnlyDict(e=CoverallFlatError.TooManyVariants))
 
 class PyGetters:
     def get_bool(self, v, arg2):


### PR DESCRIPTION
We noticed a regression in `0.25.x` where dictionaries containing flat errors caused code not to be compiled.  We never officially supported compound types that stored errors, but it seems better to allow the code to compile in this case.

The reason this isn't supported is that we can't lift flat errors, so therefore we can't lift the dictionary.  A better fix for this would be to not implement `Lift` on the dictionary in this case, which would cause a compile error rather than a runtime panic.  However, that's actually not so simple as noted in the comment so I went for an easier way.

This brings this very close to how they worked in `0.24.x` where we would generate an `FfiConverter` implementation for flat errors, but the lift half of it would just be panics.