### PR TITLE
Generate underyling enum variant literals for swift and kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@
 
 [All changes in v0.26.1](https://github.com/mozilla/uniffi-rs/compare/v0.26.0...v0.26.1).
 
+### What's new?
+
+- Enums created with proc macros can now produce literals for variants in Kotlin and Swift bindings specifically for unsigned types.. See
+[the section on enum proc-macros](https://mozilla.github.io/uniffi-rs/proc_macro/index.html#the-uniffienum-derive) for more information.
+
 ## v0.26.0 (backend crates: v0.26.0) - (_2024-01-23_)
 
 ### What's changed?

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,6 +1569,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-fixture-enum-types"
+version = "0.22.0"
+dependencies = [
+ "thiserror",
+ "uniffi",
+]
+
+[[package]]
 name = "uniffi-fixture-error-types"
 version = "0.22.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ members = [
   "fixtures/swift-bridging-header-compile",
   "fixtures/type-limits",
   "fixtures/large-enum",
+  "fixtures/enum-types",
 ]
 
 resolver = "2"

--- a/docs/manual/src/proc_macro/index.md
+++ b/docs/manual/src/proc_macro/index.md
@@ -210,9 +210,66 @@ pub enum MyEnum {
 }
 ```
 
+### Variant Discriminants
+
 Variant discriminants are accepted by the macro but how they are used depends on the bindings.
-Most would be likely ignore it in the example above due to the nature of the enum,
-but some expose it for simple "unit" enums.
+
+Currently only `unsigned integer` variant discriminants are passed through to the foreign bindings. For example this enum:
+
+```rust
+#[derive(uniffi::Enum)]
+pub enum MyEnum {
+    Foo = 3,
+    Bar = 4,
+}
+```
+
+would give you in Kotlin & Swift:
+
+```swift
+// kotlin
+enum class MyEnum {   
+    FOO,
+    BAR;
+    companion object
+}
+// swift 
+public enum MyEnum {    
+    case foo
+    case bar
+}
+```
+
+which means you cannot use the platforms helpful methods like `value` or `rawValue` to get the underlying discriminants. Adding a `repr` will allow the type to be defined in the foreign bindings.
+
+For example:
+
+```rust
+// added the repr(u8), also u16 -> u64 supported
+#[repr(u8)]
+#[derive(uniffi::Enum)]
+pub enum MyEnum {
+    Foo = 3,
+    Bar = 4,
+}
+```
+
+will now generate:
+
+```swift
+// kotlin
+enum class MyEnum(val value: UByte) {
+    FOO(3u),
+    BAR(4u);
+    companion object
+}
+
+// swift
+public enum MyEnum : UInt8 {
+    case foo = 3
+    case bar = 4
+}
+```
 
 ## The `uniffi::Object` derive
 

--- a/fixtures/enum-types/Cargo.toml
+++ b/fixtures/enum-types/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "uniffi-fixture-enum-types"
+version = "0.22.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+edition = "2021"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "enum_types"
+
+[dependencies]
+uniffi = { workspace = true }
+thiserror = "1.0"
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["build"] }
+
+[dev-dependencies]
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/enum-types/build.rs
+++ b/fixtures/enum-types/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::generate_scaffolding("src/enum_types.udl").unwrap();
+}

--- a/fixtures/enum-types/src/enum_types.udl
+++ b/fixtures/enum-types/src/enum_types.udl
@@ -1,0 +1,7 @@
+namespace enum_types {};
+
+
+enum Animal {
+  "Dog",
+  "Cat"
+};

--- a/fixtures/enum-types/src/lib.rs
+++ b/fixtures/enum-types/src/lib.rs
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+enum Animal {
+    Dog,
+    Cat,
+}
+
+// Though it has the proc-macro, we drop the variant
+// literals if there is not a repr type defined
+#[derive(uniffi::Enum)]
+pub enum AnimalNoReprInt {
+    Dog = 3,
+    Cat = 4,
+}
+
+#[repr(u8)]
+#[derive(uniffi::Enum)]
+pub enum AnimalUInt {
+    Dog = 3,
+    Cat = 4,
+}
+
+#[repr(u64)]
+#[derive(uniffi::Enum)]
+pub enum AnimalLargeUInt {
+    Dog = 4294967298, // u32::MAX as u64 + 3
+    Cat = 4294967299, // u32::MAX as u64 + 4
+}
+
+// Signed is currently NOT supported but included to ensure we don't break
+// things for current users of the enum proc-macro
+#[repr(i8)]
+#[derive(uniffi::Enum)]
+pub enum AnimalSignedInt {
+    Dog = -3,
+    Cat = -4,
+}
+
+uniffi::include_scaffolding!("enum_types");

--- a/fixtures/enum-types/tests/bindings/test_enum_types.kts
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.kts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import uniffi.enum_types.*
+
+
+assert(AnimalUInt.DOG.value == 3.toUByte())
+assert(AnimalUInt.CAT.value == 4.toUByte())
+
+assert(AnimalLargeUInt.DOG.value == 4294967298.toULong())
+assert(AnimalLargeUInt.CAT.value == 4294967299.toULong())

--- a/fixtures/enum-types/tests/bindings/test_enum_types.py
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.py
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import unittest
+from enum_types import *
+
+assert(Animal.DOG.value == 0)
+assert(Animal.CAT.value == 1)
+
+assert(AnimalNoReprInt.DOG.value == 3)
+assert(AnimalNoReprInt.CAT.value == 4)
+
+assert(AnimalUInt.DOG.value == 3)
+assert(AnimalUInt.CAT.value == 4)
+
+assert(AnimalLargeUInt.DOG.value == (4294967295 + 3))
+assert(AnimalLargeUInt.CAT.value == (4294967295 + 4))

--- a/fixtures/enum-types/tests/bindings/test_enum_types.swift
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.swift
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import enum_types
+
+
+assert(AnimalUInt.dog.rawValue == 3)
+assert(AnimalUInt.cat.rawValue == 4)
+
+assert(AnimalLargeUInt.dog.rawValue == 4294967298)
+assert(AnimalLargeUInt.cat.rawValue == 4294967299)

--- a/fixtures/enum-types/tests/test_generated_bindings.rs
+++ b/fixtures/enum-types/tests/test_generated_bindings.rs
@@ -1,0 +1,5 @@
+uniffi::build_foreign_language_testcases!(
+    "tests/bindings/test_enum_types.kts",
+    "tests/bindings/test_enum_types.py",
+    "tests/bindings/test_enum_types.swift"
+);

--- a/fixtures/enum-types/uniffi.toml
+++ b/fixtures/enum-types/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.kotlin]
+package_name = "uniffi.enum_types"

--- a/uniffi_bindgen/src/backend/filters.rs
+++ b/uniffi_bindgen/src/backend/filters.rs
@@ -13,12 +13,12 @@ use std::fmt;
 // Need to define an error that implements std::error::Error, which neither String nor
 // anyhow::Error do.
 #[derive(Debug)]
-struct UniFFIError {
+pub struct UniFFIError {
     message: String,
 }
 
 impl UniFFIError {
-    fn new(message: String) -> Self {
+    pub fn new(message: String) -> Self {
         Self { message }
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -573,6 +573,7 @@ impl SwiftCodeOracle {
 pub mod filters {
     use super::*;
     pub use crate::backend::filters::*;
+    use uniffi_meta::LiteralMetadata;
 
     fn oracle() -> &'static SwiftCodeOracle {
         &SwiftCodeOracle
@@ -620,6 +621,15 @@ pub mod filters {
         as_type: &impl AsType,
     ) -> Result<String, askama::Error> {
         Ok(oracle().find(&as_type.as_type()).literal(literal))
+    }
+
+    // Get the idiomatic Swift rendering of an individual enum variant's discriminant
+    pub fn variant_discr_literal(e: &Enum, index: &usize) -> Result<String, askama::Error> {
+        let literal = e.variant_discr(*index).expect("invalid index");
+        match literal {
+            LiteralMetadata::UInt(v, _, _) => Ok(v.to_string()),
+            _ => unreachable!("expected an UInt!"),
+        }
     }
 
     /// Get the Swift type for an FFIType

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -235,6 +235,10 @@ impl Enum {
         Ok(Literal::new_uint(this))
     }
 
+    pub fn variant_discr_type(&self) -> &Option<Type> {
+        &self.discr_type
+    }
+
     pub fn is_flat(&self) -> bool {
         self.flat
     }


### PR DESCRIPTION
Part of #1792 


I started with proc macros as trying to get the types in UDL is painful (without trying to hackily do stuff like putting the type into the string, etc). I still would like to write up some documentation on this but wanted to get the PR up for early eyes!