### PR TITLE
Adding the `TypeId` FFI trait

### DIFF
--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -103,9 +103,9 @@ mod test_type_ids {
     use super::*;
     use std::collections::HashMap;
     use std::sync::Arc;
-    use uniffi_core::Lower;
+    use uniffi_core::TypeId;
 
-    fn check_type_id<T: Lower<UniFfiTag>>(correct_type: Type) {
+    fn check_type_id<T: TypeId<UniFfiTag>>(correct_type: Type) {
         let buf = &mut T::TYPE_ID_META.as_ref();
         assert_eq!(
             uniffi_meta::read_metadata_type(buf).unwrap(),

--- a/fixtures/uitests/tests/ui/invalid_types_in_signatures.stderr
+++ b/fixtures/uitests/tests/ui/invalid_types_in_signatures.stderr
@@ -16,23 +16,6 @@ error[E0277]: the trait bound `Result<(), ErrorType>: Lift<UniFfiTag>` is not sa
            and $N others
    = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Result<(), ErrorType>: Lift<UniFfiTag>` is not satisfied
-  --> tests/ui/invalid_types_in_signatures.rs:18:25
-   |
-18 | pub fn input_result(_r: Result<(), ErrorType>) { }
-   |                         ^^^^^^^^^^^^^^^^^^^^^ the trait `Lift<UniFfiTag>` is not implemented for `Result<(), ErrorType>`
-   |
-   = help: the following other types implement trait `Lift<UT>`:
-             bool
-             i8
-             i16
-             i32
-             i64
-             u8
-             u16
-             u32
-           and $N others
-
 error[E0277]: the trait bound `Result<(), ErrorType>: Lower<UniFfiTag>` is not satisfied
   --> tests/ui/invalid_types_in_signatures.rs:20:1
    |
@@ -52,22 +35,3 @@ error[E0277]: the trait bound `Result<(), ErrorType>: Lower<UniFfiTag>` is not s
    = note: required for `Option<Result<(), ErrorType>>` to implement `Lower<UniFfiTag>`
    = note: required for `Option<Result<(), ErrorType>>` to implement `LowerReturn<UniFfiTag>`
    = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `Result<(), ErrorType>: Lower<UniFfiTag>` is not satisfied
-  --> tests/ui/invalid_types_in_signatures.rs:21:34
-   |
-21 | pub fn return_option_result() -> Option<Result<(), ErrorType>> {
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Lower<UniFfiTag>` is not implemented for `Result<(), ErrorType>`, which is required by `Option<Result<(), ErrorType>>: LowerReturn<UniFfiTag>`
-   |
-   = help: the following other types implement trait `Lower<UT>`:
-             bool
-             i8
-             i16
-             i32
-             i64
-             u8
-             u16
-             u32
-           and $N others
-   = note: required for `Option<Result<(), ErrorType>>` to implement `Lower<UniFfiTag>`
-   = note: required for `Option<Result<(), ErrorType>>` to implement `LowerReturn<UniFfiTag>`

--- a/uniffi/tests/ui/proc_macro_arc.stderr
+++ b/uniffi/tests/ui/proc_macro_arc.stderr
@@ -14,12 +14,11 @@ error[E0277]: the trait bound `Foo: FfiConverterArc<UniFfiTag>` is not satisfied
   --> tests/ui/proc_macro_arc.rs:11:18
    |
 11 | fn make_foo() -> Arc<Foo> {
-   |                  ^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `Foo`, which is required by `Arc<Foo>: LowerReturn<UniFfiTag>`
+   |                  ^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `Foo`, which is required by `Arc<Foo>: uniffi::TypeId<UniFfiTag>`
    |
-   = help: the trait `LowerReturn<UT>` is implemented for `Arc<T>`
+   = help: the trait `uniffi::TypeId<UT>` is implemented for `Arc<T>`
    = note: required for `Arc<Foo>` to implement `FfiConverter<UniFfiTag>`
-   = note: required for `Arc<Foo>` to implement `Lower<UniFfiTag>`
-   = note: required for `Arc<Foo>` to implement `LowerReturn<UniFfiTag>`
+   = note: required for `Arc<Foo>` to implement `uniffi::TypeId<UniFfiTag>`
 
 error[E0277]: the trait bound `child::Foo: FfiConverterArc<UniFfiTag>` is not satisfied
   --> tests/ui/proc_macro_arc.rs:20:5
@@ -36,8 +35,8 @@ error[E0277]: the trait bound `child::Foo: FfiConverterArc<UniFfiTag>` is not sa
   --> tests/ui/proc_macro_arc.rs:21:22
    |
 21 |     fn take_foo(foo: Arc<Foo>) {
-   |                      ^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `child::Foo`, which is required by `Arc<child::Foo>: Lift<UniFfiTag>`
+   |                      ^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `child::Foo`, which is required by `Arc<child::Foo>: uniffi::TypeId<UniFfiTag>`
    |
-   = help: the trait `Lift<UT>` is implemented for `Arc<T>`
+   = help: the trait `uniffi::TypeId<UT>` is implemented for `Arc<T>`
    = note: required for `Arc<child::Foo>` to implement `FfiConverter<UniFfiTag>`
-   = note: required for `Arc<child::Foo>` to implement `Lift<UniFfiTag>`
+   = note: required for `Arc<child::Foo>` to implement `uniffi::TypeId<UniFfiTag>`

--- a/uniffi_core/src/lib.rs
+++ b/uniffi_core/src/lib.rs
@@ -46,7 +46,7 @@ pub mod metadata;
 pub use ffi::*;
 pub use ffi_converter_traits::{
     ConvertError, FfiConverter, FfiConverterArc, HandleAlloc, Lift, LiftRef, LiftReturn, Lower,
-    LowerReturn,
+    LowerReturn, TypeId,
 };
 pub use metadata::*;
 

--- a/uniffi_macros/src/custom.rs
+++ b/uniffi_macros/src/custom.rs
@@ -45,7 +45,7 @@ pub(crate) fn expand_ffi_converter_custom_type(
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_CUSTOM)
                 .concat_str(#mod_path)
                 .concat_str(#name)
-                .concat(<#builtin as ::uniffi::Lower<crate::UniFfiTag>>::TYPE_ID_META);
+                .concat(<#builtin as ::uniffi::TypeId<crate::UniFfiTag>>::TYPE_ID_META);
         }
 
         #derive_ffi_traits

--- a/uniffi_macros/src/enum_.rs
+++ b/uniffi_macros/src/enum_.rs
@@ -230,7 +230,7 @@ pub(crate) fn enum_meta_static_var(
     };
     metadata_expr.extend(match discr_type {
         None => quote! { .concat_bool(false) },
-        Some(t) => quote! { .concat_bool(true).concat(<#t as ::uniffi::Lower<crate::UniFfiTag>>::TYPE_ID_META) }
+        Some(t) => quote! { .concat_bool(true).concat(<#t as ::uniffi::TypeId<crate::UniFfiTag>>::TYPE_ID_META) }
     });
     metadata_expr.extend(variant_metadata(enum_)?);
     metadata_expr.extend(quote! {
@@ -328,7 +328,7 @@ pub fn variant_metadata(enum_: &DataEnum) -> syn::Result<Vec<TokenStream>> {
                 .concat_value(#fields_len)
                     #(
                         .concat_str(#field_names)
-                        .concat(<#field_types as ::uniffi::Lower<crate::UniFfiTag>>::TYPE_ID_META)
+                        .concat(<#field_types as ::uniffi::TypeId<crate::UniFfiTag>>::TYPE_ID_META)
                         // field defaults not yet supported for enums
                         .concat_bool(false)
                         .concat_long_str(#field_docstrings)

--- a/uniffi_macros/src/error.rs
+++ b/uniffi_macros/src/error.rs
@@ -89,6 +89,7 @@ fn flat_error_ffi_converter_impl(
     let name = ident_to_string(ident);
     let lower_impl_spec = tagged_impl_header("Lower", ident, udl_mode);
     let lift_impl_spec = tagged_impl_header("Lift", ident, udl_mode);
+    let type_id_impl_spec = tagged_impl_header("TypeId", ident, udl_mode);
     let derive_ffi_traits = derive_ffi_traits(ident, udl_mode, &["ConvertError"]);
     let mod_path = match mod_path() {
         Ok(p) => p,
@@ -126,10 +127,6 @@ fn flat_error_ffi_converter_impl(
                 fn lower(obj: Self) -> ::uniffi::RustBuffer {
                     <Self as ::uniffi::Lower<crate::UniFfiTag>>::lower_into_rust_buffer(obj)
                 }
-
-                const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_ENUM)
-                    .concat_str(#mod_path)
-                    .concat_str(#name);
             }
         }
     };
@@ -158,10 +155,7 @@ fn flat_error_ffi_converter_impl(
                 fn try_lift(v: ::uniffi::RustBuffer) -> ::uniffi::deps::anyhow::Result<Self> {
                     <Self as ::uniffi::Lift<crate::UniFfiTag>>::try_lift_from_rust_buffer(v)
                 }
-
-                const TYPE_ID_META: ::uniffi::MetadataBuffer = <Self as ::uniffi::Lower<crate::UniFfiTag>>::TYPE_ID_META;
             }
-
         }
     } else {
         quote! {
@@ -183,8 +177,6 @@ fn flat_error_ffi_converter_impl(
                 fn try_lift(v: ::uniffi::RustBuffer) -> ::uniffi::deps::anyhow::Result<Self> {
                     panic!("Can't lift flat errors")
                 }
-
-                const TYPE_ID_META: ::uniffi::MetadataBuffer = <Self as ::uniffi::Lower<crate::UniFfiTag>>::TYPE_ID_META;
             }
         }
     };
@@ -192,6 +184,14 @@ fn flat_error_ffi_converter_impl(
     quote! {
         #lower_impl
         #lift_impl
+
+        #[automatically_derived]
+        #type_id_impl_spec {
+            const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_ENUM)
+                .concat_str(#mod_path)
+                .concat_str(#name);
+        }
+
         #derive_ffi_traits
     }
 }

--- a/uniffi_macros/src/export/callback_interface.rs
+++ b/uniffi_macros/src/export/callback_interface.rs
@@ -135,6 +135,7 @@ pub fn ffi_converter_callback_interface_impl(
     let dyn_trait = quote! { dyn #trait_ident };
     let box_dyn_trait = quote! { ::std::boxed::Box<#dyn_trait> };
     let lift_impl_spec = tagged_impl_header("Lift", &box_dyn_trait, udl_mode);
+    let type_id_impl_spec = tagged_impl_header("TypeId", &box_dyn_trait, udl_mode);
     let derive_ffi_traits = derive_ffi_traits(&box_dyn_trait, udl_mode, &["LiftRef", "LiftReturn"]);
     let mod_path = match mod_path() {
         Ok(p) => p,
@@ -156,7 +157,11 @@ pub fn ffi_converter_callback_interface_impl(
                 ::uniffi::check_remaining(buf, 8)?;
                 <Self as ::uniffi::Lift<crate::UniFfiTag>>::try_lift(buf.get_u64())
             }
+        }
 
+        #[doc(hidden)]
+        #[automatically_derived]
+        #type_id_impl_spec {
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(
                 ::uniffi::metadata::codes::TYPE_CALLBACK_INTERFACE,
             )
@@ -256,7 +261,7 @@ pub(super) fn metadata_items(
 
     iter::once(Ok(callback_interface_items))
         .chain(items.iter().map(|item| match item {
-            ImplItem::Method(sig) => sig.metadata_items_for_callback_interface(),
+            ImplItem::Method(sig) => sig.metadata_items(),
             _ => unreachable!("traits have no constructors"),
         }))
         .collect()

--- a/uniffi_macros/src/fnsig.rs
+++ b/uniffi_macros/src/fnsig.rs
@@ -271,7 +271,7 @@ impl FnSignature {
                     .concat_bool(#is_async)
                     .concat_value(#args_len)
                     #(#arg_metadata_calls)*
-                    .concat(<#return_ty as ::uniffi::LowerReturn<crate::UniFfiTag>>::TYPE_ID_META)
+                    .concat(<#return_ty as ::uniffi::TypeId<crate::UniFfiTag>>::TYPE_ID_META)
                     .concat_long_str(#docstring)
             }),
 
@@ -285,7 +285,7 @@ impl FnSignature {
                         .concat_bool(#is_async)
                         .concat_value(#args_len)
                         #(#arg_metadata_calls)*
-                        .concat(<#return_ty as ::uniffi::LowerReturn<crate::UniFfiTag>>::TYPE_ID_META)
+                        .concat(<#return_ty as ::uniffi::TypeId<crate::UniFfiTag>>::TYPE_ID_META)
                         .concat_long_str(#docstring)
                 })
             }
@@ -301,7 +301,7 @@ impl FnSignature {
                         .concat_bool(#is_async)
                         .concat_value(#args_len)
                         #(#arg_metadata_calls)*
-                        .concat(<#return_ty as ::uniffi::LowerReturn<crate::UniFfiTag>>::TYPE_ID_META)
+                        .concat(<#return_ty as ::uniffi::TypeId<crate::UniFfiTag>>::TYPE_ID_META)
                         .concat_long_str(#docstring)
                 })
             }
@@ -316,7 +316,7 @@ impl FnSignature {
                         .concat_bool(#is_async)
                         .concat_value(#args_len)
                         #(#arg_metadata_calls)*
-                        .concat(<#return_ty as ::uniffi::LowerReturn<crate::UniFfiTag>>::TYPE_ID_META)
+                        .concat(<#return_ty as ::uniffi::TypeId<crate::UniFfiTag>>::TYPE_ID_META)
                         .concat_long_str(#docstring)
                 })
             }
@@ -362,69 +362,6 @@ impl FnSignature {
                     Some(self.checksum_symbol_name()),
                 ))
             }
-        }
-    }
-
-    /// Generate metadata items for callback interfaces
-    ///
-    /// Unfortunately, most of this is duplicate code from [Self::metadata_items] and
-    /// [Self::metadata_expr].  However, one issue with that code is that it needs to assume if the
-    /// arguments are being lifted vs lowered in order to get TYPE_ID_META.  That code uses
-    /// `<Type as Lift>::TYPE_ID_META` for arguments and `<Type as LowerReturn>::TYPE_ID_META` for
-    /// return types, which works for accidental/historical reasons.
-    ///
-    /// The one exception is callback interfaces (#1947), which are handled by this method.
-    ///
-    /// TODO: fix the metadata system so that this is not needed.
-    pub(crate) fn metadata_items_for_callback_interface(&self) -> syn::Result<TokenStream> {
-        let Self {
-            name,
-            return_ty,
-            is_async,
-            mod_path,
-            docstring,
-            ..
-        } = &self;
-        match &self.kind {
-            FnKind::TraitMethod {
-                self_ident, index, ..
-            } => {
-                let object_name = ident_to_string(self_ident);
-                let args_len = try_metadata_value_from_usize(
-                    // Use param_lifts to calculate this instead of sig.inputs to avoid counting any self
-                    // params
-                    self.args.len(),
-                    "UniFFI limits functions to 256 arguments",
-                )?;
-                let arg_metadata_calls = self
-                    .args
-                    .iter()
-                    .map(NamedArg::arg_metadata)
-                    .collect::<syn::Result<Vec<_>>>()?;
-                let metadata_expr = quote! {
-                    ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TRAIT_METHOD)
-                        .concat_str(#mod_path)
-                        .concat_str(#object_name)
-                        .concat_u32(#index)
-                        .concat_str(#name)
-                        .concat_bool(#is_async)
-                        .concat_value(#args_len)
-                        #(#arg_metadata_calls)*
-                        .concat(<#return_ty as ::uniffi::LiftReturn<crate::UniFfiTag>>::TYPE_ID_META)
-                        .concat_long_str(#docstring)
-                };
-                Ok(create_metadata_items(
-                    "method",
-                    &format!("{object_name}_{name}"),
-                    metadata_expr,
-                    Some(self.checksum_symbol_name()),
-                ))
-            }
-
-            // This should never happen and indicates an error in the internal code
-            _ => panic!(
-                "metadata_items_for_callback_interface can only be called with `TraitMethod` sigs"
-            ),
         }
     }
 
@@ -548,11 +485,11 @@ impl NamedArg {
 
     pub(crate) fn arg_metadata(&self) -> syn::Result<TokenStream> {
         let name = &self.name;
-        let lift_impl = self.lift_impl();
+        let ty = &self.ty;
         let default_calls = default_value_metadata_calls(&self.default)?;
         Ok(quote! {
             .concat_str(#name)
-            .concat(#lift_impl::TYPE_ID_META)
+            .concat(<#ty as ::uniffi::TypeId<crate::UniFfiTag>>::TYPE_ID_META)
             #default_calls
         })
     }

--- a/uniffi_macros/src/object.rs
+++ b/uniffi_macros/src/object.rs
@@ -64,6 +64,7 @@ pub(crate) fn interface_impl(ident: &Ident, udl_mode: bool) -> TokenStream {
     let name = ident_to_string(ident);
     let impl_spec = tagged_impl_header("FfiConverterArc", ident, udl_mode);
     let lower_return_impl_spec = tagged_impl_header("LowerReturn", ident, udl_mode);
+    let type_id_impl_spec = tagged_impl_header("TypeId", ident, udl_mode);
     let lift_ref_impl_spec = tagged_impl_header("LiftRef", ident, udl_mode);
     let mod_path = match mod_path() {
         Ok(p) => p,
@@ -142,12 +143,14 @@ pub(crate) fn interface_impl(ident: &Ident, udl_mode: bool) -> TokenStream {
             fn lower_return(obj: Self) -> ::std::result::Result<Self::ReturnType, ::uniffi::RustBuffer> {
                 Ok(<Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::lower(::std::sync::Arc::new(obj)))
             }
-
-            const TYPE_ID_META: ::uniffi::MetadataBuffer = <Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::TYPE_ID_META;
         }
 
         unsafe #lift_ref_impl_spec {
             type LiftType = ::std::sync::Arc<Self>;
+        }
+
+        #type_id_impl_spec {
+            const TYPE_ID_META: ::uniffi::MetadataBuffer = <Self as ::uniffi::FfiConverterArc<crate::UniFfiTag>>::TYPE_ID_META;
         }
     }
 }

--- a/uniffi_macros/src/record.rs
+++ b/uniffi_macros/src/record.rs
@@ -132,7 +132,7 @@ pub(crate) fn record_meta_static_var(
             // TYPE_ID_META should be the same for both traits.
             Ok(quote! {
                 .concat_str(#name)
-                .concat(<#ty as ::uniffi::Lower<crate::UniFfiTag>>::TYPE_ID_META)
+                .concat(<#ty as ::uniffi::TypeId<crate::UniFfiTag>>::TYPE_ID_META)
                 #default
                 .concat_long_str(#docstring)
             })


### PR DESCRIPTION
The metadata code now uses this trait to get the `TYPE_ID_METADATA` rather than Lift/Lower.  This feels cleaner, since it was often not clear which trait to use before. This removes the hacky handling of type id metadata for callback interfaces that I added in #1950.

Let's not merge this until after 0.26.0 is released.  It feels like too big of a change at this point in the process.