### PR TITLE
Reject [uniffi::export()] arguments used in invalid contexts.

### DIFF
--- a/fixtures/uitests/tests/ui/export_attrs.rs
+++ b/fixtures/uitests/tests/ui/export_attrs.rs
@@ -1,0 +1,20 @@
+fn main() {} /* empty main required by `trybuild` */
+
+#[uniffi::constructor] // <--- should be an error!
+// Someone might try to 'export' a struct instead of deriving it.
+#[uniffi::export]
+struct S {}
+
+#[uniffi::export(Dixplay)]
+struct S2 {}
+
+#[derive(uniffi::Object)]
+struct Object;
+
+#[uniffi::export(callback_interface)]
+impl Object {}
+
+#[uniffi::export(with_foreign)]
+fn foreign() {}
+
+uniffi_macros::setup_scaffolding!();

--- a/fixtures/uitests/tests/ui/export_attrs.stderr
+++ b/fixtures/uitests/tests/ui/export_attrs.stderr
@@ -1,0 +1,25 @@
+error: uniffi::export on a struct must supply a builtin trait name. Did you mean `#[derive(uniffi::Object)]`?
+ --> tests/ui/export_attrs.rs:5:1
+  |
+5 | #[uniffi::export]
+  | ^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: uniffi::export struct attributes must be builtin trait names; `Dixplay` is invalid
+ --> tests/ui/export_attrs.rs:8:18
+  |
+8 | #[uniffi::export(Dixplay)]
+  |                  ^^^^^^^
+
+error: uniffi::export attribute `callback_interface` is not supported here.
+  --> tests/ui/export_attrs.rs:14:18
+   |
+14 | #[uniffi::export(callback_interface)]
+   |                  ^^^^^^^^^^^^^^^^^^
+
+error: uniffi::export attribute `with_foreign` is not supported here.
+  --> tests/ui/export_attrs.rs:17:18
+   |
+17 | #[uniffi::export(with_foreign)]
+   |                  ^^^^^^^^^^^^

--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -37,8 +37,9 @@ pub trait r#{{ obj.name() }} {
 struct {{ obj.rust_name() }} { }
 
 {%- for cons in obj.constructors() %}
-#[::uniffi::export_for_udl(constructor)]
+#[::uniffi::export_for_udl]
 impl {{ obj.rust_name() }} {
+    #[uniffi::constructor]
     pub fn r#{{ cons.name() }}(
         {%- for arg in cons.arguments() %}
         r#{{ arg.name() }}: {% if arg.by_ref() %}&{% endif %}{{ arg.as_type().borrow()|type_rs }},

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -6,12 +6,12 @@ use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use std::iter;
 
-use super::attributes::{AsyncRuntime, ExportAttributeArguments};
+use super::attributes::{AsyncRuntime, ExportFnArgs};
 use crate::fnsig::{FnKind, FnSignature, NamedArg};
 
 pub(super) fn gen_fn_scaffolding(
     sig: FnSignature,
-    arguments: &ExportAttributeArguments,
+    arguments: &ExportFnArgs,
     udl_mode: bool,
 ) -> syn::Result<TokenStream> {
     if sig.receiver.is_some() {
@@ -41,7 +41,7 @@ pub(super) fn gen_fn_scaffolding(
 
 pub(super) fn gen_constructor_scaffolding(
     sig: FnSignature,
-    arguments: &ExportAttributeArguments,
+    arguments: &ExportFnArgs,
     udl_mode: bool,
 ) -> syn::Result<TokenStream> {
     if sig.receiver.is_some() {
@@ -66,7 +66,7 @@ pub(super) fn gen_constructor_scaffolding(
 
 pub(super) fn gen_method_scaffolding(
     sig: FnSignature,
-    arguments: &ExportAttributeArguments,
+    arguments: &ExportFnArgs,
     udl_mode: bool,
 ) -> syn::Result<TokenStream> {
     let scaffolding_func = if sig.receiver.is_none() {
@@ -203,7 +203,7 @@ impl ScaffoldingBits {
 /// `rust_fn` is the Rust function to call.
 pub(super) fn gen_ffi_function(
     sig: &FnSignature,
-    arguments: &ExportAttributeArguments,
+    arguments: &ExportFnArgs,
     udl_mode: bool,
 ) -> syn::Result<TokenStream> {
     let ScaffoldingBits {

--- a/uniffi_macros/src/export/trait_interface.rs
+++ b/uniffi_macros/src/export/trait_interface.rs
@@ -9,7 +9,8 @@ use uniffi_meta::ObjectImpl;
 
 use crate::{
     export::{
-        attributes::ExportAttributeArguments, callback_interface, gen_method_scaffolding,
+        attributes::{ExportFnArgs, ExportTraitArgs},
+        callback_interface, gen_method_scaffolding,
         item::ImplItem,
     },
     object::interface_meta_static_var,
@@ -18,7 +19,7 @@ use crate::{
 
 pub(super) fn gen_trait_scaffolding(
     mod_path: &str,
-    args: ExportAttributeArguments,
+    args: ExportTraitArgs,
     self_ident: Ident,
     items: Vec<ImplItem>,
     udl_mode: bool,
@@ -92,7 +93,10 @@ pub(super) fn gen_trait_scaffolding(
                         "async trait methods are not supported",
                     ));
                 }
-                gen_method_scaffolding(sig, &args, udl_mode)
+                let fn_args = ExportFnArgs {
+                    async_runtime: None,
+                };
+                gen_method_scaffolding(sig, &fn_args, udl_mode)
             }
             _ => unreachable!("traits have no constructors"),
         })

--- a/uniffi_macros/src/export/utrait.rs
+++ b/uniffi_macros/src/export/utrait.rs
@@ -6,7 +6,7 @@ use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use syn::ext::IdentExt;
 
-use super::{attributes::ExportAttributeArguments, gen_ffi_function};
+use super::{attributes::ExportFnArgs, gen_ffi_function};
 use crate::fnsig::FnSignature;
 use crate::util::extract_docstring;
 use uniffi_meta::UniffiTraitDiscriminants;
@@ -162,7 +162,7 @@ fn process_uniffi_trait_method(
 
     let ffi_func = gen_ffi_function(
         &FnSignature::new_method(self_ident.clone(), item.sig.clone(), docstring.clone())?,
-        &ExportAttributeArguments::default(),
+        &ExportFnArgs::default(),
         udl_mode,
     )?;
     // metadata for the method, which will be packed inside metadata for the trait.

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -93,9 +93,8 @@ fn do_export(attr_args: TokenStream, input: TokenStream, udl_mode: bool) -> Toke
     let copied_input = (!udl_mode).then(|| proc_macro2::TokenStream::from(input.clone()));
 
     let gen_output = || {
-        let args = syn::parse(attr_args)?;
         let item = syn::parse(input)?;
-        expand_export(item, args, udl_mode)
+        expand_export(item, attr_args, udl_mode)
     };
     let output = gen_output().unwrap_or_else(syn::Error::into_compile_error);
 

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -396,6 +396,7 @@ impl UniffiTraitMetadata {
 }
 
 #[repr(u8)]
+#[derive(Eq, PartialEq, Hash)]
 pub enum UniffiTraitDiscriminants {
     Debug,
     Display,


### PR DESCRIPTION
Allows for better UX because attributes which don't make sense in a particular context are rejected rather than ingored.

Replaces ExportAttributeArguments with multiple structs, one per export context (ie, a struct, fn, trait, etc)

Also removes the undocumented `uniffi::export(constructor)` attribute on an impl block, just use `uniffi::constructor` on each fn.
