### PR TITLE
fix: Prevent Vec capacity from triggering panics in RustBuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### What's fixed?
  
 - Fixed a memory leak in callback interface handling.
+- Prevent `Vec<u8>` capacity from unecessarily triggering panics in `RustBuffer::from_vec`
 
 ### ⚠️ Breaking Changes for external bindings authors ⚠️
 

--- a/uniffi_core/src/ffi/rustbuffer.rs
+++ b/uniffi_core/src/ffi/rustbuffer.rs
@@ -230,7 +230,7 @@ pub fn uniffi_rustbuffer_from_bytes(
         let bytes = bytes.as_slice();
         let mut bytes = bytes.to_vec();
         bytes.shrink_to(i32::MAX as usize);
-        Ok(RustBuffer::from_vec(bytes.to_vec()))
+        Ok(RustBuffer::from_vec(bytes))
     })
 }
 

--- a/uniffi_core/src/ffi/rustbuffer.rs
+++ b/uniffi_core/src/ffi/rustbuffer.rs
@@ -228,6 +228,8 @@ pub fn uniffi_rustbuffer_from_bytes(
 ) -> RustBuffer {
     rust_call(call_status, || {
         let bytes = bytes.as_slice();
+        let mut bytes = bytes.to_vec();
+        bytes.shrink_to(i32::MAX as usize);
         Ok(RustBuffer::from_vec(bytes.to_vec()))
     })
 }
@@ -254,7 +256,8 @@ pub fn uniffi_rustbuffer_free(buf: RustBuffer, call_status: &mut RustCallStatus)
 ///
 /// The second argument must be the minimum number of *additional* bytes to reserve
 /// capacity for in the buffer; it is likely to reserve additional capacity in practice
-/// due to amortized growth strategy of Rust vectors.
+/// due to amortized growth strategy of Rust vectors. If the additional capacity  exceeds
+/// i32::MAX, the buffer will be reallocated to have exactly i32::MAX capacity.
 ///
 /// # Safety
 /// The first argument *must* be a uniquely-owned `RustBuffer` previously obtained from a call
@@ -271,6 +274,7 @@ pub fn uniffi_rustbuffer_reserve(
             .expect("additional buffer length negative or overflowed");
         let mut v = buf.destroy_into_vec();
         v.reserve(additional);
+        v.shrink_to(i32::MAX as usize);
         Ok(RustBuffer::from_vec(v))
     })
 }

--- a/uniffi_core/src/ffi_converter_traits.rs
+++ b/uniffi_core/src/ffi_converter_traits.rs
@@ -247,6 +247,7 @@ pub unsafe trait Lower<UT>: Sized {
     fn lower_into_rust_buffer(obj: Self) -> RustBuffer {
         let mut buf = ::std::vec::Vec::new();
         Self::write(obj, &mut buf);
+        buf.shrink_to(i32::MAX as usize);
         RustBuffer::from_vec(buf)
     }
 


### PR DESCRIPTION
This is a proposal to help fix #1976. We use `Vec.shrink_to` to impose a ceiling on vector capacity that is in line with the max `RustBuffer::from_vec` can handle.