### PR TITLE
Implement LiftRef for str and [T]

### DIFF
--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -270,4 +270,9 @@ fn get_externals(e: Option<Externals>) -> Externals {
     e.unwrap_or_default()
 }
 
+#[uniffi::export]
+pub fn join(parts: &[String], sep: &str) -> String {
+    parts.join(sep)
+}
+
 uniffi::include_scaffolding!("proc-macro");

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
@@ -27,6 +27,7 @@ val three = Three(obj)
 
 assert(makeZero().inner == "ZERO")
 assert(makeRecordWithBytes().someBytes.contentEquals(byteArrayOf(0, 1, 2, 3, 4)))
+assert(join(listOf("a", "b", "c"), ":") == "a:b:c")
 
 try {
     alwaysFails()

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -38,6 +38,8 @@ assert(make_hashmap(1, 2) == {1: 2})
 # d = {1, 2}
 # assert(return_hashmap(d) == d)
 
+assert(join(["a", "b", "c"], ":") == "a:b:c")
+
 try:
     always_fails()
 except BasicError.OsError:

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
@@ -33,6 +33,7 @@ let three = Three(obj: obj)
 
 assert(makeZero().inner == "ZERO")
 assert(makeRecordWithBytes().someBytes == Data([0, 1, 2, 3, 4]))
+assert(join(parts: ["a", "b", "c"], sep: ":") == "a:b:c")
 
 do {
     try alwaysFails()

--- a/uniffi_core/src/ffi_converter_impls.rs
+++ b/uniffi_core/src/ffi_converter_impls.rs
@@ -23,8 +23,8 @@
 /// "UT" means an abitrary `UniFfiTag` type.
 use crate::{
     check_remaining, derive_ffi_traits, ffi_converter_rust_buffer_lift_and_lower, metadata,
-    ConvertError, FfiConverter, Lift, LiftReturn, Lower, LowerReturn, MetadataBuffer, Result,
-    RustBuffer, UnexpectedUniFFICallbackError,
+    ConvertError, FfiConverter, Lift, LiftRef, LiftReturn, Lower, LowerReturn, MetadataBuffer,
+    Result, RustBuffer, UnexpectedUniFFICallbackError,
 };
 use anyhow::bail;
 use bytes::buf::{Buf, BufMut};
@@ -517,4 +517,15 @@ where
     const TYPE_ID_META: MetadataBuffer = MetadataBuffer::from_code(metadata::codes::TYPE_RESULT)
         .concat(R::TYPE_ID_META)
         .concat(E::TYPE_ID_META);
+}
+
+unsafe impl<T, UT> LiftRef<UT> for [T]
+where
+    T: Lift<UT>,
+{
+    type LiftType = Vec<T>;
+}
+
+unsafe impl<UT> LiftRef<UT> for str {
+    type LiftType = String;
 }


### PR DESCRIPTION
This is needed to allow these to work with proc-macros.

This is not needed for UDL, because there we generate a scaffolding function than inputs `&String`, then pass that value to the Rust function than inputs `&str`.  Rust can handle that conversion automatically.  However, with proc-macros the scaffolding function types are always exactly the same as the source function types.