### PR TITLE
Swift open classes

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -139,7 +139,7 @@ open class {{ impl_class_name }}:
         )
     }
     {%-         when UniffiTrait::Eq { eq, ne } %}
-    open static func == (lhs: {{ impl_class_name }}, other: {{ impl_class_name }}) -> Bool {
+    public static func == (lhs: {{ impl_class_name }}, other: {{ impl_class_name }}) -> Bool {
         return {% call swift::try(eq) %} {{ eq.return_type().unwrap()|lift_fn }}(
             {% call swift::to_ffi_call_with_prefix("lhs.uniffiClonePointer()", eq) %}
         )


### PR DESCRIPTION
With https://github.com/mozilla/uniffi-rs/pull/1918 in limbo and based on [this comment](https://github.com/mozilla/uniffi-rs/pull/1918#issuecomment-1872161231) I went ahead and extracted out only the bits that open up generated swift classes. 
This shouldn't be controversial and will allow us to mock client side.

Previously done for Kotlin here https://github.com/mozilla/uniffi-rs/pull/1815