### PR TITLE
Escape """ in python docstrings

### DIFF
--- a/fixtures/docstring-proc-macro/src/lib.rs
+++ b/fixtures/docstring-proc-macro/src/lib.rs
@@ -84,6 +84,11 @@ pub fn test() {
     let _ = ErrorTest::Two;
 }
 
+/// <docstring-multiline-function>
+/// <second-line>
+#[uniffi::export]
+pub fn test_multiline() {}
+
 #[uniffi::export]
 pub fn test_without_docstring() {}
 

--- a/fixtures/docstring-proc-macro/tests/bindings/test_docstring.kts
+++ b/fixtures/docstring-proc-macro/tests/bindings/test_docstring.kts
@@ -10,6 +10,7 @@
 import uniffi.fixture.docstring.proc.macro.*;
 
 test()
+testMultiline()
 
 EnumTest.ONE
 EnumTest.TWO

--- a/fixtures/docstring-proc-macro/tests/bindings/test_docstring.py
+++ b/fixtures/docstring-proc-macro/tests/bindings/test_docstring.py
@@ -9,17 +9,18 @@ assert uniffi_docstring_proc_macro.__doc__
 from uniffi_docstring_proc_macro import *
 
 # Test function
-assert test.__doc__ == "<docstring-function>"
+assert test.__doc__.strip() == "<docstring-function>"
+assert test_multiline.__doc__.strip() == "<docstring-multiline-function>\n    <second-line>"
 assert test_without_docstring.__doc__ is None
 
 # Test enums
-assert EnumTest.__doc__ == "<docstring-enum>"
+assert EnumTest.__doc__.strip() == "<docstring-enum>"
 
 # Simple enum variants can't be tested, because `__doc__` is not supported for enums
 # assert EnumTest.ONE.__doc__ == "<docstring-enum-variant>"
 # assert EnumTest.TWO.__doc__ == "<docstring-enum-variant-2>"
 
-assert AssociatedEnumTest.__doc__ == "<docstring-associated-enum>"
+assert AssociatedEnumTest.__doc__.strip() == "<docstring-associated-enum>"
 
 # `__doc__` is lost because of how enum templates are generated
 # https://github.com/mozilla/uniffi-rs/blob/eb97592f8c48a7f5cf02a94662b8b7861a6544f3/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py#L60
@@ -27,26 +28,26 @@ assert AssociatedEnumTest.__doc__ == "<docstring-associated-enum>"
 # assert AssociatedEnumTest.TEST2.__doc__ == "<docstring-associated-enum-variant-2>"
 
 # Test errors
-assert ErrorTest.__doc__ == "<docstring-error>"
-assert ErrorTest.One.__doc__ == "<docstring-error-variant>"
-assert ErrorTest.Two.__doc__ == "<docstring-error-variant-2>"
+assert ErrorTest.__doc__.strip() == "<docstring-error>"
+assert ErrorTest.One.__doc__.strip() == "<docstring-error-variant>"
+assert ErrorTest.Two.__doc__.strip() == "<docstring-error-variant-2>"
 
-assert AssociatedErrorTest.__doc__ == "<docstring-associated-error>"
-assert AssociatedErrorTest.Test.__doc__ == "<docstring-associated-error-variant>"
-assert AssociatedErrorTest.Test2.__doc__ == "<docstring-associated-error-variant-2>"
+assert AssociatedErrorTest.__doc__.strip() == "<docstring-associated-error>"
+assert AssociatedErrorTest.Test.__doc__.strip() == "<docstring-associated-error-variant>"
+assert AssociatedErrorTest.Test2.__doc__.strip() == "<docstring-associated-error-variant-2>"
 
 # Test objects
-assert ObjectTest.__doc__ == "<docstring-object>"
-assert ObjectTest.__init__.__doc__ == "<docstring-primary-constructor>"
-assert ObjectTest.new_alternate.__doc__ == "<docstring-alternate-constructor>"
-assert ObjectTest.test.__doc__ == "<docstring-method>"
+assert ObjectTest.__doc__.strip() == "<docstring-object>"
+assert ObjectTest.__init__.__doc__.strip() == "<docstring-primary-constructor>"
+assert ObjectTest.new_alternate.__doc__.strip() == "<docstring-alternate-constructor>"
+assert ObjectTest.test.__doc__.strip() == "<docstring-method>"
 
 # Test records
-assert RecordTest.__doc__ == "<docstring-record>"
+assert RecordTest.__doc__.strip() == "<docstring-record>"
 
 # `__doc__` is not supported for class fields
 # assert RecordTest.test.__doc__ == "<docstring-record-field>"
 
 # Test callbacks
-assert CallbackTest.__doc__ == "<docstring-callback>"
-assert CallbackTest.test.__doc__ == "<docstring-callback-method>"
+assert CallbackTest.__doc__.strip() == "<docstring-callback>"
+assert CallbackTest.test.__doc__.strip() == "<docstring-callback-method>"

--- a/fixtures/docstring-proc-macro/tests/bindings/test_docstring.swift
+++ b/fixtures/docstring-proc-macro/tests/bindings/test_docstring.swift
@@ -10,6 +10,7 @@
 import uniffi_docstring_proc_macro
 
 test()
+testMultiline()
 
 var _ = EnumTest.one
 var _ = EnumTest.two

--- a/fixtures/docstring/src/docstring.udl
+++ b/fixtures/docstring/src/docstring.udl
@@ -3,6 +3,10 @@ namespace uniffi_docstring {
     /// <docstring-function>
     void test();
 
+    /// <docstring-multiline-function>
+    /// <second-line>
+    void test_multiline();
+
     void test_without_docstring();
 };
 

--- a/fixtures/docstring/src/lib.rs
+++ b/fixtures/docstring/src/lib.rs
@@ -51,6 +51,8 @@ pub fn test() {
     let _ = ErrorTest::Two;
 }
 
+pub fn test_multiline() {}
+
 pub fn test_without_docstring() {}
 
 pub trait CallbackTest {

--- a/fixtures/docstring/tests/bindings/test_docstring.kts
+++ b/fixtures/docstring/tests/bindings/test_docstring.kts
@@ -10,7 +10,7 @@
 import uniffi.fixture.docstring.*;
 
 test()
-test_multiline()
+testMultiline()
 
 EnumTest.ONE
 EnumTest.TWO

--- a/fixtures/docstring/tests/bindings/test_docstring.kts
+++ b/fixtures/docstring/tests/bindings/test_docstring.kts
@@ -10,6 +10,7 @@
 import uniffi.fixture.docstring.*;
 
 test()
+test_multiline()
 
 EnumTest.ONE
 EnumTest.TWO

--- a/fixtures/docstring/tests/bindings/test_docstring.py
+++ b/fixtures/docstring/tests/bindings/test_docstring.py
@@ -10,7 +10,6 @@ from uniffi_docstring import *
 
 # Test function
 assert test.__doc__.strip() == "<docstring-function>"
-print(test_multiline.__doc__.strip())
 assert test_multiline.__doc__.strip() == "<docstring-function-multiline>\n    <second-line>"
 assert test_without_docstring.__doc__ is None
 

--- a/fixtures/docstring/tests/bindings/test_docstring.py
+++ b/fixtures/docstring/tests/bindings/test_docstring.py
@@ -20,7 +20,7 @@ assert EnumTest.__doc__.strip() == "<docstring-enum>"
 # assert EnumTest.ONE.__doc__ == "<docstring-enum-variant>"
 # assert EnumTest.TWO.__doc__ == "<docstring-enum-variant-2>"
 
-assert AssociatedEnumTest.__doc__ .strip()== "<docstring-associated-enum>"
+assert AssociatedEnumTest.__doc__ .strip() == "<docstring-associated-enum>"
 
 # `__doc__` is lost because of how enum templates are generated
 # https://github.com/mozilla/uniffi-rs/blob/eb97592f8c48a7f5cf02a94662b8b7861a6544f3/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py#L60

--- a/fixtures/docstring/tests/bindings/test_docstring.py
+++ b/fixtures/docstring/tests/bindings/test_docstring.py
@@ -10,6 +10,8 @@ from uniffi_docstring import *
 
 # Test function
 assert test.__doc__.strip() == "<docstring-function>"
+print(test_multiline.__doc__.strip())
+assert test_multiline.__doc__.strip() == "<docstring-function-multiline>\n    <second-line>"
 assert test_without_docstring.__doc__ is None
 
 # Test enums

--- a/fixtures/docstring/tests/bindings/test_docstring.py
+++ b/fixtures/docstring/tests/bindings/test_docstring.py
@@ -10,7 +10,7 @@ from uniffi_docstring import *
 
 # Test function
 assert test.__doc__.strip() == "<docstring-function>"
-assert test_multiline.__doc__.strip() == "<docstring-function-multiline>\n    <second-line>"
+assert test_multiline.__doc__.strip() == "<docstring-multiline-function>\n    <second-line>"
 assert test_without_docstring.__doc__ is None
 
 # Test enums

--- a/fixtures/docstring/tests/bindings/test_docstring.py
+++ b/fixtures/docstring/tests/bindings/test_docstring.py
@@ -9,17 +9,17 @@ assert uniffi_docstring.__doc__
 from uniffi_docstring import *
 
 # Test function
-assert test.__doc__ == "<docstring-function>"
+assert test.__doc__.strip() == "<docstring-function>"
 assert test_without_docstring.__doc__ is None
 
 # Test enums
-assert EnumTest.__doc__ == "<docstring-enum>"
+assert EnumTest.__doc__.strip() == "<docstring-enum>"
 
 # Simple enum variants can't be tested, because `__doc__` is not supported for enums
 # assert EnumTest.ONE.__doc__ == "<docstring-enum-variant>"
 # assert EnumTest.TWO.__doc__ == "<docstring-enum-variant-2>"
 
-assert AssociatedEnumTest.__doc__ == "<docstring-associated-enum>"
+assert AssociatedEnumTest.__doc__ .strip()== "<docstring-associated-enum>"
 
 # `__doc__` is lost because of how enum templates are generated
 # https://github.com/mozilla/uniffi-rs/blob/eb97592f8c48a7f5cf02a94662b8b7861a6544f3/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py#L60
@@ -27,26 +27,26 @@ assert AssociatedEnumTest.__doc__ == "<docstring-associated-enum>"
 # assert AssociatedEnumTest.TEST2.__doc__ == "<docstring-associated-enum-variant-2>"
 
 # Test errors
-assert ErrorTest.__doc__ == "<docstring-error>"
-assert ErrorTest.One.__doc__ == "<docstring-error-variant>"
-assert ErrorTest.Two.__doc__ == "<docstring-error-variant-2>"
+assert ErrorTest.__doc__.strip() == "<docstring-error>"
+assert ErrorTest.One.__doc__.strip() == "<docstring-error-variant>"
+assert ErrorTest.Two.__doc__.strip() == "<docstring-error-variant-2>"
 
-assert AssociatedErrorTest.__doc__ == "<docstring-associated-error>"
-assert AssociatedErrorTest.Test.__doc__ == "<docstring-associated-error-variant>"
-assert AssociatedErrorTest.Test2.__doc__ == "<docstring-associated-error-variant-2>"
+assert AssociatedErrorTest.__doc__.strip() == "<docstring-associated-error>"
+assert AssociatedErrorTest.Test.__doc__.strip() == "<docstring-associated-error-variant>"
+assert AssociatedErrorTest.Test2.__doc__.strip() == "<docstring-associated-error-variant-2>"
 
 # Test objects
-assert ObjectTest.__doc__ == "<docstring-object>"
-assert ObjectTest.__init__.__doc__ == "<docstring-primary-constructor>"
-assert ObjectTest.new_alternate.__doc__ == "<docstring-alternate-constructor>"
-assert ObjectTest.test.__doc__ == "<docstring-method>"
+assert ObjectTest.__doc__.strip() == "<docstring-object>"
+assert ObjectTest.__init__.__doc__.strip() == "<docstring-primary-constructor>"
+assert ObjectTest.new_alternate.__doc__.strip() == "<docstring-alternate-constructor>"
+assert ObjectTest.test.__doc__.strip() == "<docstring-method>"
 
 # Test records
-assert RecordTest.__doc__ == "<docstring-record>"
+assert RecordTest.__doc__.strip() == "<docstring-record>"
 
 # `__doc__` is not supported for class fields
 # assert RecordTest.test.__doc__ == "<docstring-record-field>"
 
 # Test callbacks
-assert CallbackTest.__doc__ == "<docstring-callback>"
-assert CallbackTest.test.__doc__ == "<docstring-callback-method>"
+assert CallbackTest.__doc__.strip() == "<docstring-callback>"
+assert CallbackTest.test.__doc__.strip() == "<docstring-callback-method>"

--- a/fixtures/docstring/tests/bindings/test_docstring.py
+++ b/fixtures/docstring/tests/bindings/test_docstring.py
@@ -20,7 +20,7 @@ assert EnumTest.__doc__.strip() == "<docstring-enum>"
 # assert EnumTest.ONE.__doc__ == "<docstring-enum-variant>"
 # assert EnumTest.TWO.__doc__ == "<docstring-enum-variant-2>"
 
-assert AssociatedEnumTest.__doc__ .strip() == "<docstring-associated-enum>"
+assert AssociatedEnumTest.__doc__.strip() == "<docstring-associated-enum>"
 
 # `__doc__` is lost because of how enum templates are generated
 # https://github.com/mozilla/uniffi-rs/blob/eb97592f8c48a7f5cf02a94662b8b7861a6544f3/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py#L60

--- a/fixtures/docstring/tests/bindings/test_docstring.swift
+++ b/fixtures/docstring/tests/bindings/test_docstring.swift
@@ -10,6 +10,7 @@
 import uniffi_docstring
 
 test()
+test_multiline()
 
 var _ = EnumTest.one
 var _ = EnumTest.two

--- a/fixtures/docstring/tests/bindings/test_docstring.swift
+++ b/fixtures/docstring/tests/bindings/test_docstring.swift
@@ -10,7 +10,7 @@
 import uniffi_docstring
 
 test()
-test_multiline()
+testMultiline()
 
 var _ = EnumTest.one
 var _ = EnumTest.two

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -527,12 +527,14 @@ pub mod filters {
 mod tests {
     #[test]
     fn test_docstring_escape() {
-        let docstring = r#"This is a docstring with "quotes" in it.
+        let docstring = r#""""This is a docstring beginning with triple quotes.
+Contains "quotes" in it.
 It also has a triple quote: """
 And a even longer quote: """"""#;
 
         let expected = r#""""
-This is a docstring with "quotes" in it.
+\"\"\"This is a docstring beginning with triple quotes.
+Contains "quotes" in it.
 It also has a triple quote: \"\"\"
 And a even longer quote: \"\"\"""
 """"#;


### PR DESCRIPTION
Uniffi docstrings can currently produce invalid python code if the rust comment contains double quotes.

To avoid this the python docstring implementation has been adjusted slightly.

* Always use multi-line docstrings.
* Escape `"""` with `\"\"\"`.

The following comment:

```rust
/// This is a docstring with "quotes" in it.
/// It also has a triple quote: """
/// And a even longer quote: """"""
```

Will produce the following python code:

```py
"""
This is a docstring with "quotes" in it.
It also has a triple quote: \"\"\"
And a even longer quote: \"\"\"""
"""
```

I believe this leaves the comments mostly intact which is in my opinion important since it's one of the few parts of the generated code that will be visible to consumer through intellisense. I would have preferred longer sequences of quotes would all be escaped but the code got unwieldy and it should be a rare enough edge case to never actually happen.

Resolves #1927 