### PR TITLE
Try removing build dependency in procmacro example

### DIFF
--- a/examples/arithmetic-procmacro/Cargo.toml
+++ b/examples/arithmetic-procmacro/Cargo.toml
@@ -14,8 +14,5 @@ name = "arithmeticpm"
 uniffi = { workspace = true }
 thiserror = "1.0"
 
-[build-dependencies]
-uniffi = { workspace = true, features = ["build"] }
-
 [dev-dependencies]
 uniffi = { workspace = true, features = ["bindgen-tests"] }


### PR DESCRIPTION
Since there is no `build.rs` file, I don't think the build dependency has any effect.