### PR TITLE
Update the scaffolding template comments to point to the macro code

### DIFF
--- a/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
@@ -1,10 +1,5 @@
 {#
-// For each enum declared in the UDL, we assume the caller has provided a corresponding
-// rust `enum`. We provide the traits for sending it across the FFI, which will fail to
-// compile if the provided struct has a different shape to the one declared in the UDL.
-//
-// We define a unit-struct to implement the trait to sidestep Rust's orphan rule (ADR-0006). It's
-// public so other crates can refer to it via an `[External='crate'] typedef`
+// Forward work to `uniffi_macros` This keeps macro-based and UDL-based generated code consistent.
 #}
 
 #[::uniffi::derive_enum_for_udl]

--- a/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ErrorTemplate.rs
@@ -1,10 +1,5 @@
 {#
-// For each error declared in the UDL, we assume the caller has provided a corresponding
-// rust `enum`. We provide the traits for sending it across the FFI, which will fail to
-// compile if the provided struct has a different shape to the one declared in the UDL.
-//
-// We define a unit-struct to implement the trait to sidestep Rust's orphan rule (ADR-0006). It's
-// public so other crates can refer to it via an `[External='crate'] typedef`
+// Forward work to `uniffi_macros` This keeps macro-based and UDL-based generated code consistent.
 #}
 
 #[::uniffi::derive_error_for_udl(

--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -1,14 +1,6 @@
-// For each Object definition, we assume the caller has provided an appropriately-shaped `struct T`
-// with an `impl` for each method on the object. We create an `Arc<T>` for "safely" handing out
-// references to these structs to foreign language code, and we provide a `pub extern "C"` function
-// corresponding to each method.
-//
-// (Note that "safely" is in "scare quotes" - that's because we use functions on an `Arc` that
-// that are inherently unsafe, but the code we generate is safe in practice.)
-//
-// If the caller's implementation of the struct does not match with the methods or types specified
-// in the UDL, then the rust compiler will complain with a (hopefully at least somewhat helpful!)
-// error message when processing this generated code.
+{#
+// Forward work to `uniffi_macros` This keeps macro-based and UDL-based generated code consistent.
+#}
 
 {%- match obj.imp() -%}
 {%- when ObjectImpl::Trait %}

--- a/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
@@ -1,11 +1,5 @@
 {#
-// For each record declared in the UDL, we assume the caller has provided a corresponding
-// rust `struct` with the declared fields. We provide the traits for sending it across the FFI.
-// If the caller's struct does not match the shape and types declared in the UDL then the rust
-// compiler will complain with a type error.
-//
-// We define a unit-struct to implement the trait to sidestep Rust's orphan rule (ADR-0006). It's
-// public so other crates can refer to it via an `[External='crate'] typedef`
+// Forward work to `uniffi_macros` This keeps macro-based and UDL-based generated code consistent.
 #}
 
 #[::uniffi::derive_record_for_udl]

--- a/uniffi_bindgen/src/scaffolding/templates/TopLevelFunctionTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/TopLevelFunctionTemplate.rs
@@ -1,3 +1,6 @@
+{#
+// Forward work to `uniffi_macros` This keeps macro-based and UDL-based generated code consistent.
+#}
 #[::uniffi::export_for_udl]
 pub {% if func.is_async() %}async {% endif %}fn r#{{ func.name() }}(
     {%- for arg in func.arguments() %}


### PR DESCRIPTION
Some of these were out of date.  I think the best policy is to point to the macro code and use that as the source of truth.