### PR TITLE
Allow enum discriminant type to be specified

### DIFF
--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -39,10 +39,16 @@ mod state {
 
 mod enum_repr {
     #[derive(uniffi::Enum, Debug)]
+    #[repr(u8)]
     pub enum ReprU8 {
         One = 1,
         Three = 3,
         Fifteen = 0x0F,
+    }
+
+    #[derive(uniffi::Enum, Debug)]
+    pub enum NoRepr {
+        One = 1,
     }
 }
 
@@ -202,6 +208,7 @@ mod test_metadata {
                 module_path: "uniffi_fixture_metadata".into(),
                 name: "Weapon".into(),
                 forced_flatness: None,
+                discr_type: None,
                 variants: vec![
                     VariantMetadata {
                         name: "Rock".into(),
@@ -236,6 +243,7 @@ mod test_metadata {
                 module_path: "uniffi_fixture_metadata".into(),
                 name: "State".into(),
                 forced_flatness: None,
+                discr_type: None,
                 variants: vec![
                     VariantMetadata {
                         name: "Uninitialized".into(),
@@ -283,6 +291,7 @@ mod test_metadata {
                 module_path: "uniffi_fixture_metadata".into(),
                 name: "ReprU8".into(),
                 forced_flatness: None,
+                discr_type: Some(Type::UInt8),
                 variants: vec![
                     VariantMetadata {
                         name: "One".into(),
@@ -310,6 +319,27 @@ mod test_metadata {
     }
 
     #[test]
+    fn test_no_repr_enum() {
+        check_metadata(
+            &enum_repr::UNIFFI_META_UNIFFI_FIXTURE_METADATA_ENUM_NOREPR,
+            EnumMetadata {
+                module_path: "uniffi_fixture_metadata".into(),
+                name: "NoRepr".into(),
+                forced_flatness: None,
+                discr_type: None,
+                variants: vec![VariantMetadata {
+                    name: "One".into(),
+                    discr: Some(LiteralMetadata::new_uint(1)),
+                    fields: vec![],
+                    docstring: None,
+                }],
+                non_exhaustive: false,
+                docstring: None,
+            },
+        );
+    }
+
+    #[test]
     fn test_simple_error() {
         check_metadata(
             &error::UNIFFI_META_UNIFFI_FIXTURE_METADATA_ERROR_FLATERROR,
@@ -317,6 +347,7 @@ mod test_metadata {
                 module_path: "uniffi_fixture_metadata".into(),
                 name: "FlatError".into(),
                 forced_flatness: Some(true),
+                discr_type: None,
                 variants: vec![
                     VariantMetadata {
                         name: "Overflow".into(),
@@ -345,6 +376,7 @@ mod test_metadata {
                 module_path: "uniffi_fixture_metadata".into(),
                 name: "ComplexError".into(),
                 forced_flatness: Some(false),
+                discr_type: None,
                 variants: vec![
                     VariantMetadata {
                         name: "NotFound".into(),

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -174,6 +174,7 @@ use super::{AsType, Literal, Type, TypeIterator};
 pub struct Enum {
     pub(super) name: String,
     pub(super) module_path: String,
+    pub(super) discr_type: Option<Type>,
     pub(super) variants: Vec<Variant>,
     // NOTE: `flat` is a misleading name and to make matters worse, has 2 different
     // meanings depending on the context :(
@@ -260,6 +261,7 @@ impl Enum {
         Ok(Self {
             name: meta.name,
             module_path: meta.module_path,
+            discr_type: meta.discr_type,
             variants: meta
                 .variants
                 .into_iter()
@@ -649,6 +651,7 @@ mod test {
         let mut e = Enum {
             module_path: "test".to_string(),
             name: "test".to_string(),
+            discr_type: None,
             variants: vec![],
             flat: false,
             non_exhaustive: false,

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -1066,6 +1066,7 @@ mod test {
 existing definition: Enum {
     name: \"Testing\",
     module_path: \"crate_name\",
+    discr_type: None,
     variants: [
         Variant {
             name: \"one\",
@@ -1087,6 +1088,7 @@ existing definition: Enum {
 new definition: Enum {
     name: \"Testing\",
     module_path: \"crate_name\",
+    discr_type: None,
     variants: [
         Variant {
             name: \"three\",

--- a/uniffi_macros/src/error.rs
+++ b/uniffi_macros/src/error.rs
@@ -211,6 +211,7 @@ pub(crate) fn error_meta_static_var(
                 .concat_str(#module_path)
                 .concat_str(#name)
                 .concat_option_bool(Some(#flat))
+                .concat_bool(false) // discr_type: None
     };
     if flat {
         metadata_expr.extend(flat_error_variant_metadata(enum_)?)

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -310,6 +310,7 @@ pub struct EnumMetadata {
     pub name: String,
     pub forced_flatness: Option<bool>,
     pub variants: Vec<VariantMetadata>,
+    pub discr_type: Option<Type>,
     pub non_exhaustive: bool,
     pub docstring: Option<String>,
 }

--- a/uniffi_meta/src/reader.rs
+++ b/uniffi_meta/src/reader.rs
@@ -311,6 +311,11 @@ impl<'a> MetadataReader<'a> {
             2 => Some(true),
             _ => unreachable!("invalid flatness"),
         };
+        let discr_type = if self.read_bool()? {
+            Some(self.read_type()?)
+        } else {
+            None
+        };
         let variants = if forced_flatness == Some(true) {
             self.read_flat_variants()?
         } else {
@@ -321,6 +326,7 @@ impl<'a> MetadataReader<'a> {
             module_path,
             name,
             forced_flatness,
+            discr_type,
             variants,
             non_exhaustive: self.read_bool()?,
             docstring: self.read_optional_long_string()?,

--- a/uniffi_udl/src/converters/enum_.rs
+++ b/uniffi_udl/src/converters/enum_.rs
@@ -18,6 +18,7 @@ impl APIConverter<EnumMetadata> for weedle::EnumDefinition<'_> {
             module_path: ci.module_path(),
             name: self.identifier.0.to_string(),
             forced_flatness: None,
+            discr_type: None,
             variants: self
                 .values
                 .body
@@ -60,6 +61,7 @@ impl APIConverter<EnumMetadata> for weedle::InterfaceDefinition<'_> {
                     ),
                 })
                 .collect::<Result<Vec<_>>>()?,
+            discr_type: None,
             non_exhaustive: attributes.contains_non_exhaustive_attr(),
             docstring: self.docstring.as_ref().map(|v| convert_docstring(&v.0)),
             // Enums declared using the `[Enum] interface` syntax might have variants with fields.


### PR DESCRIPTION
Towards #1792 we should record the type of enum discriminants - python doesn't care, but others do.