### PR TITLE
Remove uniffi_meta::ErrorMetadata.

### DIFF
--- a/fixtures/docstring-proc-macro/src/lib.rs
+++ b/fixtures/docstring-proc-macro/src/lib.rs
@@ -28,7 +28,7 @@ pub enum AssociatedEnumTest {
 /// <docstring-error>
 #[derive(uniffi::Error, Debug, thiserror::Error)]
 #[uniffi(flat_error)]
-enum ErrorTest {
+pub enum ErrorTest {
     /// <docstring-error-variant>
     #[error("Test")]
     One,
@@ -39,7 +39,7 @@ enum ErrorTest {
 
 /// <docstring-associated-error>
 #[derive(uniffi::Error, Debug, thiserror::Error)]
-enum AssociatedErrorTest {
+pub enum AssociatedErrorTest {
     /// <docstring-associated-error-variant>
     #[error("Test")]
     Test { code: i16 },
@@ -79,9 +79,10 @@ struct RecordTest {
 
 /// <docstring-function>
 #[uniffi::export]
-pub fn test() {
+pub fn test() -> Result<(), ErrorTest> {
     let _ = ErrorTest::One;
     let _ = ErrorTest::Two;
+    Ok(())
 }
 
 /// <docstring-multiline-function>
@@ -90,7 +91,9 @@ pub fn test() {
 pub fn test_multiline() {}
 
 #[uniffi::export]
-pub fn test_without_docstring() {}
+pub fn test_without_docstring() -> Result<(), AssociatedErrorTest> {
+    Ok(())
+}
 
 /// <docstring-callback>
 #[uniffi::export(callback_interface)]

--- a/fixtures/docstring-proc-macro/tests/bindings/test_docstring.swift
+++ b/fixtures/docstring-proc-macro/tests/bindings/test_docstring.swift
@@ -9,7 +9,7 @@
 
 import uniffi_docstring_proc_macro
 
-test()
+try! test()
 testMultiline()
 
 var _ = EnumTest.one

--- a/fixtures/docstring/src/docstring.udl
+++ b/fixtures/docstring/src/docstring.udl
@@ -1,13 +1,13 @@
 /// <docstring-namespace>
 namespace uniffi_docstring {
     /// <docstring-function>
-    void test();
+    [Throws=ErrorTest] void test();
 
     /// <docstring-multiline-function>
     /// <second-line>
     void test_multiline();
 
-    void test_without_docstring();
+    [Throws=AssociatedErrorTest] void test_without_docstring();
 };
 
 /// <docstring-enum>

--- a/fixtures/docstring/src/lib.rs
+++ b/fixtures/docstring/src/lib.rs
@@ -13,7 +13,7 @@ pub enum AssociatedEnumTest {
 }
 
 #[derive(Debug, thiserror::Error)]
-enum ErrorTest {
+pub enum ErrorTest {
     #[error("Test")]
     One,
     #[error("Two")]
@@ -21,7 +21,7 @@ enum ErrorTest {
 }
 
 #[derive(Debug, thiserror::Error)]
-enum AssociatedErrorTest {
+pub enum AssociatedErrorTest {
     #[error("Test")]
     Test { code: i16 },
     #[error("Test2")]
@@ -46,14 +46,17 @@ struct RecordTest {
     test: i32,
 }
 
-pub fn test() {
+pub fn test() -> Result<(), ErrorTest> {
     let _ = ErrorTest::One;
     let _ = ErrorTest::Two;
+    Ok(())
 }
 
 pub fn test_multiline() {}
 
-pub fn test_without_docstring() {}
+pub fn test_without_docstring() -> Result<(), AssociatedErrorTest> {
+    Ok(())
+}
 
 pub trait CallbackTest {
     fn test(&self);

--- a/fixtures/docstring/tests/bindings/test_docstring.swift
+++ b/fixtures/docstring/tests/bindings/test_docstring.swift
@@ -9,7 +9,7 @@
 
 import uniffi_docstring
 
-test()
+try! test()
 testMultiline()
 
 var _ = EnumTest.one

--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -201,6 +201,7 @@ mod test_metadata {
             EnumMetadata {
                 module_path: "uniffi_fixture_metadata".into(),
                 name: "Weapon".into(),
+                forced_flatness: None,
                 variants: vec![
                     VariantMetadata {
                         name: "Rock".into(),
@@ -234,6 +235,7 @@ mod test_metadata {
             EnumMetadata {
                 module_path: "uniffi_fixture_metadata".into(),
                 name: "State".into(),
+                forced_flatness: None,
                 variants: vec![
                     VariantMetadata {
                         name: "Uninitialized".into(),
@@ -280,6 +282,7 @@ mod test_metadata {
             EnumMetadata {
                 module_path: "uniffi_fixture_metadata".into(),
                 name: "ReprU8".into(),
+                forced_flatness: None,
                 variants: vec![
                     VariantMetadata {
                         name: "One".into(),
@@ -310,28 +313,26 @@ mod test_metadata {
     fn test_simple_error() {
         check_metadata(
             &error::UNIFFI_META_UNIFFI_FIXTURE_METADATA_ERROR_FLATERROR,
-            ErrorMetadata::Enum {
-                enum_: EnumMetadata {
-                    module_path: "uniffi_fixture_metadata".into(),
-                    name: "FlatError".into(),
-                    variants: vec![
-                        VariantMetadata {
-                            name: "Overflow".into(),
-                            discr: None,
-                            fields: vec![],
-                            docstring: None,
-                        },
-                        VariantMetadata {
-                            name: "DivideByZero".into(),
-                            discr: None,
-                            fields: vec![],
-                            docstring: None,
-                        },
-                    ],
-                    non_exhaustive: false,
-                    docstring: None,
-                },
-                is_flat: true,
+            EnumMetadata {
+                module_path: "uniffi_fixture_metadata".into(),
+                name: "FlatError".into(),
+                forced_flatness: Some(true),
+                variants: vec![
+                    VariantMetadata {
+                        name: "Overflow".into(),
+                        discr: None,
+                        fields: vec![],
+                        docstring: None,
+                    },
+                    VariantMetadata {
+                        name: "DivideByZero".into(),
+                        discr: None,
+                        fields: vec![],
+                        docstring: None,
+                    },
+                ],
+                non_exhaustive: false,
+                docstring: None,
             },
         );
     }
@@ -340,47 +341,45 @@ mod test_metadata {
     fn test_complex_error() {
         check_metadata(
             &error::UNIFFI_META_UNIFFI_FIXTURE_METADATA_ERROR_COMPLEXERROR,
-            ErrorMetadata::Enum {
-                enum_: EnumMetadata {
-                    module_path: "uniffi_fixture_metadata".into(),
-                    name: "ComplexError".into(),
-                    variants: vec![
-                        VariantMetadata {
-                            name: "NotFound".into(),
-                            discr: None,
-                            fields: vec![],
+            EnumMetadata {
+                module_path: "uniffi_fixture_metadata".into(),
+                name: "ComplexError".into(),
+                forced_flatness: Some(false),
+                variants: vec![
+                    VariantMetadata {
+                        name: "NotFound".into(),
+                        discr: None,
+                        fields: vec![],
+                        docstring: None,
+                    },
+                    VariantMetadata {
+                        name: "PermissionDenied".into(),
+                        discr: None,
+                        fields: vec![FieldMetadata {
+                            name: "reason".into(),
+                            ty: Type::String,
+                            default: None,
                             docstring: None,
-                        },
-                        VariantMetadata {
-                            name: "PermissionDenied".into(),
-                            discr: None,
-                            fields: vec![FieldMetadata {
-                                name: "reason".into(),
-                                ty: Type::String,
-                                default: None,
-                                docstring: None,
-                            }],
+                        }],
+                        docstring: None,
+                    },
+                    VariantMetadata {
+                        name: "InvalidWeapon".into(),
+                        discr: None,
+                        fields: vec![FieldMetadata {
+                            name: "weapon".into(),
+                            ty: Type::Enum {
+                                module_path: "uniffi_fixture_metadata".into(),
+                                name: "Weapon".into(),
+                            },
+                            default: None,
                             docstring: None,
-                        },
-                        VariantMetadata {
-                            name: "InvalidWeapon".into(),
-                            discr: None,
-                            fields: vec![FieldMetadata {
-                                name: "weapon".into(),
-                                ty: Type::Enum {
-                                    module_path: "uniffi_fixture_metadata".into(),
-                                    name: "Weapon".into(),
-                                },
-                                default: None,
-                                docstring: None,
-                            }],
-                            docstring: None,
-                        },
-                    ],
-                    non_exhaustive: false,
-                    docstring: None,
-                },
-                is_flat: false,
+                        }],
+                        docstring: None,
+                    },
+                ],
+                non_exhaustive: false,
+                docstring: None,
             },
         );
     }

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -94,7 +94,9 @@
 //!
 //! ```
 //! # let ci = uniffi_bindgen::interface::ComponentInterface::from_webidl(r##"
-//! # namespace example {};
+//! # namespace example {
+//! #   [Throws=Example] void func();
+//! # };
 //! # [Error]
 //! # enum Example {
 //! #   "one",
@@ -130,7 +132,9 @@
 //!
 //! ```
 //! # let ci = uniffi_bindgen::interface::ComponentInterface::from_webidl(r##"
-//! # namespace example {};
+//! # namespace example {
+//! #   [Throws=Example] void func();
+//! # };
 //! # [Error]
 //! # interface Example {
 //! #   one();
@@ -496,7 +500,10 @@ mod test {
     #[test]
     fn test_variants() {
         const UDL: &str = r#"
-            namespace test{};
+            namespace test{
+                [Throws=Testing]
+                void func();
+            };
             [Error]
             enum Testing { "one", "two", "three" };
         "#;
@@ -535,7 +542,10 @@ mod test {
     #[test]
     fn test_variant_data() {
         const UDL: &str = r#"
-            namespace test{};
+            namespace test{
+                [Throws=Testing]
+                void func();
+            };
 
             [Error]
             interface Testing {

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -770,6 +770,8 @@ impl ComponentInterface {
             bail!("Conflicting type definition for \"{}\"", defn.name());
         }
         self.types.add_known_types(defn.iter_types())?;
+        defn.throws_name()
+            .map(|n| self.errors.insert(n.to_string()));
         self.functions.push(defn);
 
         Ok(())
@@ -781,6 +783,8 @@ impl ComponentInterface {
         let defn: Constructor = meta.into();
 
         self.types.add_known_types(defn.iter_types())?;
+        defn.throws_name()
+            .map(|n| self.errors.insert(n.to_string()));
         object.constructors.push(defn);
 
         Ok(())
@@ -792,6 +796,9 @@ impl ComponentInterface {
             .ok_or_else(|| anyhow!("add_method_meta: object {} not found", &method.object_name))?;
 
         self.types.add_known_types(method.iter_types())?;
+        method
+            .throws_name()
+            .map(|n| self.errors.insert(n.to_string()));
         method.object_impl = object.imp;
         object.methods.push(method);
         Ok(())
@@ -815,10 +822,6 @@ impl ComponentInterface {
         self.types.add_known_types(defn.iter_types())?;
         self.objects.push(defn);
         Ok(())
-    }
-
-    pub(super) fn note_name_used_as_error(&mut self, name: &str) {
-        self.errors.insert(name.to_string());
     }
 
     pub fn is_name_used_as_error(&self, name: &str) -> bool {
@@ -848,6 +851,9 @@ impl ComponentInterface {
                 self.callback_interface_throws_types.insert(error.clone());
             }
             self.types.add_known_types(method.iter_types())?;
+            method
+                .throws_name()
+                .map(|n| self.errors.insert(n.to_string()));
             cbi.methods.push(method);
         } else {
             self.add_method_meta(meta)?;

--- a/uniffi_core/src/metadata.rs
+++ b/uniffi_core/src/metadata.rs
@@ -32,7 +32,6 @@ pub mod codes {
     pub const RECORD: u8 = 2;
     pub const ENUM: u8 = 3;
     pub const INTERFACE: u8 = 4;
-    pub const ERROR: u8 = 5;
     pub const NAMESPACE: u8 = 6;
     pub const CONSTRUCTOR: u8 = 7;
     pub const UDL_FILE: u8 = 8;
@@ -168,6 +167,15 @@ impl MetadataBuffer {
     // allocated an extra buffer.
     pub const fn concat_bool(self, value: bool) -> Self {
         self.concat_value(value as u8)
+    }
+
+    // Option<bool>
+    pub const fn concat_option_bool(self, value: Option<bool>) -> Self {
+        self.concat_value(match value {
+            None => 0,
+            Some(false) => 1,
+            Some(true) => 2,
+        })
     }
 
     // Concatenate a string to this buffer. The maximum string length is 255 bytes. For longer strings,

--- a/uniffi_macros/src/enum_.rs
+++ b/uniffi_macros/src/enum_.rs
@@ -180,6 +180,7 @@ pub(crate) fn enum_meta_static_var(
         ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::ENUM)
             .concat_str(#module_path)
             .concat_str(#name)
+            .concat_option_bool(None) // forced_flatness
     };
     metadata_expr.extend(variant_metadata(enum_)?);
     metadata_expr.extend(quote! {

--- a/uniffi_macros/src/error.rs
+++ b/uniffi_macros/src/error.rs
@@ -207,12 +207,10 @@ pub(crate) fn error_meta_static_var(
     let flat = attr.flat.is_some();
     let non_exhaustive = attr.non_exhaustive.is_some();
     let mut metadata_expr = quote! {
-            ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::ERROR)
-                // first our is-flat flag
-                .concat_bool(#flat)
-                // followed by an enum
+            ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::ENUM)
                 .concat_str(#module_path)
                 .concat_str(#name)
+                .concat_option_bool(Some(#flat))
     };
     if flat {
         metadata_expr.extend(flat_error_variant_metadata(enum_)?)

--- a/uniffi_meta/src/group.rs
+++ b/uniffi_meta/src/group.rs
@@ -130,12 +130,6 @@ impl<'a> ExternalTypeConverter<'a> {
                 ..meta
             }),
             Metadata::Enum(meta) => Metadata::Enum(self.convert_enum(meta)),
-            Metadata::Error(meta) => Metadata::Error(match meta {
-                ErrorMetadata::Enum { enum_, is_flat } => ErrorMetadata::Enum {
-                    enum_: self.convert_enum(enum_),
-                    is_flat,
-                },
-            }),
             _ => item,
         }
     }

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -308,6 +308,7 @@ pub struct FieldMetadata {
 pub struct EnumMetadata {
     pub module_path: String,
     pub name: String,
+    pub forced_flatness: Option<bool>,
     pub variants: Vec<VariantMetadata>,
     pub non_exhaustive: bool,
     pub docstring: Option<String>,
@@ -414,25 +415,6 @@ impl UniffiTraitDiscriminants {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub enum ErrorMetadata {
-    Enum { enum_: EnumMetadata, is_flat: bool },
-}
-
-impl ErrorMetadata {
-    pub fn name(&self) -> &String {
-        match self {
-            Self::Enum { enum_, .. } => &enum_.name,
-        }
-    }
-
-    pub fn module_path(&self) -> &String {
-        match self {
-            Self::Enum { enum_, .. } => &enum_.module_path,
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CustomTypeMetadata {
     pub module_path: String,
     pub name: String,
@@ -459,7 +441,6 @@ pub enum Metadata {
     CallbackInterface(CallbackInterfaceMetadata),
     Record(RecordMetadata),
     Enum(EnumMetadata),
-    Error(ErrorMetadata),
     Constructor(ConstructorMetadata),
     Method(MethodMetadata),
     TraitMethod(TraitMethodMetadata),
@@ -484,7 +465,6 @@ impl Metadata {
             Metadata::Object(meta) => &meta.module_path,
             Metadata::CallbackInterface(meta) => &meta.module_path,
             Metadata::TraitMethod(meta) => &meta.module_path,
-            Metadata::Error(meta) => meta.module_path(),
             Metadata::CustomType(meta) => &meta.module_path,
             Metadata::UniffiTrait(meta) => meta.module_path(),
         }
@@ -530,12 +510,6 @@ impl From<RecordMetadata> for Metadata {
 impl From<EnumMetadata> for Metadata {
     fn from(e: EnumMetadata) -> Self {
         Self::Enum(e)
-    }
-}
-
-impl From<ErrorMetadata> for Metadata {
-    fn from(e: ErrorMetadata) -> Self {
-        Self::Error(e)
     }
 }
 

--- a/uniffi_meta/src/metadata.rs
+++ b/uniffi_meta/src/metadata.rs
@@ -15,7 +15,6 @@ pub mod codes {
     pub const RECORD: u8 = 2;
     pub const ENUM: u8 = 3;
     pub const INTERFACE: u8 = 4;
-    pub const ERROR: u8 = 5;
     pub const NAMESPACE: u8 = 6;
     pub const CONSTRUCTOR: u8 = 7;
     pub const UDL_FILE: u8 = 8;

--- a/uniffi_udl/src/collectors.rs
+++ b/uniffi_udl/src/collectors.rs
@@ -172,15 +172,13 @@ impl APIBuilder for weedle::Definition<'_> {
         match self {
             weedle::Definition::Namespace(d) => d.process(ci)?,
             weedle::Definition::Enum(d) => {
+                let mut e: uniffi_meta::EnumMetadata = d.convert(ci)?;
                 // We check if the enum represents an error...
                 let attrs = attributes::EnumAttributes::try_from(d.attributes.as_ref())?;
                 if attrs.contains_error_attr() {
-                    let e: uniffi_meta::ErrorMetadata = d.convert(ci)?;
-                    ci.add_definition(e.into())?;
-                } else {
-                    let e: uniffi_meta::EnumMetadata = d.convert(ci)?;
-                    ci.add_definition(e.into())?;
+                    e.forced_flatness = Some(true);
                 }
+                ci.add_definition(e.into())?;
             }
             weedle::Definition::Dictionary(d) => {
                 let rec = d.convert(ci)?;
@@ -188,11 +186,8 @@ impl APIBuilder for weedle::Definition<'_> {
             }
             weedle::Definition::Interface(d) => {
                 let attrs = attributes::InterfaceAttributes::try_from(d.attributes.as_ref())?;
-                if attrs.contains_enum_attr() {
+                if attrs.contains_enum_attr() || attrs.contains_error_attr() {
                     let e: uniffi_meta::EnumMetadata = d.convert(ci)?;
-                    ci.add_definition(e.into())?;
-                } else if attrs.contains_error_attr() {
-                    let e: uniffi_meta::ErrorMetadata = d.convert(ci)?;
                     ci.add_definition(e.into())?;
                 } else {
                     let obj: uniffi_meta::ObjectMetadata = d.convert(ci)?;


### PR DESCRIPTION
This means that we determine whether a name is used as an error by checking if, well, it's used as an error - it's not impacted by how the name is declared. This has been done primarily for future "objects as errors" work where we don't want to force an object to be declared specially to have it be able to be used as an error.

This has a side-effect which should be invisible to most users but is visible in our test suites - some of our test UDL declares an enum with `[Error]` but doesn't actually use that enum as an error. Previously this enum would get error semantics, whereas now it has been necessary to change these fixtures to use the object as an error. This should be invisible to real users because objects declared as being an error are either (a) used as an error or (b) unused, where the actual semantics don't matter.

@bendk I flagged you as reviewer but it can wait until you get the rest of your queue landed etc - it's not at all urgent