### PR TITLE
Error fix proposal for missing type path to returned Result in Object macro

### DIFF
--- a/uniffi_macros/src/object.rs
+++ b/uniffi_macros/src/object.rs
@@ -139,7 +139,7 @@ pub(crate) fn interface_impl(ident: &Ident, udl_mode: bool) -> TokenStream {
         unsafe #lower_return_impl_spec {
             type ReturnType = <Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::FfiType;
 
-            fn lower_return(obj: Self) -> Result<Self::ReturnType, ::uniffi::RustBuffer> {
+            fn lower_return(obj: Self) -> ::std::result::Result<Self::ReturnType, ::uniffi::RustBuffer> {
                 Ok(<Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::lower(::std::sync::Arc::new(obj)))
             }
 


### PR DESCRIPTION
We have found an issue - a compilation error, when using `Object` macro on some struct which uses type alias for `Result` as function return.
Affected version: `main` from commit: [59c1e3ef15b1ea5143402e25264e933dbf8d1a1f](https://github.com/mozilla/uniffi-rs/commit/59c1e3ef15b1ea5143402e25264e933dbf8d1a1f).
Proposed fix by @0xOmarA is to add full type path to the return `Result` in `lower_return()` function (content of this PR). 

Minimal program to reproduce this error (for simple reproduction it can be put in newly created `uniffi/tests/lib.rs` file):
```
pub struct UniFfiTag;

#[test]
fn error_reproduction() {
    use uniffi::Object;
    use std::sync::Arc;

    pub type Result<T> = ::std::result::Result<T, u8>;

    #[derive(Object)]
    pub struct Foo;

    impl Foo {
        pub fn function() -> Result<Arc<Self>> {
            Ok(Arc::new(Self))
        }
    }

    Foo::function().unwrap();
}
```
Compilation error occurs:
```
cargo test error_reproduction
Compiling uniffi v0.25.3 (/Users/michal.strug/rust/uniffi-main/uniffi-rs/uniffi)
error[E0107]: type alias takes 1 generic argument but 2 generic arguments were supplied
  --> uniffi/tests/lib.rs:12:14
   |
12 |     #[derive(Object)]
   |              ^^^^^^
   |              |
   |              expected 1 generic argument
   |              help: remove this generic argument
   |
note: type alias defined here, with 1 generic parameter: `T`
  --> uniffi/tests/lib.rs:10:14
   |
10 |     pub type Result<T> = ::std::result::Result<T, u8>;
   |              ^^^^^^ -
```