### PR TITLE
Updated lower validation for Python/Ruby

### DIFF
--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -456,6 +456,10 @@ pub mod filters {
         Ok(format!("{}.lift", ffi_converter_name(as_ct)?))
     }
 
+    pub(super) fn check_lower_fn(as_ct: &impl AsCodeType) -> Result<String, askama::Error> {
+        Ok(format!("{}.check_lower", ffi_converter_name(as_ct)?))
+    }
+
     pub(super) fn lower_fn(as_ct: &impl AsCodeType) -> Result<String, askama::Error> {
         Ok(format!("{}.lower", ffi_converter_name(as_ct)?))
     }

--- a/uniffi_bindgen/src/bindings/python/templates/BooleanHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/BooleanHelper.py
@@ -1,16 +1,20 @@
-class _UniffiConverterBool(_UniffiConverterPrimitive):
+class _UniffiConverterBool:
     @classmethod
-    def check(cls, value):
+    def check_lower(cls, value):
         return not not value
+
+    @classmethod
+    def lower(cls, value):
+        return 1 if value else 0
+
+    @staticmethod
+    def lift(value):
+        return value != 0
 
     @classmethod
     def read(cls, buf):
         return cls.lift(buf.read_u8())
 
     @classmethod
-    def write_unchecked(cls, value, buf):
+    def write(cls, value, buf):
         buf.write_u8(value)
-
-    @staticmethod
-    def lift(value):
-        return value != 0

--- a/uniffi_bindgen/src/bindings/python/templates/BytesHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/BytesHelper.py
@@ -7,10 +7,13 @@ class _UniffiConverterBytes(_UniffiConverterRustBuffer):
         return buf.read(size)
 
     @staticmethod
-    def write(value, buf):
+    def check_lower(value):
         try:
             memoryview(value)
         except TypeError:
             raise TypeError("a bytes-like object is required, not {!r}".format(type(value).__name__))
+
+    @staticmethod
+    def write(value, buf):
         buf.write_i32(len(value))
         buf.write(value)

--- a/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceRuntime.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceRuntime.py
@@ -54,6 +54,10 @@ class UniffiCallbackInterfaceFfiConverter:
         cls.lift(handle)
 
     @classmethod
+    def check_lower(cls, cb):
+        pass
+
+    @classmethod
     def lower(cls, cb):
         handle = cls._handle_map.insert(cb)
         return handle

--- a/uniffi_bindgen/src/bindings/python/templates/CustomType.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CustomType.py
@@ -18,6 +18,10 @@ class _UniffiConverterType{{ name }}:
         return {{ builtin|ffi_converter_name }}.lift(value)
 
     @staticmethod
+    def check_lower(value):
+        return {{ builtin|ffi_converter_name }}.check_lower(value)
+
+    @staticmethod
     def lower(value):
         return {{ builtin|ffi_converter_name }}.lower(value)
 
@@ -50,6 +54,11 @@ class _UniffiConverterType{{ name }}:
     def lift(value):
         builtin_value = {{ builtin|lift_fn }}(value)
         return {{ config.into_custom.render("builtin_value") }}
+
+    @staticmethod
+    def check_lower(value):
+        builtin_value = {{ config.from_custom.render("value") }}
+        return {{ builtin|check_lower_fn }}(builtin_value)
 
     @staticmethod
     def lower(value):

--- a/uniffi_bindgen/src/bindings/python/templates/DurationHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/DurationHelper.py
@@ -12,10 +12,14 @@ class _UniffiConverterDuration(_UniffiConverterRustBuffer):
         return datetime.timedelta(seconds=seconds, microseconds=microseconds)
 
     @staticmethod
+    def check_lower(value):
+        seconds = value.seconds + value.days * 24 * 3600
+        if seconds < 0:
+            raise ValueError("Invalid duration, must be non-negative")
+
+    @staticmethod
     def write(value, buf):
         seconds = value.seconds + value.days * 24 * 3600
         nanoseconds = value.microseconds * 1000
-        if seconds < 0:
-            raise ValueError("Invalid duration, must be non-negative")
         buf.write_i64(seconds)
         buf.write_u32(nanoseconds)

--- a/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
@@ -87,6 +87,25 @@ class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
         {%- endfor %}
         raise InternalError("Raw enum value doesn't match any cases")
 
+    @staticmethod
+    def check_lower(value):
+        {%- if e.variants().is_empty() %}
+        pass
+        {%- else %}
+        {%- for variant in e.variants() %}
+        {%- if e.is_flat() %}
+        if value == {{ type_name }}.{{ variant.name()|enum_variant_py }}:
+        {%- else %}
+        if value.is_{{ variant.name()|var_name }}():
+        {%- endif %}
+            {%- for field in variant.fields() %}
+            {{ field|check_lower_fn }}(value.{{ field.name()|var_name }})
+            {%- endfor %}
+            return
+        {%- endfor %}
+        {%- endif %}
+
+    @staticmethod
     def write(value, buf):
         {%- for variant in e.variants() %}
         {%- if e.is_flat() %}

--- a/uniffi_bindgen/src/bindings/python/templates/ErrorTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ErrorTemplate.py
@@ -65,6 +65,20 @@ class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
         raise InternalError("Raw enum value doesn't match any cases")
 
     @staticmethod
+    def check_lower(value):
+        {%- if e.variants().is_empty() %}
+        pass
+        {%- else %}
+        {%- for variant in e.variants() %}
+        if isinstance(value, {{ type_name }}.{{ variant.name()|class_name }}):
+            {%- for field in variant.fields() %}
+            {{ field|check_lower_fn }}(value.{{ field.name()|var_name }})
+            {%- endfor %}
+            return
+        {%- endfor %}
+        {%- endif %}
+
+    @staticmethod
     def write(value, buf):
         {%- for variant in e.variants() %}
         if isinstance(value, {{ type_name }}.{{ variant.name()|class_name }}):

--- a/uniffi_bindgen/src/bindings/python/templates/Float32Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Float32Helper.py
@@ -4,5 +4,5 @@ class _UniffiConverterFloat(_UniffiConverterPrimitiveFloat):
         return buf.read_float()
 
     @staticmethod
-    def write_unchecked(value, buf):
+    def write(value, buf):
         buf.write_float(value)

--- a/uniffi_bindgen/src/bindings/python/templates/Float64Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Float64Helper.py
@@ -4,5 +4,5 @@ class _UniffiConverterDouble(_UniffiConverterPrimitiveFloat):
         return buf.read_double()
 
     @staticmethod
-    def write_unchecked(value, buf):
+    def write(value, buf):
         buf.write_double(value)

--- a/uniffi_bindgen/src/bindings/python/templates/ForeignExecutorTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ForeignExecutorTemplate.py
@@ -12,9 +12,12 @@ class {{ ffi_converter_name }}:
     _pointer_manager = _UniffiPointerManager()
 
     @classmethod
-    def lower(cls, eventloop):
+    def check_lower(cls, eventloop):
         if not isinstance(eventloop, asyncio.BaseEventLoop):
             raise TypeError("_uniffi_executor_callback: Expected EventLoop instance")
+
+    @classmethod
+    def lower(cls, eventloop):
         return cls._pointer_manager.new_pointer(eventloop)
 
     @classmethod

--- a/uniffi_bindgen/src/bindings/python/templates/Int16Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int16Helper.py
@@ -8,5 +8,5 @@ class _UniffiConverterInt16(_UniffiConverterPrimitiveInt):
         return buf.read_i16()
 
     @staticmethod
-    def write_unchecked(value, buf):
+    def write(value, buf):
         buf.write_i16(value)

--- a/uniffi_bindgen/src/bindings/python/templates/Int32Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int32Helper.py
@@ -8,5 +8,5 @@ class _UniffiConverterInt32(_UniffiConverterPrimitiveInt):
         return buf.read_i32()
 
     @staticmethod
-    def write_unchecked(value, buf):
+    def write(value, buf):
         buf.write_i32(value)

--- a/uniffi_bindgen/src/bindings/python/templates/Int64Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int64Helper.py
@@ -8,5 +8,5 @@ class _UniffiConverterInt64(_UniffiConverterPrimitiveInt):
         return buf.read_i64()
 
     @staticmethod
-    def write_unchecked(value, buf):
+    def write(value, buf):
         buf.write_i64(value)

--- a/uniffi_bindgen/src/bindings/python/templates/Int8Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int8Helper.py
@@ -8,5 +8,5 @@ class _UniffiConverterInt8(_UniffiConverterPrimitiveInt):
         return buf.read_i8()
 
     @staticmethod
-    def write_unchecked(value, buf):
+    def write(value, buf):
         buf.write_i8(value)

--- a/uniffi_bindgen/src/bindings/python/templates/MapTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/MapTemplate.py
@@ -3,6 +3,12 @@
 
 class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
     @classmethod
+    def check_lower(cls, items):
+        for (key, value) in items.items():
+            {{ key_ffi_converter }}.check_lower(key)
+            {{ value_ffi_converter }}.check_lower(value)
+
+    @classmethod
     def write(cls, items, buf):
         buf.write_i32(len(items))
         for (key, value) in items.items():

--- a/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
@@ -89,6 +89,15 @@ class {{ ffi_converter_name }}:
         return {{ impl_name }}._make_instance_(value)
 
     @staticmethod
+    def check_lower(value: {{ type_name }}):
+        {%- if obj.is_trait_interface() %}
+        pass
+        {%- else %}
+        if not isinstance(value, {{ impl_name }}):
+            raise TypeError("Expected {{ impl_name }} instance, {} found".format(type(value).__name__))
+        {%- endif %}
+
+    @staticmethod
     def lower(value: {{ protocol_name }}):
         {%- match obj.imp() %}
         {%- when ObjectImpl::Struct %}

--- a/uniffi_bindgen/src/bindings/python/templates/OptionalTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/OptionalTemplate.py
@@ -2,6 +2,11 @@
 
 class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
     @classmethod
+    def check_lower(cls, value):
+        if value is not None:
+            {{ inner_ffi_converter }}.check_lower(value)
+
+    @classmethod
     def write(cls, value, buf):
         if value is None:
             buf.write_u8(0)

--- a/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
@@ -47,6 +47,16 @@ class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
         )
 
     @staticmethod
+    def check_lower(value):
+        {%- if rec.fields().is_empty() %}
+        pass
+        {%- else %}
+        {%- for field in rec.fields() %}
+        {{ field|check_lower_fn }}(value.{{ field.name()|var_name }})
+        {%- endfor %}
+        {%- endif %}
+
+    @staticmethod
     def write(value, buf):
         {%- if rec.has_fields() %}
         {%- for field in rec.fields() %}

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferHelper.py
@@ -1,28 +1,16 @@
 # Types conforming to `_UniffiConverterPrimitive` pass themselves directly over the FFI.
 class _UniffiConverterPrimitive:
     @classmethod
-    def check(cls, value):
-        return value
-
-    @classmethod
     def lift(cls, value):
         return value
-
+ 
     @classmethod
     def lower(cls, value):
-        return cls.lowerUnchecked(cls.check(value))
-
-    @classmethod
-    def lowerUnchecked(cls, value):
         return value
-
-    @classmethod
-    def write(cls, value, buf):
-        cls.write_unchecked(cls.check(value), buf)
 
 class _UniffiConverterPrimitiveInt(_UniffiConverterPrimitive):
     @classmethod
-    def check(cls, value):
+    def check_lower(cls, value):
         try:
             value = value.__index__()
         except Exception:
@@ -31,18 +19,16 @@ class _UniffiConverterPrimitiveInt(_UniffiConverterPrimitive):
             raise TypeError("__index__ returned non-int (type {})".format(type(value).__name__))
         if not cls.VALUE_MIN <= value < cls.VALUE_MAX:
             raise ValueError("{} requires {} <= value < {}".format(cls.CLASS_NAME, cls.VALUE_MIN, cls.VALUE_MAX))
-        return super().check(value)
 
 class _UniffiConverterPrimitiveFloat(_UniffiConverterPrimitive):
     @classmethod
-    def check(cls, value):
+    def check_lower(cls, value):
         try:
             value = value.__float__()
         except Exception:
             raise TypeError("must be real number, not {}".format(type(value).__name__))
         if not isinstance(value, float):
             raise TypeError("__float__ returned non-float (type {})".format(type(value).__name__))
-        return super().check(value)
 
 # Helper class for wrapper types that will always go through a _UniffiRustBuffer.
 # Classes should inherit from this and implement the `read` and `write` static methods.

--- a/uniffi_bindgen/src/bindings/python/templates/SequenceTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/SequenceTemplate.py
@@ -2,6 +2,11 @@
 
 class {{ ffi_converter_name}}(_UniffiConverterRustBuffer):
     @classmethod
+    def check_lower(cls, value):
+        for item in value:
+            {{ inner_ffi_converter }}.check_lower(item)
+
+    @classmethod
     def write(cls, value, buf):
         items = len(value)
         buf.write_i32(items)

--- a/uniffi_bindgen/src/bindings/python/templates/StringHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/StringHelper.py
@@ -1,6 +1,6 @@
 class _UniffiConverterString:
     @staticmethod
-    def check(value):
+    def check_lower(value):
         if not isinstance(value, str):
             raise TypeError("argument must be str, not {}".format(type(value).__name__))
         return value
@@ -15,7 +15,6 @@ class _UniffiConverterString:
 
     @staticmethod
     def write(value, buf):
-        value = _UniffiConverterString.check(value)
         utf8_bytes = value.encode("utf-8")
         buf.write_i32(len(utf8_bytes))
         buf.write(utf8_bytes)
@@ -27,7 +26,6 @@ class _UniffiConverterString:
 
     @staticmethod
     def lower(value):
-        value = _UniffiConverterString.check(value)
         with _UniffiRustBuffer.alloc_with_builder() as builder:
             builder.write(value.encode("utf-8"))
             return builder.finalize()

--- a/uniffi_bindgen/src/bindings/python/templates/TimestampHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/TimestampHelper.py
@@ -18,6 +18,10 @@ class _UniffiConverterTimestamp(_UniffiConverterRustBuffer):
             return datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc) - datetime.timedelta(seconds=-seconds, microseconds=microseconds)
 
     @staticmethod
+    def check_lower(value):
+        pass
+
+    @staticmethod
     def write(value, buf):
         if value >= datetime.datetime.fromtimestamp(0, datetime.timezone.utc):
             sign = 1

--- a/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
@@ -2,6 +2,7 @@
 
 def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}):
     {%- call py::docstring(func, 4) %}
+    {%- call py::setup_args(func) %}
     return _uniffi_rust_call_async(
         _UniffiLib.{{ func.ffi_func().name() }}({% call py::arg_list_lowered(func) %}),
         _UniffiLib.{{func.ffi_rust_future_poll(ci) }},

--- a/uniffi_bindgen/src/bindings/python/templates/UInt16Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt16Helper.py
@@ -8,5 +8,5 @@ class _UniffiConverterUInt16(_UniffiConverterPrimitiveInt):
         return buf.read_u16()
 
     @staticmethod
-    def write_unchecked(value, buf):
+    def write(value, buf):
         buf.write_u16(value)

--- a/uniffi_bindgen/src/bindings/python/templates/UInt32Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt32Helper.py
@@ -8,5 +8,5 @@ class _UniffiConverterUInt32(_UniffiConverterPrimitiveInt):
         return buf.read_u32()
 
     @staticmethod
-    def write_unchecked(value, buf):
+    def write(value, buf):
         buf.write_u32(value)

--- a/uniffi_bindgen/src/bindings/python/templates/UInt64Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt64Helper.py
@@ -8,5 +8,5 @@ class _UniffiConverterUInt64(_UniffiConverterPrimitiveInt):
         return buf.read_u64()
 
     @staticmethod
-    def write_unchecked(value, buf):
+    def write(value, buf):
         buf.write_u64(value)

--- a/uniffi_bindgen/src/bindings/python/templates/UInt8Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt8Helper.py
@@ -8,5 +8,5 @@ class _UniffiConverterUInt8(_UniffiConverterPrimitiveInt):
         return buf.read_u8()
 
     @staticmethod
-    def write_unchecked(value, buf):
+    def write(value, buf):
         buf.write_u8(value)

--- a/uniffi_bindgen/src/bindings/python/templates/macros.py
+++ b/uniffi_bindgen/src/bindings/python/templates/macros.py
@@ -83,6 +83,7 @@ _rust_call(
  #}
 {%- macro setup_args(func) %}
     {%- for arg in func.arguments() %}
+    {{ arg|check_lower_fn }}({{ arg.name()|var_name }})
     {%- match arg.default_value() %}
     {%- when None %}
     {%- when Some with(literal) %}
@@ -98,6 +99,7 @@ _rust_call(
  #}
 {%- macro setup_args_extra_indent(func) %}
         {%- for arg in func.arguments() %}
+        {{ arg|check_lower_fn }}({{ arg.name()|var_name }})
         {%- match arg.default_value() %}
         {%- when None %}
         {%- when Some with(literal) %}

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -270,6 +270,24 @@ mod filters {
         })
     }
 
+    pub fn check_lower_rb(nm: &str, type_: &Type) -> Result<String, askama::Error> {
+        Ok(match type_ {
+            Type::Object { name, .. } => {
+                format!("({}._uniffi_check_lower {nm})", class_name_rb(name)?)
+            }
+            Type::Enum { .. }
+            | Type::Record { .. }
+            | Type::Optional { .. }
+            | Type::Sequence { .. }
+            | Type::Map { .. } => format!(
+                "RustBuffer.check_lower_{}({})",
+                class_name_rb(&canonical_name(type_))?,
+                nm
+            ),
+            _ => "".to_owned(),
+        })
+    }
+
     pub fn lower_rb(nm: &str, type_: &Type) -> Result<String, askama::Error> {
         Ok(match type_ {
             Type::Int8

--- a/uniffi_bindgen/src/bindings/ruby/templates/ObjectTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/ObjectTemplate.rb
@@ -25,17 +25,20 @@ class {{ obj.name()|class_name_rb }}
   # A private helper for lowering instances into a raw pointer.
   # This does an explicit typecheck, because accidentally lowering a different type of
   # object in a place where this type is expected, could lead to memory unsafety.
-  def self._uniffi_lower(inst)
+  def self._uniffi_check_lower(inst)
     if not inst.is_a? self
       raise TypeError.new "Expected a {{ obj.name()|class_name_rb }} instance, got #{inst}"
     end
+  end
+
+  def self._uniffi_lower(inst)
     return inst.instance_variable_get :@pointer
   end
 
   {%- match obj.primary_constructor() %}
   {%- when Some with (cons) %}
   def initialize({% call rb::arg_list_decl(cons) -%})
-    {%- call rb::coerce_args_extra_indent(cons) %}
+    {%- call rb::setup_args_extra_indent(cons) %}
     pointer = {% call rb::to_ffi_call(cons) %}
     @pointer = pointer
     ObjectSpace.define_finalizer(self, self.class._uniffi_define_finalizer_by_pointer(pointer, self.object_id))
@@ -45,7 +48,7 @@ class {{ obj.name()|class_name_rb }}
 
   {% for cons in obj.alternate_constructors() -%}
   def self.{{ cons.name()|fn_name_rb }}({% call rb::arg_list_decl(cons) %})
-    {%- call rb::coerce_args_extra_indent(cons) %}
+    {%- call rb::setup_args_extra_indent(cons) %}
     # Call the (fallible) function before creating any half-baked object instances.
     # Lightly yucky way to bypass the usual "initialize" logic
     # and just create a new instance with the required pointer.
@@ -58,14 +61,14 @@ class {{ obj.name()|class_name_rb }}
 
   {%- when Some with (return_type) -%}
   def {{ meth.name()|fn_name_rb }}({% call rb::arg_list_decl(meth) %})
-    {%- call rb::coerce_args_extra_indent(meth) %}
+    {%- call rb::setup_args_extra_indent(meth) %}
     result = {% call rb::to_ffi_call_with_prefix("@pointer", meth) %}
     return {{ "result"|lift_rb(return_type) }}
   end
 
   {%- when None -%}
   def {{ meth.name()|fn_name_rb }}({% call rb::arg_list_decl(meth) %})
-      {%- call rb::coerce_args_extra_indent(meth) %}
+      {%- call rb::setup_args_extra_indent(meth) %}
       {% call rb::to_ffi_call_with_prefix("@pointer", meth) %}
   end
   {% endmatch %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
@@ -128,6 +128,12 @@ class RustBuffer < FFI::Struct
   {%- let rec = ci|get_record_definition(record_name) -%}
   # The Record type {{ record_name }}.
 
+  def self.check_lower_{{ canonical_type_name }}(v)
+    {%- for field in rec.fields() %}
+    {{ "v.{}"|format(field.name()|var_name_rb)|check_lower_rb(field.as_type().borrow()) }}
+    {%- endfor %}
+  end
+
   def self.alloc_from_{{ canonical_type_name }}(v)
     RustBuffer.allocWithBuilder do |builder|
       builder.write_{{ canonical_type_name }}(v)
@@ -146,6 +152,19 @@ class RustBuffer < FFI::Struct
   {%- let e = ci|get_enum_definition(enum_name) -%}
   # The Enum type {{ enum_name }}.
 
+  def self.check_lower_{{ canonical_type_name }}(v)
+    {%- if !e.is_flat() %}
+    {%- for variant in e.variants() %}
+    if v.{{ variant.name()|var_name_rb }}?
+      {%- for field in variant.fields() %}
+        {{ "v.{}"|format(field.name())|check_lower_rb(field.as_type().borrow()) }}
+      {%- endfor %}
+      return
+    end
+    {%- endfor %}
+    {%- endif %}
+  end
+
   def self.alloc_from_{{ canonical_type_name }}(v)
     RustBuffer.allocWithBuilder do |builder|
       builder.write_{{ canonical_type_name }}(v)
@@ -162,6 +181,12 @@ class RustBuffer < FFI::Struct
 
   {% when Type::Optional { inner_type } -%}
   # The Optional<T> type for {{ canonical_name(inner_type) }}.
+  
+  def self.check_lower_{{ canonical_type_name }}(v)
+    if not v.nil?
+      {{ "v"|check_lower_rb(inner_type.borrow()) }}
+    end
+  end
 
   def self.alloc_from_{{ canonical_type_name }}(v)
     RustBuffer.allocWithBuilder do |builder|
@@ -179,6 +204,12 @@ class RustBuffer < FFI::Struct
   {% when Type::Sequence { inner_type } -%}
   # The Sequence<T> type for {{ canonical_name(inner_type) }}.
 
+  def self.check_lower_{{ canonical_type_name }}(v)
+    v.each do |item|
+      {{ "item"|check_lower_rb(inner_type.borrow()) }}
+    end
+  end
+
   def self.alloc_from_{{ canonical_type_name }}(v)
     RustBuffer.allocWithBuilder do |builder|
       builder.write_{{ canonical_type_name }}(v)
@@ -194,6 +225,13 @@ class RustBuffer < FFI::Struct
 
   {% when Type::Map { key_type: k, value_type: inner_type } -%}
   # The Map<T> type for {{ canonical_name(inner_type) }}.
+
+  def self.check_lower_{{ canonical_type_name }}(v)
+    v.each do |k, v|
+      {{ "k"|check_lower_rb(k.borrow()) }}
+      {{ "v"|check_lower_rb(inner_type.borrow()) }}
+    end
+  end
 
   def self.alloc_from_{{ canonical_type_name }}(v)
     RustBuffer.allocWithBuilder do |builder|

--- a/uniffi_bindgen/src/bindings/ruby/templates/TopLevelFunctionTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/TopLevelFunctionTemplate.rb
@@ -2,7 +2,7 @@
 {%- when Some with (return_type) %}
 
 def self.{{ func.name()|fn_name_rb }}({%- call rb::arg_list_decl(func) -%})
-  {%- call rb::coerce_args(func) %}
+  {%- call rb::setup_args(func) %}
   result = {% call rb::to_ffi_call(func) %}
   return {{ "result"|lift_rb(return_type) }}
 end
@@ -10,7 +10,7 @@ end
 {% when None %}
 
 def self.{{ func.name()|fn_name_rb }}({%- call rb::arg_list_decl(func) -%})
-  {%- call rb::coerce_args(func) %}
+  {%- call rb::setup_args(func) %}
   {% call rb::to_ffi_call(func) %}
 end
 {% endmatch %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
@@ -60,14 +60,16 @@
     [{%- for arg in func.arguments() -%}{{ arg.type_().borrow()|type_ffi }}, {% endfor -%} RustCallStatus.by_ref]
 {%- endmacro -%}
 
-{%- macro coerce_args(func) %}
+{%- macro setup_args(func) %}
     {%- for arg in func.arguments() %}
-    {{ arg.name() }} = {{ arg.name()|coerce_rb(ci.namespace()|class_name_rb, arg.as_type().borrow()) -}}
+    {{ arg.name() }} = {{ arg.name()|coerce_rb(ci.namespace()|class_name_rb, arg.as_type().borrow()) }}
+    {{ arg.name()|check_lower_rb(arg.as_type().borrow()) }}
     {% endfor -%}
 {%- endmacro -%}
 
-{%- macro coerce_args_extra_indent(func) %}
-        {%- for arg in func.arguments() %}
+{%- macro setup_args_extra_indent(meth) %}
+        {%- for arg in meth.arguments() %}
         {{ arg.name() }} = {{ arg.name()|coerce_rb(ci.namespace()|class_name_rb, arg.as_type().borrow()) }}
+        {{ arg.name()|check_lower_rb(arg.as_type().borrow()) }}
         {%- endfor %}
 {%- endmacro -%}


### PR DESCRIPTION
I want to fix #1797 by cloning the object handle in lower().  However, this presents an issue in the dynamic languages because they perform various failable checks in lower(): type checks, bounds checks, etc.  If the check fails, then the cloned handle will be leaked.

Prevent this by adding a `check()` method.  We do the check first then once we get to `lower()`, nothing can fail.