### PR TITLE
Update min supported JNA version in docs

### DIFF
--- a/docs/manual/src/kotlin/gradle.md
+++ b/docs/manual/src/kotlin/gradle.md
@@ -51,13 +51,13 @@ allprojects {
 ## JNA dependency
 
 UniFFI relies on [JNA] for the ability to call native methods.
-JNA 5.7 or greater is required.
+JNA 5.12.0 or greater is required.
 
 Set the dependency in your `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation "net.java.dev.jna:jna:5.7.0@aar"
+    implementation "net.java.dev.jna:jna:5.12.0@aar"
 }
 ```
 


### PR DESCRIPTION
Using JNA's Cleaner API in https://github.com/mozilla/uniffi-rs/pull/1869, which has been merged to main, needs at least JNA `v5.12.0` as we discovered later [here](https://github.com/mozilla/uniffi-rs/pull/1869#issuecomment-1902237867).

When I asked in the UniFFI Matrix room @badboy said the docs should be updated, so this should take care of that.