### PR TITLE
Destroy argument buffer after invoking a foreign callback

### DIFF
--- a/uniffi_core/src/ffi/callbackinterface.rs
+++ b/uniffi_core/src/ffi/callbackinterface.rs
@@ -182,6 +182,7 @@ impl ForeignCallbackInternals {
                 &mut ret_rbuf,
             )
         };
+        RustBuffer::destroy(args);
         let result = CallbackResult::try_from(raw_result)
             .unwrap_or_else(|code| panic!("Callback failed with unexpected return code: {code}"));
         match result {


### PR DESCRIPTION
I guess the good thing about making a 0.26.1 release is that we can get this fix in.