### PR TITLE
[Swift] Generate open classes, methods and mocks

### DIFF
--- a/uniffi_bindgen/src/bindings/mod.rs
+++ b/uniffi_bindgen/src/bindings/mod.rs
@@ -123,3 +123,29 @@ pub fn write_bindings(
     }
     Ok(())
 }
+
+pub fn write_mocks(
+    config: &Config,
+    ci: &ComponentInterface,
+    out_dir: &Utf8Path,
+    language: TargetLanguage,
+    try_format_code: bool,
+) -> Result<()> {
+    match language {
+        TargetLanguage::Kotlin => {
+            return Err(anyhow::anyhow!(
+                "Mock generation is not supported for Kotlin"
+            ))
+        }
+        TargetLanguage::Swift => swift::write_mocks(&config.swift, ci, out_dir, try_format_code)?,
+        TargetLanguage::Python => {
+            return Err(anyhow::anyhow!(
+                "Mock generation is not supported for Python"
+            ))
+        }
+        TargetLanguage::Ruby => {
+            return Err(anyhow::anyhow!("Mock generation is not supported for Ruby"))
+        }
+    }
+    Ok(())
+}

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -361,7 +361,7 @@ impl<'a> TypeRenderer<'a> {
 /// Generate UniFFI mocks for Swift, as strings in memory.
 ///
 pub fn generate_mocks(config: &Config, ci: &ComponentInterface) -> Result<String> {
-    let mocks_renderer = MocksRenderer::new(&config, ci);
+    let mocks_renderer = MocksRenderer::new(config, ci);
     let mocks = mocks_renderer
         .render()
         .context("failed to render Swift mocks")?;

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -358,6 +358,31 @@ impl<'a> TypeRenderer<'a> {
     }
 }
 
+/// Generate UniFFI mocks for Swift, as strings in memory.
+///
+pub fn generate_mocks(config: &Config, ci: &ComponentInterface) -> Result<String> {
+    let mocks_renderer = MocksRenderer::new(&config, ci);
+    let mocks = mocks_renderer
+        .render()
+        .context("failed to render Swift mocks")?;
+
+    Ok(mocks)
+}
+
+/// Renders Swift mocks helper code for all types
+#[derive(Template)]
+#[template(syntax = "swift", escape = "none", path = "wrapper_mocks.swift")]
+pub struct MocksRenderer<'a> {
+    config: &'a Config,
+    ci: &'a ComponentInterface,
+}
+
+impl<'a> MocksRenderer<'a> {
+    fn new(config: &'a Config, ci: &'a ComponentInterface) -> Self {
+        Self { config, ci }
+    }
+}
+
 /// Template for generating the `.h` file that defines the low-level C FFI.
 ///
 /// This file defines only the low-level structs and functions that are exposed
@@ -576,6 +601,10 @@ pub mod filters {
 
     pub fn type_name(as_type: &impl AsType) -> Result<String, askama::Error> {
         Ok(oracle().find(&as_type.as_type()).type_label())
+    }
+
+    pub fn type_is_optional(as_type: &impl AsType) -> Result<bool, askama::Error> {
+        Ok(matches!(&as_type.as_type(), Type::Optional { .. }))
     }
 
     pub fn canonical_name(as_type: &impl AsType) -> Result<String, askama::Error> {

--- a/uniffi_bindgen/src/bindings/swift/templates/MockFunctionTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/MockFunctionTemplate.swift
@@ -1,0 +1,116 @@
+{#
+// Template used to generate mock function.
+// if is_alternate_constructor is true, then it generates a class function.
+#}
+
+    // MARK: - {{ meth.name()|fn_name }}
+
+    {# // CallsCount -#}
+    public {% if is_alternate_constructor %}static {% endif -%} var {% call swift::mock_var_prefix(meth) %}CallsCount = 0
+    public {% if is_alternate_constructor %}static {% endif -%} var {% call swift::mock_var_prefix(meth) %}Called: Bool {
+        return {% if is_alternate_constructor %}Self.{% endif %}{% call swift::mock_var_prefix(meth) %}CallsCount > 0
+    }
+    {% if meth.arguments().len() > 0 -%}
+    {# // ReceivedInvocations -#}
+    public {% if is_alternate_constructor %}static {% endif -%} var {% call swift::mock_var_prefix(meth) %}ReceivedInvocations: [
+    {%- if meth.arguments().len() > 1 -%}
+    ({% call swift::arg_list_decl(meth) %})
+    {%- else -%}
+    {{ meth.arguments()[0]|type_name }}
+    {%- endif -%}
+    ] = []
+    {# // ReceivedArguments -#}
+    public {% if is_alternate_constructor %}static {% endif -%} var {% call swift::mock_var_prefix(meth) %}
+    {%- if meth.arguments().len() > 1 -%}
+    ReceivedArguments: ({% call swift::arg_list_decl(meth) %})?
+    {%- else -%}
+    ReceivedArgument: {{ meth.arguments()[0]|type_name }}{% if meth.arguments()[0]|type_is_optional == false %}?{% endif %}
+    {% endif %}
+    {# // ThrowableError -#}
+    {%- endif %}
+    {%- if meth.throws() -%}
+    public {% if is_alternate_constructor %}static {% endif -%} var {% call swift::mock_var_prefix(meth) %}ThrowableError: Error?
+    {%- endif %}
+    {# // Closure -#}
+    public {% if is_alternate_constructor %}static {% endif -%} var {% call swift::mock_var_prefix(meth) -%}Closure: ((
+        {%- for arg in meth.arguments() -%}
+        {{ arg|type_name }}
+        {%- if !loop.last %}, {% endif -%}
+        {%- endfor -%}
+    ) {% call swift::throws(meth) -%} -> {% match meth.return_type() %}{% when Some with (return_type) %}{{ return_type|type_name }}{% when None %}Void{% endmatch %})?
+    {# // ReturnValue -#}
+    {%- match meth.return_type() -%}
+    {%- when Some with (return_type) %}
+    public {% if is_alternate_constructor %}static {% endif -%} var {% call swift::mock_var_prefix(meth) %}ReturnValue: {{ return_type|type_name }}{% if return_type|type_is_optional == false %}!{% endif %}
+    {%- when None -%}
+    {%- endmatch %}
+    {# // Documentation -#}
+    {% call swift::docstring(meth, 4) %}
+    {# // Implementation -#}
+    {%- if is_alternate_constructor -%}
+    public override class func {{ meth.name()|fn_name }}({% call swift::arg_list_decl(meth) %}) {% call swift::throws(meth) %} -> {{ impl_class_name }} {
+    {%- else -%}
+    public override func {{ meth.name()|fn_name }}({%- call swift::arg_list_decl(meth) -%}) 
+        {%- if meth.is_async() %} async{% endif %} {% call swift::throws(meth) %}
+        {%- match meth.return_type() %}{% when Some with (return_type) -%} -> {{ return_type|type_name }}{% when None %}{% endmatch %} {
+    {%- endif %}
+        {# // Check for throwable error -#}
+        {% if meth.throws() -%}
+        if let error = {% if is_alternate_constructor %}Self.{% endif %}{% call swift::mock_var_prefix(meth) -%}ThrowableError {
+            throw error
+        }
+        {%- endif %}
+        {% if meth.arguments().len() > 0 -%}
+        {# // Update received arguments -#}
+        {%- if meth.arguments().len() > 1 -%}
+        {% if is_alternate_constructor %}Self.{% endif %}{% call swift::mock_var_prefix(meth) %}ReceivedArguments = (
+            {%- for arg in meth.arguments() -%}
+            {{ arg.name()|var_name }}: {{ arg.name()|var_name }}
+            {%- if !loop.last %}, {% endif -%}
+            {%- endfor -%}
+        )
+        {% else %}
+        {% if is_alternate_constructor %}Self.{% endif %}{% call swift::mock_var_prefix(meth) %}ReceivedArgument = {{ meth.arguments()[0].name()|var_name }}
+        {% endif %}
+        {# // Update received invocations -#}
+        {% if is_alternate_constructor %}Self.{% endif %}{% call swift::mock_var_prefix(meth) %}ReceivedInvocations.append(
+            {%- if meth.arguments().len() > 1 -%}
+            (
+                {%- for arg in meth.arguments() -%}
+                {{ arg.name()|var_name }}: {{ arg.name()|var_name }}
+                {%- if !loop.last %}, {% endif -%}
+                {%- endfor -%}
+            )
+            {%- else -%}
+            {{ meth.arguments()[0].name()|var_name }}
+            {%- endif -%}
+        )
+        {% endif %}
+        {# // Update calls count -#}
+        {% if is_alternate_constructor %}Self.{% endif %}{% call swift::mock_var_prefix(meth) %}CallsCount += 1
+        {% match meth.return_type() -%}
+        {%- when Some with (return_type) %}
+        {# // Check for closure -#}
+        if let closure = {% if is_alternate_constructor %}Self.{% endif %}{% call swift::mock_var_prefix(meth) %}Closure {            
+            return {% if meth.throws() %}try {% endif -%} closure(
+                {%- for arg in meth.arguments() -%}
+                {{ arg.name()|var_name }}
+                {%- if !loop.last %}, {% endif -%}
+                {%- endfor -%}
+            )
+        }
+        {# // Returns the return value -#}
+        return {% if is_alternate_constructor %}Self.{% endif %}{% call swift::mock_var_prefix(meth) -%}ReturnValue
+        {%- when None %}
+        {# // Check for closure -#}
+        if let closure = {% if is_alternate_constructor %}Self.{% endif %}{% call swift::mock_var_prefix(meth) %}Closure {
+            {% if meth.throws() %}try {% endif -%}
+            closure(
+                {%- for arg in meth.arguments() -%}
+                {{ arg.name()|var_name }}
+                {%- if !loop.last %}, {% endif -%}
+                {%- endfor -%}
+            )
+        }
+        {%- endmatch %}
+    }

--- a/uniffi_bindgen/src/bindings/swift/templates/MockTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/MockTemplate.swift
@@ -1,0 +1,26 @@
+{%- let obj = ci|get_object_definition(name) %}
+{%- let (protocol_name, impl_class_name) = obj|object_names %}
+{%- let methods = obj.methods() %}
+{%- let protocol_docstring = obj.docstring() %}
+
+{% call swift::docstring(obj, 0) %}
+public class {{ impl_class_name }}Mock: {{ impl_class_name }} {
+
+    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        fatalError("Not supported")
+    }
+
+    public init() {
+        super.init(noPointer: NoPointer())
+    }
+
+    {%- let is_alternate_constructor = true -%}
+    {%- for meth in obj.alternate_constructors() -%}
+    {% include "MockFunctionTemplate.swift" %}
+    {%- endfor -%}
+
+    {%- let is_alternate_constructor = false -%}
+    {%- for meth in obj.methods() -%}
+    {% include "MockFunctionTemplate.swift" %}
+    {%- endfor %}
+}

--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -142,7 +142,7 @@ open class {{ impl_class_name }}:
         )
     }
     {%-         when UniffiTrait::Eq { eq, ne } %}
-    open static func == (lhs: {{ impl_class_name }}, other: {{ impl_class_name }}) -> Bool {
+    public static func == (lhs: {{ impl_class_name }}, other: {{ impl_class_name }}) -> Bool {
         return {% call swift::try(eq) %} {{ eq.return_type().unwrap()|lift_fn }}(
             {% call swift::to_ffi_call_with_prefix("lhs.uniffiClonePointer()", eq) %}
         )

--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -58,12 +58,15 @@ open class {{ impl_class_name }}:
     {%- endmatch %}
 
     deinit {
+        guard let pointer = self.pointer else {
+            return
+        }
         try! rustCall { {{ obj.ffi_object_free().name() }}(pointer, $0) }
     }
 
     {% for cons in obj.alternate_constructors() %}
     {%- call swift::docstring(cons, 4) %}
-    public static func {{ cons.name()|fn_name }}({% call swift::arg_list_decl(cons) %}) {% call swift::throws(cons) %} -> {{ impl_class_name }} {
+    open class func {{ cons.name()|fn_name }}({% call swift::arg_list_decl(cons) %}) {% call swift::throws(cons) %} -> {{ impl_class_name }} {
         return {{ impl_class_name }}(unsafeFromRawPointer: {% call swift::to_ffi_call(cons) %})
     }
 

--- a/uniffi_bindgen/src/bindings/swift/templates/macros.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/macros.swift
@@ -52,6 +52,13 @@
     {%- endfor %}
 {%- endmacro %}
 
+{% macro mock_var_prefix(func) -%}
+    {{ func.name()|fn_name }}
+    {%- for arg in func.arguments() -%}
+        {{ arg.name()|var_name|capitalize }}
+    {%- endfor %}
+{%- endmacro -%}
+
 {#-
 // Field lists as used in Swift declarations of Records and Enums.
 // Note the var_name and type_name filters.

--- a/uniffi_bindgen/src/bindings/swift/templates/wrapper_mocks.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/wrapper_mocks.swift
@@ -1,0 +1,18 @@
+{%- import "macros.swift" as swift %}
+
+import Foundation
+
+{% for type_ in ci.iter_types() %}
+{%- let type_name = type_|type_name %}
+{%- let ffi_converter_name = type_|ffi_converter_name %}
+{%- let canonical_type_name = type_|canonical_name %}
+{%- let contains_object_references = ci.item_contains_object_references(type_) %}
+
+{%- match type_ %}
+
+{%- when Type::Object{ name, module_path, imp } %}
+{%- include "MockTemplate.swift" %}
+
+{%- else %}
+{%- endmatch %}
+{%- endfor %}

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -202,6 +202,44 @@ impl BindingGenerator for BindingGeneratorDefault {
     }
 }
 
+struct MocksGenerator {
+    target_languages: Vec<TargetLanguage>,
+    try_format_code: bool,
+}
+
+impl BindingGenerator for MocksGenerator {
+    type Config = Config;
+
+    fn write_bindings(
+        &self,
+        ci: &ComponentInterface,
+        config: &Self::Config,
+        out_dir: &Utf8Path,
+    ) -> Result<()> {
+        for &language in &self.target_languages {
+            bindings::write_mocks(
+                &config.bindings,
+                ci,
+                out_dir,
+                language,
+                self.try_format_code,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn check_library_path(&self, library_path: &Utf8Path, cdylib_name: Option<&str>) -> Result<()> {
+        for &language in &self.target_languages {
+            if cdylib_name.is_none() && language != TargetLanguage::Swift {
+                bail!(
+                    "Generate mocks for {language} requires a cdylib, but {library_path} was given"
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
 /// Generate bindings for an external binding generator
 /// Ideally, this should replace the [`generate_bindings`] function below
 ///

--- a/uniffi_bindgen/src/library_mode.rs
+++ b/uniffi_bindgen/src/library_mode.rs
@@ -17,7 +17,7 @@
 ///     package maps.
 use crate::{
     bindings::TargetLanguage, load_initial_config, macro_metadata, BindingGenerator,
-    BindingGeneratorDefault, BindingsConfig, ComponentInterface, Result,
+    BindingGeneratorDefault, BindingsConfig, ComponentInterface, MocksGenerator, Result,
 };
 use anyhow::{bail, Context};
 use camino::Utf8Path;
@@ -113,6 +113,29 @@ pub fn generate_external_bindings<T: BindingGenerator>(
     }
 
     Ok(sources)
+}
+
+/// Generate foreign mocks
+///
+/// Returns the list of sources used to generate the mocks, in no particular order.
+pub fn generate_mocks(
+    library_path: &Utf8Path,
+    crate_name: Option<String>,
+    target_languages: &[TargetLanguage],
+    config_file_override: Option<&Utf8Path>,
+    out_dir: &Utf8Path,
+    try_format_code: bool,
+) -> Result<Vec<Source<crate::Config>>> {
+    generate_external_bindings(
+        MocksGenerator {
+            target_languages: target_languages.into(),
+            try_format_code,
+        },
+        library_path,
+        crate_name,
+        config_file_override,
+        out_dir,
+    )
 }
 
 // A single source that we generate bindings for


### PR DESCRIPTION
This PR is the Swift version of this [Kotlin PR](https://github.com/mozilla/uniffi-rs/pull/1815), as it makes the concrete type open.

Making the concrete types `open` allows them to be extended to write mocks, but there is still a lot of code to be written to extend classes before writing a unit test. That's why this PR also includes the ability to generate Swift mocks directly from `uniffi-bindgen`.


Changes made to generate mocks:
- a new `generate_mocks` function is now exposed in `library_mode`, it uses a new `MocksGenerator` which is used to render mocks (see `wrapper_mocks.swift` template)
- Each mock class inherits from the mocked class (thanks to the `open` change, this will also work if the mocks are placed in the client application instead of being packaged with the uniffi generated classes).
- Mocks are written to a special file and are only generated when `generate_mocks` is called.

Here is an overview of what a mock class that has been generated will look like:
```
public class TestClassMock: TestClass {

    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
        fatalError("Not supported")
    }

    public init() {
        super.init(noPointer: NoPointer())
    }

    // MARK: - testFunction

    public var testFunctionParameternameCallsCount = 0
    public var testFunctionParameternameCalled: Bool {
        return testFunctionParameternameCallsCount > 0
    }
    public var testFunctionParameternameReceivedInvocations: [String] = []
    public var testFunctionParameternameReceivedArgument: String?
    
    public var testFunctionParameternameThrowableError: Error?
    public var testFunctionParameternameClosure: ((String) throws -> Void)?
    
    /**
     * Test Function documentation
     */
    public override func testFunction(parameterName: String) throws  {
        if let error = testFunctionParameternameThrowableError {
            throw error
        }
        
        testFunctionParameternameReceivedArgument = parameterName
        
        testFunctionParameternameReceivedInvocations.append(parameterName)
        
        testFunctionParameternameCallsCount += 1
        
        if let closure = testFunctionParameternameClosure {
            try closure(parameterName)
        }
    }
}
```
