### PR TITLE
Allow external traits to be used in UDL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - UDL files can reference types defined in procmacros in this crate - see
   [the external types docs](https://mozilla.github.io/uniffi-rs/udl/ext_types.html)
 - Add support for [docstrings in UDL](https://mozilla.github.io/uniffi-rs/udl/docstrings.html)
+- Ability for UDL to use external trait interfaces [#1831](https://github.com/mozilla/uniffi-rs/issues/1831)
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.25.2...HEAD).
 

--- a/docs/manual/src/udl/ext_types_external.md
+++ b/docs/manual/src/udl/ext_types_external.md
@@ -44,7 +44,7 @@ Your `Cargo.toml` must reference the external crate as normal.
 
 The `External` attribute can be specified on dictionaries, enums, errors.
 
-## External interface types
+## External interface and trait types
 
 If the external type is an [Interface](./interfaces.md), then use the `[ExternalInterface]` attribute instead of `[External]`:
 
@@ -52,6 +52,8 @@ If the external type is an [Interface](./interfaces.md), then use the `[External
 [ExternalInterface="demo_crate"]
 typedef extern DemoInterface;
 ```
+
+similarly for traits: use `[ExternalTrait]`.
 
 ## External procmacro types
 

--- a/fixtures/ext-types/lib/src/ext-types-lib.udl
+++ b/fixtures/ext-types/lib/src/ext-types-lib.udl
@@ -19,6 +19,7 @@ namespace imported_types_lib {
     UniffiOneInterface get_uniffi_one_interface();
     ExternalCrateInterface get_external_crate_interface(string val);
     UniffiOneProcMacroType get_uniffi_one_proc_macro_type(UniffiOneProcMacroType t);
+    UniffiOneUDLTrait? get_uniffi_one_udl_trait(UniffiOneUDLTrait? t);
 };
 
 // A type defined in a .udl file in the `uniffi-one` crate (ie, in
@@ -33,6 +34,10 @@ typedef extern UniffiOneEnum;
 // An interface in the same crate
 [ExternalInterface="uniffi_one"]
 typedef extern UniffiOneInterface;
+
+// An UDL defined trait
+[ExternalTrait="uniffi_one"]
+typedef extern UniffiOneUDLTrait;
 
 // A type defined via procmacros in an external crate
 [ExternalExport="uniffi_one"]

--- a/fixtures/ext-types/lib/src/lib.rs
+++ b/fixtures/ext-types/lib/src/lib.rs
@@ -4,6 +4,7 @@ use ext_types_guid::Guid;
 use std::sync::Arc;
 use uniffi_one::{
     UniffiOneEnum, UniffiOneInterface, UniffiOneProcMacroType, UniffiOneTrait, UniffiOneType,
+    UniffiOneUDLTrait,
 };
 use uniffi_sublib::SubLibType;
 use url::Url;
@@ -144,6 +145,12 @@ fn get_uniffi_one_proc_macro_type(t: UniffiOneProcMacroType) -> UniffiOneProcMac
 
 fn get_external_crate_interface(val: String) -> Arc<ExternalCrateInterface> {
     Arc::new(ExternalCrateInterface::new(val))
+}
+
+fn get_uniffi_one_udl_trait(
+    t: Option<Arc<dyn UniffiOneUDLTrait>>,
+) -> Option<Arc<dyn UniffiOneUDLTrait>> {
+    t
 }
 
 uniffi::include_scaffolding!("ext-types-lib");

--- a/fixtures/ext-types/uniffi-one/src/lib.rs
+++ b/fixtures/ext-types/uniffi-one/src/lib.rs
@@ -44,4 +44,9 @@ pub trait UniffiOneTrait: Send + Sync {
     fn hello(&self) -> String;
 }
 
+// Note `UDL` vs `Udl` is important here to test foreign binding name fixups.
+pub trait UniffiOneUDLTrait: Send + Sync {
+    fn hello(&self) -> String;
+}
+
 uniffi::include_scaffolding!("uniffi-one");

--- a/fixtures/ext-types/uniffi-one/src/uniffi-one.udl
+++ b/fixtures/ext-types/uniffi-one/src/uniffi-one.udl
@@ -14,3 +14,8 @@ interface UniffiOneInterface {
 
     i32 increment();
 };
+
+[Trait]
+interface UniffiOneUDLTrait {
+    string hello();
+};

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/external.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/external.rs
@@ -17,8 +17,8 @@ impl ExternalCodeType {
 }
 
 impl CodeType for ExternalCodeType {
-    fn type_label(&self, _ci: &ComponentInterface) -> String {
-        self.name.clone()
+    fn type_label(&self, ci: &ComponentInterface) -> String {
+        super::KotlinCodeOracle.class_name(ci, &self.name)
     }
 
     fn canonical_name(&self) -> String {

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -480,6 +480,11 @@ mod filters {
     }
 
     /// Get the idiomatic Kotlin rendering of a function name.
+    pub fn class_name(nm: &str, ci: &ComponentInterface) -> Result<String, askama::Error> {
+        Ok(KotlinCodeOracle.class_name(ci, nm))
+    }
+
+    /// Get the idiomatic Kotlin rendering of a function name.
     pub fn fn_name(nm: &str) -> Result<String, askama::Error> {
         Ok(KotlinCodeOracle.fn_name(nm))
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ExternalTypeTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ExternalTypeTemplate.kt
@@ -1,5 +1,5 @@
 {%- let package_name=self.external_type_package_name(module_path, namespace) %}
-{%- let fully_qualified_type_name = "{}.{}"|format(package_name, name) %}
+{%- let fully_qualified_type_name = "{}.{}"|format(package_name, name|class_name(ci)) %}
 {%- let fully_qualified_ffi_converter_name = "{}.FfiConverterType{}"|format(package_name, name) %}
 {%- let fully_qualified_rustbuffer_name = "{}.RustBuffer"|format(package_name) %}
 {%- let local_rustbuffer_name = "RustBuffer{}"|format(name) %}

--- a/uniffi_bindgen/src/bindings/python/gen_python/external.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/external.rs
@@ -17,7 +17,7 @@ impl ExternalCodeType {
 
 impl CodeType for ExternalCodeType {
     fn type_label(&self) -> String {
-        self.name.clone()
+        super::PythonCodeOracle.class_name(&self.name)
     }
 
     fn canonical_name(&self) -> String {

--- a/uniffi_bindgen/src/bindings/python/templates/ExternalTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ExternalTemplate.py
@@ -3,7 +3,7 @@
 # External type {{name}} is in namespace "{{namespace}}", crate {{module_path}}
 {%- let ffi_converter_name = "_UniffiConverterType{}"|format(name) %}
 {{ self.add_import_of(module, ffi_converter_name) }}
-{{ self.add_import_of(module, name) }} {#- import the type alias itself -#}
+{{ self.add_import_of(module, name|class_name) }} {#- import the type alias itself -#}
 
 {%- let rustbuffer_local_name = "_UniffiRustBuffer{}"|format(name) %}
 {{ self.add_import_of_as(module, "_UniffiRustBuffer", rustbuffer_local_name) }}

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/external.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/external.rs
@@ -17,7 +17,7 @@ impl ExternalCodeType {
 
 impl CodeType for ExternalCodeType {
     fn type_label(&self) -> String {
-        self.name.clone()
+        super::SwiftCodeOracle.class_name(&self.name)
     }
 
     fn canonical_name(&self) -> String {

--- a/uniffi_bindgen/src/interface/ffi.rs
+++ b/uniffi_bindgen/src/interface/ffi.rs
@@ -107,6 +107,11 @@ impl From<&Type> for FfiType {
                 name,
                 kind: ExternalKind::Interface,
                 ..
+            }
+            | Type::External {
+                name,
+                kind: ExternalKind::Trait,
+                ..
             } => FfiType::RustArcPtr(name.clone()),
             Type::External {
                 name,

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -64,6 +64,11 @@ mod filters {
                 kind: ExternalKind::Interface,
                 ..
             } => format!("::std::sync::Arc<r#{name}>"),
+            Type::External {
+                name,
+                kind: ExternalKind::Trait,
+                ..
+            } => format!("::std::sync::Arc<dyn r#{name}>"),
             Type::External { name, .. } => format!("r#{name}"),
         })
     }

--- a/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ExternalTypesTemplate.rs
@@ -10,6 +10,8 @@
 ::uniffi::ffi_converter_forward!(r#{{ name }}, ::{{ crate_name|crate_name_rs }}::UniFfiTag, crate::UniFfiTag);
 {%- when ExternalKind::Interface %}
 ::uniffi::ffi_converter_arc_forward!(r#{{ name }}, ::{{ crate_name|crate_name_rs }}::UniFfiTag, crate::UniFfiTag);
+{%- when ExternalKind::Trait %}
+::uniffi::ffi_converter_arc_forward!(dyn r#{{ name }}, ::{{ crate_name|crate_name_rs }}::UniFfiTag, crate::UniFfiTag);
 {%- endmatch %}
 {% endif %}
 {%- endfor %}

--- a/uniffi_macros/src/export/trait_interface.rs
+++ b/uniffi_macros/src/export/trait_interface.rs
@@ -69,7 +69,7 @@ pub(super) fn gen_trait_scaffolding(
         interface_meta_static_var(&self_ident, true, mod_path)
             .unwrap_or_else(syn::Error::into_compile_error)
     });
-    let ffi_converter_tokens = ffi_converter(mod_path, &self_ident, false);
+    let ffi_converter_tokens = ffi_converter(mod_path, &self_ident, udl_mode);
 
     Ok(quote_spanned! { self_ident.span() =>
         #meta_static_var

--- a/uniffi_meta/src/types.rs
+++ b/uniffi_meta/src/types.rs
@@ -52,6 +52,7 @@ impl ObjectImpl {
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Checksum, Ord, PartialOrd)]
 pub enum ExternalKind {
     Interface,
+    Trait,
     // Either a record or enum
     DataClass,
 }

--- a/uniffi_udl/src/attributes.rs
+++ b/uniffi_udl/src/attributes.rs
@@ -111,6 +111,16 @@ impl TryFrom<&weedle::attribute::ExtendedAttribute<'_>> for Attribute {
                         kind: ExternalKind::Interface,
                         export: true,
                     }),
+                    "ExternalTrait" => Ok(Attribute::External {
+                        crate_name: name_from_id_or_string(&identity.rhs),
+                        kind: ExternalKind::Trait,
+                        export: false,
+                    }),
+                    "ExternalTraitExport" => Ok(Attribute::External {
+                        crate_name: name_from_id_or_string(&identity.rhs),
+                        kind: ExternalKind::Trait,
+                        export: true,
+                    }),
                     "Rust" => Ok(Attribute::Rust {
                         kind: rust_kind_from_id_or_string(&identity.rhs)?,
                     }),


### PR DESCRIPTION
Fixes #1831

Also fixes naming problem bindings with external types with unusual names.