### PR TITLE
Use iterator in generated Kotlin to maintain Android API level 22 compatibility

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/SequenceTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/SequenceTemplate.kt
@@ -16,7 +16,7 @@ public object {{ ffi_converter_name }}: FfiConverterRustBuffer<List<{{ inner_typ
 
     override fun write(value: List<{{ inner_type_name }}>, buf: ByteBuffer) {
         buf.putInt(value.size)
-        value.forEach {
+        value.iterator().forEach {
             {{ inner_type|write_fn }}(it, buf)
         }
     }


### PR DESCRIPTION
The `forEach` here was not introduced until API level 24, this small tweak helps to maintain compatibility.

Tested via `cargo test` as well as in our own project (https://github.com/xmtp/libxmtp).