### PR TITLE
Don't invoke the RustFutureContinuationCallback while holding the mutex

### DIFF
--- a/uniffi_core/src/ffi/rustfuture/future.rs
+++ b/uniffi_core/src/ffi/rustfuture/future.rs
@@ -202,7 +202,7 @@ where
     // This Mutex should never block if our code is working correctly, since there should not be
     // multiple threads calling [Self::poll] and/or [Self::complete] at the same time.
     future: Mutex<WrappedFuture<F, T, UT>>,
-    scheduler: Mutex<Scheduler>,
+    scheduler: Scheduler,
     // UT is used as the generic parameter for [LowerReturn].
     // Let's model this with PhantomData as a function that inputs a UT value.
     _phantom: PhantomData<fn(UT) -> ()>,
@@ -218,7 +218,7 @@ where
     pub(super) fn new(future: F, _tag: UT) -> Arc<Self> {
         Arc::new(Self {
             future: Mutex::new(WrappedFuture::new(future)),
-            scheduler: Mutex::new(Scheduler::new()),
+            scheduler: Scheduler::new(),
             _phantom: PhantomData,
         })
     }
@@ -232,20 +232,20 @@ where
         if ready {
             callback(data, RustFuturePoll::Ready)
         } else {
-            self.scheduler.lock().unwrap().store(callback, data);
+            self.scheduler.store(callback, data);
         }
     }
 
     pub(super) fn is_cancelled(&self) -> bool {
-        self.scheduler.lock().unwrap().is_cancelled()
+        self.scheduler.is_cancelled()
     }
 
     pub(super) fn wake(&self) {
-        self.scheduler.lock().unwrap().wake();
+        self.scheduler.wake();
     }
 
     pub(super) fn cancel(&self) {
-        self.scheduler.lock().unwrap().cancel();
+        self.scheduler.cancel();
     }
 
     pub(super) fn complete(&self, call_status: &mut RustCallStatus) -> T::ReturnType {
@@ -254,7 +254,7 @@ where
 
     pub(super) fn free(self: Arc<Self>) {
         // Call cancel() to send any leftover data to the continuation callback
-        self.scheduler.lock().unwrap().cancel();
+        self.scheduler.cancel();
         // Ensure we drop our inner future, releasing all held references
         self.future.lock().unwrap().free();
     }


### PR DESCRIPTION
As described in the comments, this could lead to a deadlock if the foreign code immediately polled the future.  This doesn't currently happen with any of the core bindings, but it might with other bindings and it seems like a footgun in general.

To accomplish this, I made a separate class to handle the state and moved the mutex to only wrap that state.  The state mutation happens with the mutex locked and the callback invocation happens after it's unlocked.