### PR TITLE
Change RustBuffer length/capacity to `u64` (#1976)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 - Procmacros support tuple-enums.
 
+- `RustBuffer` was changed to use `u64` fields.
+  This eliminates panics when the capacity of the vec exceeds `i32::MAX`.
+  This can happen with the current Vec implementation when String/Vec sizes approach `i32::MAX` but don't exceed it.
+
 ### What's fixed?
  
 - Fixed a memory leak in callback interface handling.
@@ -38,6 +42,7 @@
   types including:
   - Rust futures (replacing `FfiType::RustFutureHandle` which was removed)
   - Rust future continuation data (Replacing `FfiType::RustFutureContinuationData` which was moved).
+- `RustBuffer.len` and `RustBuffer.capacity` are now `u64` rather than `i32`.
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.26.1...HEAD).
 

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -659,7 +659,7 @@ mod filters {
             }) => {
                 // Need to convert the RustBuffer from our package to the RustBuffer of the external package
                 let suffix = KotlinCodeOracle.class_name(ci, &name);
-                format!("{call}.let {{ RustBuffer{suffix}.create(it.capacity, it.len, it.data) }}")
+                format!("{call}.let {{ RustBuffer{suffix}.create(it.capacity.toULong(), it.len.toULong(), it.data) }}")
             }
             _ => call,
         };

--- a/uniffi_bindgen/src/bindings/kotlin/templates/BooleanHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/BooleanHelper.kt
@@ -11,7 +11,7 @@ public object FfiConverterBoolean: FfiConverter<Boolean, Byte> {
         return if (value) 1.toByte() else 0.toByte()
     }
 
-    override fun allocationSize(value: Boolean) = 1
+    override fun allocationSize(value: Boolean) = 1UL
 
     override fun write(value: Boolean, buf: ByteBuffer) {
         buf.put(lower(value))

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ByteArrayHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ByteArrayHelper.kt
@@ -5,8 +5,8 @@ public object FfiConverterByteArray: FfiConverterRustBuffer<ByteArray> {
         buf.get(byteArr)
         return byteArr
     }
-    override fun allocationSize(value: ByteArray): Int {
-        return 4 + value.size
+    override fun allocationSize(value: ByteArray): ULong {
+        return 4UL + value.size.toULong()
     }
     override fun write(value: ByteArray, buf: ByteBuffer) {
         buf.putInt(value.size)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceRuntime.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceRuntime.kt
@@ -21,7 +21,7 @@ public abstract class FfiConverterCallbackInterface<CallbackInterface: Any>: Ffi
 
     override fun lower(value: CallbackInterface) = handleMap.insert(value)
 
-    override fun allocationSize(value: CallbackInterface) = 8
+    override fun allocationSize(value: CallbackInterface) = 8UL
 
     override fun write(value: CallbackInterface, buf: ByteBuffer) {
         buf.putLong(lower(value))

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CustomTypeTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CustomTypeTemplate.kt
@@ -49,7 +49,7 @@ public object {{ ffi_converter_name }}: FfiConverter<{{ name }}, {{ ffi_type_nam
         return {{ config.into_custom.render("builtinValue") }}
     }
 
-    override fun allocationSize(value: {{ name }}): Int {
+    override fun allocationSize(value: {{ name }}): ULong {
         val builtinValue = {{ config.from_custom.render("value") }}
         return {{ builtin|allocation_size_fn }}(builtinValue)
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/DurationHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/DurationHelper.kt
@@ -14,7 +14,7 @@ public object FfiConverterDuration: FfiConverterRustBuffer<java.time.Duration> {
     }
 
     // 8 bytes for seconds, 4 bytes for nanoseconds
-    override fun allocationSize(value: java.time.Duration) = 12
+    override fun allocationSize(value: java.time.Duration) = 12UL
 
     override fun write(value: java.time.Duration, buf: ByteBuffer) {
         if (value.seconds < 0) {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
@@ -34,7 +34,7 @@ public object {{ e|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}
         throw RuntimeException("invalid enum value, something is very wrong!!", e)
     }
 
-    override fun allocationSize(value: {{ type_name }}) = 4
+    override fun allocationSize(value: {{ type_name }}) = 4UL
 
     override fun write(value: {{ type_name }}, buf: ByteBuffer) {
         buf.putInt(value.ordinal + 1)
@@ -99,7 +99,7 @@ public object {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }
         is {{ type_name }}.{{ variant|type_name(ci) }} -> {
             // Add the size for the Int that specifies the variant plus the size needed for all fields
             (
-                4
+                4UL
                 {%- for field in variant.fields() %}
                 + {{ field|allocation_size_fn }}(value.{%- call kt::field_name(field, loop.index) -%})
                 {%- endfor %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
@@ -78,15 +78,15 @@ public object {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }
         {%- endif %}
     }
 
-    override fun allocationSize(value: {{ type_name }}): Int {
+    override fun allocationSize(value: {{ type_name }}): ULong {
         {%- if e.is_flat() %}
-        return 4
+        return 4UL
         {%- else %}
         return when(value) {
             {%- for variant in e.variants() %}
             is {{ type_name }}.{{ variant|error_variant_name }} -> (
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
-                4
+                4UL
                 {%- for field in variant.fields() %}
                 + {{ field|allocation_size_fn }}(value.{{ field.name()|var_name }})
                 {%- endfor %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/FfiConverterTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/FfiConverterTemplate.kt
@@ -20,7 +20,7 @@ public interface FfiConverter<KotlinType, FfiType> {
     // encoding, so we pessimistically allocate the largest size possible (3
     // bytes per codepoint).  Allocating extra bytes is not really a big deal
     // because the `RustBuffer` is short-lived.
-    fun allocationSize(value: KotlinType): Int
+    fun allocationSize(value: KotlinType): ULong
 
     // Write a Kotlin type to a `ByteBuffer`
     fun write(value: KotlinType, buf: ByteBuffer)
@@ -34,11 +34,11 @@ public interface FfiConverter<KotlinType, FfiType> {
     fun lowerIntoRustBuffer(value: KotlinType): RustBuffer.ByValue {
         val rbuf = RustBuffer.alloc(allocationSize(value))
         try {
-            val bbuf = rbuf.data!!.getByteBuffer(0, rbuf.capacity.toLong()).also {
+            val bbuf = rbuf.data!!.getByteBuffer(0, rbuf.capacity).also {
                 it.order(ByteOrder.BIG_ENDIAN)
             }
             write(value, bbuf)
-            rbuf.writeField("len", bbuf.position())
+            rbuf.writeField("len", bbuf.position().toLong())
             return rbuf
         } catch (e: Throwable) {
             RustBuffer.free(rbuf)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Float32Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Float32Helper.kt
@@ -11,7 +11,7 @@ public object FfiConverterFloat: FfiConverter<Float, Float> {
         return value
     }
 
-    override fun allocationSize(value: Float) = 4
+    override fun allocationSize(value: Float) = 4UL
 
     override fun write(value: Float, buf: ByteBuffer) {
         buf.putFloat(value)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Float64Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Float64Helper.kt
@@ -11,7 +11,7 @@ public object FfiConverterDouble: FfiConverter<Double, Double> {
         return value
     }
 
-    override fun allocationSize(value: Double) = 8
+    override fun allocationSize(value: Double) = 8UL
 
     override fun write(value: Double, buf: ByteBuffer) {
         buf.putDouble(value)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Int16Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Int16Helper.kt
@@ -11,7 +11,7 @@ public object FfiConverterShort: FfiConverter<Short, Short> {
         return value
     }
 
-    override fun allocationSize(value: Short) = 2
+    override fun allocationSize(value: Short) = 2UL
 
     override fun write(value: Short, buf: ByteBuffer) {
         buf.putShort(value)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Int32Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Int32Helper.kt
@@ -11,7 +11,7 @@ public object FfiConverterInt: FfiConverter<Int, Int> {
         return value
     }
 
-    override fun allocationSize(value: Int) = 4
+    override fun allocationSize(value: Int) = 4UL
 
     override fun write(value: Int, buf: ByteBuffer) {
         buf.putInt(value)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Int64Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Int64Helper.kt
@@ -11,7 +11,7 @@ public object FfiConverterLong: FfiConverter<Long, Long> {
         return value
     }
 
-    override fun allocationSize(value: Long) = 8
+    override fun allocationSize(value: Long) = 8UL
 
     override fun write(value: Long, buf: ByteBuffer) {
         buf.putLong(value)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Int8Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Int8Helper.kt
@@ -11,7 +11,7 @@ public object FfiConverterByte: FfiConverter<Byte, Byte> {
         return value
     }
 
-    override fun allocationSize(value: Byte) = 1
+    override fun allocationSize(value: Byte) = 1UL
 
     override fun write(value: Byte, buf: ByteBuffer) {
         buf.put(value)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/MapTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/MapTemplate.kt
@@ -12,8 +12,8 @@ public object {{ ffi_converter_name }}: FfiConverterRustBuffer<Map<{{ key_type_n
         }
     }
 
-    override fun allocationSize(value: Map<{{ key_type_name }}, {{ value_type_name }}>): Int {
-        val spaceForMapSize = 4
+    override fun allocationSize(value: Map<{{ key_type_name }}, {{ value_type_name }}>): ULong {
+        val spaceForMapSize = 4UL
         val spaceForChildren = value.map { (k, v) ->
             {{ key_type|allocation_size_fn }}(k) +
             {{ value_type|allocation_size_fn }}(v)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -350,7 +350,7 @@ public object {{ ffi_converter_name }}: FfiConverter<{{ type_name }}, Pointer> {
         return lift(Pointer(buf.getLong()))
     }
 
-    override fun allocationSize(value: {{ type_name }}) = 8
+    override fun allocationSize(value: {{ type_name }}) = 8UL
 
     override fun write(value: {{ type_name }}, buf: ByteBuffer) {
         // The Rust code always expects pointers written as 8 bytes,

--- a/uniffi_bindgen/src/bindings/kotlin/templates/OptionalTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/OptionalTemplate.kt
@@ -8,11 +8,11 @@ public object {{ ffi_converter_name }}: FfiConverterRustBuffer<{{ inner_type_nam
         return {{ inner_type|read_fn }}(buf)
     }
 
-    override fun allocationSize(value: {{ inner_type_name }}?): Int {
+    override fun allocationSize(value: {{ inner_type_name }}?): ULong {
         if (value == null) {
-            return 1
+            return 1UL
         } else {
-            return 1 + {{ inner_type|allocation_size_fn }}(value)
+            return 1UL + {{ inner_type|allocation_size_fn }}(value)
         }
     }
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
@@ -53,7 +53,7 @@ public object {{ rec|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name 
         {%- for field in rec.fields() %}
             {{ field|allocation_size_fn }}(value.{{ field.name()|var_name }}){% if !loop.last %} +{% endif %}
         {%- endfor %}
-    ) {%- else %} 0 {%- endif %}
+    ) {%- else %} 0UL {%- endif %}
 
     override fun write(value: {{ type_name }}, buf: ByteBuffer) {
         {%- for field in rec.fields() %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
@@ -4,8 +4,10 @@
 
 @Structure.FieldOrder("capacity", "len", "data")
 open class RustBuffer : Structure() {
-    @JvmField var capacity: Int = 0
-    @JvmField var len: Int = 0
+    // Note: `capacity` and `len` are actually `ULong` values, but JVM only supports signed values.
+    // When dealing with these fields, make sure to call `toULong()`.
+    @JvmField var capacity: Long = 0
+    @JvmField var len: Long = 0
     @JvmField var data: Pointer? = null
 
     class ByValue: RustBuffer(), Structure.ByValue
@@ -18,18 +20,19 @@ open class RustBuffer : Structure() {
     }
 
     companion object {
-        internal fun alloc(size: Int = 0) = uniffiRustCall() { status ->
-            UniffiLib.INSTANCE.{{ ci.ffi_rustbuffer_alloc().name() }}(size, status)
+        internal fun alloc(size: ULong = 0UL) = uniffiRustCall() { status ->
+            // Note: need to convert the size to a `Long` value to make this work with JVM.
+            UniffiLib.INSTANCE.{{ ci.ffi_rustbuffer_alloc().name() }}(size.toLong(), status)
         }.also {
             if(it.data == null) {
                throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
            }
         }
 
-        internal fun create(capacity: Int, len: Int, data: Pointer?): RustBuffer.ByValue {
+        internal fun create(capacity: ULong, len: ULong, data: Pointer?): RustBuffer.ByValue {
             var buf = RustBuffer.ByValue()
-            buf.capacity = capacity
-            buf.len = len
+            buf.capacity = capacity.toLong()
+            buf.len = len.toLong()
             buf.data = data
             return buf
         }
@@ -59,9 +62,9 @@ class RustBufferByReference : ByReference(16) {
     fun setValue(value: RustBuffer.ByValue) {
         // NOTE: The offsets are as they are in the C-like struct.
         val pointer = getPointer()
-        pointer.setInt(0, value.capacity)
-        pointer.setInt(4, value.len)
-        pointer.setPointer(8, value.data)
+        pointer.setLong(0, value.capacity)
+        pointer.setLong(8, value.len)
+        pointer.setPointer(16, value.data)
     }
 
     /**
@@ -70,9 +73,9 @@ class RustBufferByReference : ByReference(16) {
     fun getValue(): RustBuffer.ByValue {
         val pointer = getPointer()
         val value = RustBuffer.ByValue()
-        value.writeField("capacity", pointer.getInt(0))
-        value.writeField("len", pointer.getInt(4))
-        value.writeField("data", pointer.getPointer(8))
+        value.writeField("capacity", pointer.getLong(0))
+        value.writeField("len", pointer.getLong(8))
+        value.writeField("data", pointer.getLong(16))
 
         return value
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/SequenceTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/SequenceTemplate.kt
@@ -8,8 +8,8 @@ public object {{ ffi_converter_name }}: FfiConverterRustBuffer<List<{{ inner_typ
         }
     }
 
-    override fun allocationSize(value: List<{{ inner_type_name }}>): Int {
-        val sizeForLength = 4
+    override fun allocationSize(value: List<{{ inner_type_name }}>): ULong {
+        val sizeForLength = 4UL
         val sizeForItems = value.map { {{ inner_type|allocation_size_fn }}(it) }.sum()
         return sizeForLength + sizeForItems
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/StringHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/StringHelper.kt
@@ -4,7 +4,7 @@ public object FfiConverterString: FfiConverter<String, RustBuffer.ByValue> {
     // store our length and avoid writing it out to the buffer.
     override fun lift(value: RustBuffer.ByValue): String {
         try {
-            val byteArr = ByteArray(value.len)
+            val byteArr = ByteArray(value.len.toInt())
             value.asByteBuffer()!!.get(byteArr)
             return byteArr.toString(Charsets.UTF_8)
         } finally {
@@ -31,7 +31,7 @@ public object FfiConverterString: FfiConverter<String, RustBuffer.ByValue> {
         val byteBuf = toUtf8(value)
         // Ideally we'd pass these bytes to `ffi_bytebuffer_from_bytes`, but doing so would require us
         // to copy them into a JNA `Memory`. So we might as well directly copy them into a `RustBuffer`.
-        val rbuf = RustBuffer.alloc(byteBuf.limit())
+        val rbuf = RustBuffer.alloc(byteBuf.limit().toULong())
         rbuf.asByteBuffer()!!.put(byteBuf)
         return rbuf
     }
@@ -39,9 +39,9 @@ public object FfiConverterString: FfiConverter<String, RustBuffer.ByValue> {
     // We aren't sure exactly how many bytes our string will be once it's UTF-8
     // encoded.  Allocate 3 bytes per UTF-16 code unit which will always be
     // enough.
-    override fun allocationSize(value: String): Int {
-        val sizeForLength = 4
-        val sizeForString = value.length * 3
+    override fun allocationSize(value: String): ULong {
+        val sizeForLength = 4UL
+        val sizeForString = value.length.toULong() * 3UL
         return sizeForLength + sizeForString
     }
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/TimestampHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/TimestampHelper.kt
@@ -14,7 +14,7 @@ public object FfiConverterTimestamp: FfiConverterRustBuffer<java.time.Instant> {
     }
 
     // 8 bytes for seconds, 4 bytes for nanoseconds
-    override fun allocationSize(value: java.time.Instant) = 12
+    override fun allocationSize(value: java.time.Instant) = 12UL
 
     override fun write(value: java.time.Instant, buf: ByteBuffer) {
         var epochOffset = java.time.Duration.between(java.time.Instant.EPOCH, value)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/UInt16Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/UInt16Helper.kt
@@ -11,7 +11,7 @@ public object FfiConverterUShort: FfiConverter<UShort, Short> {
         return value.toShort()
     }
 
-    override fun allocationSize(value: UShort) = 2
+    override fun allocationSize(value: UShort) = 2UL
 
     override fun write(value: UShort, buf: ByteBuffer) {
         buf.putShort(value.toShort())

--- a/uniffi_bindgen/src/bindings/kotlin/templates/UInt32Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/UInt32Helper.kt
@@ -11,7 +11,7 @@ public object FfiConverterUInt: FfiConverter<UInt, Int> {
         return value.toInt()
     }
 
-    override fun allocationSize(value: UInt) = 4
+    override fun allocationSize(value: UInt) = 4UL
 
     override fun write(value: UInt, buf: ByteBuffer) {
         buf.putInt(value.toInt())

--- a/uniffi_bindgen/src/bindings/kotlin/templates/UInt64Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/UInt64Helper.kt
@@ -11,7 +11,7 @@ public object FfiConverterULong: FfiConverter<ULong, Long> {
         return value.toLong()
     }
 
-    override fun allocationSize(value: ULong) = 8
+    override fun allocationSize(value: ULong) = 8UL
 
     override fun write(value: ULong, buf: ByteBuffer) {
         buf.putLong(value.toLong())

--- a/uniffi_bindgen/src/bindings/kotlin/templates/UInt8Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/UInt8Helper.kt
@@ -11,7 +11,7 @@ public object FfiConverterUByte: FfiConverter<UByte, Byte> {
         return value.toByte()
     }
 
-    override fun allocationSize(value: UByte) = 1
+    override fun allocationSize(value: UByte) = 1UL
 
     override fun write(value: UByte, buf: ByteBuffer) {
         buf.put(value.toByte())

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
@@ -1,8 +1,8 @@
 
 class _UniffiRustBuffer(ctypes.Structure):
     _fields_ = [
-        ("capacity", ctypes.c_int32),
-        ("len", ctypes.c_int32),
+        ("capacity", ctypes.c_uint64),
+        ("len", ctypes.c_uint64),
         ("data", ctypes.POINTER(ctypes.c_char)),
     ]
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
@@ -1,6 +1,6 @@
 class RustBuffer < FFI::Struct
-  layout :capacity, :int32,
-         :len,      :int32,
+  layout :capacity, :uint64,
+         :len,      :uint64,
          :data,     :pointer
 
   def self.alloc(size)

--- a/uniffi_bindgen/src/bindings/swift/templates/BridgingHeaderTemplate.h
+++ b/uniffi_bindgen/src/bindings/swift/templates/BridgingHeaderTemplate.h
@@ -24,8 +24,8 @@
 
 typedef struct RustBuffer
 {
-    int32_t capacity;
-    int32_t len;
+    uint64_t capacity;
+    uint64_t len;
     uint8_t *_Nullable data;
 } RustBuffer;
 

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -420,7 +420,7 @@ impl ComponentInterface {
             is_async: false,
             arguments: vec![FfiArgument {
                 name: "size".to_string(),
-                type_: FfiType::Int32,
+                type_: FfiType::UInt64,
             }],
             return_type: Some(FfiType::RustBuffer(None)),
             has_rust_call_status_arg: true,
@@ -476,7 +476,7 @@ impl ComponentInterface {
                 },
                 FfiArgument {
                     name: "additional".to_string(),
-                    type_: FfiType::Int32,
+                    type_: FfiType::UInt64,
                 },
             ],
             return_type: Some(FfiType::RustBuffer(None)),

--- a/uniffi_core/src/ffi/rustbuffer.rs
+++ b/uniffi_core/src/ffi/rustbuffer.rs
@@ -52,11 +52,11 @@ use crate::ffi::{rust_call, ForeignBytes, RustCallStatus};
 #[derive(Debug)]
 pub struct RustBuffer {
     /// The allocated capacity of the underlying `Vec<u8>`.
-    /// In Rust this is a `usize`, but we use an `i32` for compatibility with JNA.
-    capacity: i32,
+    /// In Rust this is a `usize`, but we use an `u64` to keep the foreign binding code simple.
+    capacity: u64,
     /// The occupied length of the underlying `Vec<u8>`.
-    /// In Rust this is a `usize`, but we use an `i32` for compatibility with JNA.
-    len: i32,
+    /// In Rust this is a `usize`, but we use an `u64` to keep the foreign binding code simple.
+    len: u64,
     /// The pointer to the allocated buffer of the `Vec<u8>`.
     data: *mut u8,
 }
@@ -84,7 +84,7 @@ impl RustBuffer {
     /// # Safety
     ///
     /// You must ensure that the raw parts uphold the documented invariants of this class.
-    pub unsafe fn from_raw_parts(data: *mut u8, len: i32, capacity: i32) -> Self {
+    pub unsafe fn from_raw_parts(data: *mut u8, len: u64, capacity: u64) -> Self {
         Self {
             capacity,
             len,
@@ -126,12 +126,8 @@ impl RustBuffer {
     ///
     /// Panics if the requested size is too large to fit in an `i32`, and
     /// hence would risk incompatibility with some foreign-language code.
-    pub fn new_with_size(size: usize) -> Self {
-        assert!(
-            size < i32::MAX as usize,
-            "RustBuffer requested size too large"
-        );
-        Self::from_vec(vec![0u8; size])
+    pub fn new_with_size(size: u64) -> Self {
+        Self::from_vec(vec![0u8; size as usize])
     }
 
     /// Consumes a `Vec<u8>` and returns its raw parts as a `RustBuffer`.
@@ -144,8 +140,8 @@ impl RustBuffer {
     /// Panics if the vector's length or capacity are too large to fit in an `i32`,
     /// and hence would risk incompatibility with some foreign-language code.
     pub fn from_vec(v: Vec<u8>) -> Self {
-        let capacity = i32::try_from(v.capacity()).expect("buffer capacity cannot fit into a i32.");
-        let len = i32::try_from(v.len()).expect("buffer length cannot fit into a i32.");
+        let capacity = u64::try_from(v.capacity()).expect("buffer capacity cannot fit into a u64.");
+        let len = u64::try_from(v.len()).expect("buffer length cannot fit into a u64.");
         let mut v = std::mem::ManuallyDrop::new(v);
         unsafe { Self::from_raw_parts(v.as_mut_ptr(), len, capacity) }
     }
@@ -208,10 +204,8 @@ impl Default for RustBuffer {
 /// to the foreign-language code as a `RustBuffer` struct. Callers must eventually
 /// free the resulting buffer, either by explicitly calling [`uniffi_rustbuffer_free`] defined
 /// below, or by passing ownership of the buffer back into Rust code.
-pub fn uniffi_rustbuffer_alloc(size: i32, call_status: &mut RustCallStatus) -> RustBuffer {
-    rust_call(call_status, || {
-        Ok(RustBuffer::new_with_size(size.max(0) as usize))
-    })
+pub fn uniffi_rustbuffer_alloc(size: u64, call_status: &mut RustCallStatus) -> RustBuffer {
+    rust_call(call_status, || Ok(RustBuffer::new_with_size(size)))
 }
 
 /// This helper copies bytes owned by the foreign-language code into a new byte buffer owned
@@ -262,7 +256,7 @@ pub fn uniffi_rustbuffer_free(buf: RustBuffer, call_status: &mut RustCallStatus)
 /// corrupting the allocator state.
 pub fn uniffi_rustbuffer_reserve(
     buf: RustBuffer,
-    additional: i32,
+    additional: u64,
     call_status: &mut RustCallStatus,
 ) -> RustBuffer {
     rust_call(call_status, || {
@@ -323,24 +317,6 @@ mod test {
     fn test_rustbuffer_null_must_have_zero_length() {
         // We guard against foreign-language code providing this kind of invalid struct.
         let rbuf = unsafe { RustBuffer::from_raw_parts(std::ptr::null_mut(), 12, 0) };
-        rbuf.destroy_into_vec();
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_rustbuffer_provided_capacity_must_be_non_negative() {
-        // We guard against foreign-language code providing this kind of invalid struct.
-        let mut v = vec![0u8, 1, 2];
-        let rbuf = unsafe { RustBuffer::from_raw_parts(v.as_mut_ptr(), 3, -7) };
-        rbuf.destroy_into_vec();
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_rustbuffer_provided_len_must_be_non_negative() {
-        // We guard against foreign-language code providing this kind of invalid struct.
-        let mut v = vec![0u8, 1, 2];
-        let rbuf = unsafe { RustBuffer::from_raw_parts(v.as_mut_ptr(), -1, 3) };
         rbuf.destroy_into_vec();
     }
 

--- a/uniffi_macros/src/setup_scaffolding.rs
+++ b/uniffi_macros/src/setup_scaffolding.rs
@@ -60,7 +60,7 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
         #[allow(clippy::missing_safety_doc, missing_docs)]
         #[doc(hidden)]
         #[no_mangle]
-        pub extern "C" fn #ffi_rustbuffer_alloc_ident(size: i32, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
+        pub extern "C" fn #ffi_rustbuffer_alloc_ident(size: u64, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
             uniffi::ffi::uniffi_rustbuffer_alloc(size, call_status)
         }
 
@@ -81,7 +81,7 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
         #[allow(clippy::missing_safety_doc, missing_docs)]
         #[doc(hidden)]
         #[no_mangle]
-        pub unsafe extern "C" fn #ffi_rustbuffer_reserve_ident(buf: uniffi::RustBuffer, additional: i32, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
+        pub unsafe extern "C" fn #ffi_rustbuffer_reserve_ident(buf: uniffi::RustBuffer, additional: u64, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
             uniffi::ffi::uniffi_rustbuffer_reserve(buf, additional, call_status)
         }
 


### PR DESCRIPTION
This fixes #1976, which tracks Rust panics with values that overflow the `RustBuffer` fields.  Note that `capacity` can overflow even if the rust buffer size is < `i32::MAX` because of the way vectors grow.  As discussed in https://github.com/mozilla/uniffi-rs/pull/1977 one of the simplest ways to fix this is to just make the fields bigger.

In theory, this should be a pretty safe change.  I'm a bit worried that I missed some detail though -- especially with Kotlin since JNA always feels like it's full of footguns.

I'd love to know how others feel about this.  How risky does it feel to others?  Does anyone have performance concerns?

Note: we still write 32-bit lengths to the RustBuffer itself.  Should we increase that to 64-bits as well?