### PR TITLE
Be more consistent with Python variable prefixes

### DIFF
--- a/uniffi_bindgen/src/bindings/python/templates/Async.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Async.py
@@ -57,7 +57,7 @@ async def _uniffi_rust_call_async(rust_future, ffi_poll, ffi_complete, ffi_free,
                 break
 
         return lift_func(
-            _rust_call_with_error(error_ffi_converter, ffi_complete, rust_future)
+            _uniffi_rust_call_with_error(error_ffi_converter, ffi_complete, rust_future)
         )
     finally:
         ffi_free(rust_future)

--- a/uniffi_bindgen/src/bindings/python/templates/Helpers.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Helpers.py
@@ -32,11 +32,11 @@ class _UniffiRustCallStatus(ctypes.Structure):
         else:
             return "_UniffiRustCallStatus(<invalid code>)"
 
-def _rust_call(fn, *args):
+def _uniffi_rust_call(fn, *args):
     # Call a rust function
-    return _rust_call_with_error(None, fn, *args)
+    return _uniffi_rust_call_with_error(None, fn, *args)
 
-def _rust_call_with_error(error_ffi_converter, fn, *args):
+def _uniffi_rust_call_with_error(error_ffi_converter, fn, *args):
     # Call a rust function and handle any errors
     #
     # This function is used for rust calls that return Result<> and therefore can set the CALL_ERROR status code.
@@ -54,7 +54,7 @@ def _uniffi_check_call_status(error_ffi_converter, call_status):
     elif call_status.code == _UniffiRustCallStatus.CALL_ERROR:
         if error_ffi_converter is None:
             call_status.error_buf.free()
-            raise InternalError("_rust_call_with_error: CALL_ERROR, but error_ffi_converter is None")
+            raise InternalError("_uniffi_rust_call_with_error: CALL_ERROR, but error_ffi_converter is None")
         else:
             raise error_ffi_converter.lift(call_status.error_buf)
     elif call_status.code == _UniffiRustCallStatus.CALL_UNEXPECTED_ERROR:

--- a/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
@@ -34,10 +34,10 @@ class {{ impl_name }}:
         # In case of partial initialization of instances.
         pointer = getattr(self, "_pointer", None)
         if pointer is not None:
-            _rust_call(_UniffiLib.{{ obj.ffi_object_free().name() }}, pointer)
+            _uniffi_rust_call(_UniffiLib.{{ obj.ffi_object_free().name() }}, pointer)
 
     def _uniffi_clone_pointer(self):
-        return _rust_call(_UniffiLib.{{ obj.ffi_object_clone().name() }}, self._pointer)
+        return _uniffi_rust_call(_UniffiLib.{{ obj.ffi_object_clone().name() }}, self._pointer)
 
     # Used by alternative constructors or any methods which return this type.
     @classmethod

--- a/uniffi_bindgen/src/bindings/python/templates/README.md
+++ b/uniffi_bindgen/src/bindings/python/templates/README.md
@@ -1,0 +1,14 @@
+# Rules for the Python template code
+
+## Naming
+
+Private variables, classes, functions, etc. should be prefixed with `_uniffi`, `_Uniffi`, or `_UNIFFI`.
+The `_` indicates the variable is private and removes it from the autocomplete list.
+The `uniffi` part avoids naming collisions with user-defined items.
+Users can use leading underscores in their names if they want, but "uniffi" is reserved for our purposes.
+
+In particular, make sure to use the `_uniffi` prefix for any variable names in generated functions.
+If you name a variable something like `result` the code will probably work initially.
+Then it will break later on when a user decides to define a function with a parameter named `result`.
+
+Note: this doesn't apply to items that we want to expose, for example users may want to catch `InternalError` so doesn't get the `Uniffi` prefix.

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
@@ -12,14 +12,14 @@ class _UniffiRustBuffer(ctypes.Structure):
 
     @staticmethod
     def alloc(size):
-        return _rust_call(_UniffiLib.{{ ci.ffi_rustbuffer_alloc().name() }}, size)
+        return _uniffi_rust_call(_UniffiLib.{{ ci.ffi_rustbuffer_alloc().name() }}, size)
 
     @staticmethod
     def reserve(rbuf, additional):
-        return _rust_call(_UniffiLib.{{ ci.ffi_rustbuffer_reserve().name() }}, rbuf, additional)
+        return _uniffi_rust_call(_UniffiLib.{{ ci.ffi_rustbuffer_reserve().name() }}, rbuf, additional)
 
     def free(self):
-        return _rust_call(_UniffiLib.{{ ci.ffi_rustbuffer_free().name() }}, self)
+        return _uniffi_rust_call(_UniffiLib.{{ ci.ffi_rustbuffer_free().name() }}, self)
 
     def __str__(self):
         return "_UniffiRustBuffer(capacity={}, len={}, data={})".format(

--- a/uniffi_bindgen/src/bindings/python/templates/macros.py
+++ b/uniffi_bindgen/src/bindings/python/templates/macros.py
@@ -17,14 +17,14 @@
 {%-     when Some with (e) -%}
 {%-         match e -%}
 {%-             when Type::Enum { name, module_path } -%}
-_rust_call_with_error({{ e|ffi_converter_name }},
+_uniffi_rust_call_with_error({{ e|ffi_converter_name }},
 {%-             when Type::Object { name, module_path, imp } -%}
-_rust_call_with_error({{ e|ffi_converter_name }}__as_error,
+_uniffi_rust_call_with_error({{ e|ffi_converter_name }}__as_error,
 {%-             else %}
 # unsupported error type!
 {%-         endmatch %}
 {%- else -%}
-_rust_call(
+_uniffi_rust_call(
 {%- endmatch -%}
     _UniffiLib.{{ func.ffi_func().name() }},
     {{- prefix }}


### PR DESCRIPTION
Always use `uniffi`, `Uniffi`, or `UNIFFI` for module-level names.  Add a leading underscore for private class members.  I think this is the most Pythonic naming style. Because we define `__all__` for modules, there's no chance that users will accidentally import the UniFFI items with `from module import *`

Before there were lots of leading underscores, but I don't see the point and it doesn't feel Pythonic to me.

I think the general contract with our users should be that we own the `uniffi` prefix.  If they want to name something `UniffiFoo`, then they take the risk of a name collision.

This is my personal take on the matter, but I'm fine with any naming scheme.  I just think we should be consistent about it.