### PR TITLE
Properly dedent doc strings after parsing in the proc-macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,6 +1872,7 @@ dependencies = [
  "quote",
  "serde",
  "syn",
+ "textwrap",
  "toml",
  "uniffi_build",
  "uniffi_meta",

--- a/fixtures/docstring-proc-macro/src/lib.rs
+++ b/fixtures/docstring-proc-macro/src/lib.rs
@@ -49,6 +49,9 @@ enum AssociatedErrorTest {
 }
 
 /// <docstring-object>
+///
+///   <docstring-object-indented-1>
+///   <docstring-object-indented-2>
 #[derive(uniffi::Object)]
 pub struct ObjectTest {}
 

--- a/fixtures/docstring-proc-macro/tests/bindings/test_docstring.py
+++ b/fixtures/docstring-proc-macro/tests/bindings/test_docstring.py
@@ -36,7 +36,13 @@ assert AssociatedErrorTest.Test.__doc__ == "<docstring-associated-error-variant>
 assert AssociatedErrorTest.Test2.__doc__ == "<docstring-associated-error-variant-2>"
 
 # Test objects
-assert ObjectTest.__doc__ == "<docstring-object>"
+expected_object_doc = """
+    <docstring-object>
+
+      <docstring-object-indented-1>
+      <docstring-object-indented-2>
+    """
+assert ObjectTest.__doc__ == expected_object_doc
 assert ObjectTest.__init__.__doc__ == "<docstring-primary-constructor>"
 assert ObjectTest.new_alternate.__doc__ == "<docstring-alternate-constructor>"
 assert ObjectTest.test.__doc__ == "<docstring-method>"

--- a/fixtures/docstring/src/docstring.udl
+++ b/fixtures/docstring/src/docstring.udl
@@ -42,6 +42,9 @@ interface AssociatedErrorTest {
 };
 
 /// <docstring-object>
+///
+///   <docstring-object-indented-1>
+///   <docstring-object-indented-2>
 interface ObjectTest {
     /// <docstring-primary-constructor>
     constructor();

--- a/fixtures/docstring/tests/bindings/test_docstring.py
+++ b/fixtures/docstring/tests/bindings/test_docstring.py
@@ -36,7 +36,13 @@ assert AssociatedErrorTest.Test.__doc__ == "<docstring-associated-error-variant>
 assert AssociatedErrorTest.Test2.__doc__ == "<docstring-associated-error-variant-2>"
 
 # Test objects
-assert ObjectTest.__doc__ == "<docstring-object>"
+expected_object_doc = """
+    <docstring-object>
+
+      <docstring-object-indented-1>
+      <docstring-object-indented-2>
+    """
+assert ObjectTest.__doc__ == expected_object_doc
 assert ObjectTest.__init__.__doc__ == "<docstring-primary-constructor>"
 assert ObjectTest.new_alternate.__doc__ == "<docstring-alternate-constructor>"
 assert ObjectTest.test.__doc__ == "<docstring-method>"

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -23,6 +23,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 serde = "1.0.136"
 syn = { version = "2.0", features = ["full", "visit-mut"] }
+textwrap = "0.16.0"
 toml = "0.5.9"
 uniffi_build = { path = "../uniffi_build", version = "=0.25.3" }
 uniffi_meta = { path = "../uniffi_meta", version = "=0.25.3" }

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -285,11 +285,11 @@ pub(crate) fn extract_docstring(attrs: &[Attribute]) -> syn::Result<String> {
             let name_value = attr.meta.require_name_value()?;
             if let Expr::Lit(expr) = &name_value.value {
                 if let Lit::Str(lit_str) = &expr.lit {
-                    return Ok(lit_str.value().trim().to_owned());
+                    return Ok(lit_str.value());
                 }
             }
             Err(syn::Error::new_spanned(attr, "Cannot parse doc attribute"))
         })
         .collect::<syn::Result<Vec<_>>>()
-        .map(|lines| lines.join("\n"));
+        .map(|lines| textwrap::dedent(&lines.join("\n")));
 }


### PR DESCRIPTION
Fixes #1884

---

I changed both docstring tests. We can unify those tests in a followup.