### PR TITLE
Fixing the Kotlin async function signatures

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/Async.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Async.kt
@@ -1,13 +1,13 @@
 // Async return type handlers
 
-internal const val UNIFFI_RUST_FUTURE_POLL_READY = 0.toShort()
-internal const val UNIFFI_RUST_FUTURE_POLL_MAYBE_READY = 1.toShort()
+internal const val UNIFFI_RUST_FUTURE_POLL_READY = 0.toByte()
+internal const val UNIFFI_RUST_FUTURE_POLL_MAYBE_READY = 1.toByte()
 
-internal val uniffiContinuationHandleMap = UniFfiHandleMap<CancellableContinuation<Short>>()
+internal val uniffiContinuationHandleMap = UniFfiHandleMap<CancellableContinuation<Byte>>()
 
 // FFI type for Rust future continuations
 internal object uniffiRustFutureContinuationCallback: UniFffiRustFutureContinuationCallbackType {
-    override fun callback(continuationHandle: USize, pollResult: Short) {
+    override fun callback(continuationHandle: USize, pollResult: Byte) {
         uniffiContinuationHandleMap.remove(continuationHandle)?.resume(pollResult)
     }
 }
@@ -22,7 +22,7 @@ internal suspend fun<T, F, E: Exception> uniffiRustCallAsync(
 ): T {
     try {
         do {
-            val pollResult = suspendCancellableCoroutine<Short> { continuation ->
+            val pollResult = suspendCancellableCoroutine<Byte> { continuation ->
                 pollFunc(
                     rustFuture,
                     uniffiRustFutureContinuationCallback,

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
@@ -157,5 +157,5 @@ internal class UniFfiHandleMap<T: Any> {
 
 // FFI type for Rust future continuations
 internal interface UniFffiRustFutureContinuationCallbackType : com.sun.jna.Callback {
-    fun callback(continuationHandle: USize, pollResult: Short);
+    fun callback(continuationHandle: USize, pollResult: Byte);
 }


### PR DESCRIPTION
PollResult is an `i8` in Rust, but was incorrectly specified as a `Short` in Kotlin.  Things seem to be working accidentally, but this should be fixed.