### PR TITLE
Use a workspace dependency for the top-level uniffi crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,6 @@ members = [
 ]
 
 resolver = "2"
+
+[workspace.dependencies]
+uniffi = { path = "./uniffi", version = "0.25" }

--- a/examples/app/uniffi-bindgen-cli/Cargo.toml
+++ b/examples/app/uniffi-bindgen-cli/Cargo.toml
@@ -9,4 +9,4 @@ name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 
 [dependencies]
-uniffi = { path = "../../../uniffi", version = "0.25", features = ["cli"] }
+uniffi = { workspace = true, features = ["cli"] }

--- a/examples/arithmetic-procmacro/Cargo.toml
+++ b/examples/arithmetic-procmacro/Cargo.toml
@@ -11,11 +11,11 @@ crate-type = ["lib", "cdylib"]
 name = "arithmeticpm"
 
 [dependencies]
-uniffi = {path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -11,11 +11,11 @@ crate-type = ["lib", "cdylib"]
 name = "arithmetical"
 
 [dependencies]
-uniffi = {path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/examples/callbacks/Cargo.toml
+++ b/examples/callbacks/Cargo.toml
@@ -11,11 +11,11 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_callbacks"
 
 [dependencies]
-uniffi = {path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/examples/custom-types/Cargo.toml
+++ b/examples/custom-types/Cargo.toml
@@ -13,11 +13,11 @@ name = "custom_types"
 [dependencies]
 anyhow = "1"
 bytes = "1.3"
-uniffi = {path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 url = "2.2"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/examples/futures/Cargo.toml
+++ b/examples/futures/Cargo.toml
@@ -12,10 +12,10 @@ crate-type = ["lib", "cdylib"]
 [dependencies]
 async-std = "1.12.0"
 thiserror = "1.0"
-uniffi = {path = "../../uniffi" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/examples/geometry/Cargo.toml
+++ b/examples/geometry/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_geometry"
 
 [dependencies]
-uniffi = {path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/examples/rondpoint/Cargo.toml
+++ b/examples/rondpoint/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_rondpoint"
 
 [dependencies]
-uniffi = {path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/examples/sprites/Cargo.toml
+++ b/examples/sprites/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_sprites"
 
 [dependencies]
-uniffi = {path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/examples/todolist/Cargo.toml
+++ b/examples/todolist/Cargo.toml
@@ -11,12 +11,12 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_todolist"
 
 [dependencies]
-uniffi = {path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 once_cell = "1.12"
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/examples/traits/Cargo.toml
+++ b/examples/traits/Cargo.toml
@@ -11,12 +11,12 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_traits"
 
 [dependencies]
-uniffi = {path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }
 

--- a/fixtures/benchmarks/Cargo.toml
+++ b/fixtures/benchmarks/Cargo.toml
@@ -12,12 +12,12 @@ name = "uniffi_benchmarks"
 bench = false
 
 [dependencies]
-uniffi = {path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 clap = { version = "4", features = ["cargo", "std", "derive"] }
 criterion = "0.5.1"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
 uniffi_bindgen = {path = "../../uniffi_bindgen"}

--- a/fixtures/callbacks/Cargo.toml
+++ b/fixtures/callbacks/Cargo.toml
@@ -11,11 +11,11 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_fixture_callbacks"
 
 [dependencies]
-uniffi = {path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/coverall/Cargo.toml
+++ b/fixtures/coverall/Cargo.toml
@@ -11,12 +11,12 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_coverall"
 
 [dependencies]
-uniffi = {path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 once_cell = "1.12"
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/ext-types/guid/Cargo.toml
+++ b/fixtures/ext-types/guid/Cargo.toml
@@ -14,10 +14,10 @@ name = "ext_types_guid"
 anyhow = "1"
 bytes = "1.3"
 thiserror = "1.0"
-uniffi = {path = "../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/ext-types/http-headermap/Cargo.toml
+++ b/fixtures/ext-types/http-headermap/Cargo.toml
@@ -14,10 +14,10 @@ anyhow = "1"
 bytes = "1.3"
 http = "0.2.9"
 thiserror = "1.0"
-uniffi = {path = "../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/ext-types/lib/Cargo.toml
+++ b/fixtures/ext-types/lib/Cargo.toml
@@ -22,7 +22,7 @@ name = "uniffi_ext_types_lib"
 [dependencies]
 anyhow = "1"
 bytes = "1.3"
-uniffi = {path = "../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 uniffi-fixture-ext-types-external-crate = {path = "../external-crate"}
 uniffi-fixture-ext-types-lib-one = {path = "../uniffi-one"}
@@ -35,7 +35,7 @@ uniffi-example-custom-types = {path = "../../../examples/custom-types"}
 url = "2.2"
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/ext-types/proc-macro-lib/Cargo.toml
+++ b/fixtures/ext-types/proc-macro-lib/Cargo.toml
@@ -20,7 +20,7 @@ name = "uniffi_ext_types_proc_macro_lib"
 [dependencies]
 anyhow = "1"
 bytes = "1.3"
-uniffi = {path = "../../../uniffi"}
+uniffi = { workspace = true }
 
 uniffi-fixture-ext-types-lib-one = {path = "../uniffi-one"}
 uniffi-fixture-ext-types-guid = {path = "../guid"}
@@ -31,7 +31,7 @@ uniffi-example-custom-types = {path = "../../../examples/custom-types"}
 url = "2.2"
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../../uniffi", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/ext-types/sub-lib/Cargo.toml
+++ b/fixtures/ext-types/sub-lib/Cargo.toml
@@ -17,11 +17,11 @@ name = "uniffi_sublib"
 
 [dependencies]
 anyhow = "1"
-uniffi = {path = "../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 uniffi-fixture-ext-types-lib-one = {path = "../uniffi-one"}
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/ext-types/uniffi-one/Cargo.toml
+++ b/fixtures/ext-types/uniffi-one/Cargo.toml
@@ -14,7 +14,7 @@ name = "uniffi_one"
 [dependencies]
 anyhow = "1"
 bytes = "1.3"
-uniffi = {path = "../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }

--- a/fixtures/futures/Cargo.toml
+++ b/fixtures/futures/Cargo.toml
@@ -15,13 +15,13 @@ name = "uniffi-fixtures-futures"
 path = "src/bin.rs"
 
 [dependencies]
-uniffi = { path = "../../uniffi", version = "0.25", features = ["tokio", "cli"] }
+uniffi = { workspace = true, features = ["tokio", "cli"] }
 thiserror = "1.0"
 tokio = { version = "1.24.1", features = ["time", "sync"] }
 once_cell = "1.18.0"
 
 [build-dependencies]
-uniffi = { path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = { path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/keywords/kotlin/Cargo.toml
+++ b/fixtures/keywords/kotlin/Cargo.toml
@@ -11,10 +11,10 @@ name = "uniffi_keywords_kotlin"
 
 [dependencies]
 thiserror = "1.0"
-uniffi = {path = "../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/keywords/rust/Cargo.toml
+++ b/fixtures/keywords/rust/Cargo.toml
@@ -11,10 +11,10 @@ name = "uniffi_keywords_rust"
 
 [dependencies]
 thiserror = "1.0"
-uniffi = {path = "../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/keywords/swift/Cargo.toml
+++ b/fixtures/keywords/swift/Cargo.toml
@@ -11,10 +11,10 @@ name = "uniffi_keywords_swift"
 
 [dependencies]
 thiserror = "1.0"
-uniffi = {path = "../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/large-enum/Cargo.toml
+++ b/fixtures/large-enum/Cargo.toml
@@ -11,11 +11,11 @@ crate-type = ["lib", "cdylib"]
 name = "large_enum"
 
 [dependencies]
-uniffi = {path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/metadata/Cargo.toml
+++ b/fixtures/metadata/Cargo.toml
@@ -10,6 +10,6 @@ name = "uniffi_fixture_metadata"
 
 [dependencies]
 thiserror = "1.0"
-uniffi = { path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 uniffi_meta = { path = "../../uniffi_meta" }
 uniffi_core = { path = "../../uniffi_core" }

--- a/fixtures/proc-macro/Cargo.toml
+++ b/fixtures/proc-macro/Cargo.toml
@@ -11,12 +11,12 @@ name = "uniffi_proc_macro"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-uniffi = { path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 thiserror = "1.0"
 lazy_static = "1.4"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
+++ b/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
@@ -11,11 +11,11 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_empty"
 
 [dependencies]
-uniffi = {path = "../../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 uniffi-fixture-regression-cdylib-dependency = {path = "../cdylib-dependency"}
 
 [build-dependencies]
-uniffi = {path = "../../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
+++ b/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_regression_test_i356"
 
 [dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/regressions/fully-qualified-types/Cargo.toml
+++ b/fixtures/regressions/fully-qualified-types/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_regression_test_i1015"
 
 [dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }

--- a/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
+++ b/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_regression_test_kt_unsigned_types"
 
 [dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/regressions/logging-callback-interface/Cargo.toml
+++ b/fixtures/regressions/logging-callback-interface/Cargo.toml
@@ -11,10 +11,10 @@ name = "uniffi_regression_logging_callback_interface"
 
 [dependencies]
 log = "0.4"
-uniffi = {path = "../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/regressions/missing-newline/Cargo.toml
+++ b/fixtures/regressions/missing-newline/Cargo.toml
@@ -10,10 +10,10 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_regression_test_missing_newline"
 
 [dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/regressions/nested-module-import/Cargo.toml
+++ b/fixtures/regressions/nested-module-import/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_regression_test_nested_module_import"
 
 [dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }

--- a/fixtures/regressions/swift-callbacks-omit-labels/Cargo.toml
+++ b/fixtures/regressions/swift-callbacks-omit-labels/Cargo.toml
@@ -10,10 +10,10 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_regression_test_callbacks_omit_labels"
 
 [dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/regressions/swift-dictionary-nesting/Cargo.toml
+++ b/fixtures/regressions/swift-dictionary-nesting/Cargo.toml
@@ -10,10 +10,10 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_regression_test_swift_dictionary_nesting"
 
 [dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/regressions/unary-result-alias/Cargo.toml
+++ b/fixtures/regressions/unary-result-alias/Cargo.toml
@@ -10,11 +10,11 @@ name = "uniffi_unary_result_alias"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-uniffi = { path = "../../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/simple-fns/Cargo.toml
+++ b/fixtures/simple-fns/Cargo.toml
@@ -11,10 +11,10 @@ name = "uniffi_simple_fns"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-uniffi = { path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/simple-iface/Cargo.toml
+++ b/fixtures/simple-iface/Cargo.toml
@@ -11,12 +11,12 @@ name = "uniffi_simple_iface"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-uniffi = { path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 thiserror = "1.0"
 lazy_static = "1.4"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/swift-bridging-header-compile/Cargo.toml
+++ b/fixtures/swift-bridging-header-compile/Cargo.toml
@@ -10,13 +10,13 @@ name = "uniffi_swift_bridging_header_compiler"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-uniffi = { path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 camino = "1.0.8"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests", "cli"] }
+uniffi = { workspace = true, features = ["bindgen-tests", "cli"] }
 uniffi_testing = { path = "../../uniffi_testing" }
 anyhow = "1"

--- a/fixtures/swift-omit-labels/Cargo.toml
+++ b/fixtures/swift-omit-labels/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_omit_argument_labels"
 
 [dependencies]
-uniffi = {path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/trait-methods/Cargo.toml
+++ b/fixtures/trait-methods/Cargo.toml
@@ -10,13 +10,13 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_trait_methods"
 
 [dependencies]
-uniffi = {path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 once_cell = "1.12"
 thiserror = "1.0"
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }
 

--- a/fixtures/type-limits/Cargo.toml
+++ b/fixtures/type-limits/Cargo.toml
@@ -10,10 +10,10 @@ name = "uniffi_type_limits"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-uniffi = { path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/uitests/Cargo.toml
+++ b/fixtures/uitests/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 name = "uniffi_uitests"
 
 [dependencies]
-uniffi = {path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 uniffi_macros = {path = "../../uniffi_macros"}
 thiserror = "1.0"
 

--- a/fixtures/uniffi-fixture-time/Cargo.toml
+++ b/fixtures/uniffi-fixture-time/Cargo.toml
@@ -11,12 +11,12 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_chronological"
 
 [dependencies]
-uniffi = {path = "../../uniffi", version = "0.25" }
+uniffi = { workspace = true }
 thiserror = "1.0"
 chrono = { version = "0.4.23", default-features = false, features = ["alloc", "std"] }
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", version = "0.25", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/version-mismatch/Cargo.toml
+++ b/fixtures/version-mismatch/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 proc_macro_v2 = []
 
 [dependencies]
-uniffi = { path = "../../uniffi", version = "0.25", features = ["cli"]}
+uniffi = { workspace = true, features = ["cli"]}
 
 [build-dependencies]
-uniffi = { path = "../../uniffi", version = "0.25", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }


### PR DESCRIPTION
This is only done for the top-level uniffi crate now, so really only impacts our examples and fixtures. It might be the case that we could extend this to the sub-crates but the versioning for them is less clear.

I can't see a good reason to not do this - is there one I'm missing?