### PR TITLE
Switch to portable bash shebang

### DIFF
--- a/docker/cargo-docker.sh
+++ b/docker/cargo-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Key points for these cmd-line args:
 #  * run a transient image that deletes itself on successful completion

--- a/fixtures/version-mismatch/kotlin-contract-mismatch.sh
+++ b/fixtures/version-mismatch/kotlin-contract-mismatch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/fixtures/version-mismatch/kotlin-macro-mismatch.sh
+++ b/fixtures/version-mismatch/kotlin-macro-mismatch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/fixtures/version-mismatch/kotlin-udl-mismatch.sh
+++ b/fixtures/version-mismatch/kotlin-udl-mismatch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/fixtures/version-mismatch/python-contract-mismatch.sh
+++ b/fixtures/version-mismatch/python-contract-mismatch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/fixtures/version-mismatch/python-macro-mismatch.sh
+++ b/fixtures/version-mismatch/python-macro-mismatch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/fixtures/version-mismatch/python-udl-mismatch.sh
+++ b/fixtures/version-mismatch/python-udl-mismatch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/fixtures/version-mismatch/swift-contract-mismatch.sh
+++ b/fixtures/version-mismatch/swift-contract-mismatch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/fixtures/version-mismatch/swift-macro-mismatch.sh
+++ b/fixtures/version-mismatch/swift-macro-mismatch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/fixtures/version-mismatch/swift-udl-mismatch.sh
+++ b/fixtures/version-mismatch/swift-udl-mismatch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 


### PR DESCRIPTION
Search the path for `bash` vs expecting it at `/bin`. Just something small that I kept having to fix locally.