### PR TITLE
Allow callback interfaces to return other callback interfaces (#1947)

### DIFF
--- a/fixtures/proc-macro/src/callback_interface.rs
+++ b/fixtures/proc-macro/src/callback_interface.rs
@@ -12,4 +12,10 @@ pub trait TestCallbackInterface {
     fn with_bytes(&self, rwb: RecordWithBytes) -> Vec<u8>;
     fn try_parse_int(&self, value: String) -> Result<u32, BasicError>;
     fn callback_handler(&self, h: std::sync::Arc<Object>) -> u32;
+    fn get_other_callback_interface(&self) -> Box<dyn OtherCallbackInterface>;
+}
+
+#[uniffi::export(callback_interface)]
+pub trait OtherCallbackInterface {
+    fn multiply(&self, a: u32, b: u32) -> u32;
 }

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -179,6 +179,8 @@ fn call_callback_interface(cb: Box<dyn TestCallbackInterface>) {
         Err(BasicError::UnexpectedError { .. }),
     ));
     assert_eq!(42, cb.callback_handler(Object::new()));
+
+    assert_eq!(6, cb.get_other_callback_interface().multiply(2, 3));
 }
 
 // Type that's defined in the UDL and not wrapped with #[uniffi::export]

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
@@ -78,6 +78,12 @@ class KtTestCallbackInterface : TestCallbackInterface {
         val v = o.takeError(BasicException.InvalidInput());
         return v
     }
+
+    override fun getOtherCallbackInterface() = KtTestCallbackInterface2()
+}
+
+class KtTestCallbackInterface2 : OtherCallbackInterface {
+    override fun multiply(a: UInt, b: UInt) = a * b
 }
 
 callCallbackInterface(KtTestCallbackInterface())

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -88,6 +88,13 @@ class PyTestCallbackInterface(TestCallbackInterface):
         v = h.take_error(BasicError.InvalidInput())
         return v
 
+    def get_other_callback_interface(self):
+        return PyTestCallbackInterface2()
+
+class PyTestCallbackInterface2(OtherCallbackInterface):
+    def multiply(self, a, b):
+        return a * b
+
 call_callback_interface(PyTestCallbackInterface())
 
 # udl exposed functions with procmacro types.

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
@@ -87,6 +87,16 @@ class SwiftTestCallbackInterface : TestCallbackInterface {
         var v = h.takeError(e: BasicError.InvalidInput)
         return v
     }
+
+    func getOtherCallbackInterface() -> OtherCallbackInterface {
+        SwiftTestCallbackInterface2()
+    }
+}
+
+class SwiftTestCallbackInterface2 : OtherCallbackInterface {
+    func multiply(a: UInt32, b: UInt32) -> UInt32 {
+        return a * b;
+    }
 }
 
 callCallbackInterface(cb: SwiftTestCallbackInterface())

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -224,7 +224,11 @@ pub(crate) fn derive_all_ffi_traits(ty: &Ident, udl_mode: bool) -> TokenStream {
     }
 }
 
-pub(crate) fn derive_ffi_traits(ty: &Ident, udl_mode: bool, trait_names: &[&str]) -> TokenStream {
+pub(crate) fn derive_ffi_traits(
+    ty: impl ToTokens,
+    udl_mode: bool,
+    trait_names: &[&str],
+) -> TokenStream {
     let trait_idents = trait_names
         .iter()
         .map(|name| Ident::new(name, Span::call_site()));


### PR DESCRIPTION
The easy part was implementing `LiftReturn`.  The hard part was figuring out how to handle TYPE_ID_META in the metadata code.  In general, we have an issue: should we get that from `Lift`/`LiftReturn` or `Lower`/`LowerReturn`.

As mentioned in the `fnsig` code, I feel like this is a bid of a band-aid.  However, I think a real fix would require significant changes to the FFI trait system and I don't want to do that so close to the v0.26 release.