### PR TITLE
Make foreign trait implementations opt-in (#1827)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 - Rust traits `Display`, `Hash` and `Eq` exposed to Kotlin and Swift [#1817](https://github.com/mozilla/uniffi-rs/pull/1817)
 - Foreign types can now implement trait interfaces [#1791](https://github.com/mozilla/uniffi-rs/pull/1791)
+  - UDL: use the `[WithForeign]` attribute
+  - proc-macros: use the `#[uniffi::export(with_foreign)]` attribute
 - Generated Python code is able to specify a package name for the module [#1784](https://github.com/mozilla/uniffi-rs/pull/1784)
 - UDL can describe async function [#1834](https://github.com/mozilla/uniffi-rs/pull/1834)
 - UDL files can reference types defined in procmacros in this crate - see

--- a/docs/manual/src/proc_macro/index.md
+++ b/docs/manual/src/proc_macro/index.md
@@ -89,6 +89,13 @@ trait MyTrait {
     // ...
 }
 
+// Corresponding UDL:
+// [Trait, WithForeign]
+// interface MyTrait {};
+#[uniffi::export(with_foreign)]
+trait MyTrait {
+    // ...
+}
 ```
 
 

--- a/docs/manual/src/udl/ext_types.md
+++ b/docs/manual/src/udl/ext_types.md
@@ -37,6 +37,6 @@ namespace app {
 ```
 
 Supported values:
-*  "enum", "trait", "callback"
+*  "enum", "trait", "callback", "trait_with_foreign"
 * For records, either "record" or "dictionary"
 * For objects, either "object" or "interface"

--- a/docs/manual/src/udl/interfaces.md
+++ b/docs/manual/src/udl/interfaces.md
@@ -124,7 +124,14 @@ fn press(button: Arc<dyn Button>) -> Arc<dyn Button> { ... }
 
 ### Foreign implementations
 
-Traits can also be implemented on the foreign side passed into Rust, for example:
+Use the `WithForeign` attribute to allow traits to also be implemented on the foreign side passed into Rust, for example:
+
+```idl
+[Trait, WithForeign]
+interface Button {
+    string name();
+};
+```
 
 ```python
 class PyButton(uniffi_module.Button):
@@ -134,7 +141,7 @@ class PyButton(uniffi_module.Button):
 uniffi_module.press(PyButton())
 ```
 
-Note: This is currently supported on Python, Kotlin, and Swift.
+Note: This is currently only supported on Python, Kotlin, and Swift.
 
 ### Traits construction
 

--- a/examples/callbacks/src/callbacks.udl
+++ b/examples/callbacks/src/callbacks.udl
@@ -3,7 +3,7 @@ namespace callbacks {
 };
 
 // This trait is implemented in Rust and in foreign bindings.
-[Trait]
+[Trait, WithForeign]
 interface SimCard {
   string name(); // The name of the carrier/provider.
 };

--- a/examples/traits/src/traits.udl
+++ b/examples/traits/src/traits.udl
@@ -6,7 +6,7 @@ namespace traits {
 };
 
 // This is a trait in Rust.
-[Trait]
+[Trait, WithForeign]
 interface Button {
     string name();
 };

--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -23,6 +23,8 @@ namespace coverall {
 
     sequence<string> ancestor_names(NodeTrait node);
 
+    sequence<StringUtil> get_string_util_traits();
+
     ReturnOnlyDict output_return_only_dict();
     ReturnOnlyEnum output_return_only_enum();
 
@@ -220,10 +222,10 @@ interface ThreadsafeCounter {
   i32 increment_if_busy();
 };
 
-// Test trait #1
+// Test trait interface #1
 //
 // The goal here is to test all possible arg, return, and error types.
-[Trait]
+[Trait, WithForeign]
 interface Getters {
     boolean get_bool(boolean v, boolean arg2);
     [Throws=CoverallError]
@@ -235,10 +237,10 @@ interface Getters {
     Coveralls round_trip_object(Coveralls coveralls);
 };
 
-// Test trait #2
+// Test trait interface #2
 //
 // The goal here is test passing objects back and forth between Rust and the foreign side
-[Trait]
+[Trait, WithForeign]
 interface NodeTrait {
     string name(); // The name of the this node
 
@@ -252,6 +254,14 @@ interface NodeTrait {
     /// Calls `Arc::strong_count()` on the `Arc` containing `self`.
     [Self=ByArc]
     u64 strong_count();
+};
+
+// Test trait interface #3
+//
+// The goal here is test Rust-only trait interfaces
+[Trait]
+interface StringUtil {
+    string concat([ByRef]string a, [ByRef]string b);
 };
 
 // Forward/backward declarations are fine in UDL.

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -11,8 +11,8 @@ use once_cell::sync::Lazy;
 
 mod traits;
 pub use traits::{
-    ancestor_names, get_traits, make_rust_getters, test_getters, test_round_trip_through_foreign,
-    test_round_trip_through_rust, Getters, NodeTrait,
+    ancestor_names, get_string_util_traits, get_traits, make_rust_getters, test_getters,
+    test_round_trip_through_foreign, test_round_trip_through_rust, Getters, NodeTrait, StringUtil,
 };
 
 static NUM_ALIVE: Lazy<RwLock<u64>> = Lazy::new(|| RwLock::new(0));

--- a/fixtures/coverall/src/traits.rs
+++ b/fixtures/coverall/src/traits.rs
@@ -200,3 +200,26 @@ impl NodeTrait for Trait2 {
         (*self.parent.lock().unwrap()).as_ref().map(Arc::clone)
     }
 }
+
+pub trait StringUtil: Send + Sync {
+    fn concat(&self, a: &str, b: &str) -> String;
+}
+
+pub struct StringUtilImpl1;
+pub struct StringUtilImpl2;
+
+pub fn get_string_util_traits() -> Vec<Arc<dyn StringUtil>> {
+    vec![Arc::new(StringUtilImpl1), Arc::new(StringUtilImpl2)]
+}
+
+impl StringUtil for StringUtilImpl1 {
+    fn concat(&self, a: &str, b: &str) -> String {
+        format!("{a}{b}")
+    }
+}
+
+impl StringUtil for StringUtilImpl2 {
+    fn concat(&self, a: &str, b: &str) -> String {
+        format!("{a}{b}")
+    }
+}

--- a/fixtures/coverall/tests/bindings/test_coverall.kts
+++ b/fixtures/coverall/tests/bindings/test_coverall.kts
@@ -406,6 +406,12 @@ makeRustGetters().let { rustGetters ->
     testRoundTripThroughForeign(KotlinGetters())
 }
 
+// Test StringUtil
+getStringUtilTraits().let { traits ->
+    assert(traits[0].concat("cow", "boy") == "cowboy")
+    assert(traits[1].concat("cow", "boy") == "cowboy")
+}
+
 // This tests that the UniFFI-generated scaffolding doesn't introduce any unexpected locking.
 // We have one thread busy-wait for a some period of time, while a second thread repeatedly
 // increments the counter and then checks if the object is still busy. The second thread should

--- a/fixtures/coverall/tests/bindings/test_coverall.py
+++ b/fixtures/coverall/tests/bindings/test_coverall.py
@@ -443,5 +443,10 @@ class TraitsTest(unittest.TestCase):
 
         test_round_trip_through_foreign(PyGetters())
 
+    def test_rust_only_traits(self):
+        traits = get_string_util_traits()
+        self.assertEqual(traits[0].concat("cow", "boy"), "cowboy")
+        self.assertEqual(traits[1].concat("cow", "boy"), "cowboy")
+
 if __name__=='__main__':
     unittest.main()

--- a/fixtures/coverall/tests/bindings/test_coverall.swift
+++ b/fixtures/coverall/tests/bindings/test_coverall.swift
@@ -457,3 +457,10 @@ do {
 
     testRoundTripThroughForeign(getters: SwiftGetters())
 }
+
+// Test rust-only traits
+do {
+    let stringUtils = getStringUtilTraits()
+    assert(stringUtils[0].concat(a: "cow", b: "boy") == "cowboy")
+    assert(stringUtils[1].concat(a: "cow", b: "boy") == "cowboy")
+}

--- a/fixtures/ext-types/uniffi-one/src/lib.rs
+++ b/fixtures/ext-types/uniffi-one/src/lib.rs
@@ -39,7 +39,7 @@ async fn get_uniffi_one_async() -> UniffiOneEnum {
     UniffiOneEnum::One
 }
 
-#[uniffi::export]
+#[uniffi::export(with_foreign)]
 pub trait UniffiOneTrait: Send + Sync {
     fn hello(&self) -> String;
 }

--- a/fixtures/ext-types/uniffi-one/src/uniffi-one.udl
+++ b/fixtures/ext-types/uniffi-one/src/uniffi-one.udl
@@ -15,7 +15,7 @@ interface UniffiOneInterface {
     i32 increment();
 };
 
-[Trait]
+[Trait, WithForeign]
 interface UniffiOneUDLTrait {
     string hello();
 };

--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -476,6 +476,15 @@ mod test_function_metadata {
         }
     }
 
+    #[uniffi::export(with_foreign)]
+    pub trait TraitWithForeign: Send + Sync {
+        fn test_method(&self, a: String, b: u32) -> String;
+    }
+
+    #[allow(unused)]
+    #[uniffi::export]
+    fn input_trait_with_foreign(val: Arc<dyn TraitWithForeign>) {}
+
     #[test]
     fn test_function() {
         check_metadata(
@@ -685,20 +694,48 @@ mod test_function_metadata {
     }
 
     #[test]
-    fn test_trait_result() {
+    fn test_trait_metadata() {
+        check_metadata(
+            &UNIFFI_META_UNIFFI_FIXTURE_METADATA_INTERFACE_CALCULATORDISPLAY,
+            ObjectMetadata {
+                module_path: "uniffi_fixture_metadata".into(),
+                name: "CalculatorDisplay".into(),
+                imp: ObjectImpl::Trait,
+                docstring: None,
+            },
+        );
+    }
+
+    #[test]
+    fn test_trait_with_foreign_metadata() {
+        check_metadata(
+            &UNIFFI_META_UNIFFI_FIXTURE_METADATA_INTERFACE_TRAITWITHFOREIGN,
+            ObjectMetadata {
+                module_path: "uniffi_fixture_metadata".into(),
+                name: "TraitWithForeign".into(),
+                imp: ObjectImpl::CallbackTrait,
+                docstring: None,
+            },
+        );
+    }
+
+    #[test]
+    fn test_trait_type_data() {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATOR_GET_DISPLAY,
             MethodMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
-                self_name: "Calculator".into(),
-                name: "get_display".into(),
-                is_async: false,
-                inputs: vec![],
+                // The main point of this test is to check the `Type` value for a trait interface
                 return_type: Some(Type::Object {
                     module_path: "uniffi_fixture_metadata".into(),
                     name: "CalculatorDisplay".into(),
                     imp: ObjectImpl::Trait,
                 }),
+                // We might as well test other fields too though
+                module_path: "uniffi_fixture_metadata".into(),
+                self_name: "Calculator".into(),
+                name: "get_display".into(),
+                is_async: false,
+                inputs: vec![],
                 throws: None,
                 takes_self_by_arc: false,
                 checksum: Some(
@@ -728,6 +765,37 @@ mod test_function_metadata {
                 takes_self_by_arc: false,
                 checksum: Some(UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATORDISPLAY_DISPLAY_RESULT
                     .checksum()),
+                docstring: None,
+            },
+        );
+    }
+
+    #[test]
+    fn test_trait_with_foreign_type_data() {
+        check_metadata(
+            &UNIFFI_META_UNIFFI_FIXTURE_METADATA_FUNC_INPUT_TRAIT_WITH_FOREIGN,
+            FnMetadata {
+                inputs: vec![
+                    // The main point of this test is to check the `Type` value for a trait interface
+                    FnParamMetadata::simple(
+                        "val",
+                        Type::Object {
+                            module_path: "uniffi_fixture_metadata".into(),
+                            name: "TraitWithForeign".into(),
+                            imp: ObjectImpl::CallbackTrait,
+                        },
+                    ),
+                ],
+                // We might as well test other fields too though
+                return_type: None,
+                module_path: "uniffi_fixture_metadata".into(),
+                name: "input_trait_with_foreign".into(),
+                is_async: false,
+                throws: None,
+                checksum: Some(
+                    UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_FUNC_INPUT_TRAIT_WITH_FOREIGN
+                        .checksum(),
+                ),
                 docstring: None,
             },
         );

--- a/fixtures/proc-macro/src/proc-macro.udl
+++ b/fixtures/proc-macro/src/proc-macro.udl
@@ -16,6 +16,9 @@ typedef extern Object;
 [Rust="trait"]
 typedef extern Trait;
 
+[Rust="trait_with_foreign"]
+typedef extern TraitWithForeign;
+
 // Then stuff defined here but referencing the imported types.
 dictionary Externals {
     One? one;
@@ -28,5 +31,6 @@ namespace proc_macro {
     MaybeBool get_bool(MaybeBool? b);
     Object get_object(Object? o);
     Trait get_trait(Trait? t);
+    TraitWithForeign get_trait_with_foreign(TraitWithForeign? t);
     Externals get_externals(Externals? e);
 };

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
@@ -44,9 +44,13 @@ try {
 }
 
 val traitImpl = obj.getTrait(null)
-assert(traitImpl.name() == "TraitImpl")
-assert(obj.getTrait(traitImpl).name() == "TraitImpl")
-assert(getTraitNameByRef(traitImpl) == "TraitImpl")
+assert(traitImpl.concatStrings("foo", "bar") == "foobar")
+assert(obj.getTrait(traitImpl).concatStrings("foo", "bar") == "foobar")
+assert(concatStringsByRef(traitImpl, "foo", "bar") == "foobar")
+
+val traitImpl2 = obj.getTraitWithForeign(null)
+assert(traitImpl2.name() == "RustTraitImpl")
+assert(obj.getTraitWithForeign(traitImpl2).name() == "RustTraitImpl")
 
 
 class KtTestCallbackInterface : TestCallbackInterface {

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -21,9 +21,13 @@ obj2 = Object()
 assert obj.is_other_heavy(obj2) == MaybeBool.UNCERTAIN
 
 trait_impl = obj.get_trait(None)
-assert trait_impl.name() == "TraitImpl"
-assert obj.get_trait(trait_impl).name() == "TraitImpl"
-assert get_trait_name_by_ref(trait_impl) == "TraitImpl"
+assert trait_impl.concat_strings("foo", "bar") == "foobar"
+assert obj.get_trait(trait_impl).concat_strings("foo", "bar") == "foobar"
+assert concat_strings_by_ref(trait_impl, "foo", "bar") == "foobar"
+
+trait_impl2 = obj.get_trait_with_foreign(None)
+assert trait_impl2.name() == "RustTraitImpl"
+assert obj.get_trait_with_foreign(trait_impl2).name() == "RustTraitImpl"
 
 assert enum_identity(MaybeBool.TRUE) == MaybeBool.TRUE
 
@@ -90,7 +94,7 @@ call_callback_interface(PyTestCallbackInterface())
 assert get_one(None).inner == 0
 assert get_bool(None) == MaybeBool.UNCERTAIN
 assert get_object(None).is_heavy() == MaybeBool.UNCERTAIN
-assert get_trait(None).name() == "TraitImpl"
+assert get_trait_with_foreign(None).name() == "RustTraitImpl"
 assert get_externals(None).one is None
 
 # values for enums without an explicit value are their index.

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
@@ -22,9 +22,13 @@ let obj2 = Object()
 assert(obj.isOtherHeavy(other: obj2) == .uncertain)
 
 let traitImpl = obj.getTrait(inc: nil)
-assert(traitImpl.name() == "TraitImpl")
-assert(obj.getTrait(inc: traitImpl).name() == "TraitImpl")
-assert(getTraitNameByRef(t: traitImpl) == "TraitImpl")
+assert(traitImpl.concatStrings(a: "foo", b: "bar") == "foobar")
+assert(obj.getTrait(inc: traitImpl).concatStrings(a: "foo", b: "bar") == "foobar")
+assert(concatStringsByRef(t: traitImpl, a: "foo", b: "bar") == "foobar")
+
+let traitImpl2 = obj.getTraitWithForeign(inc: nil)
+assert(traitImpl2.name() == "RustTraitImpl")
+assert(obj.getTraitWithForeign(inc: traitImpl2).name() == "RustTraitImpl")
 
 assert(enumIdentity(value: .true) == .true)
 

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/object.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/object.rs
@@ -27,9 +27,8 @@ impl CodeType for ObjectCodeType {
     }
 
     fn initialization_fn(&self) -> Option<String> {
-        match &self.imp {
-            ObjectImpl::Struct => None,
-            ObjectImpl::Trait => Some(format!("uniffiCallbackInterface{}.register", self.name)),
-        }
+        self.imp
+            .has_callback_interface()
+            .then(|| format!("uniffiCallbackInterface{}.register", self.name))
     }
 }

--- a/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
@@ -75,7 +75,7 @@ class {{ impl_name }}:
 {%      endmatch %}
 {% endfor %}
 
-{%- if obj.is_trait_interface() %}
+{%- if obj.has_callback_interface() %}
 {%- let callback_handler_class = format!("UniffiCallbackInterface{}", name) %}
 {%- let callback_handler_obj = format!("uniffiCallbackInterface{}", name) %}
 {%- let ffi_init_callback = obj.ffi_init_callback() %}
@@ -83,7 +83,7 @@ class {{ impl_name }}:
 {%- endif %}
 
 class {{ ffi_converter_name }}:
-    {%- if obj.is_trait_interface() %}
+    {%- if obj.has_callback_interface() %}
     _handle_map = ConcurrentHandleMap()
     {%- endif %}
 
@@ -93,7 +93,7 @@ class {{ ffi_converter_name }}:
 
     @staticmethod
     def check_lower(value: {{ type_name }}):
-        {%- if obj.is_trait_interface() %}
+        {%- if obj.has_callback_interface() %}
         pass
         {%- else %}
         if not isinstance(value, {{ impl_name }}):
@@ -102,14 +102,13 @@ class {{ ffi_converter_name }}:
 
     @staticmethod
     def lower(value: {{ protocol_name }}):
-        {%- match obj.imp() %}
-        {%- when ObjectImpl::Struct %}
+        {%- if obj.has_callback_interface() %}
+        return {{ ffi_converter_name }}._handle_map.insert(value)
+        {%- else %}
         if not isinstance(value, {{ impl_name }}):
             raise TypeError("Expected {{ impl_name }} instance, {} found".format(type(value).__name__))
         return value._uniffi_clone_pointer()
-        {%- when ObjectImpl::Trait %}
-        return {{ ffi_converter_name }}._handle_map.insert(value)
-        {%- endmatch %}
+        {%- endif %}
 
     @classmethod
     def read(cls, buf: _UniffiRustBuffer):

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -548,20 +548,19 @@ impl SwiftCodeOracle {
 
     /// Get the name of the protocol and class name for an object.
     ///
-    /// For struct impls, the class name is the object name and the protocol name is derived from that.
-    /// For trait impls, the protocol name is the object name, and the class name is derived from that.
+    /// If we support callback interfaces, the protocol name is the object name, and the class name is derived from that.
+    /// Otherwise, the class name is the object name and the protocol name is derived from that.
     ///
-    /// This split is needed because of the `FfiConverter` protocol.  For struct impls, `lower`
-    /// can only lower the concrete class.  For trait impls, `lower` can lower anything that
-    /// implement the protocol.
+    /// This split determines what types `FfiConverter.lower()` inputs.  If we support callback
+    /// interfaces, `lower` must lower anything that implements the protocol.  If not, then lower
+    /// only lowers the concrete class.
     fn object_names(&self, obj: &Object) -> (String, String) {
         let class_name = self.class_name(obj.name());
-        match obj.imp() {
-            ObjectImpl::Struct => (format!("{class_name}Protocol"), class_name),
-            ObjectImpl::Trait => {
-                let protocol_name = format!("{class_name}Impl");
-                (class_name, protocol_name)
-            }
+        if obj.has_callback_interface() {
+            let impl_name = format!("{class_name}Impl");
+            (class_name, impl_name)
+        } else {
+            (format!("{class_name}Protocol"), class_name)
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/object.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/object.rs
@@ -27,9 +27,8 @@ impl CodeType for ObjectCodeType {
     }
 
     fn initialization_fn(&self) -> Option<String> {
-        match &self.imp {
-            ObjectImpl::Struct => None,
-            ObjectImpl::Trait => Some(format!("uniffiCallbackInit{}", self.name)),
-        }
+        self.imp
+            .has_callback_interface()
+            .then(|| format!("uniffiCallbackInit{}", self.name))
     }
 }

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -257,7 +257,7 @@ impl ComponentInterface {
             .chain(
                 self.object_definitions()
                     .iter()
-                    .filter(|o| o.is_trait_interface())
+                    .filter(|o| o.has_callback_interface())
                     .flat_map(|o| o.methods()),
             )
             .any(|m| m.throws_type() == Some(&e.as_type()));

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -127,7 +127,11 @@ impl Object {
     }
 
     pub fn is_trait_interface(&self) -> bool {
-        matches!(self.imp, ObjectImpl::Trait)
+        self.imp.is_trait_interface()
+    }
+
+    pub fn has_callback_interface(&self) -> bool {
+        self.imp.has_callback_interface()
     }
 
     pub fn constructors(&self) -> Vec<&Constructor> {
@@ -214,7 +218,7 @@ impl Object {
         }];
         self.ffi_func_free.return_type = None;
         self.ffi_func_free.is_object_free_function = true;
-        if self.is_trait_interface() {
+        if self.has_callback_interface() {
             self.ffi_init_callback =
                 Some(FfiFunction::callback_init(&self.module_path, &self.name));
         }

--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -2,9 +2,8 @@
 // Forward work to `uniffi_macros` This keeps macro-based and UDL-based generated code consistent.
 #}
 
-{%- match obj.imp() -%}
-{%- when ObjectImpl::Trait %}
-#[::uniffi::export_for_udl]
+{%- if obj.is_trait_interface() %}
+#[::uniffi::export_for_udl{% if obj.has_callback_interface() %}(with_foreign){% endif %}]
 pub trait r#{{ obj.name() }} {
     {%- for meth in obj.methods() %}
     fn {% if meth.is_async() %}async {% endif %}r#{{ meth.name() }}(
@@ -21,7 +20,7 @@ pub trait r#{{ obj.name() }} {
     {%- endmatch %}
     {% endfor %}
 }
-{% when ObjectImpl::Struct %}
+{%- else %}
 {%- for tm in obj.uniffi_traits() %}
 {%      match tm %}
 {%          when UniffiTrait::Debug { fmt }%}
@@ -78,4 +77,4 @@ impl {{ obj.rust_name() }} {
 }
 {%- endfor %}
 
-{% endmatch %}
+{% endif %}

--- a/uniffi_core/src/metadata.rs
+++ b/uniffi_core/src/metadata.rs
@@ -39,6 +39,8 @@ pub mod codes {
     pub const CALLBACK_INTERFACE: u8 = 9;
     pub const TRAIT_METHOD: u8 = 10;
     pub const UNIFFI_TRAIT: u8 = 11;
+    pub const TRAIT_INTERFACE: u8 = 12;
+    pub const CALLBACK_TRAIT_INTERFACE: u8 = 13;
     pub const UNKNOWN: u8 = 255;
 
     // Type codes
@@ -66,7 +68,8 @@ pub mod codes {
     pub const TYPE_CALLBACK_INTERFACE: u8 = 21;
     pub const TYPE_CUSTOM: u8 = 22;
     pub const TYPE_RESULT: u8 = 23;
-    pub const TYPE_FUTURE: u8 = 24;
+    pub const TYPE_TRAIT_INTERFACE: u8 = 24;
+    pub const TYPE_CALLBACK_TRAIT_INTERFACE: u8 = 25;
     pub const TYPE_UNIT: u8 = 255;
 
     // Literal codes for LiteralMetadata - note that we don't support

--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -67,16 +67,24 @@ pub(crate) fn expand_export(
         ExportItem::Trait {
             items,
             self_ident,
-            callback_interface: false,
+            with_foreign,
+            callback_interface_only: false,
             docstring,
         } => trait_interface::gen_trait_scaffolding(
-            &mod_path, args, self_ident, items, udl_mode, docstring,
+            &mod_path,
+            args,
+            self_ident,
+            items,
+            udl_mode,
+            with_foreign,
+            docstring,
         ),
         ExportItem::Trait {
             items,
             self_ident,
-            callback_interface: true,
+            callback_interface_only: true,
             docstring,
+            ..
         } => {
             let trait_name = ident_to_string(&self_ident);
             let trait_impl_ident = callback_interface::trait_impl_ident(&trait_name);

--- a/uniffi_macros/src/export/attributes.rs
+++ b/uniffi_macros/src/export/attributes.rs
@@ -11,6 +11,7 @@ use syn::{
 pub struct ExportAttributeArguments {
     pub(crate) async_runtime: Option<AsyncRuntime>,
     pub(crate) callback_interface: Option<kw::callback_interface>,
+    pub(crate) with_foreign: Option<kw::with_foreign>,
     pub(crate) constructor: Option<kw::constructor>,
     // tried to make this a vec but that got messy quickly...
     pub(crate) trait_debug: Option<kw::Debug>,
@@ -38,6 +39,11 @@ impl UniffiAttributeArgs for ExportAttributeArguments {
         } else if lookahead.peek(kw::callback_interface) {
             Ok(Self {
                 callback_interface: input.parse()?,
+                ..Self::default()
+            })
+        } else if lookahead.peek(kw::with_foreign) {
+            Ok(Self {
+                with_foreign: input.parse()?,
                 ..Self::default()
             })
         } else if lookahead.peek(kw::constructor) {
@@ -71,18 +77,26 @@ impl UniffiAttributeArgs for ExportAttributeArguments {
     }
 
     fn merge(self, other: Self) -> syn::Result<Self> {
-        Ok(Self {
+        let merged = Self {
             async_runtime: either_attribute_arg(self.async_runtime, other.async_runtime)?,
             callback_interface: either_attribute_arg(
                 self.callback_interface,
                 other.callback_interface,
             )?,
+            with_foreign: either_attribute_arg(self.with_foreign, other.with_foreign)?,
             constructor: either_attribute_arg(self.constructor, other.constructor)?,
             trait_debug: either_attribute_arg(self.trait_debug, other.trait_debug)?,
             trait_display: either_attribute_arg(self.trait_display, other.trait_display)?,
             trait_hash: either_attribute_arg(self.trait_hash, other.trait_hash)?,
             trait_eq: either_attribute_arg(self.trait_eq, other.trait_eq)?,
-        })
+        };
+        if merged.callback_interface.is_some() && merged.with_foreign.is_some() {
+            return Err(syn::Error::new(
+                merged.callback_interface.unwrap().span,
+                "`callback_interface` and `with_foreign` are mutually exclusive",
+            ));
+        }
+        Ok(merged)
     }
 }
 

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -247,6 +247,7 @@ pub(crate) fn derive_ffi_traits(ty: &Ident, udl_mode: bool, trait_names: &[&str]
 pub mod kw {
     syn::custom_keyword!(async_runtime);
     syn::custom_keyword!(callback_interface);
+    syn::custom_keyword!(with_foreign);
     syn::custom_keyword!(constructor);
     syn::custom_keyword!(default);
     syn::custom_keyword!(flat_error);

--- a/uniffi_meta/src/metadata.rs
+++ b/uniffi_meta/src/metadata.rs
@@ -7,7 +7,7 @@
 // `uniffi_core`.
 // This is the easy way out of that issue and is a temporary hacky solution.
 
-/// Metadata constants, make sure to keep this in sync with copy in `uniffi_meta::reader`
+/// Metadata constants, make sure to keep this in sync with copy in `uniffi_core::metadata`
 pub mod codes {
     // Top-level metadata item codes
     pub const FUNC: u8 = 0;
@@ -22,6 +22,8 @@ pub mod codes {
     pub const CALLBACK_INTERFACE: u8 = 9;
     pub const TRAIT_METHOD: u8 = 10;
     pub const UNIFFI_TRAIT: u8 = 11;
+    pub const TRAIT_INTERFACE: u8 = 12;
+    pub const CALLBACK_TRAIT_INTERFACE: u8 = 13;
     //pub const UNKNOWN: u8 = 255;
 
     // Type codes
@@ -49,7 +51,8 @@ pub mod codes {
     pub const TYPE_CALLBACK_INTERFACE: u8 = 21;
     pub const TYPE_CUSTOM: u8 = 22;
     pub const TYPE_RESULT: u8 = 23;
-    //pub const TYPE_FUTURE: u8 = 24;
+    pub const TYPE_TRAIT_INTERFACE: u8 = 24;
+    pub const TYPE_CALLBACK_TRAIT_INTERFACE: u8 = 25;
     pub const TYPE_UNIT: u8 = 255;
 
     // Literal codes

--- a/uniffi_meta/src/reader.rs
+++ b/uniffi_meta/src/reader.rs
@@ -54,7 +54,9 @@ impl<'a> MetadataReader<'a> {
             codes::RECORD => self.read_record()?.into(),
             codes::ENUM => self.read_enum(false)?.into(),
             codes::ERROR => self.read_error()?.into(),
-            codes::INTERFACE => self.read_object()?.into(),
+            codes::INTERFACE => self.read_object(ObjectImpl::Struct)?.into(),
+            codes::TRAIT_INTERFACE => self.read_object(ObjectImpl::Trait)?.into(),
+            codes::CALLBACK_TRAIT_INTERFACE => self.read_object(ObjectImpl::CallbackTrait)?.into(),
             codes::CALLBACK_INTERFACE => self.read_callback_interface()?.into(),
             codes::TRAIT_METHOD => self.read_trait_method()?.into(),
             codes::UNIFFI_TRAIT => self.read_uniffi_trait()?.into(),
@@ -155,7 +157,17 @@ impl<'a> MetadataReader<'a> {
             codes::TYPE_INTERFACE => Type::Object {
                 module_path: self.read_string()?,
                 name: self.read_string()?,
-                imp: ObjectImpl::from_is_trait(self.read_bool()?),
+                imp: ObjectImpl::Struct,
+            },
+            codes::TYPE_TRAIT_INTERFACE => Type::Object {
+                module_path: self.read_string()?,
+                name: self.read_string()?,
+                imp: ObjectImpl::Trait,
+            },
+            codes::TYPE_CALLBACK_TRAIT_INTERFACE => Type::Object {
+                module_path: self.read_string()?,
+                name: self.read_string()?,
+                imp: ObjectImpl::CallbackTrait,
             },
             codes::TYPE_CALLBACK_INTERFACE => Type::CallbackInterface {
                 module_path: self.read_string()?,
@@ -315,11 +327,11 @@ impl<'a> MetadataReader<'a> {
         Ok(ErrorMetadata::Enum { enum_, is_flat })
     }
 
-    fn read_object(&mut self) -> Result<ObjectMetadata> {
+    fn read_object(&mut self, imp: ObjectImpl) -> Result<ObjectMetadata> {
         Ok(ObjectMetadata {
             module_path: self.read_string()?,
             name: self.read_string()?,
-            imp: ObjectImpl::from_is_trait(self.read_bool()?),
+            imp,
             docstring: self.read_optional_long_string()?,
         })
     }

--- a/uniffi_meta/src/types.rs
+++ b/uniffi_meta/src/types.rs
@@ -21,8 +21,12 @@ use crate::Checksum;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Checksum, Ord, PartialOrd)]
 pub enum ObjectImpl {
+    // A single Rust type
     Struct,
+    // A trait that's can be implemented by Rust types
     Trait,
+    // A trait + a callback interface -- can be implemented by both Rust and foreign types.
+    CallbackTrait,
 }
 
 impl ObjectImpl {
@@ -31,21 +35,19 @@ impl ObjectImpl {
     /// Includes `r#`, traits get a leading `dyn`. If we ever supported associated types, then
     /// this would also include them.
     pub fn rust_name_for(&self, name: &str) -> String {
-        if self == &ObjectImpl::Trait {
+        if self.is_trait_interface() {
             format!("dyn r#{name}")
         } else {
             format!("r#{name}")
         }
     }
 
-    // uniffi_meta and procmacro support tend to carry around `is_trait` bools. This makes that
-    // mildly less painful
-    pub fn from_is_trait(is_trait: bool) -> Self {
-        if is_trait {
-            ObjectImpl::Trait
-        } else {
-            ObjectImpl::Struct
-        }
+    pub fn is_trait_interface(&self) -> bool {
+        matches!(self, Self::Trait | Self::CallbackTrait)
+    }
+
+    pub fn has_callback_interface(&self) -> bool {
+        matches!(self, Self::CallbackTrait)
     }
 }
 

--- a/uniffi_udl/src/converters/interface.rs
+++ b/uniffi_udl/src/converters/interface.rs
@@ -23,7 +23,7 @@ impl APIConverter<ObjectMetadata> for weedle::InterfaceDefinition<'_> {
         };
 
         let object_name = self.identifier.0;
-        let object_impl = attributes.object_impl();
+        let object_impl = attributes.object_impl()?;
         // Convert each member into a constructor or method, guarding against duplicate names.
         // They get added to the ci and aren't carried in ObjectMetadata.
         let mut member_names = HashSet::new();

--- a/uniffi_udl/src/finder.rs
+++ b/uniffi_udl/src/finder.rs
@@ -75,7 +75,7 @@ impl TypeFinder for weedle::InterfaceDefinition<'_> {
                 Type::Object {
                     name,
                     module_path: types.module_path(),
-                    imp: attrs.object_impl(),
+                    imp: attrs.object_impl()?,
                 },
             )
         }
@@ -141,6 +141,11 @@ impl TypeFinder for weedle::TypedefDefinition<'_> {
                     module_path,
                     name,
                     imp: ObjectImpl::Trait,
+                },
+                Some(RustKind::CallbackTrait) => Type::Object {
+                    module_path,
+                    name,
+                    imp: ObjectImpl::CallbackTrait,
                 },
                 Some(RustKind::Record) => Type::Record { module_path, name },
                 Some(RustKind::Enum) => Type::Enum { module_path, name },


### PR DESCRIPTION
This changes the default behavior for exported trait interfaces to not generate a foreign callback interface implementation for them.  Users can opt-in to this using the `TraitWithCallbackInterface` attribute for UDL and the `with_callback_interface` for proc-macros.

The main reason for this change is that callback interfaces and trait interfaces aren't completely compatible.  For example, `ByRef` is not supported for callback interfaces, but it is supported for trait interfaces that only have Rust implementations.