### PR TITLE
Update oneshot-uniffi to 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,9 +919,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "oneshot-uniffi"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae4988774e7a7e6a0783d119bdc683ea8c1d01a24d4fff9b4bdc280e07bd99e"
+checksum = "6c548d5c78976f6955d72d0ced18c48ca07030f7a1d4024529fedd7c1c01b29c"
 
 [[package]]
 name = "oorandom"


### PR DESCRIPTION
This brings in the `into_raw` and `from_raw` methods that we may want to use to pass oneshot senders over the FFI.  It still uses my patched version to avoid #1736.