### PR TITLE
Bump weedle2 to 5.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "weedle2"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "fs-err",
  "nom",

--- a/uniffi_udl/Cargo.toml
+++ b/uniffi_udl/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 
 [dependencies]
 anyhow = "1"
-weedle2 = { version = "4.0.1", path = "../weedle2" }
+weedle2 = { version = "5.0.0", path = "../weedle2" }
 textwrap = "0.16"
 uniffi_meta = { path = "../uniffi_meta", version = "=0.26.0" }
 uniffi_testing = { path = "../uniffi_testing", version = "=0.26.0" }

--- a/weedle2/Cargo.toml
+++ b/weedle2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weedle2"
-version = "4.0.1"
+version = "5.0.0"
 authors = ["Sharad Chand <sharad.d.chand@gmail.com>", "Jan-Erik Rediger <jrediger@mozilla.com>"]
 description = "A WebIDL Parser"
 license = "MIT"

--- a/weedle2/README.md
+++ b/weedle2/README.md
@@ -28,7 +28,7 @@ Parses valid WebIDL definitions & produces a data structure starting from
 
 ```toml
 [dependencies]
-weedle2 = "4.0.0"
+weedle2 = "5.0.0"
 ```
 
 ### `src/main.rs`


### PR DESCRIPTION
(Backported from the release-v0.26.x branch)

This was previously published as weedle 4.0.1, but this change was actually breaking:

https://github.com/mozilla/uniffi-rs/commit/bf9097cc2f8ef0ec37fd37795a0eeb3e26bbffe5#diff-389c79acae386eb845b5e78c7a4b3e284837370f5afb4e31daf5455c8cb200f9R238

I yanked the 4.0.1 release, let's release this with a new major version instead.