### PR TITLE
Add an arithmetic-procmacro example and tweaks to the examples README

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-example-arithmetic-procmacro"
+version = "0.22.0"
+dependencies = [
+ "thiserror",
+ "uniffi",
+]
+
+[[package]]
 name = "uniffi-example-callbacks"
 version = "0.22.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
 
   "examples/app/uniffi-bindgen-cli",
   "examples/arithmetic",
+  "examples/arithmetic-procmacro",
   "examples/callbacks",
   "examples/custom-types",
   "examples/futures",

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,8 @@ Newcomers are recommended to explore them in the following order:
 
 * [`./arithmetic/`](./arithmetic/) is the most minimal example - just some plain functions that operate
   on integers, and some minimal error handling.
+* [`./arithmetic-procmacro/`](./arithmetic-procmacro/) is a copy of the above example implemented using
+  procmacros - it has no UDL file nor `build.rs` script.
 * [`./geometry/`](./geometry/) shows how to use records and nullable types for working with more complex
   data.
 * [`./sprites/`](./sprites/) shows how to work with stateful objects that have methods, in classical
@@ -24,9 +26,8 @@ Each example has the following structure:
 * `src/<namespace>.udl`, the component interface definition which defines the main object and its methods.
   This is processed by functions in `build.rs` to generate Rust scaffolding for the component.
 * `src/lib.rs`, the core implementation of the component in Rust. This basically
-  pulls in the generated Rust scaffolding via `include!()` and fills in function implementations.
-* `Cargo.toml` configures the crate to build a `cdylib` with an appropriate name, matching the
-  namespace defined in the UDL file.
+  pulls in the generated Rust scaffolding via `uniffi::include_scaffolding!()` and fills in function implementations.
+* `Cargo.toml` configures the crate to build a `cdylib` with an appropriate name.
 * Some small test scripts that double as API examples in each target foreign language:
   * Kotlin `tests/bindings/test_<namespace>.kts`
   * Swift `tests/bindings/test_<namespace>.swift`
@@ -53,10 +54,11 @@ With that in place, try the following:
 * Run `cargo test`.  This will run each of the foreign-language testcases against the compiled Rust code,
   confirming whether everything is working as intended.
 * Explore the build process in more detail:
-  * Run `cargo run -p uniffi -- scaffolding ./src/<namespace>.udl`.
+  * Change to the root directory of this repo, so the `uniffi-bindgen` package referenced below can be found.
+  * Run `cargo run --bin uniffi-bindgen -- scaffolding examples/<example>/src/<namespace>.udl`.
     This will generate the Rust scaffolding code which exposes a C FFI for the component.
     You can view the generatd code in `./src/<namespace>.uniffi.rs`.
-  * Run `cargo run -p uniffi -- generate --language kotlin ./src/<namespace>.udl`.
+  * Run `cargo run --bin uniffi-bindgen -- generate --language kotlin examples/<example>/src/<namespace>.udl`.
     This will generate the foreign-language bindings for Kotlin, which load the compiled Rust code
     and use the C FFI generated above to interact with it.
     You can view the generated code in `./src/uniffi/<namespace>/<namespace>.kt`.

--- a/examples/arithmetic-procmacro/Cargo.toml
+++ b/examples/arithmetic-procmacro/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "uniffi-example-arithmetic-procmacro"
+edition = "2021"
+version = "0.22.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "arithmeticpm"
+
+[dependencies]
+uniffi = {path = "../../uniffi", version = "0.25" }
+thiserror = "1.0"
+
+[build-dependencies]
+uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+
+[dev-dependencies]
+uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }

--- a/examples/arithmetic-procmacro/src/lib.rs
+++ b/examples/arithmetic-procmacro/src/lib.rs
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This example uses `uniffi::` macros to describe the interface.
+
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum ArithmeticError {
+    #[error("Integer overflow on an operation with {a} and {b}")]
+    IntegerOverflow { a: u64, b: u64 },
+}
+
+#[uniffi::export]
+fn add(a: u64, b: u64) -> Result<u64> {
+    a.checked_add(b)
+        .ok_or(ArithmeticError::IntegerOverflow { a, b })
+}
+
+#[uniffi::export]
+fn sub(a: u64, b: u64) -> Result<u64> {
+    a.checked_sub(b)
+        .ok_or(ArithmeticError::IntegerOverflow { a, b })
+}
+
+#[uniffi::export]
+fn div(dividend: u64, divisor: u64) -> u64 {
+    if divisor == 0 {
+        panic!("Can't divide by zero");
+    }
+    dividend / divisor
+}
+
+#[uniffi::export]
+fn equal(a: u64, b: u64) -> bool {
+    a == b
+}
+
+type Result<T, E = ArithmeticError> = std::result::Result<T, E>;
+
+uniffi::setup_scaffolding!();

--- a/examples/arithmetic-procmacro/tests/test.py
+++ b/examples/arithmetic-procmacro/tests/test.py
@@ -1,0 +1,14 @@
+from arithmeticpm import *
+
+try:
+    add(18446744073709551615, 1)
+    assert(not("Should have thrown a IntegerOverflow exception!"))
+except ArithmeticError.IntegerOverflow:
+    # It's okay!
+    pass
+
+assert add(2, 4) == 6
+assert sub(4, 2) == 2
+assert div(8, 4) == 2
+assert equal(2, 2)
+assert not equal(4, 8)

--- a/examples/arithmetic-procmacro/tests/test_generated_bindings.rs
+++ b/examples/arithmetic-procmacro/tests/test_generated_bindings.rs
@@ -1,3 +1,3 @@
-// See the tests from the `aritmetic` crate for more comprehensive
+// See the tests from the `arithmetic` crate for more comprehensive
 // examples - there's just a Python smoke-test here.
 uniffi::build_foreign_language_testcases!("tests/test.py");

--- a/examples/arithmetic-procmacro/tests/test_generated_bindings.rs
+++ b/examples/arithmetic-procmacro/tests/test_generated_bindings.rs
@@ -1,0 +1,3 @@
+// See the tests from the `aritmetic` crate for more comprehensive
+// examples - there's just a Python smoke-test here.
+uniffi::build_foreign_language_testcases!("tests/test.py");


### PR DESCRIPTION
I figured it made sense for someone who got pointed to our `examples` directory to be able to see what procmacros look like.