### PR TITLE
Kill `UniFfiTag`

### DIFF
--- a/examples/custom-types/src/lib.rs
+++ b/examples/custom-types/src/lib.rs
@@ -118,4 +118,9 @@ pub fn get_example_custom_type() -> ExampleCustomType {
     ExampleCustomType("abadidea".to_string())
 }
 
+#[uniffi::export]
+pub fn get_url(url: Option<Url>) -> Url {
+    url.unwrap_or_else(|| Url::parse("https://mozilla.org").unwrap())
+}
+
 uniffi::include_scaffolding!("custom-types");

--- a/fixtures/metadata/src/lib.rs
+++ b/fixtures/metadata/src/lib.rs
@@ -7,5 +7,3 @@
 /// on all the functionality.
 #[cfg(test)]
 mod tests;
-
-pub struct UniFfiTag;

--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -5,7 +5,6 @@
 /// This entire crate is just a set of tests for metadata handling.  We use a separate crate
 /// for testing because the metadata handling is split up between several crates, and no crate
 /// owns all the functionality.
-use crate::UniFfiTag;
 use uniffi_meta::*;
 
 mod person {
@@ -90,7 +89,7 @@ mod test_type_ids {
     use std::sync::Arc;
     use uniffi_core::Lower;
 
-    fn check_type_id<T: Lower<UniFfiTag>>(correct_type: Type) {
+    fn check_type_id<T: Lower>(correct_type: Type) {
         let buf = &mut T::TYPE_ID_META.as_ref();
         assert_eq!(
             uniffi_meta::read_metadata_type(buf).unwrap(),

--- a/fixtures/reexport-scaffolding-macro/src/lib.rs
+++ b/fixtures/reexport-scaffolding-macro/src/lib.rs
@@ -11,8 +11,6 @@ mod tests {
     use uniffi::{FfiConverter, ForeignCallback, RustBuffer, RustCallStatus, RustCallStatusCode};
     use uniffi_bindgen::ComponentInterface;
 
-    struct UniFfiTag;
-
     // Load the dynamic library that was built for this crate.  The external functions from
     // `uniffi_callbacks' and `uniffi_coverall` should be present.
     pub fn load_library() -> Library {
@@ -170,7 +168,7 @@ mod tests {
 
         let obj_id = unsafe {
             coveralls_new(
-                <String as FfiConverter<UniFfiTag>>::lower("TestName".into()),
+                <String as FfiConverter>::lower("TestName".into()),
                 &mut call_status,
             )
         };
@@ -179,7 +177,7 @@ mod tests {
         let name_buf = unsafe { coveralls_get_name(obj_id, &mut call_status) };
         assert_eq!(call_status.code, RustCallStatusCode::Success);
         assert_eq!(
-            <String as FfiConverter<UniFfiTag>>::try_lift(name_buf).unwrap(),
+            <String as FfiConverter>::try_lift(name_buf).unwrap(),
             "TestName"
         );
 

--- a/uniffi/tests/ui/proc_macro_arc.rs
+++ b/uniffi/tests/ui/proc_macro_arc.rs
@@ -2,9 +2,6 @@ use std::sync::Arc;
 
 fn main() {}
 
-// Normally this is defined by the scaffolding code, manually define it for the UI test
-pub struct UniFfiTag;
-
 pub struct Foo;
 
 #[uniffi::export]

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
@@ -124,7 +124,7 @@ inline fun <T : Disposable?, R> T.use(block: (T) -> R) =
 {%- when Type::Custom { module_path, name, builtin } %}
 {% include "CustomTypeTemplate.kt" %}
 
-{%- when Type::External { module_path, name, namespace, kind, tagged } %}
+{%- when Type::External { module_path, name, namespace, kind } %}
 {% include "ExternalTypeTemplate.kt" %}
 
 {%- else %}

--- a/uniffi_bindgen/src/bindings/python/templates/Types.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Types.py
@@ -91,7 +91,7 @@
 {%- when Type::Custom { name, module_path, builtin } %}
 {%- include "CustomType.py" %}
 
-{%- when Type::External { name, module_path, namespace, kind, tagged } %}
+{%- when Type::External { name, module_path, namespace, kind } %}
 {%- include "ExternalTemplate.py" %}
 
 {%- when Type::ForeignExecutor %}

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -265,28 +265,6 @@ impl ComponentInterface {
         self.is_name_used_as_error(&e.name) && (fielded || used_in_foreign_interface)
     }
 
-    /// Get details about all `Type::External` types.
-    /// Returns an iterator of (name, crate_name, kind)
-    pub fn iter_external_types(
-        &self,
-    ) -> impl Iterator<Item = (&String, String, ExternalKind, bool)> {
-        self.types.iter_known_types().filter_map(|t| match t {
-            Type::External {
-                name,
-                module_path,
-                kind,
-                tagged,
-                ..
-            } => Some((
-                name,
-                module_path.split("::").next().unwrap().to_string(),
-                *kind,
-                *tagged,
-            )),
-            _ => None,
-        })
-    }
-
     /// Get details about all `Type::Custom` types
     pub fn iter_custom_types(&self) -> impl Iterator<Item = (&String, &Type)> {
         self.types.iter_known_types().filter_map(|t| match t {

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -70,7 +70,7 @@ mod filters {
 
     // Map a type to Rust code that specifies the FfiConverter implementation.
     //
-    // This outputs something like `<MyStruct as Lift<crate::UniFfiTag>>`
+    // This outputs something like `<MyStruct as Lift>`
     pub fn ffi_trait(type_: &Type, trait_name: &str) -> Result<String, askama::Error> {
         Ok(match type_ {
             Type::External {
@@ -78,12 +78,9 @@ mod filters {
                 kind: ExternalKind::Interface,
                 ..
             } => {
-                format!("<::std::sync::Arc<r#{name}> as ::uniffi::{trait_name}<crate::UniFfiTag>>")
+                format!("<::std::sync::Arc<r#{name}> as ::uniffi::{trait_name}>")
             }
-            _ => format!(
-                "<{} as ::uniffi::{trait_name}<crate::UniFfiTag>>",
-                type_rs(type_)?
-            ),
+            _ => format!("<{} as ::uniffi::{trait_name}>", type_rs(type_)?),
         })
     }
 

--- a/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/CallbackInterfaceTemplate.rs
@@ -40,7 +40,7 @@ impl {{ trait_impl }} {
 
 impl Drop for {{ trait_impl }} {
     fn drop(&mut self) {
-        {{ foreign_callback_internals }}.invoke_callback::<(), crate::UniFfiTag>(
+        {{ foreign_callback_internals }}.invoke_callback::<()>(
             self.handle, uniffi::IDX_CALLBACK_FREE, Default::default()
         )
     }
@@ -74,7 +74,7 @@ impl r#{{ trait_name }} for {{ trait_impl }} {
         let args_rbuf = uniffi::RustBuffer::from_vec(args_buf);
 
         {#- Calling into foreign code. #}
-        {{ foreign_callback_internals }}.invoke_callback::<{{ meth|return_type }}, crate::UniFfiTag>(self.handle, {{ loop.index }}, args_rbuf)
+        {{ foreign_callback_internals }}.invoke_callback::<{{ meth|return_type }}>(self.handle, {{ loop.index }}, args_rbuf)
     }
     {%- endfor %}
 }

--- a/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
@@ -1,19 +1,5 @@
 // Support for external types.
 
-// Types with an external `FfiConverter`...
-{% for (name, crate_name, kind, tagged) in ci.iter_external_types() %}
-// The FfiConverter for `{{ name }}` is defined in `{{ crate_name }}`
-// If it has its existing FfiConverter defined with a UniFFITag, it needs forwarding.
-{% if tagged %}
-{%- match kind %}
-{%- when ExternalKind::DataClass %}
-::uniffi::ffi_converter_forward!(r#{{ name }}, ::{{ crate_name|crate_name_rs }}::UniFfiTag, crate::UniFfiTag);
-{%- when ExternalKind::Interface %}
-::uniffi::ffi_converter_arc_forward!(r#{{ name }}, ::{{ crate_name|crate_name_rs }}::UniFfiTag, crate::UniFfiTag);
-{%- endmatch %}
-{% endif %}
-{%- endfor %}
-
 // We generate support for each Custom Type and the builtin type it uses.
 {%- for (name, builtin) in ci.iter_custom_types() %}
 ::uniffi::custom_type!(r#{{ name }}, {{builtin|type_rs}});

--- a/uniffi_core/src/ffi/callbackinterface.rs
+++ b/uniffi_core/src/ffi/callbackinterface.rs
@@ -167,9 +167,9 @@ impl ForeignCallbackInternals {
     }
 
     /// Invoke a callback interface method on the foreign side and return the result
-    pub fn invoke_callback<R, UniFfiTag>(&self, handle: u64, method: u32, args: RustBuffer) -> R
+    pub fn invoke_callback<R>(&self, handle: u64, method: u32, args: RustBuffer) -> R
     where
-        R: LiftReturn<UniFfiTag>,
+        R: LiftReturn,
     {
         let mut ret_rbuf = RustBuffer::new();
         let callback = self.callback_cell.get();
@@ -189,7 +189,7 @@ impl ForeignCallbackInternals {
             CallbackResult::Error => R::lift_callback_error(ret_rbuf),
             CallbackResult::UnexpectedError => {
                 let reason = if !ret_rbuf.is_empty() {
-                    match <String as Lift<UniFfiTag>>::try_lift(ret_rbuf) {
+                    match <String as Lift>::try_lift(ret_rbuf) {
                         Ok(s) => s,
                         Err(e) => {
                             log::error!("{{ trait_name }} Error reading ret_buf: {e}");

--- a/uniffi_macros/src/custom.rs
+++ b/uniffi_macros/src/custom.rs
@@ -25,27 +25,27 @@ pub(crate) fn expand_ffi_converter_custom_type(
             // Note: the builtin type needs to implement both `Lower` and `Lift'.  We use the
             // `Lower` trait to get the associated type `FfiType` and const `TYPE_ID_META`.  These
             // can't differ between `Lower` and `Lift`.
-            type FfiType = <#builtin as ::uniffi::Lower<crate::UniFfiTag>>::FfiType;
+            type FfiType = <#builtin as ::uniffi::Lower>::FfiType;
             fn lower(obj: #ident ) -> Self::FfiType {
-                <#builtin as ::uniffi::Lower<crate::UniFfiTag>>::lower(<#ident as crate::UniffiCustomTypeConverter>::from_custom(obj))
+                <#builtin as ::uniffi::Lower>::lower(<#ident as crate::UniffiCustomTypeConverter>::from_custom(obj))
             }
 
             fn try_lift(v: Self::FfiType) -> uniffi::Result<#ident> {
-                <#ident as crate::UniffiCustomTypeConverter>::into_custom(<#builtin as ::uniffi::Lift<crate::UniFfiTag>>::try_lift(v)?)
+                <#ident as crate::UniffiCustomTypeConverter>::into_custom(<#builtin as ::uniffi::Lift>::try_lift(v)?)
             }
 
             fn write(obj: #ident, buf: &mut Vec<u8>) {
-                <#builtin as ::uniffi::Lower<crate::UniFfiTag>>::write(<#ident as crate::UniffiCustomTypeConverter>::from_custom(obj), buf);
+                <#builtin as ::uniffi::Lower>::write(<#ident as crate::UniffiCustomTypeConverter>::from_custom(obj), buf);
             }
 
             fn try_read(buf: &mut &[u8]) -> uniffi::Result<#ident> {
-                <#ident as crate::UniffiCustomTypeConverter>::into_custom(<#builtin as ::uniffi::Lift<crate::UniFfiTag>>::try_read(buf)?)
+                <#ident as crate::UniffiCustomTypeConverter>::into_custom(<#builtin as ::uniffi::Lift>::try_read(buf)?)
             }
 
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_CUSTOM)
                 .concat_str(#mod_path)
                 .concat_str(#name)
-                .concat(<#builtin as ::uniffi::Lower<crate::UniFfiTag>>::TYPE_ID_META);
+                .concat(<#builtin as ::uniffi::Lower>::TYPE_ID_META);
         }
 
         #derive_ffi_traits

--- a/uniffi_macros/src/enum_.rs
+++ b/uniffi_macros/src/enum_.rs
@@ -108,7 +108,7 @@ fn enum_or_error_ffi_converter_impl(
     quote! {
         #[automatically_derived]
         unsafe #impl_spec {
-            ::uniffi::ffi_converter_rust_buffer_lift_and_lower!(crate::UniFfiTag);
+            ::uniffi::ffi_converter_rust_buffer_lift_and_lower!();
 
             fn write(obj: Self, buf: &mut ::std::vec::Vec<u8>) {
                 #write_impl
@@ -132,7 +132,7 @@ fn write_field(f: &Field) -> TokenStream {
     let ty = &f.ty;
 
     quote! {
-        <#ty as ::uniffi::Lower<crate::UniFfiTag>>::write(#ident, buf);
+        <#ty as ::uniffi::Lower>::write(#ident, buf);
     }
 }
 
@@ -184,7 +184,7 @@ pub fn variant_metadata(enum_: &DataEnum) -> syn::Result<Vec<TokenStream>> {
                         .concat_value(#fields_len)
                             #(
                                 .concat_str(#field_names)
-                                .concat(<#field_types as ::uniffi::Lower<crate::UniFfiTag>>::TYPE_ID_META)
+                                .concat(<#field_types as ::uniffi::Lower>::TYPE_ID_META)
                                 // field defaults not yet supported for enums
                                 .concat_bool(false)
                             )*

--- a/uniffi_macros/src/error.rs
+++ b/uniffi_macros/src/error.rs
@@ -102,7 +102,7 @@ fn flat_error_ffi_converter_impl(
             quote! {
                 Self::#v_ident { .. } => {
                     ::uniffi::deps::bytes::BufMut::put_i32(buf, #idx);
-                    <::std::string::String as ::uniffi::Lower<crate::UniFfiTag>>::write(error_msg, buf);
+                    <::std::string::String as ::uniffi::Lower>::write(error_msg, buf);
                 }
             }
         });
@@ -118,7 +118,7 @@ fn flat_error_ffi_converter_impl(
                 }
 
                 fn lower(obj: Self) -> ::uniffi::RustBuffer {
-                    <Self as ::uniffi::Lower<crate::UniFfiTag>>::lower_into_rust_buffer(obj)
+                    <Self as ::uniffi::Lower>::lower_into_rust_buffer(obj)
                 }
 
                 const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_ENUM)
@@ -150,10 +150,10 @@ fn flat_error_ffi_converter_impl(
                 }
 
                 fn try_lift(v: ::uniffi::RustBuffer) -> ::uniffi::deps::anyhow::Result<Self> {
-                    <Self as ::uniffi::Lift<crate::UniFfiTag>>::try_lift_from_rust_buffer(v)
+                    <Self as ::uniffi::Lift>::try_lift_from_rust_buffer(v)
                 }
 
-                const TYPE_ID_META: ::uniffi::MetadataBuffer = <Self as ::uniffi::Lower<crate::UniFfiTag>>::TYPE_ID_META;
+                const TYPE_ID_META: ::uniffi::MetadataBuffer = <Self as ::uniffi::Lower>::TYPE_ID_META;
             }
 
         }
@@ -178,7 +178,7 @@ fn flat_error_ffi_converter_impl(
                     panic!("Can't lift flat errors")
                 }
 
-                const TYPE_ID_META: ::uniffi::MetadataBuffer = <Self as ::uniffi::Lower<crate::UniFfiTag>>::TYPE_ID_META;
+                const TYPE_ID_META: ::uniffi::MetadataBuffer = <Self as ::uniffi::Lower>::TYPE_ID_META;
             }
         }
     };

--- a/uniffi_macros/src/export/callback_interface.rs
+++ b/uniffi_macros/src/export/callback_interface.rs
@@ -56,7 +56,7 @@ pub(super) fn trait_impl(
 
         impl ::std::ops::Drop for #trait_impl_ident {
             fn drop(&mut self) {
-                #internals_ident.invoke_callback::<(), crate::UniFfiTag>(
+                #internals_ident.invoke_callback::<()>(
                     self.handle, uniffi::IDX_CALLBACK_FREE, Default::default()
                 )
             }
@@ -115,7 +115,7 @@ pub fn ffi_converter_callback_interface_impl(
             fn try_read(buf: &mut &[u8]) -> ::uniffi::deps::anyhow::Result<Self> {
                 use uniffi::deps::bytes::Buf;
                 ::uniffi::check_remaining(buf, 8)?;
-                <Self as ::uniffi::Lift<crate::UniFfiTag>>::try_lift(buf.get_u64())
+                <Self as ::uniffi::Lift>::try_lift(buf.get_u64())
             }
 
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(
@@ -173,7 +173,7 @@ fn gen_method_impl(sig: &FnSignature, internals_ident: &Ident) -> syn::Result<To
             #(#write_exprs;)*
             let uniffi_args_rbuf = uniffi::RustBuffer::from_vec(#buf_ident);
 
-            #internals_ident.invoke_callback::<#return_ty, crate::UniFfiTag>(self.handle, #index, uniffi_args_rbuf)
+            #internals_ident.invoke_callback::<#return_ty>(self.handle, #index, uniffi_args_rbuf)
         }
     })
 }

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -127,11 +127,11 @@ impl ScaffoldingBits {
         let ident = &sig.ident;
         let lift_impl = if is_trait {
             quote! {
-                <::std::sync::Arc<dyn #self_ident> as ::uniffi::Lift<crate::UniFfiTag>>
+                <::std::sync::Arc<dyn #self_ident> as ::uniffi::Lift>
             }
         } else {
             quote! {
-                <::std::sync::Arc<#self_ident> as ::uniffi::Lift<crate::UniFfiTag>>
+                <::std::sync::Arc<#self_ident> as ::uniffi::Lift>
             }
         };
         let params: Vec<_> = iter::once(quote! { uniffi_self_lowered: #lift_impl::FfiType })
@@ -271,7 +271,6 @@ pub(super) fn gen_ffi_function(
                     Ok(uniffi_args) => {
                         ::uniffi::rust_future_new(
                             async move { #future_expr.await },
-                            crate::UniFfiTag
                         )
                     },
                     Err((arg_name, anyhow_error)) => {
@@ -279,7 +278,6 @@ pub(super) fn gen_ffi_function(
                             async move {
                                 #return_impl::handle_failed_lift(arg_name, anyhow_error)
                             },
-                            crate::UniFfiTag,
                         )
                     },
                 }

--- a/uniffi_macros/src/export/trait_interface.rs
+++ b/uniffi_macros/src/export/trait_interface.rs
@@ -108,14 +108,14 @@ pub(crate) fn ffi_converter(mod_path: &str, trait_ident: &Ident, udl_mode: bool)
                 ::uniffi::deps::static_assertions::const_assert!(::std::mem::size_of::<*const ::std::ffi::c_void>() <= 8);
                 ::uniffi::deps::bytes::BufMut::put_u64(
                     buf,
-                    <Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::lower(obj) as u64,
+                    <Self as ::uniffi::FfiConverterArc>::lower(obj) as u64,
                 );
             }
 
             fn try_read(buf: &mut &[u8]) -> ::uniffi::Result<::std::sync::Arc<Self>> {
                 ::uniffi::deps::static_assertions::const_assert!(::std::mem::size_of::<*const ::std::ffi::c_void>() <= 8);
                 ::uniffi::check_remaining(buf, 8)?;
-                <Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::try_lift(
+                <Self as ::uniffi::FfiConverterArc>::try_lift(
                     ::uniffi::deps::bytes::Buf::get_u64(buf) as Self::FfiType)
             }
 

--- a/uniffi_macros/src/fnsig.rs
+++ b/uniffi_macros/src/fnsig.rs
@@ -103,7 +103,7 @@ impl FnSignature {
     pub fn return_impl(&self) -> TokenStream {
         let return_ty = &self.return_ty;
         quote! {
-            <#return_ty as ::uniffi::LowerReturn<crate::UniFfiTag>>
+            <#return_ty as ::uniffi::LowerReturn>
         }
     }
 
@@ -211,7 +211,7 @@ impl FnSignature {
                     .concat_bool(#is_async)
                     .concat_value(#args_len)
                     #(#arg_metadata_calls)*
-                    .concat(<#return_ty as ::uniffi::LowerReturn<crate::UniFfiTag>>::TYPE_ID_META)
+                    .concat(<#return_ty as ::uniffi::LowerReturn>::TYPE_ID_META)
             }),
 
             FnKind::Method { self_ident } => {
@@ -224,7 +224,7 @@ impl FnSignature {
                         .concat_bool(#is_async)
                         .concat_value(#args_len)
                         #(#arg_metadata_calls)*
-                        .concat(<#return_ty as ::uniffi::LowerReturn<crate::UniFfiTag>>::TYPE_ID_META)
+                        .concat(<#return_ty as ::uniffi::LowerReturn>::TYPE_ID_META)
                 })
             }
 
@@ -239,7 +239,7 @@ impl FnSignature {
                         .concat_bool(#is_async)
                         .concat_value(#args_len)
                         #(#arg_metadata_calls)*
-                        .concat(<#return_ty as ::uniffi::LowerReturn<crate::UniFfiTag>>::TYPE_ID_META)
+                        .concat(<#return_ty as ::uniffi::LowerReturn>::TYPE_ID_META)
                 })
             }
 
@@ -252,7 +252,7 @@ impl FnSignature {
                         .concat_str(#name)
                         .concat_value(#args_len)
                         #(#arg_metadata_calls)*
-                        .concat(<#return_ty as ::uniffi::LowerReturn<crate::UniFfiTag>>::TYPE_ID_META)
+                        .concat(<#return_ty as ::uniffi::LowerReturn>::TYPE_ID_META)
                 })
             }
         }
@@ -389,7 +389,7 @@ impl NamedArg {
                 Self {
                     name: ident_to_string(&ident),
                     ident,
-                    ty: quote! { <#inner as ::uniffi::LiftRef<crate::UniFfiTag>>::LiftType },
+                    ty: quote! { <#inner as ::uniffi::LiftRef>::LiftType },
                     ref_type: Some(*inner.clone()),
                 }
             }
@@ -404,12 +404,12 @@ impl NamedArg {
 
     pub(crate) fn lift_impl(&self) -> TokenStream {
         let ty = &self.ty;
-        quote! { <#ty as ::uniffi::Lift<crate::UniFfiTag>> }
+        quote! { <#ty as ::uniffi::Lift> }
     }
 
     pub(crate) fn lower_impl(&self) -> TokenStream {
         let ty = &self.ty;
-        quote! { <#ty as ::uniffi::Lower<crate::UniFfiTag>> }
+        quote! { <#ty as ::uniffi::Lower> }
     }
 
     /// Generate the parameter for this Arg

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -199,21 +199,8 @@ pub fn custom_newtype(tokens: TokenStream) -> TokenStream {
 // In UDL mode, we don't export the static metadata symbols or generate the checksum
 // functions.  This could be changed, but there doesn't seem to be much benefit at this point.
 //
-// ## The FfiConverter<UT> parameter
-//
-// In UDL-mode, we only implement `FfiConverter` for the local tag (`FfiConverter<crate::UniFfiTag>`)
-//
-// The reason for this split is remote types, i.e. types defined in remote crates that we
-// don't control and therefore can't define a blanket impl on because of the orphan rules.
-//
-// With UDL, we handle this by only implementing `FfiConverter<crate::UniFfiTag>` for the
-// type.  This gets around the orphan rules since a local type is in the trait, but requires
-// a `uniffi::ffi_converter_forward!` call if the type is used in a second local crate (an
-// External typedef).  This is natural for UDL-based generation, since you always need to
-// define the external type in the UDL file.
-//
-// With proc-macros this system isn't so natural.  Instead, we create a blanket implementation
-// for all UT and support for remote types is still TODO.
+// ## Blanket implementation
+// TODO
 
 #[doc(hidden)]
 #[proc_macro_attribute]
@@ -336,10 +323,8 @@ fn use_udl_simple_type(tokens: TokenStream) -> TokenStream {
         type_ident,
         ..
     } = parse_macro_input!(tokens);
-    quote! {
-        ::uniffi::ffi_converter_forward!(#type_ident, #crate_ident::UniFfiTag, crate::UniFfiTag);
-    }
-    .into()
+    // XXX
+    quote! {}.into()
 }
 
 #[proc_macro]
@@ -349,9 +334,7 @@ pub fn use_udl_object(tokens: TokenStream) -> TokenStream {
         type_ident,
         ..
     } = parse_macro_input!(tokens);
-    quote! {
-        ::uniffi::ffi_converter_arc_forward!(#type_ident, #crate_ident::UniFfiTag, crate::UniFfiTag);
-    }.into()
+    quote! {}.into()
 }
 
 /// A helper macro to generate and include component scaffolding.

--- a/uniffi_macros/src/object.rs
+++ b/uniffi_macros/src/object.rs
@@ -101,7 +101,7 @@ pub(crate) fn interface_impl(ident: &Ident, udl_mode: bool) -> TokenStream {
             /// function for other types may lead to undefined behaviour.
             fn write(obj: ::std::sync::Arc<Self>, buf: &mut Vec<u8>) {
                 ::uniffi::deps::static_assertions::const_assert!(::std::mem::size_of::<*const ::std::ffi::c_void>() <= 8);
-                ::uniffi::deps::bytes::BufMut::put_u64(buf, <Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::lower(obj) as u64);
+                ::uniffi::deps::bytes::BufMut::put_u64(buf, <Self as ::uniffi::FfiConverterArc>::lower(obj) as u64);
             }
 
             /// When reading as a field of a complex structure, we receive a "borrow" of the `Arc`
@@ -112,7 +112,7 @@ pub(crate) fn interface_impl(ident: &Ident, udl_mode: bool) -> TokenStream {
             fn try_read(buf: &mut &[u8]) -> ::uniffi::Result<::std::sync::Arc<Self>> {
                 ::uniffi::deps::static_assertions::const_assert!(::std::mem::size_of::<*const ::std::ffi::c_void>() <= 8);
                 ::uniffi::check_remaining(buf, 8)?;
-                <Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::try_lift(::uniffi::deps::bytes::Buf::get_u64(buf) as Self::FfiType)
+                <Self as ::uniffi::FfiConverterArc>::try_lift(::uniffi::deps::bytes::Buf::get_u64(buf) as Self::FfiType)
             }
 
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_INTERFACE)

--- a/uniffi_macros/src/record.rs
+++ b/uniffi_macros/src/record.rs
@@ -50,7 +50,7 @@ pub(crate) fn record_ffi_converter_impl(
     Ok(quote! {
         #[automatically_derived]
         unsafe #impl_spec {
-            ::uniffi::ffi_converter_rust_buffer_lift_and_lower!(crate::UniFfiTag);
+            ::uniffi::ffi_converter_rust_buffer_lift_and_lower!();
 
             fn write(obj: Self, buf: &mut ::std::vec::Vec<u8>) {
                 #write_impl
@@ -74,7 +74,7 @@ fn write_field(f: &Field) -> TokenStream {
     let ty = &f.ty;
 
     quote! {
-        <#ty as ::uniffi::Lower<crate::UniFfiTag>>::write(obj.#ident, buf);
+        <#ty as ::uniffi::Lower>::write(obj.#ident, buf);
     }
 }
 
@@ -160,7 +160,7 @@ pub(crate) fn record_meta_static_var(
             // TYPE_ID_META should be the same for both traits.
             Ok(quote! {
                 .concat_str(#name)
-                .concat(<#ty as ::uniffi::Lower<crate::UniFfiTag>>::TYPE_ID_META)
+                .concat(<#ty as ::uniffi::Lower>::TYPE_ID_META)
                 #default
             })
         })

--- a/uniffi_macros/src/setup_scaffolding.rs
+++ b/uniffi_macros/src/setup_scaffolding.rs
@@ -27,14 +27,10 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
     Ok(quote! {
         // Unit struct to parameterize the FfiConverter trait.
         //
-        // We use FfiConverter<UniFfiTag> to handle lowering/lifting/serializing types for this crate.  See
+        // We use FfiConverter to handle lowering/lifting/serializing types for this crate.  See
         // https://mozilla.github.io/uniffi-rs/internals/lifting_and_lowering.html#code-generation-and-the-fficonverter-trait
         // for details.
         //
-        // This is pub, since we need to access it to support external types
-        #[doc(hidden)]
-        pub struct UniFfiTag;
-
         #[allow(clippy::missing_safety_doc, missing_docs)]
         #[doc(hidden)]
         #[no_mangle]

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -80,7 +80,7 @@ pub fn try_read_field(f: &syn::Field) -> TokenStream {
     let ty = &f.ty;
 
     quote! {
-        #ident: <#ty as ::uniffi::Lift<crate::UniFfiTag>>::try_read(buf)?,
+        #ident: <#ty as ::uniffi::Lift>::try_read(buf)?,
     }
 }
 
@@ -209,37 +209,21 @@ pub(crate) fn tagged_impl_header(
     udl_mode: bool,
 ) -> TokenStream {
     let trait_name = Ident::new(trait_name, Span::call_site());
-    if udl_mode {
-        quote! { impl ::uniffi::#trait_name<crate::UniFfiTag> for #ident }
-    } else {
-        quote! { impl<T> ::uniffi::#trait_name<T> for #ident }
-    }
+    quote! { impl ::uniffi::#trait_name for #ident }
 }
 
 pub(crate) fn derive_all_ffi_traits(ty: &Ident, udl_mode: bool) -> TokenStream {
-    if udl_mode {
-        quote! { ::uniffi::derive_ffi_traits!(local #ty); }
-    } else {
-        quote! { ::uniffi::derive_ffi_traits!(blanket #ty); }
-    }
+    quote! { ::uniffi::derive_ffi_traits!(blanket #ty); }
 }
 
 pub(crate) fn derive_ffi_traits(ty: &Ident, udl_mode: bool, trait_names: &[&str]) -> TokenStream {
     let trait_idents = trait_names
         .iter()
         .map(|name| Ident::new(name, Span::call_site()));
-    if udl_mode {
-        quote! {
-            #(
-                ::uniffi::derive_ffi_traits!(impl #trait_idents<crate::UniFfiTag> for #ty);
-            )*
-        }
-    } else {
-        quote! {
-            #(
-                ::uniffi::derive_ffi_traits!(impl<UT> #trait_idents<UT> for #ty);
-            )*
-        }
+    quote! {
+        #(
+            ::uniffi::derive_ffi_traits!(impl #trait_idents for #ty);
+        )*
     }
 }
 

--- a/uniffi_meta/src/group.rs
+++ b/uniffi_meta/src/group.rs
@@ -189,7 +189,6 @@ impl<'a> ExternalTypeConverter<'a> {
                     module_path,
                     name,
                     kind: ExternalKind::DataClass,
-                    tagged: false,
                 }
             }
             Type::Custom {
@@ -202,7 +201,6 @@ impl<'a> ExternalTypeConverter<'a> {
                     module_path,
                     name,
                     kind: ExternalKind::DataClass,
-                    tagged: false,
                 }
             }
             Type::Object {
@@ -212,7 +210,6 @@ impl<'a> ExternalTypeConverter<'a> {
                 module_path,
                 name,
                 kind: ExternalKind::Interface,
-                tagged: false,
             },
             Type::CallbackInterface { module_path, name }
                 if self.is_module_path_external(&module_path) =>
@@ -249,7 +246,6 @@ impl<'a> ExternalTypeConverter<'a> {
                 module_path,
                 name,
                 kind,
-                tagged,
             } => {
                 assert!(namespace.is_empty());
                 Type::External {
@@ -257,7 +253,6 @@ impl<'a> ExternalTypeConverter<'a> {
                     module_path,
                     name,
                     kind,
-                    tagged,
                 }
             }
 

--- a/uniffi_meta/src/types.rs
+++ b/uniffi_meta/src/types.rs
@@ -117,7 +117,6 @@ pub enum Type {
         #[checksum_ignore] // The namespace is not known generating scaffolding.
         namespace: String,
         kind: ExternalKind,
-        tagged: bool, // does its FfiConverter use <UniFFITag>?
     },
     // Custom type on the scaffolding side
     Custom {

--- a/uniffi_udl/src/finder.rs
+++ b/uniffi_udl/src/finder.rs
@@ -148,13 +148,11 @@ impl TypeFinder for weedle::TypedefDefinition<'_> {
                 // must be external
                 None => {
                     let kind = attrs.external_kind().expect("External missing kind");
-                    let tagged = attrs.external_tagged().expect("External missing tagged");
                     Type::External {
                         name,
                         namespace: "".to_string(), // we don't know this yet
                         module_path: attrs.get_crate_name(),
                         kind,
-                        tagged,
                     }
                 }
             };


### PR DESCRIPTION
Works perfectly - until we get to custom types :(

```
error[E0117]: only traits defined in the current crate can be implemented for types defined outside of the crate
  --> /Users/skip/src/moz/uniffi-rs/target/debug/build/uniffi-example-custom-types-d2c6ba7186877117/out/custom-types.uniffi.rs:73:1
   |
73 | ::uniffi::custom_type!(r#Url, String);
   | ^^^^^^^^^^^^^^^^^^^^^^^-----
   | |                      |
   | |                      `Url` is not defined in the current crate
   | impl doesn't use only types from inside the current crate
   |
   = note: define and implement a trait or new type instead
   = note: this error originates in the macro `::uniffi::custom_type` (in Nightly builds, run with -Z macro-backtrace for more info)
```