### PR TITLE
Add more errors when #[uniffi] attributes are used incorrectly.

### DIFF
--- a/fixtures/uitests/tests/ui/export_attrs.rs
+++ b/fixtures/uitests/tests/ui/export_attrs.rs
@@ -1,6 +1,6 @@
 fn main() {} /* empty main required by `trybuild` */
 
-#[uniffi::constructor] // <--- should be an error!
+#[uniffi::constructor] // <--- would ideally be an error.
 // Someone might try to 'export' a struct instead of deriving it.
 #[uniffi::export]
 struct S {}
@@ -16,5 +16,23 @@ impl Object {}
 
 #[uniffi::export(with_foreign)]
 fn foreign() {}
+
+#[derive(uniffi::Record)]
+// Records have explicit `#[uniffi()]` handling.
+#[uniffi(flat_error)]
+pub struct One {}
+
+#[derive(uniffi::Record)]
+pub struct Two {
+    #[uniffi(flat_error)]
+    inner: i32,
+}
+
+#[derive(thiserror::Error, uniffi::Error, Debug)]
+pub enum Error {
+    #[error("Oops")]
+    #[uniffi(flat_error)]
+    Oops,
+}
 
 uniffi_macros::setup_scaffolding!();

--- a/fixtures/uitests/tests/ui/export_attrs.stderr
+++ b/fixtures/uitests/tests/ui/export_attrs.stderr
@@ -23,3 +23,21 @@ error: uniffi::export attribute `with_foreign` is not supported here.
    |
 17 | #[uniffi::export(with_foreign)]
    |                  ^^^^^^^^^^^^
+
+error: attribute arguments are not currently recognized in this position
+  --> tests/ui/export_attrs.rs:22:10
+   |
+22 | #[uniffi(flat_error)]
+   |          ^^^^^^^^^^
+
+error: expected `default`
+  --> tests/ui/export_attrs.rs:27:14
+   |
+27 |     #[uniffi(flat_error)]
+   |              ^^^^^^^^^^
+
+error: attribute arguments are not currently recognized in this position
+  --> tests/ui/export_attrs.rs:34:14
+   |
+34 |     #[uniffi(flat_error)]
+   |              ^^^^^^^^^^

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -5,9 +5,6 @@
 #![warn(rust_2018_idioms, unused_qualifications)]
 
 //! Macros for `uniffi`.
-//!
-//! Currently this is just for easily generating integration tests, but maybe
-//! we'll put some other code-annotation helper macros in here at some point.
 
 use camino::Utf8Path;
 use proc_macro::TokenStream;
@@ -369,14 +366,16 @@ pub fn generate_and_include_scaffolding(udl_file: TokenStream) -> TokenStream {
     }.into()
 }
 
-/// A dummy macro that does nothing.
+/// An attribute for constructors.
+///
+/// Constructors are in `impl` blocks which have a `#[uniffi::export]` attribute,
 ///
 /// This exists so `#[uniffi::export]` can emit its input verbatim without
-/// causing unexpected errors, plus some extra code in case everything is okay.
+/// causing unexpected errors in the entire exported block.
+/// This happens very often when the proc-macro is run on an incomplete
+/// input by rust-analyzer while the developer is typing.
 ///
-/// It is important for `#[uniffi::export]` to not raise unexpected errors if it
-/// fails to parse the input as this happens very often when the proc-macro is
-/// run on an incomplete input by rust-analyzer while the developer is typing.
+/// So much better to do nothing here then let the impl block find the attribute.
 #[proc_macro_attribute]
 pub fn constructor(_attrs: TokenStream, input: TokenStream) -> TokenStream {
     input

--- a/uniffi_macros/src/record.rs
+++ b/uniffi_macros/src/record.rs
@@ -12,6 +12,9 @@ use crate::util::{
 };
 
 pub fn expand_record(input: DeriveInput, udl_mode: bool) -> syn::Result<TokenStream> {
+    if let Some(e) = input.attrs.uniffi_attr_args_not_allowed_here() {
+        return Err(e);
+    }
     let record = match input.data {
         Data::Struct(s) => s,
         _ => {

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -151,13 +151,7 @@ pub fn parse_comma_separated<T: UniffiAttributeArgs>(input: ParseStream<'_>) -> 
 }
 
 #[derive(Default)]
-pub struct ArgumentNotAllowedHere;
-
-impl Parse for ArgumentNotAllowedHere {
-    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        parse_comma_separated(input)
-    }
-}
+struct ArgumentNotAllowedHere;
 
 impl UniffiAttributeArgs for ArgumentNotAllowedHere {
     fn parse_one(input: ParseStream<'_>) -> syn::Result<Self> {
@@ -252,7 +246,6 @@ pub mod kw {
     syn::custom_keyword!(async_runtime);
     syn::custom_keyword!(callback_interface);
     syn::custom_keyword!(with_foreign);
-    syn::custom_keyword!(constructor);
     syn::custom_keyword!(default);
     syn::custom_keyword!(flat_error);
     syn::custom_keyword!(None);


### PR DESCRIPTION
I added some more explicit errors when uniffi attributes are used incorrectly.

I started out seeing if I could do the same for `#[uniffi::constructor]`, but I don't think I can. I updated the comments for this attribute - I *think* the old comment was stale, but I'm really not sure how accurate my new comment is - after updating the uitest I realized I really don't understand things well at all.

@jplatte do you mind checking that the comments I removed were indeed stale, and that the comments I added are at least an improvement? Any insights to make the comments more accurate would obviously be welcome too.