### PR TITLE
Remove assertEquals calls

### DIFF
--- a/fixtures/ext-types/guid/tests/bindings/test_guid.py
+++ b/fixtures/ext-types/guid/tests/bindings/test_guid.py
@@ -51,8 +51,8 @@ class TestGuid(unittest.TestCase):
 
         test_callback = TestCallback()
         guid = run_callback(test_callback)
-        self.assertEquals(guid, "callback-test-payload")
-        self.assertEquals(test_callback.saw_guid, "callback-test-payload")
+        self.assertEqual(guid, "callback-test-payload")
+        self.assertEqual(test_callback.saw_guid, "callback-test-payload")
 
 if __name__=='__main__':
     unittest.main()


### PR DESCRIPTION
This has been long deprecated and was removed in Python 3.12