### PR TITLE
Be more consistent with Ruby variable prefixes

### DIFF
--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -265,7 +265,7 @@ mod filters {
     pub fn check_lower_rb(nm: &str, type_: &Type) -> Result<String, askama::Error> {
         Ok(match type_ {
             Type::Object { name, .. } => {
-                format!("({}._uniffi_check_lower {nm})", class_name_rb(name)?)
+                format!("({}.uniffi_check_lower {nm})", class_name_rb(name)?)
             }
             Type::Enum { .. }
             | Type::Record { .. }
@@ -295,7 +295,7 @@ mod filters {
             Type::Boolean => format!("({nm} ? 1 : 0)"),
             Type::String => format!("RustBuffer.allocFromString({nm})"),
             Type::Bytes => format!("RustBuffer.allocFromBytes({nm})"),
-            Type::Object { name, .. } => format!("({}._uniffi_lower {nm})", class_name_rb(name)?),
+            Type::Object { name, .. } => format!("({}.uniffi_lower {nm})", class_name_rb(name)?),
             Type::CallbackInterface { .. } => {
                 panic!("No support for lowering callback interfaces yet")
             }
@@ -329,7 +329,7 @@ mod filters {
             Type::Boolean => format!("1 == {nm}"),
             Type::String => format!("{nm}.consumeIntoString"),
             Type::Bytes => format!("{nm}.consumeIntoBytes"),
-            Type::Object { name, .. } => format!("{}._uniffi_allocate({nm})", class_name_rb(name)?),
+            Type::Object { name, .. } => format!("{}.uniffi_allocate({nm})", class_name_rb(name)?),
             Type::CallbackInterface { .. } => {
                 panic!("No support for lifting callback interfaces, yet")
             }

--- a/uniffi_bindgen/src/bindings/ruby/templates/ObjectTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/ObjectTemplate.rb
@@ -2,18 +2,18 @@ class {{ obj.name()|class_name_rb }}
 
   # A private helper for initializing instances of the class from a raw pointer,
   # bypassing any initialization logic and ensuring they are GC'd properly.
-  def self._uniffi_allocate(pointer)
+  def self.uniffi_allocate(pointer)
     pointer.autorelease = false
     inst = allocate
     inst.instance_variable_set :@pointer, pointer
-    ObjectSpace.define_finalizer(inst, _uniffi_define_finalizer_by_pointer(pointer, inst.object_id))
+    ObjectSpace.define_finalizer(inst, uniffi_define_finalizer_by_pointer(pointer, inst.object_id))
     return inst
   end
 
   # A private helper for registering an object finalizer.
   # N.B. it's important that this does not capture a reference
   # to the actual instance, only its underlying pointer.
-  def self._uniffi_define_finalizer_by_pointer(pointer, object_id)
+  def self.uniffi_define_finalizer_by_pointer(pointer, object_id)
     Proc.new do |_id|
       {{ ci.namespace()|class_name_rb }}.rust_call(
         :{{ obj.ffi_object_free().name() }},
@@ -25,21 +25,21 @@ class {{ obj.name()|class_name_rb }}
   # A private helper for lowering instances into a raw pointer.
   # This does an explicit typecheck, because accidentally lowering a different type of
   # object in a place where this type is expected, could lead to memory unsafety.
-  def self._uniffi_check_lower(inst)
+  def self.uniffi_check_lower(inst)
     if not inst.is_a? self
       raise TypeError.new "Expected a {{ obj.name()|class_name_rb }} instance, got #{inst}"
     end
   end
 
-  def _uniffi_clone_pointer()
+  def uniffi_clone_pointer()
     return {{ ci.namespace()|class_name_rb }}.rust_call(
       :{{ obj.ffi_object_clone().name() }},
       @pointer
     )
   end
 
-  def self._uniffi_lower(inst)
-    return inst._uniffi_clone_pointer()
+  def self.uniffi_lower(inst)
+    return inst.uniffi_clone_pointer()
   end
 
   {%- match obj.primary_constructor() %}
@@ -48,7 +48,7 @@ class {{ obj.name()|class_name_rb }}
     {%- call rb::setup_args_extra_indent(cons) %}
     pointer = {% call rb::to_ffi_call(cons) %}
     @pointer = pointer
-    ObjectSpace.define_finalizer(self, self.class._uniffi_define_finalizer_by_pointer(pointer, self.object_id))
+    ObjectSpace.define_finalizer(self, self.class.uniffi_define_finalizer_by_pointer(pointer, self.object_id))
   end
   {%- when None %}
   {%- endmatch %}
@@ -59,7 +59,7 @@ class {{ obj.name()|class_name_rb }}
     # Call the (fallible) function before creating any half-baked object instances.
     # Lightly yucky way to bypass the usual "initialize" logic
     # and just create a new instance with the required pointer.
-    return _uniffi_allocate({% call rb::to_ffi_call(cons) %})
+    return uniffi_allocate({% call rb::to_ffi_call(cons) %})
   end
   {% endfor %}
 
@@ -69,14 +69,14 @@ class {{ obj.name()|class_name_rb }}
   {%- when Some with (return_type) -%}
   def {{ meth.name()|fn_name_rb }}({% call rb::arg_list_decl(meth) %})
     {%- call rb::setup_args_extra_indent(meth) %}
-    result = {% call rb::to_ffi_call_with_prefix("_uniffi_clone_pointer()", meth) %}
+    result = {% call rb::to_ffi_call_with_prefix("uniffi_clone_pointer()", meth) %}
     return {{ "result"|lift_rb(return_type) }}
   end
 
   {%- when None -%}
   def {{ meth.name()|fn_name_rb }}({% call rb::arg_list_decl(meth) %})
       {%- call rb::setup_args_extra_indent(meth) %}
-      {% call rb::to_ffi_call_with_prefix("_uniffi_clone_pointer()", meth) %}
+      {% call rb::to_ffi_call_with_prefix("uniffi_clone_pointer()", meth) %}
   end
   {% endmatch %}
   {% endfor %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -163,7 +163,7 @@ class RustBufferBuilder
   # The Object type {{ object_name }}.
 
   def write_{{ canonical_type_name }}(obj)
-    pointer = {{ object_name|class_name_rb}}._uniffi_lower obj
+    pointer = {{ object_name|class_name_rb}}.uniffi_lower obj
     pack_into(8, 'Q>', pointer.address)
   end
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
@@ -155,7 +155,7 @@ class RustBufferStream
 
   def read{{ canonical_type_name }}
     pointer = FFI::Pointer.new unpack_from 8, 'Q>'
-    return {{ object_name|class_name_rb }}._uniffi_allocate(pointer)
+    return {{ object_name|class_name_rb }}.uniffi_allocate(pointer)
   end
 
   {% when Type::Enum { name, module_path } -%}


### PR DESCRIPTION
Let's always use `uniffi`, `Uniffi`, or `UNIFFI`. Before some of the variable names had leading underscores, which seems redundant and not idomatic Kotlin.  My guess is that it comes from copy and pasted Python code.

I think the general contract with our users should be that we own the `uniffi` prefix.  If they want to name something `UniffiFoo`, then they take the risk of a name collision.

This is my personal take on the matter, but I'm fine with any naming scheme.  I just think we should be consistent about it.