### PR TITLE
Support docstrings longer than 255 characters

### DIFF
--- a/fixtures/docstring-proc-macro/src/lib.rs
+++ b/fixtures/docstring-proc-macro/src/lib.rs
@@ -94,4 +94,11 @@ pub trait CallbackTest {
     fn test(&self);
 }
 
+/// This is a very long multi line test docstring that exceeds 255 characters.
+/// This is a very long multi line test docstring that exceeds 255 characters.
+/// This is a very long multi line test docstring that exceeds 255 characters.
+/// This is a very long multi line test docstring that exceeds 255 characters.
+#[uniffi::export]
+pub fn test_long_docstring() {}
+
 uniffi::include_scaffolding!("docstring-proc-macro");

--- a/uniffi_macros/src/enum_.rs
+++ b/uniffi_macros/src/enum_.rs
@@ -152,7 +152,7 @@ pub(crate) fn enum_meta_static_var(
             .concat_str(#name)
     };
     metadata_expr.extend(variant_metadata(enum_)?);
-    metadata_expr.extend(quote! { .concat_str(#docstring) });
+    metadata_expr.extend(quote! { .concat_long_str(#docstring) });
     Ok(create_metadata_items("enum", &name, metadata_expr, None))
 }
 
@@ -200,9 +200,9 @@ pub fn variant_metadata(enum_: &DataEnum) -> syn::Result<Vec<TokenStream>> {
                                 .concat(<#field_types as ::uniffi::Lower<crate::UniFfiTag>>::TYPE_ID_META)
                                 // field defaults not yet supported for enums
                                 .concat_bool(false)
-                                .concat_str(#field_docstrings)
+                                .concat_long_str(#field_docstrings)
                             )*
-                        .concat_str(#docstring)
+                        .concat_long_str(#docstring)
                     })
                 })
         )

--- a/uniffi_macros/src/error.rs
+++ b/uniffi_macros/src/error.rs
@@ -212,7 +212,7 @@ pub(crate) fn error_meta_static_var(
     } else {
         metadata_expr.extend(variant_metadata(enum_)?);
     }
-    metadata_expr.extend(quote! { .concat_str(#docstring) });
+    metadata_expr.extend(quote! { .concat_long_str(#docstring) });
     Ok(create_metadata_items("error", &name, metadata_expr, None))
 }
 
@@ -225,7 +225,7 @@ pub fn flat_error_variant_metadata(enum_: &DataEnum) -> syn::Result<Vec<TokenStr
             let docstring = extract_docstring(&v.attrs)?;
             Ok(quote! {
                 .concat_str(#name)
-                .concat_str(#docstring)
+                .concat_long_str(#docstring)
             })
         }))
         .collect()

--- a/uniffi_macros/src/export/callback_interface.rs
+++ b/uniffi_macros/src/export/callback_interface.rs
@@ -192,7 +192,7 @@ pub(super) fn metadata_items(
             ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::CALLBACK_INTERFACE)
                 .concat_str(#module_path)
                 .concat_str(#trait_name)
-                .concat_str(#docstring)
+                .concat_long_str(#docstring)
         },
         None,
     );

--- a/uniffi_macros/src/fnsig.rs
+++ b/uniffi_macros/src/fnsig.rs
@@ -224,7 +224,7 @@ impl FnSignature {
                     .concat_value(#args_len)
                     #(#arg_metadata_calls)*
                     .concat(<#return_ty as ::uniffi::LowerReturn<crate::UniFfiTag>>::TYPE_ID_META)
-                    .concat_str(#docstring)
+                    .concat_long_str(#docstring)
             }),
 
             FnKind::Method { self_ident } => {
@@ -238,7 +238,7 @@ impl FnSignature {
                         .concat_value(#args_len)
                         #(#arg_metadata_calls)*
                         .concat(<#return_ty as ::uniffi::LowerReturn<crate::UniFfiTag>>::TYPE_ID_META)
-                        .concat_str(#docstring)
+                        .concat_long_str(#docstring)
                 })
             }
 
@@ -254,7 +254,7 @@ impl FnSignature {
                         .concat_value(#args_len)
                         #(#arg_metadata_calls)*
                         .concat(<#return_ty as ::uniffi::LowerReturn<crate::UniFfiTag>>::TYPE_ID_META)
-                        .concat_str(#docstring)
+                        .concat_long_str(#docstring)
                 })
             }
 
@@ -268,7 +268,7 @@ impl FnSignature {
                         .concat_value(#args_len)
                         #(#arg_metadata_calls)*
                         .concat(<#return_ty as ::uniffi::LowerReturn<crate::UniFfiTag>>::TYPE_ID_META)
-                        .concat_str(#docstring)
+                        .concat_long_str(#docstring)
                 })
             }
         }

--- a/uniffi_macros/src/object.rs
+++ b/uniffi_macros/src/object.rs
@@ -146,7 +146,7 @@ pub(crate) fn interface_meta_static_var(
                 .concat_str(#module_path)
                 .concat_str(#name)
                 .concat_bool(#is_trait)
-                .concat_str(#docstring)
+                .concat_long_str(#docstring)
         },
         None,
     ))

--- a/uniffi_macros/src/record.rs
+++ b/uniffi_macros/src/record.rs
@@ -166,7 +166,7 @@ pub(crate) fn record_meta_static_var(
                 .concat_str(#name)
                 .concat(<#ty as ::uniffi::Lower<crate::UniFfiTag>>::TYPE_ID_META)
                 #default
-                .concat_str(#docstring)
+                .concat_long_str(#docstring)
             })
         })
         .collect::<syn::Result<_>>()?;
@@ -180,7 +180,7 @@ pub(crate) fn record_meta_static_var(
                 .concat_str(#name)
                 .concat_value(#fields_len)
                 #concat_fields
-                .concat_str(#docstring)
+                .concat_long_str(#docstring)
         },
         None,
     ))


### PR DESCRIPTION
Fixes #1874

Docstrings are now using a u16 for length encoding to remove the 255 character limit. This should be more than enough for the buffer size that is used.

Implemented using separate long_string encoding to avoid increasing the size of the rest of the metadata.