### PR TITLE
More macro defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
   This eliminates panics when the capacity of the vec exceeds `i32::MAX`.
   This can happen with the current Vec implementation when String/Vec sizes approach `i32::MAX` but don't exceed it.
 
+- Proc-macro function/method arguments can now have defaults
+
+- Proc-macro record defaults now support empty vecs and Some values.
+
 ### What's fixed?
  
 - Fixed a memory leak in callback interface handling.
@@ -77,7 +81,6 @@
 - Add support for docstrings via procmacros [#1862](https://github.com/mozilla/uniffi-rs/pull/1862)
   and [in UDL](https://mozilla.github.io/uniffi-rs/udl/docstrings.html)
 - Objects can now be returned from functions/constructors/methods without wrapping them in an `Arc<>`.
-- Proc-macro function/method arguments can now have defaults
 
 [All changes in v0.26.0](https://github.com/mozilla/uniffi-rs/compare/v0.25.3...v0.26.0).
 

--- a/docs/manual/src/proc_macro/index.md
+++ b/docs/manual/src/proc_macro/index.md
@@ -176,7 +176,8 @@ impl TextSplitter {
 
 Supported default values:
   - String, integer, float, and boolean literals
-  - `None` for Option<T> types
+  - `[]` for empty Vecs
+  - `Option<T>` allows either `None` or `Some(T)`
 
 ### Renaming functions, methods and constructors
 

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -343,10 +343,18 @@ fn renamed_rename_test() -> bool {
 #[derive(uniffi::Record)]
 pub struct RecordWithDefaults {
     no_default_string: String,
+    #[uniffi(default = true)]
+    boolean: bool,
+    #[uniffi(default = 42)]
+    integer: i32,
+    #[uniffi(default = 4.2)]
+    float: f64,
+    #[uniffi(default=[])]
+    vec: Vec<bool>,
     #[uniffi(default=None)]
     opt_vec: Option<Vec<bool>>,
-    #[uniffi(default = 42)]
-    number: i32,
+    #[uniffi(default = Some(42))]
+    opt_integer: Option<i32>,
 }
 
 /// Test defaults on top-level functions

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
@@ -47,8 +47,12 @@ try {
 
 val recordWithDefaults = RecordWithDefaults("Test")
 assert(recordWithDefaults.noDefaultString == "Test")
+assert(recordWithDefaults.boolean == true)
+assert(recordWithDefaults.integer == 42)
+assert(recordWithDefaults.float == 4.2)
+assert(recordWithDefaults.vec.isEmpty())
 assert(recordWithDefaults.optVec == null)
-assert(recordWithDefaults.number == 42)
+assert(recordWithDefaults.optInteger == 42)
 
 assert(doubleWithDefault() == 42)
 

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -69,8 +69,12 @@ else:
 
 record_with_defaults = RecordWithDefaults(no_default_string="Test")
 assert(record_with_defaults.no_default_string == "Test")
+assert(record_with_defaults.boolean == True)
+assert(record_with_defaults.integer == 42)
+assert(record_with_defaults.float == 4.2)
+assert(record_with_defaults.vec == [])
 assert(record_with_defaults.opt_vec == None)
-assert(record_with_defaults.number == 42)
+assert(record_with_defaults.opt_integer == 42)
 
 assert(double_with_default() == 42)
 

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
@@ -59,8 +59,12 @@ struct SomeOtherError: Error { }
 
 let recordWithDefaults = RecordWithDefaults(noDefaultString: "Test")
 assert(recordWithDefaults.noDefaultString == "Test")
+assert(recordWithDefaults.boolean == true)
+assert(recordWithDefaults.integer == 42)
+assert(recordWithDefaults.float == 4.2)
+assert(recordWithDefaults.vec == [])
 assert(recordWithDefaults.optVec == nil)
-assert(recordWithDefaults.number == 42)
+assert(recordWithDefaults.optInteger == 42)
 
 assert(doubleWithDefault() == 42)
 

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/compounds.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/compounds.rs
@@ -5,55 +5,81 @@
 use super::{AsCodeType, CodeType};
 use crate::backend::{Literal, Type};
 use crate::ComponentInterface;
-use paste::paste;
 
-fn render_literal(literal: &Literal, inner: &Type, ci: &ComponentInterface) -> String {
-    match literal {
-        Literal::Null => "null".into(),
-        Literal::EmptySequence => "listOf()".into(),
-        Literal::EmptyMap => "mapOf()".into(),
+#[derive(Debug)]
+pub struct OptionalCodeType {
+    inner: Type,
+}
 
-        // For optionals
-        _ => super::KotlinCodeOracle.find(inner).literal(literal, ci),
+impl OptionalCodeType {
+    pub fn new(inner: Type) -> Self {
+        Self { inner }
+    }
+    fn inner(&self) -> &Type {
+        &self.inner
     }
 }
 
-macro_rules! impl_code_type_for_compound {
-     ($T:ty, $type_label_pattern:literal, $canonical_name_pattern: literal) => {
-        paste! {
-            #[derive(Debug)]
-            pub struct $T {
-                inner: Type,
-            }
+impl CodeType for OptionalCodeType {
+    fn type_label(&self, ci: &ComponentInterface) -> String {
+        format!(
+            "{}?",
+            super::KotlinCodeOracle.find(self.inner()).type_label(ci)
+        )
+    }
 
-            impl $T {
-                pub fn new(inner: Type) -> Self {
-                    Self { inner }
-                }
-                fn inner(&self) -> &Type {
-                    &self.inner
-                }
-            }
+    fn canonical_name(&self) -> String {
+        format!(
+            "Optional{}",
+            super::KotlinCodeOracle.find(self.inner()).canonical_name()
+        )
+    }
 
-            impl CodeType for $T  {
-                fn type_label(&self, ci: &ComponentInterface) -> String {
-                    format!($type_label_pattern, super::KotlinCodeOracle.find(self.inner()).type_label(ci))
-                }
-
-                fn canonical_name(&self) -> String {
-                    format!($canonical_name_pattern, super::KotlinCodeOracle.find(self.inner()).canonical_name())
-                }
-
-                fn literal(&self, literal: &Literal, ci: &ComponentInterface) -> String {
-                    render_literal(literal, self.inner(), ci)
-                }
-            }
+    fn literal(&self, literal: &Literal, ci: &ComponentInterface) -> String {
+        match literal {
+            Literal::None => "null".into(),
+            Literal::Some { inner } => super::KotlinCodeOracle.find(&self.inner).literal(inner, ci),
+            _ => panic!("Invalid literal for Optional type: {literal:?}"),
         }
     }
- }
+}
 
-impl_code_type_for_compound!(OptionalCodeType, "{}?", "Optional{}");
-impl_code_type_for_compound!(SequenceCodeType, "List<{}>", "Sequence{}");
+#[derive(Debug)]
+pub struct SequenceCodeType {
+    inner: Type,
+}
+
+impl SequenceCodeType {
+    pub fn new(inner: Type) -> Self {
+        Self { inner }
+    }
+    fn inner(&self) -> &Type {
+        &self.inner
+    }
+}
+
+impl CodeType for SequenceCodeType {
+    fn type_label(&self, ci: &ComponentInterface) -> String {
+        format!(
+            "List<{}>",
+            super::KotlinCodeOracle.find(self.inner()).type_label(ci)
+        )
+    }
+
+    fn canonical_name(&self) -> String {
+        format!(
+            "Sequence{}",
+            super::KotlinCodeOracle.find(self.inner()).canonical_name()
+        )
+    }
+
+    fn literal(&self, literal: &Literal, _ci: &ComponentInterface) -> String {
+        match literal {
+            Literal::EmptySequence => "listOf()".into(),
+            _ => panic!("Invalid literal for List type: {literal:?}"),
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct MapCodeType {
@@ -92,7 +118,10 @@ impl CodeType for MapCodeType {
         )
     }
 
-    fn literal(&self, literal: &Literal, ci: &ComponentInterface) -> String {
-        render_literal(literal, &self.value, ci)
+    fn literal(&self, literal: &Literal, _ci: &ComponentInterface) -> String {
+        match literal {
+            Literal::EmptyMap => "mapOf()".into(),
+            _ => panic!("Invalid literal for Map type: {literal:?}"),
+        }
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/primitives.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/primitives.rs
@@ -9,7 +9,11 @@ use paste::paste;
 
 fn render_literal(literal: &Literal, _ci: &ComponentInterface) -> String {
     fn typed_number(type_: &Type, num_str: String) -> String {
-        match type_ {
+        let unwrapped_type = match type_ {
+            Type::Optional { inner_type } => inner_type,
+            t => t,
+        };
+        match unwrapped_type {
             // Bytes, Shorts and Ints can all be inferred from the type.
             Type::Int8 | Type::Int16 | Type::Int32 => num_str,
             Type::Int64 => format!("{num_str}L"),
@@ -19,7 +23,7 @@ fn render_literal(literal: &Literal, _ci: &ComponentInterface) -> String {
 
             Type::Float32 => format!("{num_str}f"),
             Type::Float64 => num_str,
-            _ => panic!("Unexpected literal: {num_str} is not a number"),
+            _ => panic!("Unexpected literal: {num_str} for type: {type_:?}"),
         }
     }
 

--- a/uniffi_bindgen/src/bindings/python/gen_python/compounds.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/compounds.rs
@@ -36,8 +36,9 @@ impl CodeType for OptionalCodeType {
 
     fn literal(&self, literal: &Literal) -> String {
         match literal {
-            Literal::Null => "None".into(),
-            _ => super::PythonCodeOracle.find(&self.inner).literal(literal),
+            Literal::None => "None".into(),
+            Literal::Some { inner } => super::PythonCodeOracle.find(&self.inner).literal(inner),
+            _ => panic!("Invalid literal for Optional type: {literal:?}"),
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -202,7 +202,8 @@ mod filters {
             }
             // use the double-quote form to match with the other languages, and quote escapes.
             Literal::String(s) => format!("\"{s}\""),
-            Literal::Null => "nil".into(),
+            Literal::None => "nil".into(),
+            Literal::Some { inner } => literal_rb(inner)?,
             Literal::EmptySequence => "[]".into(),
             Literal::EmptyMap => "{}".into(),
             Literal::Enum(v, type_) => match type_ {

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/compounds.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/compounds.rs
@@ -30,8 +30,9 @@ impl CodeType for OptionalCodeType {
 
     fn literal(&self, literal: &Literal) -> String {
         match literal {
-            Literal::Null => "nil".into(),
-            _ => super::SwiftCodeOracle.find(&self.inner).literal(literal),
+            Literal::None => "nil".into(),
+            Literal::Some { inner } => super::SwiftCodeOracle.find(&self.inner).literal(inner),
+            _ => panic!("Invalid literal for Optional type: {literal:?}"),
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/primitives.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/primitives.rs
@@ -9,7 +9,11 @@ use paste::paste;
 
 fn render_literal(literal: &Literal) -> String {
     fn typed_number(type_: &Type, num_str: String) -> String {
-        match type_ {
+        let unwrapped_type = match type_ {
+            Type::Optional { inner_type } => inner_type,
+            t => t,
+        };
+        match unwrapped_type {
             // special case Int32.
             Type::Int32 => num_str,
             // otherwise use constructor e.g. UInt8(x)
@@ -29,7 +33,7 @@ fn render_literal(literal: &Literal) -> String {
                     super::SwiftCodeOracle.find(type_).type_label()
                 )
             }
-            _ => panic!("Unexpected literal: {num_str} is not a number"),
+            _ => panic!("Unexpected literal: {num_str} for type: {type_:?}"),
         }
     }
 

--- a/uniffi_core/src/metadata.rs
+++ b/uniffi_core/src/metadata.rs
@@ -71,13 +71,14 @@ pub mod codes {
     pub const TYPE_CALLBACK_TRAIT_INTERFACE: u8 = 25;
     pub const TYPE_UNIT: u8 = 255;
 
-    // Literal codes for LiteralMetadata - note that we don't support
-    // all variants in the "emit/reader" context.
+    // Literal codes for LiteralMetadata
     pub const LIT_STR: u8 = 0;
     pub const LIT_INT: u8 = 1;
     pub const LIT_FLOAT: u8 = 2;
     pub const LIT_BOOL: u8 = 3;
-    pub const LIT_NULL: u8 = 4;
+    pub const LIT_NONE: u8 = 4;
+    pub const LIT_SOME: u8 = 5;
+    pub const LIT_EMPTY_SEQ: u8 = 6;
 }
 
 // For large errors (e.g. enums) a buffer size of ~4k - ~8k

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -254,6 +254,7 @@ pub mod kw {
     syn::custom_keyword!(default);
     syn::custom_keyword!(flat_error);
     syn::custom_keyword!(None);
+    syn::custom_keyword!(Some);
     syn::custom_keyword!(with_try_read);
     syn::custom_keyword!(name);
     syn::custom_keyword!(non_exhaustive);

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -270,7 +270,8 @@ pub enum LiteralMetadata {
     Enum(String, Type),
     EmptySequence,
     EmptyMap,
-    Null,
+    None,
+    Some { inner: Box<LiteralMetadata> },
 }
 
 impl LiteralMetadata {

--- a/uniffi_meta/src/metadata.rs
+++ b/uniffi_meta/src/metadata.rs
@@ -59,7 +59,9 @@ pub mod codes {
     pub const LIT_INT: u8 = 1;
     pub const LIT_FLOAT: u8 = 2;
     pub const LIT_BOOL: u8 = 3;
-    pub const LIT_NULL: u8 = 4;
+    pub const LIT_NONE: u8 = 4;
+    pub const LIT_SOME: u8 = 5;
+    pub const LIT_EMPTY_SEQ: u8 = 6;
 }
 
 // Create a checksum for a MetadataBuffer

--- a/uniffi_meta/src/reader.rs
+++ b/uniffi_meta/src/reader.rs
@@ -405,7 +405,7 @@ impl<'a> MetadataReader<'a> {
             .map(|_| {
                 let name = self.read_string()?;
                 let ty = self.read_type()?;
-                let default = self.read_default(&name, &ty)?;
+                let default = self.read_optional_default(&name, &ty)?;
                 Ok(FieldMetadata {
                     name,
                     ty,
@@ -422,7 +422,7 @@ impl<'a> MetadataReader<'a> {
             .map(|_| {
                 Ok(VariantMetadata {
                     name: self.read_string()?,
-                    discr: self.read_default("<variant-value>", &Type::UInt64)?,
+                    discr: self.read_optional_default("<variant-value>", &Type::UInt64)?,
                     fields: self.read_fields()?,
                     docstring: self.read_optional_long_string()?,
                 })
@@ -450,7 +450,7 @@ impl<'a> MetadataReader<'a> {
             .map(|_| {
                 let name = self.read_string()?;
                 let ty = self.read_type()?;
-                let default = self.read_default(&name, &ty)?;
+                let default = self.read_optional_default(&name, &ty)?;
                 Ok(FnParamMetadata {
                     name,
                     ty,
@@ -469,14 +469,18 @@ impl<'a> MetadataReader<'a> {
         Some(checksum_metadata(metadata_buf))
     }
 
-    fn read_default(&mut self, name: &str, ty: &Type) -> Result<Option<LiteralMetadata>> {
-        let has_default = self.read_bool()?;
-        if !has_default {
-            return Ok(None);
+    fn read_optional_default(&mut self, name: &str, ty: &Type) -> Result<Option<LiteralMetadata>> {
+        if self.read_bool()? {
+            Ok(Some(self.read_default(name, ty)?))
+        } else {
+            Ok(None)
         }
+    }
 
+    fn read_default(&mut self, name: &str, ty: &Type) -> Result<LiteralMetadata> {
         let literal_kind = self.read_u8()?;
-        Ok(Some(match literal_kind {
+
+        Ok(match literal_kind {
             codes::LIT_STR => {
                 ensure!(
                     matches!(ty, Type::String),
@@ -534,8 +538,18 @@ impl<'a> MetadataReader<'a> {
                 }
             },
             codes::LIT_BOOL => LiteralMetadata::Boolean(self.read_bool()?),
-            codes::LIT_NULL => LiteralMetadata::Null,
+            codes::LIT_NONE => match ty {
+                Type::Optional { .. } => LiteralMetadata::None,
+                _ => bail!("field {name} of type {ty:?} can't have a default value of None"),
+            },
+            codes::LIT_SOME => match ty {
+                Type::Optional { inner_type, .. } => LiteralMetadata::Some {
+                    inner: Box::new(self.read_default(name, inner_type)?),
+                },
+                _ => bail!("field {name} of type {ty:?} can't have a default value of None"),
+            },
+            codes::LIT_EMPTY_SEQ => LiteralMetadata::EmptySequence,
             _ => bail!("Unexpected literal kind code: {literal_kind:?}"),
-        }))
+        })
     }
 }

--- a/uniffi_udl/src/literal.rs
+++ b/uniffi_udl/src/literal.rs
@@ -84,8 +84,10 @@ pub(super) fn convert_default_value(
         (weedle::literal::DefaultValue::String(s), Type::Enum { .. }) => {
             Literal::Enum(s.0.to_string(), type_.clone())
         }
-        (weedle::literal::DefaultValue::Null(_), Type::Optional { .. }) => Literal::Null,
-        (_, Type::Optional { inner_type, .. }) => convert_default_value(default_value, inner_type)?,
+        (weedle::literal::DefaultValue::Null(_), Type::Optional { .. }) => Literal::None,
+        (_, Type::Optional { inner_type, .. }) => Literal::Some {
+            inner: Box::new(convert_default_value(default_value, inner_type)?),
+        },
 
         // We'll ensure the type safety in the convert_* number methods.
         (weedle::literal::DefaultValue::Integer(i), _) => convert_integer(i, type_)?,
@@ -144,7 +146,7 @@ mod test {
                     inner_type: Box::new(Type::String)
                 }
             )?,
-            Literal::Null
+            Literal::None
         ));
         Ok(())
     }


### PR DESCRIPTION
Allow more default types with proc-macros (#1925)

I implemented everything, except enum variants and also jplatte's suggestion of a function-based default.  I think those two can be done later, especially since they semi-conflict.  When you're parsing it's hard to distinguish a variant ident from a function ident.  I also think function-based defaults might be better for enums anyways, since they would work with associated data.
