### PR TITLE
Allow defaults for proc-macro function arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - Add support for docstrings via procmacros [#1862](https://github.com/mozilla/uniffi-rs/pull/1862)
   and [in UDL](https://mozilla.github.io/uniffi-rs/udl/docstrings.html)
 - Objects can now be returned from functions/constructors/methods without wrapping them in an `Arc<>`.
+- Proc-macro function/method arguments can now have defaults
 
 [All changes in v0.26.0](https://github.com/mozilla/uniffi-rs/compare/v0.25.3...v0.26.0).
 

--- a/docs/manual/src/proc_macro/index.md
+++ b/docs/manual/src/proc_macro/index.md
@@ -138,6 +138,46 @@ fn do_something(foo: MyFooRef) {
 }
 ```
 
+### Default values
+
+Exported functions/methods can have default values using the `default` argument of the attribute macro that wraps them.
+`default` inputs a comma-separated list of `[name]=[value]` items.
+
+```rust
+#[uniffi::export(default(text = " ", max_splits = None))]
+pub fn split(
+    text: String,
+    sep: String,
+    max_splits: Option<u32>,
+) -> Vec<String> {
+  ...
+}
+
+#[derive(uniffi::Object)]
+pub struct TextSplitter { ... }
+
+#[uniffi::export]
+impl TextSplitter {
+    #[uniffi::constructor(default(ignore_unicode_errors = false))]
+    fn new(ignore_unicode_errors: boolean) -> Self {
+        ...
+    }
+
+    #[uniffi::method(default(text = " ", max_splits = None))]
+    fn split(
+        text: String,
+        sep: String,
+        max_splits: Option<u32>,
+    ) -> Vec<String> {
+      ...
+    }
+}
+```
+
+Supported default values:
+  - String, integer, float, and boolean literals
+  - `None` for Option<T> types
+
 ### Renaming functions, methods and constructors
 
 A single exported function can specify an alternate name to be used by the bindings by specifying a `name` attribute.
@@ -179,8 +219,7 @@ will fail).
 pub struct MyRecord {
     pub field_a: String,
     pub field_b: Option<Arc<MyObject>>,
-    // Fields can have a default value.
-    // Currently, only string, integer, float and boolean literals are supported as defaults.
+    // Fields can have a default values
     #[uniffi(default = "hello")]
     pub greeting: String,
     #[uniffi(default = true)]

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -21,8 +21,6 @@ pub fn one_inner_by_ref(one: &One) -> i32 {
 #[derive(uniffi::Record)]
 pub struct Two {
     a: String,
-    #[uniffi(default = None)]
-    b: Option<Vec<bool>>,
 }
 
 #[derive(uniffi::Record)]
@@ -339,6 +337,41 @@ impl Renamed {
 #[uniffi::export(name = "rename_test")]
 fn renamed_rename_test() -> bool {
     true
+}
+
+/// Test defaults on Records
+#[derive(uniffi::Record)]
+pub struct RecordWithDefaults {
+    no_default_string: String,
+    #[uniffi(default=None)]
+    opt_vec: Option<Vec<bool>>,
+    #[uniffi(default = 42)]
+    number: i32,
+}
+
+/// Test defaults on top-level functions
+#[uniffi::export(default(num = 21))]
+fn double_with_default(num: i32) -> i32 {
+    num + num
+}
+
+/// Test defaults on constructors / methods
+#[derive(uniffi::Object)]
+pub struct ObjectWithDefaults {
+    num: i32,
+}
+
+#[uniffi::export]
+impl ObjectWithDefaults {
+    #[uniffi::constructor(default(num = 30))]
+    fn new(num: i32) -> Self {
+        Self { num }
+    }
+
+    #[uniffi::method(default(other = 12))]
+    fn add_to_num(&self, other: i32) -> i32 {
+        self.num + other
+    }
 }
 
 uniffi::include_scaffolding!("proc-macro");

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
@@ -43,6 +43,20 @@ try {
 } catch (e: FlatException) {
 }
 
+// Defaults
+
+val recordWithDefaults = RecordWithDefaults("Test")
+assert(recordWithDefaults.noDefaultString == "Test")
+assert(recordWithDefaults.optVec == null)
+assert(recordWithDefaults.number == 42)
+
+assert(doubleWithDefault() == 42)
+
+val objWithDefaults = ObjectWithDefaults()
+assert(objWithDefaults.addToNum() == 42)
+
+// Traits
+
 val traitImpl = obj.getTrait(null)
 assert(traitImpl.concatStrings("foo", "bar") == "foobar")
 assert(obj.getTrait(traitImpl).concatStrings("foo", "bar") == "foobar")

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -64,6 +64,20 @@ except FlatError.InvalidInput:
 else:
     raise Exception("do_stuff should throw if its argument is 0")
 
+
+# Defaults
+
+record_with_defaults = RecordWithDefaults(no_default_string="Test")
+assert(record_with_defaults.no_default_string == "Test")
+assert(record_with_defaults.opt_vec == None)
+assert(record_with_defaults.number == 42)
+
+assert(double_with_default() == 42)
+
+obj_with_defaults = ObjectWithDefaults()
+assert(obj_with_defaults.add_to_num() == 42)
+
+# Traits
 class PyTestCallbackInterface(TestCallbackInterface):
     def do_nothing(self):
         pass

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
@@ -55,6 +55,20 @@ do {
 
 struct SomeOtherError: Error { }
 
+// Defaults
+
+let recordWithDefaults = RecordWithDefaults(noDefaultString: "Test")
+assert(recordWithDefaults.noDefaultString == "Test")
+assert(recordWithDefaults.optVec == nil)
+assert(recordWithDefaults.number == 42)
+
+assert(doubleWithDefault() == 42)
+
+let objWithDefaults = ObjectWithDefaults()
+assert(objWithDefaults.addToNum() == 42)
+
+// Traits
+
 class SwiftTestCallbackInterface : TestCallbackInterface {
     func doNothing() { }
 

--- a/fixtures/uitests/tests/ui/export_attrs.rs
+++ b/fixtures/uitests/tests/ui/export_attrs.rs
@@ -51,4 +51,30 @@ impl OtherAttrs {
     fn two() {}
 }
 
+// Defaults with the wrong argument names
+#[uniffi::export(default(fooo = 0))]
+pub fn func_with_default(foo: u32) -> u32 {
+    foo
+}
+
+#[derive(uniffi::Object)]
+struct ObjWithDefault(u32);
+
+#[uniffi::export]
+impl ObjWithDefault {
+    #[uniffi::constructor(default(fooo = 0))]
+    pub fn new(foo: u32) -> Self {
+        Self(foo)
+    }
+}
+
+#[uniffi::export]
+impl ObjWithDefault {
+    #[uniffi::method(default(fooo = 0))]
+    pub fn foo_matches(&self, foo: u32) -> bool {
+        self.0 == foo
+    }
+}
+
+
 uniffi_macros::setup_scaffolding!();

--- a/fixtures/uitests/tests/ui/export_attrs.stderr
+++ b/fixtures/uitests/tests/ui/export_attrs.stderr
@@ -53,3 +53,21 @@ error: uniffi::constructor/method attribute `foo` is not supported here.
    |
 50 |     #[uniffi::method(foo)]
    |                      ^^^
+
+error: Unknown default argument: fooo
+  --> tests/ui/export_attrs.rs:55:26
+   |
+55 | #[uniffi::export(default(fooo = 0))]
+   |                          ^^^^
+
+error: Unknown default argument: fooo
+  --> tests/ui/export_attrs.rs:65:35
+   |
+65 |     #[uniffi::constructor(default(fooo = 0))]
+   |                                   ^^^^
+
+error: Unknown default argument: fooo
+  --> tests/ui/export_attrs.rs:73:30
+   |
+73 |     #[uniffi::method(default(fooo = 0))]
+   |                              ^^^^

--- a/uniffi_macros/src/default.rs
+++ b/uniffi_macros/src/default.rs
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::util::kw;
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{
+    parse::{Parse, ParseStream},
+    Lit,
+};
+
+/// Default value
+#[derive(Clone)]
+pub enum DefaultValue {
+    Literal(Lit),
+    Null(kw::None),
+}
+
+impl ToTokens for DefaultValue {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            DefaultValue::Literal(lit) => lit.to_tokens(tokens),
+            DefaultValue::Null(kw) => kw.to_tokens(tokens),
+        }
+    }
+}
+
+impl Parse for DefaultValue {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(kw::None) {
+            let none_kw: kw::None = input.parse()?;
+            Ok(Self::Null(none_kw))
+        } else {
+            Ok(Self::Literal(input.parse()?))
+        }
+    }
+}
+
+impl DefaultValue {
+    fn metadata_calls(&self) -> syn::Result<TokenStream> {
+        match self {
+            DefaultValue::Literal(Lit::Int(i)) if !i.suffix().is_empty() => Err(
+                syn::Error::new_spanned(i, "integer literals with suffix not supported here"),
+            ),
+            DefaultValue::Literal(Lit::Float(f)) if !f.suffix().is_empty() => Err(
+                syn::Error::new_spanned(f, "float literals with suffix not supported here"),
+            ),
+
+            DefaultValue::Literal(Lit::Str(s)) => Ok(quote! {
+                .concat_value(::uniffi::metadata::codes::LIT_STR)
+                .concat_str(#s)
+            }),
+            DefaultValue::Literal(Lit::Int(i)) => {
+                let digits = i.base10_digits();
+                Ok(quote! {
+                    .concat_value(::uniffi::metadata::codes::LIT_INT)
+                    .concat_str(#digits)
+                })
+            }
+            DefaultValue::Literal(Lit::Float(f)) => {
+                let digits = f.base10_digits();
+                Ok(quote! {
+                    .concat_value(::uniffi::metadata::codes::LIT_FLOAT)
+                    .concat_str(#digits)
+                })
+            }
+            DefaultValue::Literal(Lit::Bool(b)) => Ok(quote! {
+                .concat_value(::uniffi::metadata::codes::LIT_BOOL)
+                .concat_bool(#b)
+            }),
+
+            DefaultValue::Literal(_) => Err(syn::Error::new_spanned(
+                self,
+                "this type of literal is not currently supported as a default",
+            )),
+
+            DefaultValue::Null(_) => Ok(quote! {
+                .concat_value(::uniffi::metadata::codes::LIT_NULL)
+            }),
+        }
+    }
+}
+
+pub fn default_value_metadata_calls(default: &Option<DefaultValue>) -> syn::Result<TokenStream> {
+    Ok(match default {
+        Some(default) => {
+            let metadata_calls = default.metadata_calls()?;
+            quote! {
+                .concat_bool(true)
+                #metadata_calls
+            }
+        }
+        None => quote! { .concat_bool(false) },
+    })
+}

--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -20,6 +20,7 @@ use self::{
     },
 };
 use crate::util::{ident_to_string, mod_path};
+pub use attributes::{DefaultMap, ExportFnArgs, ExportedImplFnArgs};
 pub use callback_interface::ffi_converter_callback_interface_impl;
 
 // TODO(jplatte): Ensure no generics, …

--- a/uniffi_macros/src/export/item.rs
+++ b/uniffi_macros/src/export/item.rs
@@ -8,7 +8,8 @@ use proc_macro2::{Ident, Span};
 use quote::ToTokens;
 
 use super::attributes::{
-    ExportFnArgs, ExportImplArgs, ExportStructArgs, ExportTraitArgs, ExportedImplFnAttributes,
+    ExportFnArgs, ExportImplArgs, ExportStructArgs, ExportTraitArgs, ExportedImplFnArgs,
+    ExportedImplFnAttributes,
 };
 use crate::util::extract_docstring;
 use uniffi_meta::UniffiTraitDiscriminants;
@@ -43,7 +44,7 @@ impl ExportItem {
             syn::Item::Fn(item) => {
                 let args: ExportFnArgs = syn::parse(attr_args)?;
                 let docstring = extract_docstring(&item.attrs)?;
-                let sig = FnSignature::new_function(item.sig, args.name.clone(), docstring)?;
+                let sig = FnSignature::new_function(item.sig, args.clone(), docstring)?;
                 Ok(Self::Function { sig, args })
             }
             syn::Item::Impl(item) => Self::from_impl(item, attr_args),
@@ -106,14 +107,14 @@ impl ExportItem {
                     ImplItem::Constructor(FnSignature::new_constructor(
                         self_ident.clone(),
                         impl_fn.sig,
-                        attrs.name,
+                        attrs.args,
                         docstring,
                     )?)
                 } else {
                     ImplItem::Method(FnSignature::new_method(
                         self_ident.clone(),
                         impl_fn.sig,
-                        attrs.name,
+                        attrs.args,
                         docstring,
                     )?)
                 };
@@ -169,7 +170,7 @@ impl ExportItem {
                     ImplItem::Method(FnSignature::new_trait_method(
                         self_ident.clone(),
                         tim.sig,
-                        None,
+                        ExportedImplFnArgs::default(),
                         i as u32,
                         docstring,
                     )?)

--- a/uniffi_macros/src/export/utrait.rs
+++ b/uniffi_macros/src/export/utrait.rs
@@ -7,6 +7,7 @@ use quote::quote;
 use syn::ext::IdentExt;
 
 use super::gen_ffi_function;
+use crate::export::ExportedImplFnArgs;
 use crate::fnsig::FnSignature;
 use crate::util::extract_docstring;
 use uniffi_meta::UniffiTraitDiscriminants;
@@ -164,14 +165,19 @@ fn process_uniffi_trait_method(
         &FnSignature::new_method(
             self_ident.clone(),
             item.sig.clone(),
-            None,
+            ExportedImplFnArgs::default(),
             docstring.clone(),
         )?,
         &None,
         udl_mode,
     )?;
     // metadata for the method, which will be packed inside metadata for the trait.
-    let method_meta =
-        FnSignature::new_method(self_ident.clone(), item.sig, None, docstring)?.metadata_expr()?;
+    let method_meta = FnSignature::new_method(
+        self_ident.clone(),
+        item.sig,
+        ExportedImplFnArgs::default(),
+        docstring,
+    )?
+    .metadata_expr()?;
     Ok((ffi_func, method_meta))
 }

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -16,6 +16,7 @@ use syn::{
 };
 
 mod custom;
+mod default;
 mod enum_;
 mod error;
 mod export;

--- a/uniffi_macros/src/record.rs
+++ b/uniffi_macros/src/record.rs
@@ -1,14 +1,14 @@
 use proc_macro2::{Ident, Span, TokenStream};
-use quote::{quote, ToTokens};
-use syn::{
-    parse::{Parse, ParseStream},
-    Data, DataStruct, DeriveInput, Field, Lit, Token,
-};
+use quote::quote;
+use syn::{parse::ParseStream, Data, DataStruct, DeriveInput, Field, Token};
 
-use crate::util::{
-    create_metadata_items, derive_all_ffi_traits, either_attribute_arg, extract_docstring,
-    ident_to_string, kw, mod_path, tagged_impl_header, try_metadata_value_from_usize,
-    try_read_field, AttributeSliceExt, UniffiAttributeArgs,
+use crate::{
+    default::{default_value_metadata_calls, DefaultValue},
+    util::{
+        create_metadata_items, derive_all_ffi_traits, either_attribute_arg, extract_docstring,
+        ident_to_string, kw, mod_path, tagged_impl_header, try_metadata_value_from_usize,
+        try_read_field, AttributeSliceExt, UniffiAttributeArgs,
+    },
 };
 
 pub fn expand_record(input: DeriveInput, udl_mode: bool) -> syn::Result<TokenStream> {
@@ -83,35 +83,9 @@ fn write_field(f: &Field) -> TokenStream {
     }
 }
 
-pub enum FieldDefault {
-    Literal(Lit),
-    Null(kw::None),
-}
-
-impl ToTokens for FieldDefault {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        match self {
-            FieldDefault::Literal(lit) => lit.to_tokens(tokens),
-            FieldDefault::Null(kw) => kw.to_tokens(tokens),
-        }
-    }
-}
-
-impl Parse for FieldDefault {
-    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        let lookahead = input.lookahead1();
-        if lookahead.peek(kw::None) {
-            let none_kw: kw::None = input.parse()?;
-            Ok(Self::Null(none_kw))
-        } else {
-            Ok(Self::Literal(input.parse()?))
-        }
-    }
-}
-
 #[derive(Default)]
 pub struct FieldAttributeArguments {
-    pub(crate) default: Option<FieldDefault>,
+    pub(crate) default: Option<DefaultValue>,
 }
 
 impl UniffiAttributeArgs for FieldAttributeArguments {
@@ -152,16 +126,7 @@ pub(crate) fn record_meta_static_var(
             let name = ident_to_string(f.ident.as_ref().unwrap());
             let docstring = extract_docstring(&f.attrs)?;
             let ty = &f.ty;
-            let default = match attrs.default {
-                Some(default) => {
-                    let default_value = default_value_concat_calls(default)?;
-                    quote! {
-                        .concat_bool(true)
-                        #default_value
-                    }
-                }
-                None => quote! { .concat_bool(false) },
-            };
+            let default = default_value_metadata_calls(&attrs.default)?;
 
             // Note: fields need to implement both `Lower` and `Lift` to be used in a record.  The
             // TYPE_ID_META should be the same for both traits.
@@ -187,47 +152,4 @@ pub(crate) fn record_meta_static_var(
         },
         None,
     ))
-}
-
-fn default_value_concat_calls(default: FieldDefault) -> syn::Result<TokenStream> {
-    match default {
-        FieldDefault::Literal(Lit::Int(i)) if !i.suffix().is_empty() => Err(
-            syn::Error::new_spanned(i, "integer literals with suffix not supported here"),
-        ),
-        FieldDefault::Literal(Lit::Float(f)) if !f.suffix().is_empty() => Err(
-            syn::Error::new_spanned(f, "float literals with suffix not supported here"),
-        ),
-
-        FieldDefault::Literal(Lit::Str(s)) => Ok(quote! {
-            .concat_value(::uniffi::metadata::codes::LIT_STR)
-            .concat_str(#s)
-        }),
-        FieldDefault::Literal(Lit::Int(i)) => {
-            let digits = i.base10_digits();
-            Ok(quote! {
-                .concat_value(::uniffi::metadata::codes::LIT_INT)
-                .concat_str(#digits)
-            })
-        }
-        FieldDefault::Literal(Lit::Float(f)) => {
-            let digits = f.base10_digits();
-            Ok(quote! {
-                .concat_value(::uniffi::metadata::codes::LIT_FLOAT)
-                .concat_str(#digits)
-            })
-        }
-        FieldDefault::Literal(Lit::Bool(b)) => Ok(quote! {
-            .concat_value(::uniffi::metadata::codes::LIT_BOOL)
-            .concat_bool(#b)
-        }),
-
-        FieldDefault::Literal(_) => Err(syn::Error::new_spanned(
-            default,
-            "this type of literal is not currently supported as a default",
-        )),
-
-        FieldDefault::Null(_) => Ok(quote! {
-            .concat_value(::uniffi::metadata::codes::LIT_NULL)
-        }),
-    }
 }

--- a/uniffi_meta/src/reader.rs
+++ b/uniffi_meta/src/reader.rs
@@ -448,13 +448,16 @@ impl<'a> MetadataReader<'a> {
         let len = self.read_u8()?;
         (0..len)
             .map(|_| {
+                let name = self.read_string()?;
+                let ty = self.read_type()?;
+                let default = self.read_default(&name, &ty)?;
                 Ok(FnParamMetadata {
-                    name: self.read_string()?,
-                    ty: self.read_type()?,
+                    name,
+                    ty,
+                    default,
                     // not emitted by macros
                     by_ref: false,
                     optional: false,
-                    default: None,
                 })
             })
             .collect()


### PR DESCRIPTION
- Renamed `FieldDefault` to `DefaultValue` and shared it between the field and argument code.
- Updated the function argument metadata to support a default value.
- Added `FnArgAttributeArguments` which is currently exactly the same as `FieldAttributeArguments`.  I figure the repeated code is fine for now and these structs may diverge in the future.
- Changed `expand_export` to return the source item as well.  This allows it to modify the source item and strip away the defaults
- Fixed Python argument checking when there's a default.