### PR TITLE
Add support for non-exhaustive enums (#1593)

### DIFF
--- a/docs/manual/src/udl/enumerations.md
+++ b/docs/manual/src/udl/enumerations.md
@@ -18,6 +18,8 @@ enum Animal {
 };
 ```
 
+## Enums with fields
+
 Enumerations with associated data require a different syntax,
 due to the limitations of using WebIDL as the basis for UniFFI's interface language.
 An enum like this in Rust:
@@ -40,3 +42,24 @@ interface IpAddr {
 ```
 
 Only enums with named fields are supported by this syntax.
+
+## Remote, non-exhaustive enums
+
+One corner case is an enum that's:
+  - Defined in another crate.
+  - Has the [non_exhaustive` attribute](https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute).
+
+In this case, UniFFI needs to generate a default arm when matching against the enum variants, or else a compile error will be generated.
+Use the `[NonExhaustive]` attribute to handle this case:
+
+```idl
+[Enum]
+[NonExhaustive]
+interface Message {
+  Send(u32 from, u32 to, string contents);
+  Quit();
+};
+```
+
+**Note:** since UniFFI generates a default arm, if you leave out a variant, or if the upstream crate adds a new variant, this won't be caught at compile time.
+Any attempt to pass that variant across the FFI will result in a panic.

--- a/fixtures/ext-types/external-crate/src/lib.rs
+++ b/fixtures/ext-types/external-crate/src/lib.rs
@@ -8,6 +8,12 @@ pub struct ExternalCrateInterface {
     pub sval: String,
 }
 
+#[non_exhaustive]
+pub enum ExternalCrateNonExhaustiveEnum {
+    One,
+    Two,
+}
+
 // This type is referenced as an "external" type as an interface.
 impl ExternalCrateInterface {
     pub fn new(sval: String) -> Self {

--- a/fixtures/ext-types/lib/src/ext-types-lib.udl
+++ b/fixtures/ext-types/lib/src/ext-types-lib.udl
@@ -66,6 +66,12 @@ interface ExternalCrateInterface {
     string value();
 };
 
+[NonExhaustive]
+enum ExternalCrateNonExhaustiveEnum {
+    "One",
+    "Two",
+};
+
 // And a new type here to tie them all together.
 dictionary CombinedType {
     UniffiOneEnum uoe;
@@ -86,4 +92,5 @@ dictionary CombinedType {
     Handle? maybe_handle;
 
     ExternalCrateDictionary ecd;
+    ExternalCrateNonExhaustiveEnum ecnee;
 };

--- a/fixtures/ext-types/lib/src/lib.rs
+++ b/fixtures/ext-types/lib/src/lib.rs
@@ -1,5 +1,7 @@
 use custom_types::Handle;
-use ext_types_external_crate::{ExternalCrateDictionary, ExternalCrateInterface};
+use ext_types_external_crate::{
+    ExternalCrateDictionary, ExternalCrateInterface, ExternalCrateNonExhaustiveEnum,
+};
 use ext_types_guid::Guid;
 use std::sync::Arc;
 use uniffi_one::{
@@ -28,6 +30,7 @@ pub struct CombinedType {
     pub maybe_handle: Option<Handle>,
 
     pub ecd: ExternalCrateDictionary,
+    pub ecnee: ExternalCrateNonExhaustiveEnum,
 }
 
 fn get_combined_type(existing: Option<CombinedType>) -> CombinedType {
@@ -59,6 +62,7 @@ fn get_combined_type(existing: Option<CombinedType>) -> CombinedType {
         maybe_handle: Some(Handle(4)),
 
         ecd: ExternalCrateDictionary { sval: "ecd".into() },
+        ecnee: ExternalCrateNonExhaustiveEnum::One,
     })
 }
 

--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -221,6 +221,7 @@ mod test_metadata {
                         docstring: None,
                     },
                 ],
+                non_exhaustive: false,
                 docstring: None,
             },
         );
@@ -266,6 +267,7 @@ mod test_metadata {
                         docstring: None,
                     },
                 ],
+                non_exhaustive: false,
                 docstring: None,
             },
         );
@@ -298,6 +300,7 @@ mod test_metadata {
                         docstring: None,
                     },
                 ],
+                non_exhaustive: false,
                 docstring: None,
             },
         );
@@ -325,6 +328,7 @@ mod test_metadata {
                             docstring: None,
                         },
                     ],
+                    non_exhaustive: false,
                     docstring: None,
                 },
                 is_flat: true,
@@ -373,6 +377,7 @@ mod test_metadata {
                             docstring: None,
                         },
                     ],
+                    non_exhaustive: false,
                     docstring: None,
                 },
                 is_flat: false,

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -189,6 +189,7 @@ pub struct Enum {
     // * For an Enum not used as an error but which has no variants with data, `flat` will be
     //   false when generating the scaffolding but `true` when generating bindings.
     pub(super) flat: bool,
+    pub(super) non_exhaustive: bool,
     #[checksum_ignore]
     pub(super) docstring: Option<String>,
 }
@@ -233,6 +234,10 @@ impl Enum {
         self.flat
     }
 
+    pub fn is_non_exhaustive(&self) -> bool {
+        self.non_exhaustive
+    }
+
     pub fn iter_types(&self) -> TypeIterator<'_> {
         Box::new(self.variants.iter().flat_map(Variant::iter_types))
     }
@@ -257,6 +262,7 @@ impl Enum {
                 .map(TryInto::try_into)
                 .collect::<Result<_>>()?,
             flat,
+            non_exhaustive: meta.non_exhaustive,
             docstring: meta.docstring.clone(),
         })
     }
@@ -635,6 +641,7 @@ mod test {
             name: "test".to_string(),
             variants: vec![],
             flat: false,
+            non_exhaustive: false,
             docstring: None,
         };
 

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -1068,6 +1068,7 @@ existing definition: Enum {
         },
     ],
     flat: true,
+    non_exhaustive: false,
     docstring: None,
 },
 new definition: Enum {
@@ -1088,6 +1089,7 @@ new definition: Enum {
         },
     ],
     flat: true,
+    non_exhaustive: false,
     docstring: None,
 }",
         );

--- a/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
@@ -7,7 +7,11 @@
 // public so other crates can refer to it via an `[External='crate'] typedef`
 #}
 
-#[::uniffi::derive_enum_for_udl]
+#[::uniffi::derive_enum_for_udl(
+    {%- if e.is_non_exhaustive() -%}
+    non_exhaustive,
+    {%- endif %}
+)]
 enum r#{{ e.name() }} {
     {%- for variant in e.variants() %}
     r#{{ variant.name() }} {

--- a/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
@@ -14,6 +14,9 @@
     with_try_read,
     {%- endif %}
     {%- endif %}
+    {%- if e.is_non_exhaustive() -%}
+    non_exhaustive,
+    {%- endif %}
 )]
 enum r#{{ e.name() }} {
     {%- for variant in e.variants() %}

--- a/uniffi_macros/src/error.rs
+++ b/uniffi_macros/src/error.rs
@@ -6,7 +6,7 @@ use syn::{
 };
 
 use crate::{
-    enum_::{rich_error_ffi_converter_impl, variant_metadata},
+    enum_::{rich_error_ffi_converter_impl, variant_metadata, EnumAttr},
     util::{
         chain, create_metadata_items, derive_ffi_traits, either_attribute_arg, extract_docstring,
         ident_to_string, kw, mod_path, parse_comma_separated, tagged_impl_header,
@@ -35,9 +35,9 @@ pub fn expand_error(
     if let Some(attr_from_udl_mode) = attr_from_udl_mode {
         attr = attr.merge(attr_from_udl_mode)?;
     }
-    let ffi_converter_impl = error_ffi_converter_impl(ident, &enum_, &attr, udl_mode);
+    let ffi_converter_impl = error_ffi_converter_impl(ident, &enum_, &attr, udl_mode)?;
     let meta_static_var = (!udl_mode).then(|| {
-        error_meta_static_var(ident, docstring, &enum_, attr.flat.is_some())
+        error_meta_static_var(ident, docstring, &enum_, &attr)
             .unwrap_or_else(syn::Error::into_compile_error)
     });
 
@@ -68,12 +68,12 @@ fn error_ffi_converter_impl(
     enum_: &DataEnum,
     attr: &ErrorAttr,
     udl_mode: bool,
-) -> TokenStream {
-    if attr.flat.is_some() {
-        flat_error_ffi_converter_impl(ident, enum_, udl_mode, attr.with_try_read.is_some())
+) -> syn::Result<TokenStream> {
+    Ok(if attr.flat.is_some() {
+        flat_error_ffi_converter_impl(ident, enum_, udl_mode, attr)
     } else {
-        rich_error_ffi_converter_impl(ident, enum_, udl_mode)
-    }
+        rich_error_ffi_converter_impl(ident, enum_, udl_mode, &attr.clone().try_into()?)
+    })
 }
 
 // FfiConverters for "flat errors"
@@ -84,7 +84,7 @@ fn flat_error_ffi_converter_impl(
     ident: &Ident,
     enum_: &DataEnum,
     udl_mode: bool,
-    implement_lift: bool,
+    attr: &ErrorAttr,
 ) -> TokenStream {
     let name = ident_to_string(ident);
     let lower_impl_spec = tagged_impl_header("Lower", ident, udl_mode);
@@ -96,7 +96,7 @@ fn flat_error_ffi_converter_impl(
     };
 
     let lower_impl = {
-        let match_arms = enum_.variants.iter().enumerate().map(|(i, v)| {
+        let mut match_arms: Vec<_> = enum_.variants.iter().enumerate().map(|(i, v)| {
             let v_ident = &v.ident;
             let idx = Index::from(i + 1);
 
@@ -106,7 +106,12 @@ fn flat_error_ffi_converter_impl(
                     <::std::string::String as ::uniffi::Lower<crate::UniFfiTag>>::write(error_msg, buf);
                 }
             }
-        });
+        }).collect();
+        if attr.non_exhaustive.is_some() {
+            match_arms.push(quote! {
+                _ => panic!("Unexpected variant in non-exhaustive enum"),
+            })
+        }
 
         quote! {
             #[automatically_derived]
@@ -129,7 +134,7 @@ fn flat_error_ffi_converter_impl(
         }
     };
 
-    let lift_impl = if implement_lift {
+    let lift_impl = if attr.with_try_read.is_some() {
         let match_arms = enum_.variants.iter().enumerate().map(|(i, v)| {
             let v_ident = &v.ident;
             let idx = Index::from(i + 1);
@@ -195,10 +200,12 @@ pub(crate) fn error_meta_static_var(
     ident: &Ident,
     docstring: String,
     enum_: &DataEnum,
-    flat: bool,
+    attr: &ErrorAttr,
 ) -> syn::Result<TokenStream> {
     let name = ident_to_string(ident);
     let module_path = mod_path()?;
+    let flat = attr.flat.is_some();
+    let non_exhaustive = attr.non_exhaustive.is_some();
     let mut metadata_expr = quote! {
             ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::ERROR)
                 // first our is-flat flag
@@ -212,7 +219,10 @@ pub(crate) fn error_meta_static_var(
     } else {
         metadata_expr.extend(variant_metadata(enum_)?);
     }
-    metadata_expr.extend(quote! { .concat_long_str(#docstring) });
+    metadata_expr.extend(quote! {
+        .concat_bool(#non_exhaustive)
+        .concat_long_str(#docstring)
+    });
     Ok(create_metadata_items("error", &name, metadata_expr, None))
 }
 
@@ -231,10 +241,11 @@ pub fn flat_error_variant_metadata(enum_: &DataEnum) -> syn::Result<Vec<TokenStr
         .collect()
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct ErrorAttr {
-    flat: Option<kw::flat_error>,
-    with_try_read: Option<kw::with_try_read>,
+    pub flat: Option<kw::flat_error>,
+    pub with_try_read: Option<kw::with_try_read>,
+    pub non_exhaustive: Option<kw::non_exhaustive>,
 }
 
 impl UniffiAttributeArgs for ErrorAttr {
@@ -250,8 +261,13 @@ impl UniffiAttributeArgs for ErrorAttr {
                 with_try_read: input.parse()?,
                 ..Self::default()
             })
+        } else if lookahead.peek(kw::non_exhaustive) {
+            Ok(Self {
+                non_exhaustive: input.parse()?,
+                ..Self::default()
+            })
         } else if lookahead.peek(kw::handle_unknown_callback_error) {
-            // Not used anymore, but still lallowed
+            // Not used anymore, but still allowed
             Ok(Self::default())
         } else {
             Err(lookahead.error())
@@ -262,6 +278,7 @@ impl UniffiAttributeArgs for ErrorAttr {
         Ok(Self {
             flat: either_attribute_arg(self.flat, other.flat)?,
             with_try_read: either_attribute_arg(self.with_try_read, other.with_try_read)?,
+            non_exhaustive: either_attribute_arg(self.non_exhaustive, other.non_exhaustive)?,
         })
     }
 }
@@ -270,5 +287,27 @@ impl UniffiAttributeArgs for ErrorAttr {
 impl Parse for ErrorAttr {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         parse_comma_separated(input)
+    }
+}
+
+impl TryFrom<ErrorAttr> for EnumAttr {
+    type Error = syn::Error;
+
+    fn try_from(error_attr: ErrorAttr) -> Result<Self, Self::Error> {
+        if error_attr.flat.is_some() {
+            Err(syn::Error::new(
+                Span::call_site(),
+                "flat attribute not valid for rich enum errors",
+            ))
+        } else if error_attr.with_try_read.is_some() {
+            Err(syn::Error::new(
+                Span::call_site(),
+                "with_try_read attribute not valid for rich enum errors",
+            ))
+        } else {
+            Ok(EnumAttr {
+                non_exhaustive: error_attr.non_exhaustive,
+            })
+        }
     }
 }

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -115,7 +115,7 @@ pub fn derive_record(input: TokenStream) -> TokenStream {
 
 #[proc_macro_derive(Enum)]
 pub fn derive_enum(input: TokenStream) -> TokenStream {
-    expand_enum(parse_macro_input!(input), false)
+    expand_enum(parse_macro_input!(input), None, false)
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }
@@ -211,10 +211,14 @@ pub fn derive_record_for_udl(_attrs: TokenStream, input: TokenStream) -> TokenSt
 
 #[doc(hidden)]
 #[proc_macro_attribute]
-pub fn derive_enum_for_udl(_attrs: TokenStream, input: TokenStream) -> TokenStream {
-    expand_enum(syn::parse_macro_input!(input), true)
-        .unwrap_or_else(syn::Error::into_compile_error)
-        .into()
+pub fn derive_enum_for_udl(attrs: TokenStream, input: TokenStream) -> TokenStream {
+    expand_enum(
+        syn::parse_macro_input!(input),
+        Some(syn::parse_macro_input!(attrs)),
+        true,
+    )
+    .unwrap_or_else(syn::Error::into_compile_error)
+    .into()
 }
 
 #[doc(hidden)]

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -252,6 +252,7 @@ pub mod kw {
     syn::custom_keyword!(flat_error);
     syn::custom_keyword!(None);
     syn::custom_keyword!(with_try_read);
+    syn::custom_keyword!(non_exhaustive);
     syn::custom_keyword!(Debug);
     syn::custom_keyword!(Display);
     syn::custom_keyword!(Eq);

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -309,6 +309,7 @@ pub struct EnumMetadata {
     pub module_path: String,
     pub name: String,
     pub variants: Vec<VariantMetadata>,
+    pub non_exhaustive: bool,
     pub docstring: Option<String>,
 }
 

--- a/uniffi_meta/src/reader.rs
+++ b/uniffi_meta/src/reader.rs
@@ -304,6 +304,7 @@ impl<'a> MetadataReader<'a> {
             module_path,
             name,
             variants,
+            non_exhaustive: self.read_bool()?,
             docstring: self.read_optional_long_string()?,
         })
     }


### PR DESCRIPTION
UDL types can now have the `[NonExhaustive]` attribute.  If present, we add a default branch arm to make things compile correctly with non-exhaustive enums.  I didn't want to make this the default behavior, since in the normal case we want missing variants to result in compile errors.

In theory, this also adds the `non_exhaustive` attribute for proc-macros.  However, there's no way to test this because `non_exhaustive` only matters for types defined in remote crates and there's currently no proc-macro support for those.

One slightly silly part of this is the flow of metadata.  It doesn't make much sense as a metadata field, since it doesn't affect bindings generation at all.  However, it needs to be because of the way that data flows from `uniffi_udl` -> `uniffi_meta` -> `uniffi_bindgen` -> `uniffi_macros`.