### PR TITLE
Be more consistent with Kotlin variable prefixes

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -513,7 +513,7 @@ mod filters {
     ) -> Result<String, askama::Error> {
         let ffi_func = callable.ffi_rust_future_poll(ci);
         Ok(format!(
-            "{{ future, callback, continuation -> _UniFFILib.INSTANCE.{ffi_func}(future, callback, continuation) }}"
+            "{{ future, callback, continuation -> UniffiLib.INSTANCE.{ffi_func}(future, callback, continuation) }}"
         ))
     }
 
@@ -522,7 +522,7 @@ mod filters {
         ci: &ComponentInterface,
     ) -> Result<String, askama::Error> {
         let ffi_func = callable.ffi_rust_future_complete(ci);
-        let call = format!("_UniFFILib.INSTANCE.{ffi_func}(future, continuation)");
+        let call = format!("UniffiLib.INSTANCE.{ffi_func}(future, continuation)");
         let call = match callable.return_type() {
             Some(Type::External {
                 kind: ExternalKind::DataClass,
@@ -544,7 +544,7 @@ mod filters {
     ) -> Result<String, askama::Error> {
         let ffi_func = callable.ffi_rust_future_free(ci);
         Ok(format!(
-            "{{ future -> _UniFFILib.INSTANCE.{ffi_func}(future) }}"
+            "{{ future -> UniffiLib.INSTANCE.{ffi_func}(future) }}"
         ))
     }
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Async.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Async.kt
@@ -15,10 +15,10 @@ internal object uniffiRustFutureContinuationCallback: UniFffiRustFutureContinuat
 internal suspend fun<T, F, E: Exception> uniffiRustCallAsync(
     rustFuture: Pointer,
     pollFunc: (Pointer, UniFffiRustFutureContinuationCallbackType, USize) -> Unit,
-    completeFunc: (Pointer, RustCallStatus) -> F,
+    completeFunc: (Pointer, UniffiRustCallStatus) -> F,
     freeFunc: (Pointer) -> Unit,
     liftFunc: (F) -> T,
-    errorHandler: CallStatusErrorHandler<E>
+    errorHandler: UniffiRustCallStatusErrorHandler<E>
 ): T {
     try {
         do {
@@ -32,7 +32,7 @@ internal suspend fun<T, F, E: Exception> uniffiRustCallAsync(
         } while (pollResult != UNIFFI_RUST_FUTURE_POLL_READY);
 
         return liftFunc(
-            rustCallWithError(errorHandler, { status -> completeFunc(rustFuture, status) })
+            uniffiRustCallWithError(errorHandler, { status -> completeFunc(rustFuture, status) })
         )
     } finally {
         freeFunc(rustFuture)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceImpl.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceImpl.kt
@@ -3,7 +3,7 @@
 // Implement the foreign callback handler for {{ interface_name }}
 internal class {{ callback_handler_class }} : ForeignCallback {
     @Suppress("TooGenericExceptionCaught")
-    override fun invoke(handle: Handle, method: Int, argsData: Pointer, argsLen: Int, outBuf: RustBufferByReference): Int {
+    override fun invoke(handle: UniffiHandle, method: Int, argsData: Pointer, argsLen: Int, outBuf: RustBufferByReference): Int {
         val cb = {{ ffi_converter_name }}.handleMap.get(handle)
         return when (method) {
             IDX_CALLBACK_FREE -> {
@@ -99,7 +99,7 @@ internal class {{ callback_handler_class }} : ForeignCallback {
 
     // Registers the foreign callback with the Rust side.
     // This method is generated for each callback interface.
-    internal fun register(lib: _UniFFILib) {
+    internal fun register(lib: UniffiLib) {
         lib.{{ ffi_init_callback.name() }}(this)
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceTemplate.kt
@@ -9,5 +9,5 @@
 {% include "Interface.kt" %}
 {% include "CallbackInterfaceImpl.kt" %}
 
-// The ffiConverter which transforms the Callbacks in to Handles to pass to Rust.
+// The ffiConverter which transforms the Callbacks in to UniffiHandles to pass to Rust.
 public object {{ ffi_converter_name }}: FfiConverterCallbackInterface<{{ interface_name }}>()

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
@@ -10,7 +10,7 @@ sealed class {{ type_name }}(message: String): Exception(message){% if contains_
         class {{ variant|error_variant_name }}(message: String) : {{ type_name }}(message)
         {% endfor %}
 
-    companion object ErrorHandler : CallStatusErrorHandler<{{ type_name }}> {
+    companion object ErrorHandler : UniffiRustCallStatusErrorHandler<{{ type_name }}> {
         override fun lift(error_buf: RustBuffer.ByValue): {{ type_name }} = {{ ffi_converter_name }}.lift(error_buf)
     }
 }
@@ -31,7 +31,7 @@ sealed class {{ type_name }}: Exception(){% if contains_object_references %}, Di
     }
     {% endfor %}
 
-    companion object ErrorHandler : CallStatusErrorHandler<{{ type_name }}> {
+    companion object ErrorHandler : UniffiRustCallStatusErrorHandler<{{ type_name }}> {
         override fun lift(error_buf: RustBuffer.ByValue): {{ type_name }} = {{ ffi_converter_name }}.lift(error_buf)
     }
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
@@ -16,11 +16,11 @@ private inline fun <reified Lib : Library> loadIndirect(
 // A JNA Library to expose the extern-C FFI definitions.
 // This is an implementation detail which will be called internally by the public API.
 
-internal interface _UniFFILib : Library {
+internal interface UniffiLib : Library {
     companion object {
-        internal val INSTANCE: _UniFFILib by lazy {
-            loadIndirect<_UniFFILib>(componentName = "{{ ci.namespace() }}")
-            .also { lib: _UniFFILib ->
+        internal val INSTANCE: UniffiLib by lazy {
+            loadIndirect<UniffiLib>(componentName = "{{ ci.namespace() }}")
+            .also { lib: UniffiLib ->
                 uniffiCheckContractApiVersion(lib)
                 uniffiCheckApiChecksums(lib)
                 {% for fn in self.initialization_fns() -%}
@@ -37,7 +37,7 @@ internal interface _UniFFILib : Library {
     {% endfor %}
 }
 
-private fun uniffiCheckContractApiVersion(lib: _UniFFILib) {
+private fun uniffiCheckContractApiVersion(lib: UniffiLib) {
     // Get the bindings contract version from our ComponentInterface
     val bindings_contract_version = {{ ci.uniffi_contract_version() }}
     // Get the scaffolding contract version by calling the into the dylib
@@ -48,7 +48,7 @@ private fun uniffiCheckContractApiVersion(lib: _UniFFILib) {
 }
 
 @Suppress("UNUSED_PARAMETER")
-private fun uniffiCheckApiChecksums(lib: _UniFFILib) {
+private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     {%- for (name, expected_checksum) in ci.iter_checksums() %}
     if (lib.{{ name }}() != {{ expected_checksum }}.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -30,8 +30,8 @@ open class {{ impl_class_name }} : FFIObject, {{ interface_name }} {
     {%- endmatch %}
 
     override fun uniffiClonePointer(): Pointer {
-        return rustCall() { status ->
-            _UniFFILib.INSTANCE.{{ obj.ffi_object_clone().name() }}(pointer!!, status)
+        return uniffiRustCall() { status ->
+            UniffiLib.INSTANCE.{{ obj.ffi_object_clone().name() }}(pointer!!, status)
         }
     }
 
@@ -45,8 +45,8 @@ open class {{ impl_class_name }} : FFIObject, {{ interface_name }} {
      */
     override protected fun freeRustArcPtr() {
         this.pointer?.let { ptr ->
-            rustCall() { status ->
-                _UniFFILib.INSTANCE.{{ obj.ffi_object_free().name() }}(ptr, status)
+            uniffiRustCall() { status ->
+                UniffiLib.INSTANCE.{{ obj.ffi_object_free().name() }}(ptr, status)
             }
         }
     }
@@ -65,7 +65,7 @@ open class {{ impl_class_name }} : FFIObject, {{ interface_name }} {
     ){% match meth.return_type() %}{% when Some with (return_type) %} : {{ return_type|type_name(ci) }}{% when None %}{%- endmatch %} {
         return uniffiRustCallAsync(
             callWithPointer { thisPtr ->
-                _UniFFILib.INSTANCE.{{ meth.ffi_func().name() }}(
+                UniffiLib.INSTANCE.{{ meth.ffi_func().name() }}(
                     thisPtr,
                     {% call kt::arg_list_lowered(meth) %}
                 )
@@ -85,7 +85,7 @@ open class {{ impl_class_name }} : FFIObject, {{ interface_name }} {
             {%- when Some(e) %}
             {{ e|type_name(ci) }}.ErrorHandler,
             {%- when None %}
-            NullCallStatusErrorHandler,
+            UniffiNullRustCallStatusErrorHandler,
             {%- endmatch %}
         )
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/README.md
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/README.md
@@ -1,0 +1,13 @@
+# Rules for the Kotlin template code
+
+## Naming
+
+Private variables, classes, functions, etc. should be prefixed with `uniffi`, `Uniffi`, or `UNIFFI`.
+This avoids naming collisions with user-defined items.
+Users will not get name collisions as long as they don't use "uniffi", which is reserved for us.
+
+In particular, make sure to use the `uniffi` prefix for any variable names in generated functions.
+If you name a variable something like `result` the code will probably work initially.
+Then it will break later on when a user decides to define a function with a parameter named `result`.
+
+Note: this doesn't apply to items that we want to expose, for example users may want to catch `InternalException` so doesn't get the `Uniffi` prefix.

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
@@ -12,8 +12,8 @@ open class RustBuffer : Structure() {
     class ByReference: RustBuffer(), Structure.ByReference
 
     companion object {
-        internal fun alloc(size: Int = 0) = rustCall() { status ->
-            _UniFFILib.INSTANCE.{{ ci.ffi_rustbuffer_alloc().name() }}(size, status)
+        internal fun alloc(size: Int = 0) = uniffiRustCall() { status ->
+            UniffiLib.INSTANCE.{{ ci.ffi_rustbuffer_alloc().name() }}(size, status)
         }.also {
             if(it.data == null) {
                throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
@@ -28,8 +28,8 @@ open class RustBuffer : Structure() {
             return buf
         }
 
-        internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
-            _UniFFILib.INSTANCE.{{ ci.ffi_rustbuffer_free().name() }}(buf, status)
+        internal fun free(buf: RustBuffer.ByValue) = uniffiRustCall() { status ->
+            UniffiLib.INSTANCE.{{ ci.ffi_rustbuffer_free().name() }}(buf, status)
         }
     }
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
@@ -9,7 +9,7 @@
 @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
 suspend fun {{ func.name()|fn_name }}({%- call kt::arg_list_decl(func) -%}){% match func.return_type() %}{% when Some with (return_type) %} : {{ return_type|type_name(ci) }}{% when None %}{%- endmatch %} {
     return uniffiRustCallAsync(
-        _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call kt::arg_list_lowered(func) %}),
+        UniffiLib.INSTANCE.{{ func.ffi_func().name() }}({% call kt::arg_list_lowered(func) %}),
         {{ func|async_poll(ci) }},
         {{ func|async_complete(ci) }},
         {{ func|async_free(ci) }},
@@ -25,7 +25,7 @@ suspend fun {{ func.name()|fn_name }}({%- call kt::arg_list_decl(func) -%}){% ma
         {%- when Some(e) %}
         {{ e|type_name(ci) }}.ErrorHandler,
         {%- when None %}
-        NullCallStatusErrorHandler,
+        UniffiNullRustCallStatusErrorHandler,
         {%- endmatch %}
     )
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -7,22 +7,22 @@
 {%- macro to_ffi_call(func) -%}
     {%- match func.throws_type() %}
     {%- when Some with (e) %}
-    rustCallWithError({{ e|type_name(ci) }})
+    uniffiRustCallWithError({{ e|type_name(ci) }})
     {%- else %}
-    rustCall()
+    uniffiRustCall()
     {%- endmatch %} { _status ->
-    _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}({% call arg_list_lowered(func) -%} _status)
+    UniffiLib.INSTANCE.{{ func.ffi_func().name() }}({% call arg_list_lowered(func) -%} _status)
 }
 {%- endmacro -%}
 
 {%- macro to_ffi_call_with_prefix(prefix, func) %}
     {%- match func.throws_type() %}
     {%- when Some with (e) %}
-    rustCallWithError({{ e|type_name(ci) }})
+    uniffiRustCallWithError({{ e|type_name(ci) }})
     {%- else %}
-    rustCall()
+    uniffiRustCall()
     {%- endmatch %} { _status ->
-    _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}(
+    UniffiLib.INSTANCE.{{ func.ffi_func().name() }}(
         {{- prefix }},
         {% call arg_list_lowered(func) %}
         _status)
@@ -58,14 +58,14 @@
     {%- endfor %}
 {%- endmacro %}
 {#-
-// Arglist as used in the _UniFFILib function declarations.
+// Arglist as used in the UniffiLib function declarations.
 // Note unfiltered name but ffi_type_name filters.
 -#}
 {%- macro arg_list_ffi_decl(func) %}
     {%- for arg in func.arguments() %}
         {{- arg.name()|var_name }}: {{ arg.type_().borrow()|ffi_type_name_by_value -}},
     {%- endfor %}
-    {%- if func.has_rust_call_status_arg() %}_uniffi_out_err: RustCallStatus, {% endif %}
+    {%- if func.has_rust_call_status_arg() %}uniffi_out_err: UniffiRustCallStatus, {% endif %}
 {%- endmacro -%}
 
 // Macro for destroying fields


### PR DESCRIPTION
Let's always use `uniffi`, `Uniffi`, or `UNIFFI`. Before some of the variable names had leading underscores, which seems redundant and not idomatic Kotlin.  My guess is that it was copy and pasted from Python.

I think the general contract with our users should be that we own the `uniffi` prefix.  If they want to name something `UniffiFoo`, then they take the risk of a name collision.

This is my personal take on the matter, but I'm fine with any naming scheme.  I just think we should be consistent about it.