### PR TITLE
One more change for the 0.26.0 release

### DIFF
--- a/uniffi_udl/Cargo.toml
+++ b/uniffi_udl/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 
 [dependencies]
 anyhow = "1"
-weedle2 = { version = "4.0.0", path = "../weedle2" }
+weedle2 = { version = "4.0.1", path = "../weedle2" }
 textwrap = "0.16"
 uniffi_meta = { path = "../uniffi_meta", version = "=0.26.0" }
 uniffi_testing = { path = "../uniffi_testing", version = "=0.26.0" }

--- a/weedle2/Cargo.toml
+++ b/weedle2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weedle2"
-version = "4.0.0"
+version = "4.0.1"
 authors = ["Sharad Chand <sharad.d.chand@gmail.com>", "Jan-Erik Rediger <jrediger@mozilla.com>"]
 description = "A WebIDL Parser"
 license = "MIT"


### PR DESCRIPTION
After merging the changes, `cargo publish` failed for me.  I'm pretty sure it's because it's not pulling in the new weedle changes.  I believe we can fix this by bumping the weedle version, publishing that, then publishing the rest of the crates.