### PR TITLE
Be consistent with variable name prefixes

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -513,7 +513,7 @@ mod filters {
     ) -> Result<String, askama::Error> {
         let ffi_func = callable.ffi_rust_future_poll(ci);
         Ok(format!(
-            "{{ future, callback, continuation -> _UniFFILib.INSTANCE.{ffi_func}(future, callback, continuation) }}"
+            "{{ future, callback, continuation -> UniffiLib.INSTANCE.{ffi_func}(future, callback, continuation) }}"
         ))
     }
 
@@ -522,7 +522,7 @@ mod filters {
         ci: &ComponentInterface,
     ) -> Result<String, askama::Error> {
         let ffi_func = callable.ffi_rust_future_complete(ci);
-        let call = format!("_UniFFILib.INSTANCE.{ffi_func}(future, continuation)");
+        let call = format!("UniffiLib.INSTANCE.{ffi_func}(future, continuation)");
         let call = match callable.return_type() {
             Some(Type::External {
                 kind: ExternalKind::DataClass,
@@ -544,7 +544,7 @@ mod filters {
     ) -> Result<String, askama::Error> {
         let ffi_func = callable.ffi_rust_future_free(ci);
         Ok(format!(
-            "{{ future -> _UniFFILib.INSTANCE.{ffi_func}(future) }}"
+            "{{ future -> UniffiLib.INSTANCE.{ffi_func}(future) }}"
         ))
     }
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceImpl.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceImpl.kt
@@ -99,7 +99,7 @@ internal class {{ callback_handler_class }} : ForeignCallback {
 
     // Registers the foreign callback with the Rust side.
     // This method is generated for each callback interface.
-    internal fun register(lib: _UniFFILib) {
+    internal fun register(lib: UniffiLib) {
         lib.{{ ffi_init_callback.name() }}(this)
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
@@ -16,11 +16,11 @@ private inline fun <reified Lib : Library> loadIndirect(
 // A JNA Library to expose the extern-C FFI definitions.
 // This is an implementation detail which will be called internally by the public API.
 
-internal interface _UniFFILib : Library {
+internal interface UniffiLib : Library {
     companion object {
-        internal val INSTANCE: _UniFFILib by lazy {
-            loadIndirect<_UniFFILib>(componentName = "{{ ci.namespace() }}")
-            .also { lib: _UniFFILib ->
+        internal val INSTANCE: UniffiLib by lazy {
+            loadIndirect<UniffiLib>(componentName = "{{ ci.namespace() }}")
+            .also { lib: UniffiLib ->
                 uniffiCheckContractApiVersion(lib)
                 uniffiCheckApiChecksums(lib)
                 {% for fn in self.initialization_fns() -%}
@@ -37,7 +37,7 @@ internal interface _UniFFILib : Library {
     {% endfor %}
 }
 
-private fun uniffiCheckContractApiVersion(lib: _UniFFILib) {
+private fun uniffiCheckContractApiVersion(lib: UniffiLib) {
     // Get the bindings contract version from our ComponentInterface
     val bindings_contract_version = {{ ci.uniffi_contract_version() }}
     // Get the scaffolding contract version by calling the into the dylib
@@ -48,7 +48,7 @@ private fun uniffiCheckContractApiVersion(lib: _UniFFILib) {
 }
 
 @Suppress("UNUSED_PARAMETER")
-private fun uniffiCheckApiChecksums(lib: _UniFFILib) {
+private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     {%- for (name, expected_checksum) in ci.iter_checksums() %}
     if (lib.{{ name }}() != {{ expected_checksum }}.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -31,7 +31,7 @@ open class {{ impl_class_name }} : FFIObject, {{ interface_name }} {
 
     override fun uniffiClonePointer(): Pointer {
         return rustCall() { status ->
-            _UniFFILib.INSTANCE.{{ obj.ffi_object_clone().name() }}(pointer!!, status)
+            UniffiLib.INSTANCE.{{ obj.ffi_object_clone().name() }}(pointer!!, status)
         }
     }
 
@@ -46,7 +46,7 @@ open class {{ impl_class_name }} : FFIObject, {{ interface_name }} {
     override protected fun freeRustArcPtr() {
         this.pointer?.let { ptr ->
             rustCall() { status ->
-                _UniFFILib.INSTANCE.{{ obj.ffi_object_free().name() }}(ptr, status)
+                UniffiLib.INSTANCE.{{ obj.ffi_object_free().name() }}(ptr, status)
             }
         }
     }
@@ -65,7 +65,7 @@ open class {{ impl_class_name }} : FFIObject, {{ interface_name }} {
     ){% match meth.return_type() %}{% when Some with (return_type) %} : {{ return_type|type_name(ci) }}{% when None %}{%- endmatch %} {
         return uniffiRustCallAsync(
             callWithPointer { thisPtr ->
-                _UniFFILib.INSTANCE.{{ meth.ffi_func().name() }}(
+                UniffiLib.INSTANCE.{{ meth.ffi_func().name() }}(
                     thisPtr,
                     {% call kt::arg_list_lowered(meth) %}
                 )

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
@@ -13,7 +13,7 @@ open class RustBuffer : Structure() {
 
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
-            _UniFFILib.INSTANCE.{{ ci.ffi_rustbuffer_alloc().name() }}(size, status)
+            UniffiLib.INSTANCE.{{ ci.ffi_rustbuffer_alloc().name() }}(size, status)
         }.also {
             if(it.data == null) {
                throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
@@ -29,7 +29,7 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
-            _UniFFILib.INSTANCE.{{ ci.ffi_rustbuffer_free().name() }}(buf, status)
+            UniffiLib.INSTANCE.{{ ci.ffi_rustbuffer_free().name() }}(buf, status)
         }
     }
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
@@ -9,7 +9,7 @@
 @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
 suspend fun {{ func.name()|fn_name }}({%- call kt::arg_list_decl(func) -%}){% match func.return_type() %}{% when Some with (return_type) %} : {{ return_type|type_name(ci) }}{% when None %}{%- endmatch %} {
     return uniffiRustCallAsync(
-        _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call kt::arg_list_lowered(func) %}),
+        UniffiLib.INSTANCE.{{ func.ffi_func().name() }}({% call kt::arg_list_lowered(func) %}),
         {{ func|async_poll(ci) }},
         {{ func|async_complete(ci) }},
         {{ func|async_free(ci) }},

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -11,7 +11,7 @@
     {%- else %}
     rustCall()
     {%- endmatch %} { _status ->
-    _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call arg_list_lowered(func) -%} _status)
+    UniffiLib.INSTANCE.{{ func.ffi_func().name() }}({% call arg_list_lowered(func) -%} _status)
 }
 {%- endmacro -%}
 
@@ -22,7 +22,7 @@
     {%- else %}
     rustCall()
     {%- endmatch %} { _status ->
-    _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}(
+    UniffiLib.INSTANCE.{{ func.ffi_func().name() }}(
         {{- prefix }},
         {% call arg_list_lowered(func) %}
         _status)
@@ -58,14 +58,14 @@
     {%- endfor %}
 {%- endmacro %}
 {#-
-// Arglist as used in the _UniFFILib function declarations.
+// Arglist as used in the UniffiLib function declarations.
 // Note unfiltered name but ffi_type_name filters.
 -#}
 {%- macro arg_list_ffi_decl(func) %}
     {%- for arg in func.arguments() %}
         {{- arg.name()|var_name }}: {{ arg.type_().borrow()|ffi_type_name_by_value -}},
     {%- endfor %}
-    {%- if func.has_rust_call_status_arg() %}_uniffi_out_err: RustCallStatus, {% endif %}
+    {%- if func.has_rust_call_status_arg() %}uniffi_out_err: RustCallStatus, {% endif %}
 {%- endmacro -%}
 
 // Macro for destroying fields

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -351,14 +351,14 @@ impl PythonCodeOracle {
             FfiType::Float64 => "ctypes.c_double".to_string(),
             FfiType::RustArcPtr(_) => "ctypes.c_void_p".to_string(),
             FfiType::RustBuffer(maybe_suffix) => match maybe_suffix {
-                Some(suffix) => format!("_UniffiRustBuffer{suffix}"),
-                None => "_UniffiRustBuffer".to_string(),
+                Some(suffix) => format!("UniffiRustBuffer{suffix}"),
+                None => "UniffiRustBuffer".to_string(),
             },
-            FfiType::ForeignBytes => "_UniffiForeignBytes".to_string(),
-            FfiType::ForeignCallback => "_UNIFFI_FOREIGN_CALLBACK_T".to_string(),
+            FfiType::ForeignBytes => "UniffiForeignBytes".to_string(),
+            FfiType::ForeignCallback => "UNIFFI_FOREIGN_CALLBACK_T".to_string(),
             // Pointer to an `asyncio.EventLoop` instance
             FfiType::RustFutureHandle => "ctypes.c_void_p".to_string(),
-            FfiType::RustFutureContinuationCallback => "_UNIFFI_FUTURE_CONTINUATION_T".to_string(),
+            FfiType::RustFutureContinuationCallback => "UNIFFI_FUTURE_CONTINUATION_T".to_string(),
             FfiType::RustFutureContinuationData => "ctypes.c_size_t".to_string(),
         }
     }
@@ -441,7 +441,7 @@ pub mod filters {
     }
 
     pub(super) fn ffi_converter_name(as_ct: &impl AsCodeType) -> Result<String, askama::Error> {
-        Ok(String::from("_Uniffi") + &as_ct.as_codetype().ffi_converter_name()[3..])
+        Ok(String::from("Uniffi") + &as_ct.as_codetype().ffi_converter_name()[3..])
     }
 
     pub(super) fn canonical_name(as_ct: &impl AsCodeType) -> Result<String, askama::Error> {

--- a/uniffi_bindgen/src/bindings/python/templates/Async.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Async.py
@@ -1,35 +1,35 @@
 # RustFuturePoll values
-_UNIFFI_RUST_FUTURE_POLL_READY = 0
-_UNIFFI_RUST_FUTURE_POLL_MAYBE_READY = 1
+UNIFFI_RUST_FUTURE_POLL_READY = 0
+UNIFFI_RUST_FUTURE_POLL_MAYBE_READY = 1
 
-# Stores futures for _uniffi_continuation_callback
-_UniffiContinuationPointerManager = _UniffiPointerManager()
+# Stores futures for uniffi_continuation_callback
+UniffiContinuationPointerManager = UniffiPointerManager()
 
 # Continuation callback for async functions
 # lift the return value or error and resolve the future, causing the async function to resume.
-@_UNIFFI_FUTURE_CONTINUATION_T
-def _uniffi_continuation_callback(future_ptr, poll_code):
-    (eventloop, future) = _UniffiContinuationPointerManager.release_pointer(future_ptr)
-    eventloop.call_soon_threadsafe(_uniffi_set_future_result, future, poll_code)
+@UNIFFI_FUTURE_CONTINUATION_T
+def uniffi_continuation_callback(future_ptr, poll_code):
+    (eventloop, future) = UniffiContinuationPointerManager.release_pointer(future_ptr)
+    eventloop.call_soon_threadsafe(uniffi_set_future_result, future, poll_code)
 
-def _uniffi_set_future_result(future, poll_code):
+def uniffi_set_future_result(future, poll_code):
     if not future.cancelled():
         future.set_result(poll_code)
 
-async def _uniffi_rust_call_async(rust_future, ffi_poll, ffi_complete, ffi_free, lift_func, error_ffi_converter):
+async def uniffi_rust_call_async(rust_future, ffi_poll, ffi_complete, ffi_free, lift_func, error_ffi_converter):
     try:
         eventloop = asyncio.get_running_loop()
 
-        # Loop and poll until we see a _UNIFFI_RUST_FUTURE_POLL_READY value
+        # Loop and poll until we see a UNIFFI_RUST_FUTURE_POLL_READY value
         while True:
             future = eventloop.create_future()
             ffi_poll(
                 rust_future,
-                _uniffi_continuation_callback,
-                _UniffiContinuationPointerManager.new_pointer((eventloop, future)),
+                uniffi_continuation_callback,
+                UniffiContinuationPointerManager.new_pointer((eventloop, future)),
             )
             poll_code = await future
-            if poll_code == _UNIFFI_RUST_FUTURE_POLL_READY:
+            if poll_code == UNIFFI_RUST_FUTURE_POLL_READY:
                 break
 
         return lift_func(

--- a/uniffi_bindgen/src/bindings/python/templates/BooleanHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/BooleanHelper.py
@@ -1,4 +1,4 @@
-class _UniffiConverterBool:
+class UniffiConverterBool:
     @classmethod
     def check_lower(cls, value):
         return not not value

--- a/uniffi_bindgen/src/bindings/python/templates/BytesHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/BytesHelper.py
@@ -1,4 +1,4 @@
-class _UniffiConverterBytes(_UniffiConverterRustBuffer):
+class UniffiConverterBytes(UniffiConverterRustBuffer):
     @staticmethod
     def read(buf):
         size = buf.read_i32()

--- a/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceRuntime.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceRuntime.py
@@ -37,9 +37,9 @@ class ConcurrentHandleMap:
 # to free the callback once it's dropped by Rust.
 IDX_CALLBACK_FREE = 0
 # Return codes for callback calls
-_UNIFFI_CALLBACK_SUCCESS = 0
-_UNIFFI_CALLBACK_ERROR = 1
-_UNIFFI_CALLBACK_UNEXPECTED_ERROR = 2
+UNIFFI_CALLBACK_SUCCESS = 0
+UNIFFI_CALLBACK_ERROR = 1
+UNIFFI_CALLBACK_UNEXPECTED_ERROR = 2
 
 class UniffiCallbackInterfaceFfiConverter:
     _handle_map = ConcurrentHandleMap()

--- a/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceTemplate.py
@@ -9,5 +9,5 @@
 {% include "Protocol.py" %}
 {% include "CallbackInterfaceImpl.py" %}
 
-# The _UniffiConverter which transforms the Callbacks in to Handles to pass to Rust.
+# The UniffiConverter which transforms the Callbacks in to Handles to pass to Rust.
 {{ ffi_converter_name }} = UniffiCallbackInterfaceFfiConverter()

--- a/uniffi_bindgen/src/bindings/python/templates/CustomType.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CustomType.py
@@ -4,7 +4,7 @@
 # Type alias
 {{ name }} = {{ builtin|type_name }}
 
-class _UniffiConverterType{{ name }}:
+class UniffiConverterType{{ name }}:
     @staticmethod
     def write(value, buf):
         {{ builtin|ffi_converter_name }}.write(value, buf)
@@ -39,7 +39,7 @@ class _UniffiConverterType{{ name }}:
 {{ name }} = {{ builtin|type_name }}
 
 {#- Custom type config supplied, use it to convert the builtin type #}
-class _UniffiConverterType{{ name }}:
+class UniffiConverterType{{ name }}:
     @staticmethod
     def write(value, buf):
         builtin_value = {{ config.from_custom.render("value") }}

--- a/uniffi_bindgen/src/bindings/python/templates/DurationHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/DurationHelper.py
@@ -4,7 +4,7 @@ Duration = datetime.timedelta
 # There is a loss of precision when converting from Rust durations,
 # which are accurate to the nanosecond,
 # to Python durations, which are only accurate to the microsecond.
-class _UniffiConverterDuration(_UniffiConverterRustBuffer):
+class UniffiConverterDuration(UniffiConverterRustBuffer):
     @staticmethod
     def read(buf):
         seconds = buf.read_u64()

--- a/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
@@ -68,7 +68,7 @@ class {{ type_name }}:
 
 {% endif %}
 
-class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
+class {{ ffi_converter_name }}(UniffiConverterRustBuffer):
     @staticmethod
     def read(buf):
         variant = buf.read_i32()

--- a/uniffi_bindgen/src/bindings/python/templates/ErrorTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ErrorTemplate.py
@@ -8,19 +8,19 @@ class {{ type_name }}(Exception):
     {%- call py::docstring(e, 4) %}
     pass
 
-_UniffiTemp{{ type_name }} = {{ type_name }}
+UniffiTemp{{ type_name }} = {{ type_name }}
 
 class {{ type_name }}:  # type: ignore
     {%- for variant in e.variants() -%}
     {%- let variant_type_name = variant.name()|class_name -%}
     {%- if e.is_flat() %}
-    class {{ variant_type_name }}(_UniffiTemp{{ type_name }}):
+    class {{ variant_type_name }}(UniffiTemp{{ type_name }}):
         {%- call py::docstring(variant, 8) %}
 
         def __repr__(self):
             return "{{ type_name }}.{{ variant_type_name }}({})".format(repr(str(self)))
     {%- else %}
-    class {{ variant_type_name }}(_UniffiTemp{{ type_name }}):
+    class {{ variant_type_name }}(UniffiTemp{{ type_name }}):
         {%- call py::docstring(variant, 8) %}
 
         def __init__(self{% for field in variant.fields() %}, {{ field.name()|var_name }}{% endfor %}):
@@ -39,14 +39,14 @@ class {{ type_name }}:  # type: ignore
         def __repr__(self):
             return "{{ type_name }}.{{ variant_type_name }}({})".format(str(self))
     {%- endif %}
-    _UniffiTemp{{ type_name }}.{{ variant_type_name }} = {{ variant_type_name }} # type: ignore
+    UniffiTemp{{ type_name }}.{{ variant_type_name }} = {{ variant_type_name }} # type: ignore
     {%- endfor %}
 
-{{ type_name }} = _UniffiTemp{{ type_name }} # type: ignore
-del _UniffiTemp{{ type_name }}
+{{ type_name }} = UniffiTemp{{ type_name }} # type: ignore
+del UniffiTemp{{ type_name }}
 
 
-class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
+class {{ ffi_converter_name }}(UniffiConverterRustBuffer):
     @staticmethod
     def read(buf):
         variant = buf.read_i32()

--- a/uniffi_bindgen/src/bindings/python/templates/ExternalTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ExternalTemplate.py
@@ -1,9 +1,9 @@
 {%- let module = python_config.module_for_namespace(namespace) -%}
 
 # External type {{name}} is in namespace "{{namespace}}", crate {{module_path}}
-{%- let ffi_converter_name = "_UniffiConverterType{}"|format(name) %}
+{%- let ffi_converter_name = "UniffiConverterType{}"|format(name) %}
 {{ self.add_import_of(module, ffi_converter_name) }}
 {{ self.add_import_of(module, name|class_name) }} {#- import the type alias itself -#}
 
-{%- let rustbuffer_local_name = "_UniffiRustBuffer{}"|format(name) %}
-{{ self.add_import_of_as(module, "_UniffiRustBuffer", rustbuffer_local_name) }}
+{%- let rustbuffer_local_name = "UniffiRustBuffer{}"|format(name) %}
+{{ self.add_import_of_as(module, "UniffiRustBuffer", rustbuffer_local_name) }}

--- a/uniffi_bindgen/src/bindings/python/templates/Float32Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Float32Helper.py
@@ -1,4 +1,4 @@
-class _UniffiConverterFloat(_UniffiConverterPrimitiveFloat):
+class UniffiConverterFloat(UniffiConverterPrimitiveFloat):
     @staticmethod
     def read(buf):
         return buf.read_float()

--- a/uniffi_bindgen/src/bindings/python/templates/Float64Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Float64Helper.py
@@ -1,4 +1,4 @@
-class _UniffiConverterDouble(_UniffiConverterPrimitiveFloat):
+class UniffiConverterDouble(UniffiConverterPrimitiveFloat):
     @staticmethod
     def read(buf):
         return buf.read_double()

--- a/uniffi_bindgen/src/bindings/python/templates/Helpers.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Helpers.py
@@ -4,13 +4,13 @@
 class InternalError(Exception):
     pass
 
-class _UniffiRustCallStatus(ctypes.Structure):
+class UniffiRustCallStatus(ctypes.Structure):
     """
     Error runtime.
     """
     _fields_ = [
         ("code", ctypes.c_int8),
-        ("error_buf", _UniffiRustBuffer),
+        ("error_buf", UniffiRustBuffer),
     ]
 
     # These match the values from the uniffi::rustcalls module
@@ -19,14 +19,14 @@ class _UniffiRustCallStatus(ctypes.Structure):
     CALL_PANIC = 2
 
     def __str__(self):
-        if self.code == _UniffiRustCallStatus.CALL_SUCCESS:
-            return "_UniffiRustCallStatus(CALL_SUCCESS)"
-        elif self.code == _UniffiRustCallStatus.CALL_ERROR:
-            return "_UniffiRustCallStatus(CALL_ERROR)"
-        elif self.code == _UniffiRustCallStatus.CALL_PANIC:
-            return "_UniffiRustCallStatus(CALL_PANIC)"
+        if self.code == UniffiRustCallStatus.CALL_SUCCESS:
+            return "UniffiRustCallStatus(CALL_SUCCESS)"
+        elif self.code == UniffiRustCallStatus.CALL_ERROR:
+            return "UniffiRustCallStatus(CALL_ERROR)"
+        elif self.code == UniffiRustCallStatus.CALL_PANIC:
+            return "UniffiRustCallStatus(CALL_PANIC)"
         else:
-            return "_UniffiRustCallStatus(<invalid code>)"
+            return "UniffiRustCallStatus(<invalid code>)"
 
 def _rust_call(fn, *args):
     # Call a rust function
@@ -36,40 +36,40 @@ def _rust_call_with_error(error_ffi_converter, fn, *args):
     # Call a rust function and handle any errors
     #
     # This function is used for rust calls that return Result<> and therefore can set the CALL_ERROR status code.
-    # error_ffi_converter must be set to the _UniffiConverter for the error class that corresponds to the result.
-    call_status = _UniffiRustCallStatus(code=_UniffiRustCallStatus.CALL_SUCCESS, error_buf=_UniffiRustBuffer(0, 0, None))
+    # error_ffi_converter must be set to the UniffiConverter for the error class that corresponds to the result.
+    call_status = UniffiRustCallStatus(code=UniffiRustCallStatus.CALL_SUCCESS, error_buf=UniffiRustBuffer(0, 0, None))
 
     args_with_error = args + (ctypes.byref(call_status),)
     result = fn(*args_with_error)
-    _uniffi_check_call_status(error_ffi_converter, call_status)
+    uniffi_check_call_status(error_ffi_converter, call_status)
     return result
 
-def _uniffi_check_call_status(error_ffi_converter, call_status):
-    if call_status.code == _UniffiRustCallStatus.CALL_SUCCESS:
+def uniffi_check_call_status(error_ffi_converter, call_status):
+    if call_status.code == UniffiRustCallStatus.CALL_SUCCESS:
         pass
-    elif call_status.code == _UniffiRustCallStatus.CALL_ERROR:
+    elif call_status.code == UniffiRustCallStatus.CALL_ERROR:
         if error_ffi_converter is None:
             call_status.error_buf.free()
             raise InternalError("_rust_call_with_error: CALL_ERROR, but error_ffi_converter is None")
         else:
             raise error_ffi_converter.lift(call_status.error_buf)
-    elif call_status.code == _UniffiRustCallStatus.CALL_PANIC:
-        # When the rust code sees a panic, it tries to construct a _UniffiRustBuffer
+    elif call_status.code == UniffiRustCallStatus.CALL_PANIC:
+        # When the rust code sees a panic, it tries to construct a UniffiRustBuffer
         # with the message.  But if that code panics, then it just sends back
         # an empty buffer.
         if call_status.error_buf.len > 0:
-            msg = _UniffiConverterString.lift(call_status.error_buf)
+            msg = UniffiConverterString.lift(call_status.error_buf)
         else:
             msg = "Unknown rust panic"
         raise InternalError(msg)
     else:
-        raise InternalError("Invalid _UniffiRustCallStatus code: {}".format(
+        raise InternalError("Invalid UniffiRustCallStatus code: {}".format(
             call_status.code))
 
 # A function pointer for a callback as defined by UniFFI.
-# Rust definition `fn(handle: u64, method: u32, args: _UniffiRustBuffer, buf_ptr: *mut _UniffiRustBuffer) -> int`
-_UNIFFI_FOREIGN_CALLBACK_T = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_ulonglong, ctypes.c_ulong, ctypes.POINTER(ctypes.c_char), ctypes.c_int, ctypes.POINTER(_UniffiRustBuffer))
+# Rust definition `fn(handle: u64, method: u32, args: UniffiRustBuffer, buf_ptr: *mut UniffiRustBuffer) -> int`
+UNIFFI_FOREIGN_CALLBACK_T = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_ulonglong, ctypes.c_ulong, ctypes.POINTER(ctypes.c_char), ctypes.c_int, ctypes.POINTER(UniffiRustBuffer))
 
 # UniFFI future continuation
-_UNIFFI_FUTURE_CONTINUATION_T = ctypes.CFUNCTYPE(None, ctypes.c_size_t, ctypes.c_int8)
+UNIFFI_FUTURE_CONTINUATION_T = ctypes.CFUNCTYPE(None, ctypes.c_size_t, ctypes.c_int8)
 

--- a/uniffi_bindgen/src/bindings/python/templates/Int16Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int16Helper.py
@@ -1,4 +1,4 @@
-class _UniffiConverterInt16(_UniffiConverterPrimitiveInt):
+class UniffiConverterInt16(UniffiConverterPrimitiveInt):
     CLASS_NAME = "i16"
     VALUE_MIN = -2**15
     VALUE_MAX = 2**15

--- a/uniffi_bindgen/src/bindings/python/templates/Int32Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int32Helper.py
@@ -1,4 +1,4 @@
-class _UniffiConverterInt32(_UniffiConverterPrimitiveInt):
+class UniffiConverterInt32(UniffiConverterPrimitiveInt):
     CLASS_NAME = "i32"
     VALUE_MIN = -2**31
     VALUE_MAX = 2**31

--- a/uniffi_bindgen/src/bindings/python/templates/Int64Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int64Helper.py
@@ -1,4 +1,4 @@
-class _UniffiConverterInt64(_UniffiConverterPrimitiveInt):
+class UniffiConverterInt64(UniffiConverterPrimitiveInt):
     CLASS_NAME = "i64"
     VALUE_MIN = -2**63
     VALUE_MAX = 2**63

--- a/uniffi_bindgen/src/bindings/python/templates/Int8Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Int8Helper.py
@@ -1,4 +1,4 @@
-class _UniffiConverterInt8(_UniffiConverterPrimitiveInt):
+class UniffiConverterInt8(UniffiConverterPrimitiveInt):
     CLASS_NAME = "i8"
     VALUE_MIN = -2**7
     VALUE_MAX = 2**7

--- a/uniffi_bindgen/src/bindings/python/templates/MapTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/MapTemplate.py
@@ -1,7 +1,7 @@
 {%- let key_ffi_converter = key_type|ffi_converter_name %}
 {%- let value_ffi_converter = value_type|ffi_converter_name %}
 
-class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
+class {{ ffi_converter_name }}(UniffiConverterRustBuffer):
     @classmethod
     def check_lower(cls, items):
         for (key, value) in items.items():

--- a/uniffi_bindgen/src/bindings/python/templates/OptionalTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/OptionalTemplate.py
@@ -1,6 +1,6 @@
 {%- let inner_ffi_converter = inner_type|ffi_converter_name %}
 
-class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
+class {{ ffi_converter_name }}(UniffiConverterRustBuffer):
     @classmethod
     def check_lower(cls, value):
         if value is not None:

--- a/uniffi_bindgen/src/bindings/python/templates/PointerManager.py
+++ b/uniffi_bindgen/src/bindings/python/templates/PointerManager.py
@@ -1,9 +1,9 @@
-class _UniffiPointerManagerCPython:
+class UniffiPointerManagerCPython:
     """
     Manage giving out pointers to Python objects on CPython
 
     This class is used to generate opaque pointers that reference Python objects to pass to Rust.
-    It assumes a CPython platform.  See _UniffiPointerManagerGeneral for the alternative.
+    It assumes a CPython platform.  See UniffiPointerManagerGeneral for the alternative.
     """
 
     def new_pointer(self, obj):
@@ -30,11 +30,11 @@ class _UniffiPointerManagerCPython:
     def lookup(self, address):
         return ctypes.cast(address, ctypes.py_object).value
 
-class _UniffiPointerManagerGeneral:
+class UniffiPointerManagerGeneral:
     """
     Manage giving out pointers to Python objects on non-CPython platforms
 
-    This has the same API as _UniffiPointerManagerCPython, but doesn't assume we're running on
+    This has the same API as UniffiPointerManagerCPython, but doesn't assume we're running on
     CPython and is slightly slower.
 
     Instead of using real pointers, it maps integer values to objects and returns the keys as
@@ -63,6 +63,6 @@ class _UniffiPointerManagerGeneral:
 
 # Pick an pointer manager implementation based on the platform
 if platform.python_implementation() == 'CPython':
-    _UniffiPointerManager = _UniffiPointerManagerCPython # type: ignore
+    UniffiPointerManager = UniffiPointerManagerCPython # type: ignore
 else:
-    _UniffiPointerManager = _UniffiPointerManagerGeneral # type: ignore
+    UniffiPointerManager = UniffiPointerManagerGeneral # type: ignore

--- a/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
@@ -37,7 +37,7 @@ class {{ type_name }}:
         {%- endfor %}
         return True
 
-class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
+class {{ ffi_converter_name }}(UniffiConverterRustBuffer):
     @staticmethod
     def read(buf):
         return {{ type_name }}(

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferHelper.py
@@ -1,5 +1,5 @@
-# Types conforming to `_UniffiConverterPrimitive` pass themselves directly over the FFI.
-class _UniffiConverterPrimitive:
+# Types conforming to `UniffiConverterPrimitive` pass themselves directly over the FFI.
+class UniffiConverterPrimitive:
     @classmethod
     def lift(cls, value):
         return value
@@ -8,7 +8,7 @@ class _UniffiConverterPrimitive:
     def lower(cls, value):
         return value
 
-class _UniffiConverterPrimitiveInt(_UniffiConverterPrimitive):
+class UniffiConverterPrimitiveInt(UniffiConverterPrimitive):
     @classmethod
     def check_lower(cls, value):
         try:
@@ -20,7 +20,7 @@ class _UniffiConverterPrimitiveInt(_UniffiConverterPrimitive):
         if not cls.VALUE_MIN <= value < cls.VALUE_MAX:
             raise ValueError("{} requires {} <= value < {}".format(cls.CLASS_NAME, cls.VALUE_MIN, cls.VALUE_MAX))
 
-class _UniffiConverterPrimitiveFloat(_UniffiConverterPrimitive):
+class UniffiConverterPrimitiveFloat(UniffiConverterPrimitive):
     @classmethod
     def check_lower(cls, value):
         try:
@@ -30,9 +30,9 @@ class _UniffiConverterPrimitiveFloat(_UniffiConverterPrimitive):
         if not isinstance(value, float):
             raise TypeError("__float__ returned non-float (type {})".format(type(value).__name__))
 
-# Helper class for wrapper types that will always go through a _UniffiRustBuffer.
+# Helper class for wrapper types that will always go through a UniffiRustBuffer.
 # Classes should inherit from this and implement the `read` and `write` static methods.
-class _UniffiConverterRustBuffer:
+class UniffiConverterRustBuffer:
     @classmethod
     def lift(cls, rbuf):
         with rbuf.consume_with_stream() as stream:
@@ -40,6 +40,6 @@ class _UniffiConverterRustBuffer:
 
     @classmethod
     def lower(cls, value):
-        with _UniffiRustBuffer.alloc_with_builder() as builder:
+        with UniffiRustBuffer.alloc_with_builder() as builder:
             cls.write(value, builder)
             return builder.finalize()

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
@@ -1,5 +1,5 @@
 
-class _UniffiRustBuffer(ctypes.Structure):
+class UniffiRustBuffer(ctypes.Structure):
     _fields_ = [
         ("capacity", ctypes.c_int32),
         ("len", ctypes.c_int32),
@@ -8,17 +8,17 @@ class _UniffiRustBuffer(ctypes.Structure):
 
     @staticmethod
     def alloc(size):
-        return _rust_call(_UniffiLib.{{ ci.ffi_rustbuffer_alloc().name() }}, size)
+        return _rust_call(UniffiLib.{{ ci.ffi_rustbuffer_alloc().name() }}, size)
 
     @staticmethod
     def reserve(rbuf, additional):
-        return _rust_call(_UniffiLib.{{ ci.ffi_rustbuffer_reserve().name() }}, rbuf, additional)
+        return _rust_call(UniffiLib.{{ ci.ffi_rustbuffer_reserve().name() }}, rbuf, additional)
 
     def free(self):
-        return _rust_call(_UniffiLib.{{ ci.ffi_rustbuffer_free().name() }}, self)
+        return _rust_call(UniffiLib.{{ ci.ffi_rustbuffer_free().name() }}, self)
 
     def __str__(self):
-        return "_UniffiRustBuffer(capacity={}, len={}, data={})".format(
+        return "UniffiRustBuffer(capacity={}, len={}, data={})".format(
             self.capacity,
             self.len,
             self.data[0:self.len]
@@ -26,12 +26,12 @@ class _UniffiRustBuffer(ctypes.Structure):
 
     @contextlib.contextmanager
     def alloc_with_builder(*args):
-        """Context-manger to allocate a buffer using a _UniffiRustBufferBuilder.
+        """Context-manger to allocate a buffer using a UniffiRustBufferBuilder.
 
         The allocated buffer will be automatically freed if an error occurs, ensuring that
         we don't accidentally leak it.
         """
-        builder = _UniffiRustBufferBuilder()
+        builder = UniffiRustBufferBuilder()
         try:
             yield builder
         except:
@@ -40,13 +40,13 @@ class _UniffiRustBuffer(ctypes.Structure):
 
     @contextlib.contextmanager
     def consume_with_stream(self):
-        """Context-manager to consume a buffer using a _UniffiRustBufferStream.
+        """Context-manager to consume a buffer using a UniffiRustBufferStream.
 
-        The _UniffiRustBuffer will be freed once the context-manager exits, ensuring that we don't
+        The UniffiRustBuffer will be freed once the context-manager exits, ensuring that we don't
         leak it even if an error occurs.
         """
         try:
-            s = _UniffiRustBufferStream.from_rust_buffer(self)
+            s = UniffiRustBufferStream.from_rust_buffer(self)
             yield s
             if s.remaining() != 0:
                 raise RuntimeError("junk data left in buffer at end of consume_with_stream")
@@ -55,29 +55,29 @@ class _UniffiRustBuffer(ctypes.Structure):
 
     @contextlib.contextmanager
     def read_with_stream(self):
-        """Context-manager to read a buffer using a _UniffiRustBufferStream.
+        """Context-manager to read a buffer using a UniffiRustBufferStream.
 
         This is like consume_with_stream, but doesn't free the buffer afterwards.
-        It should only be used with borrowed `_UniffiRustBuffer` data.
+        It should only be used with borrowed `UniffiRustBuffer` data.
         """
-        s = _UniffiRustBufferStream.from_rust_buffer(self)
+        s = UniffiRustBufferStream.from_rust_buffer(self)
         yield s
         if s.remaining() != 0:
             raise RuntimeError("junk data left in buffer at end of read_with_stream")
 
-class _UniffiForeignBytes(ctypes.Structure):
+class UniffiForeignBytes(ctypes.Structure):
     _fields_ = [
         ("len", ctypes.c_int32),
         ("data", ctypes.POINTER(ctypes.c_char)),
     ]
 
     def __str__(self):
-        return "_UniffiForeignBytes(len={}, data={})".format(self.len, self.data[0:self.len])
+        return "UniffiForeignBytes(len={}, data={})".format(self.len, self.data[0:self.len])
 
 
-class _UniffiRustBufferStream:
+class UniffiRustBufferStream:
     """
-    Helper for structured reading of bytes from a _UniffiRustBuffer
+    Helper for structured reading of bytes from a UniffiRustBuffer
     """
 
     def __init__(self, data, len):
@@ -140,13 +140,13 @@ class _UniffiRustBufferStream:
     def read_c_size_t(self):
         return self._unpack_from(ctypes.sizeof(ctypes.c_size_t) , "@N")
 
-class _UniffiRustBufferBuilder:
+class UniffiRustBufferBuilder:
     """
-    Helper for structured writing of bytes into a _UniffiRustBuffer.
+    Helper for structured writing of bytes into a UniffiRustBuffer.
     """
 
     def __init__(self):
-        self.rbuf = _UniffiRustBuffer.alloc(16)
+        self.rbuf = UniffiRustBuffer.alloc(16)
         self.rbuf.len = 0
 
     def finalize(self):
@@ -162,7 +162,7 @@ class _UniffiRustBufferBuilder:
     @contextlib.contextmanager
     def _reserve(self, num_bytes):
         if self.rbuf.len + num_bytes > self.rbuf.capacity:
-            self.rbuf = _UniffiRustBuffer.reserve(self.rbuf, num_bytes)
+            self.rbuf = UniffiRustBuffer.reserve(self.rbuf, num_bytes)
         yield None
         self.rbuf.len += num_bytes
 

--- a/uniffi_bindgen/src/bindings/python/templates/SequenceTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/SequenceTemplate.py
@@ -1,6 +1,6 @@
 {%- let inner_ffi_converter = inner_type|ffi_converter_name %}
 
-class {{ ffi_converter_name}}(_UniffiConverterRustBuffer):
+class {{ ffi_converter_name}}(UniffiConverterRustBuffer):
     @classmethod
     def check_lower(cls, value):
         for item in value:

--- a/uniffi_bindgen/src/bindings/python/templates/StringHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/StringHelper.py
@@ -1,4 +1,4 @@
-class _UniffiConverterString:
+class UniffiConverterString:
     @staticmethod
     def check_lower(value):
         if not isinstance(value, str):
@@ -26,6 +26,6 @@ class _UniffiConverterString:
 
     @staticmethod
     def lower(value):
-        with _UniffiRustBuffer.alloc_with_builder() as builder:
+        with UniffiRustBuffer.alloc_with_builder() as builder:
             builder.write(value.encode("utf-8"))
             return builder.finalize()

--- a/uniffi_bindgen/src/bindings/python/templates/TimestampHelper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/TimestampHelper.py
@@ -4,7 +4,7 @@ Timestamp = datetime.datetime
 # There is a loss of precision when converting from Rust timestamps,
 # which are accurate to the nanosecond,
 # to Python datetimes, which have a variable precision due to the use of float as representation.
-class _UniffiConverterTimestamp(_UniffiConverterRustBuffer):
+class UniffiConverterTimestamp(UniffiConverterRustBuffer):
     @staticmethod
     def read(buf):
         seconds = buf.read_i64()

--- a/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
@@ -3,11 +3,11 @@
 def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}):
     {%- call py::docstring(func, 4) %}
     {%- call py::setup_args(func) %}
-    return _uniffi_rust_call_async(
-        _UniffiLib.{{ func.ffi_func().name() }}({% call py::arg_list_lowered(func) %}),
-        _UniffiLib.{{func.ffi_rust_future_poll(ci) }},
-        _UniffiLib.{{func.ffi_rust_future_complete(ci) }},
-        _UniffiLib.{{func.ffi_rust_future_free(ci) }},
+    return uniffi_rust_call_async(
+        UniffiLib.{{ func.ffi_func().name() }}({% call py::arg_list_lowered(func) %}),
+        UniffiLib.{{func.ffi_rust_future_poll(ci) }},
+        UniffiLib.{{func.ffi_rust_future_complete(ci) }},
+        UniffiLib.{{func.ffi_rust_future_free(ci) }},
         # lift function
         {%- match func.return_type() %}
         {%- when Some(return_type) %}

--- a/uniffi_bindgen/src/bindings/python/templates/UInt16Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt16Helper.py
@@ -1,4 +1,4 @@
-class _UniffiConverterUInt16(_UniffiConverterPrimitiveInt):
+class UniffiConverterUInt16(UniffiConverterPrimitiveInt):
     CLASS_NAME = "u16"
     VALUE_MIN = 0
     VALUE_MAX = 2**16

--- a/uniffi_bindgen/src/bindings/python/templates/UInt32Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt32Helper.py
@@ -1,4 +1,4 @@
-class _UniffiConverterUInt32(_UniffiConverterPrimitiveInt):
+class UniffiConverterUInt32(UniffiConverterPrimitiveInt):
     CLASS_NAME = "u32"
     VALUE_MIN = 0
     VALUE_MAX = 2**32

--- a/uniffi_bindgen/src/bindings/python/templates/UInt64Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt64Helper.py
@@ -1,4 +1,4 @@
-class _UniffiConverterUInt64(_UniffiConverterPrimitiveInt):
+class UniffiConverterUInt64(UniffiConverterPrimitiveInt):
     CLASS_NAME = "u64"
     VALUE_MIN = 0
     VALUE_MAX = 2**64

--- a/uniffi_bindgen/src/bindings/python/templates/UInt8Helper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/UInt8Helper.py
@@ -1,4 +1,4 @@
-class _UniffiConverterUInt8(_UniffiConverterPrimitiveInt):
+class UniffiConverterUInt8(UniffiConverterPrimitiveInt):
     CLASS_NAME = "u8"
     VALUE_MIN = 0
     VALUE_MAX = 2**8

--- a/uniffi_bindgen/src/bindings/python/templates/macros.py
+++ b/uniffi_bindgen/src/bindings/python/templates/macros.py
@@ -11,7 +11,7 @@ _rust_call_with_error({{ e|ffi_converter_name }},
     {%- else -%}
 _rust_call(
     {%- endmatch -%}
-    _UniffiLib.{{ func.ffi_func().name() }},
+    UniffiLib.{{ func.ffi_func().name() }},
     {%- call arg_list_lowered(func) -%}
 )
 {%- endmacro -%}
@@ -24,7 +24,7 @@ _rust_call_with_error(
     {%- else -%}
 _rust_call(
     {%- endmatch -%}
-    _UniffiLib.{{ func.ffi_func().name() }},
+    UniffiLib.{{ func.ffi_func().name() }},
     {{- prefix }},
     {%- call arg_list_lowered(func) -%}
 )
@@ -67,7 +67,7 @@ _rust_call(
 {%- endmacro %}
 
 {#-
-// Arglist as used in the _UniffiLib function declarations.
+// Arglist as used in the UniffiLib function declarations.
 // Note unfiltered name but ffi_type_name filters.
 -#}
 {%- macro arg_list_ffi_decl(func) %}
@@ -75,7 +75,7 @@ _rust_call(
     {{ arg.type_().borrow()|ffi_type_name }},
     {%- endfor %}
     {%- if func.has_rust_call_status_arg() %}
-    ctypes.POINTER(_UniffiRustCallStatus),{% endif %}
+    ctypes.POINTER(UniffiRustCallStatus),{% endif %}
 {% endmacro -%}
 
 {#
@@ -118,13 +118,13 @@ _rust_call(
     def {{ py_method_name }}(self, {% call arg_list_decl(meth) %}):
         {%- call docstring(meth, 8) %}
         {%- call setup_args_extra_indent(meth) %}
-        return _uniffi_rust_call_async(
-            _UniffiLib.{{ meth.ffi_func().name() }}(
-                self._uniffi_clone_pointer(), {% call arg_list_lowered(meth) %}
+        return uniffi_rust_call_async(
+            UniffiLib.{{ meth.ffi_func().name() }}(
+                self.uniffi_clone_pointer(), {% call arg_list_lowered(meth) %}
             ),
-            _UniffiLib.{{ meth.ffi_rust_future_poll(ci) }},
-            _UniffiLib.{{ meth.ffi_rust_future_complete(ci) }},
-            _UniffiLib.{{ meth.ffi_rust_future_free(ci) }},
+            UniffiLib.{{ meth.ffi_rust_future_poll(ci) }},
+            UniffiLib.{{ meth.ffi_rust_future_complete(ci) }},
+            UniffiLib.{{ meth.ffi_rust_future_free(ci) }},
             # lift function
             {%- match meth.return_type() %}
             {%- when Some(return_type) %}
@@ -150,7 +150,7 @@ _rust_call(
         {%- call docstring(meth, 8) %}
         {%- call setup_args_extra_indent(meth) %}
         return {{ return_type|lift_fn }}(
-            {% call to_ffi_call_with_prefix("self._uniffi_clone_pointer()", meth) %}
+            {% call to_ffi_call_with_prefix("self.uniffi_clone_pointer()", meth) %}
         )
 
 {%-         when None %}
@@ -158,7 +158,7 @@ _rust_call(
     def {{ py_method_name }}(self, {% call arg_list_decl(meth) %}):
         {%- call docstring(meth, 8) %}
         {%- call setup_args_extra_indent(meth) %}
-        {% call to_ffi_call_with_prefix("self._uniffi_clone_pointer()", meth) %}
+        {% call to_ffi_call_with_prefix("self.uniffi_clone_pointer()", meth) %}
 {%      endmatch %}
 {%  endif %}
 

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -265,7 +265,7 @@ mod filters {
     pub fn check_lower_rb(nm: &str, type_: &Type) -> Result<String, askama::Error> {
         Ok(match type_ {
             Type::Object { name, .. } => {
-                format!("({}._uniffi_check_lower {nm})", class_name_rb(name)?)
+                format!("({}.uniffi_check_lower {nm})", class_name_rb(name)?)
             }
             Type::Enum { .. }
             | Type::Record { .. }
@@ -295,7 +295,7 @@ mod filters {
             Type::Boolean => format!("({nm} ? 1 : 0)"),
             Type::String => format!("RustBuffer.allocFromString({nm})"),
             Type::Bytes => format!("RustBuffer.allocFromBytes({nm})"),
-            Type::Object { name, .. } => format!("({}._uniffi_lower {nm})", class_name_rb(name)?),
+            Type::Object { name, .. } => format!("({}.uniffi_lower {nm})", class_name_rb(name)?),
             Type::CallbackInterface { .. } => {
                 panic!("No support for lowering callback interfaces yet")
             }
@@ -329,7 +329,7 @@ mod filters {
             Type::Boolean => format!("1 == {nm}"),
             Type::String => format!("{nm}.consumeIntoString"),
             Type::Bytes => format!("{nm}.consumeIntoBytes"),
-            Type::Object { name, .. } => format!("{}._uniffi_allocate({nm})", class_name_rb(name)?),
+            Type::Object { name, .. } => format!("{}.uniffi_allocate({nm})", class_name_rb(name)?),
             Type::CallbackInterface { .. } => {
                 panic!("No support for lifting callback interfaces, yet")
             }

--- a/uniffi_bindgen/src/bindings/ruby/templates/ObjectTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/ObjectTemplate.rb
@@ -2,18 +2,18 @@ class {{ obj.name()|class_name_rb }}
 
   # A private helper for initializing instances of the class from a raw pointer,
   # bypassing any initialization logic and ensuring they are GC'd properly.
-  def self._uniffi_allocate(pointer)
+  def self.uniffi_allocate(pointer)
     pointer.autorelease = false
     inst = allocate
     inst.instance_variable_set :@pointer, pointer
-    ObjectSpace.define_finalizer(inst, _uniffi_define_finalizer_by_pointer(pointer, inst.object_id))
+    ObjectSpace.define_finalizer(inst, uniffi_define_finalizer_by_pointer(pointer, inst.object_id))
     return inst
   end
 
   # A private helper for registering an object finalizer.
   # N.B. it's important that this does not capture a reference
   # to the actual instance, only its underlying pointer.
-  def self._uniffi_define_finalizer_by_pointer(pointer, object_id)
+  def self.uniffi_define_finalizer_by_pointer(pointer, object_id)
     Proc.new do |_id|
       {{ ci.namespace()|class_name_rb }}.rust_call(
         :{{ obj.ffi_object_free().name() }},
@@ -25,21 +25,21 @@ class {{ obj.name()|class_name_rb }}
   # A private helper for lowering instances into a raw pointer.
   # This does an explicit typecheck, because accidentally lowering a different type of
   # object in a place where this type is expected, could lead to memory unsafety.
-  def self._uniffi_check_lower(inst)
+  def self.uniffi_check_lower(inst)
     if not inst.is_a? self
       raise TypeError.new "Expected a {{ obj.name()|class_name_rb }} instance, got #{inst}"
     end
   end
 
-  def _uniffi_clone_pointer()
+  def uniffi_clone_pointer()
     return {{ ci.namespace()|class_name_rb }}.rust_call(
       :{{ obj.ffi_object_clone().name() }},
       @pointer
     )
   end
 
-  def self._uniffi_lower(inst)
-    return inst._uniffi_clone_pointer()
+  def self.uniffi_lower(inst)
+    return inst.uniffi_clone_pointer()
   end
 
   {%- match obj.primary_constructor() %}
@@ -48,7 +48,7 @@ class {{ obj.name()|class_name_rb }}
     {%- call rb::setup_args_extra_indent(cons) %}
     pointer = {% call rb::to_ffi_call(cons) %}
     @pointer = pointer
-    ObjectSpace.define_finalizer(self, self.class._uniffi_define_finalizer_by_pointer(pointer, self.object_id))
+    ObjectSpace.define_finalizer(self, self.class.uniffi_define_finalizer_by_pointer(pointer, self.object_id))
   end
   {%- when None %}
   {%- endmatch %}
@@ -59,7 +59,7 @@ class {{ obj.name()|class_name_rb }}
     # Call the (fallible) function before creating any half-baked object instances.
     # Lightly yucky way to bypass the usual "initialize" logic
     # and just create a new instance with the required pointer.
-    return _uniffi_allocate({% call rb::to_ffi_call(cons) %})
+    return uniffi_allocate({% call rb::to_ffi_call(cons) %})
   end
   {% endfor %}
 
@@ -69,14 +69,14 @@ class {{ obj.name()|class_name_rb }}
   {%- when Some with (return_type) -%}
   def {{ meth.name()|fn_name_rb }}({% call rb::arg_list_decl(meth) %})
     {%- call rb::setup_args_extra_indent(meth) %}
-    result = {% call rb::to_ffi_call_with_prefix("_uniffi_clone_pointer()", meth) %}
+    result = {% call rb::to_ffi_call_with_prefix("uniffi_clone_pointer()", meth) %}
     return {{ "result"|lift_rb(return_type) }}
   end
 
   {%- when None -%}
   def {{ meth.name()|fn_name_rb }}({% call rb::arg_list_decl(meth) %})
       {%- call rb::setup_args_extra_indent(meth) %}
-      {% call rb::to_ffi_call_with_prefix("_uniffi_clone_pointer()", meth) %}
+      {% call rb::to_ffi_call_with_prefix("uniffi_clone_pointer()", meth) %}
   end
   {% endmatch %}
   {% endfor %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -163,7 +163,7 @@ class RustBufferBuilder
   # The Object type {{ object_name }}.
 
   def write_{{ canonical_type_name }}(obj)
-    pointer = {{ object_name|class_name_rb}}._uniffi_lower obj
+    pointer = {{ object_name|class_name_rb}}.uniffi_lower obj
     pack_into(8, 'Q>', pointer.address)
   end
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
@@ -155,7 +155,7 @@ class RustBufferStream
 
   def read{{ canonical_type_name }}
     pointer = FFI::Pointer.new unpack_from 8, 'Q>'
-    return {{ object_name|class_name_rb }}._uniffi_allocate(pointer)
+    return {{ object_name|class_name_rb }}.uniffi_allocate(pointer)
   end
 
   {% when Type::Enum { name, module_path } -%}


### PR DESCRIPTION
We've used a bunch of different prefix strategies to prevent our variable names from conflicting with the user's.  Let's try to make things consistent by using `uniffi`, `UNIFFI`, or `Uniffi`.

The main difference is removing the leading `_` character, which seems redundant.