### PR TITLE
Adding support for Rust async trait methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.26.0...HEAD).
 
+### What's new?
+
+- Rust trait interfaces can now have async functions.  See the futures manual section for details.
+
 ### What's fixed?
  
 - Fixed a memory leak in callback interface handling.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
+name = "async-trait"
+version = "0.1.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,6 +1643,7 @@ dependencies = [
 name = "uniffi-fixture-futures"
 version = "0.21.0"
 dependencies = [
+ "async-trait",
  "once_cell",
  "thiserror",
  "tokio",

--- a/docs/manual/src/futures.md
+++ b/docs/manual/src/futures.md
@@ -45,3 +45,29 @@ This code uses `asyncio` to drive the future to completion, while our exposed fu
 In Rust `Future` terminology this means the foreign bindings supply the "executor" - think event-loop, or async runtime. In this example it's `asyncio`. There's no requirement for a Rust event loop.
 
 There are [some great API docs](https://docs.rs/uniffi_core/latest/uniffi_core/ffi/rustfuture/index.html) on the implementation that are well worth a read.
+
+## Exporting async trait methods
+
+UniFFI is compatible with the [async-trait](https://crates.io/crates/async-trait) crate and this can
+be used to export trait interfaces over the FFI.
+
+When using UDL, wrap your trait with the `#[async_trait]` attribute.  In the UDL, annotate all async
+methods with `[Async]`:
+
+```idl
+[Trait]
+interface SayAfterTrait {
+    [Async]
+    string say_after(u16 ms, string who);
+};
+```
+
+When using proc-macros, make sure to put `#[uniffi::export]` outside the `#[async_trait]` attribute:
+
+```rust
+#[uniffi::export]
+#[async_trait::async_trait]
+pub trait SayAfterTrait: Send + Sync {
+    async fn say_after(&self, ms: u16, who: String) -> String;
+}
+```

--- a/fixtures/futures/Cargo.toml
+++ b/fixtures/futures/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/bin.rs"
 
 [dependencies]
 uniffi = { workspace = true, features = ["tokio", "cli"] }
+async-trait = "0.1"
 thiserror = "1.0"
 tokio = { version = "1.24.1", features = ["time", "sync"] }
 once_cell = "1.18.0"

--- a/fixtures/futures/src/futures.udl
+++ b/fixtures/futures/src/futures.udl
@@ -2,3 +2,9 @@ namespace futures {
     [Async]
     boolean always_ready();
 };
+
+[Trait]
+interface SayAfterUdlTrait {
+    [Async]
+    string say_after(u16 ms, string who);
+};

--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -326,4 +326,59 @@ pub async fn use_shared_resource(options: SharedResourceOptions) -> Result<(), A
     Ok(())
 }
 
+// Example of an trait with async methods
+#[uniffi::export]
+#[async_trait::async_trait]
+pub trait SayAfterTrait: Send + Sync {
+    async fn say_after(&self, ms: u16, who: String) -> String;
+}
+
+// Example of async trait defined in the UDL file
+#[async_trait::async_trait]
+pub trait SayAfterUdlTrait: Send + Sync {
+    async fn say_after(&self, ms: u16, who: String) -> String;
+}
+
+struct SayAfterImpl1;
+
+struct SayAfterImpl2;
+
+#[async_trait::async_trait]
+impl SayAfterTrait for SayAfterImpl1 {
+    async fn say_after(&self, ms: u16, who: String) -> String {
+        say_after(ms, who).await
+    }
+}
+
+#[async_trait::async_trait]
+impl SayAfterTrait for SayAfterImpl2 {
+    async fn say_after(&self, ms: u16, who: String) -> String {
+        say_after(ms, who).await
+    }
+}
+
+#[uniffi::export]
+fn get_say_after_traits() -> Vec<Arc<dyn SayAfterTrait>> {
+    vec![Arc::new(SayAfterImpl1), Arc::new(SayAfterImpl2)]
+}
+
+#[async_trait::async_trait]
+impl SayAfterUdlTrait for SayAfterImpl1 {
+    async fn say_after(&self, ms: u16, who: String) -> String {
+        say_after(ms, who).await
+    }
+}
+
+#[async_trait::async_trait]
+impl SayAfterUdlTrait for SayAfterImpl2 {
+    async fn say_after(&self, ms: u16, who: String) -> String {
+        say_after(ms, who).await
+    }
+}
+
+#[uniffi::export]
+fn get_say_after_udl_traits() -> Vec<Arc<dyn SayAfterUdlTrait>> {
+    vec![Arc::new(SayAfterImpl1), Arc::new(SayAfterImpl2)]
+}
+
 uniffi::include_scaffolding!("futures");

--- a/fixtures/futures/tests/bindings/test_futures.kts
+++ b/fixtures/futures/tests/bindings/test_futures.kts
@@ -112,6 +112,34 @@ runBlocking {
     assert(not_megaphone == null)
 }
 
+// Test async methods in trait interfaces
+runBlocking {
+    val traits = getSayAfterTraits()
+    val time = measureTimeMillis {
+        val result1 = traits[0].sayAfter(100U, "Alice")
+        val result2 = traits[1].sayAfter(100U, "Bob")
+
+        assert(result1 == "Hello, Alice!")
+        assert(result2 == "Hello, Bob!")
+    }
+
+    assertApproximateTime(time, 200, "async methods")
+}
+
+// Test async methods in UDL-defined trait interfaces
+runBlocking {
+    val traits = getSayAfterUdlTraits()
+    val time = measureTimeMillis {
+        val result1 = traits[0].sayAfter(100U, "Alice")
+        val result2 = traits[1].sayAfter(100U, "Bob")
+
+        assert(result1 == "Hello, Alice!")
+        assert(result2 == "Hello, Bob!")
+    }
+
+    assertApproximateTime(time, 200, "async methods")
+}
+
 // Test with the Tokio runtime.
 runBlocking {
     val time = measureTimeMillis {

--- a/fixtures/futures/tests/bindings/test_futures.py
+++ b/fixtures/futures/tests/bindings/test_futures.py
@@ -74,6 +74,36 @@ class TestFutures(unittest.TestCase):
 
         asyncio.run(test())
 
+    def test_async_trait_interface_methods(self):
+        async def test():
+            traits = get_say_after_traits()
+            t0 = now()
+            result1 = await traits[0].say_after(100, 'Alice')
+            result2 = await traits[1].say_after(100, 'Bob')
+            t1 = now()
+
+            self.assertEqual(result1, 'Hello, Alice!')
+            self.assertEqual(result2, 'Hello, Bob!')
+            t_delta = (t1 - t0).total_seconds()
+            self.assertGreater(t_delta, 0.2)
+
+        asyncio.run(test())
+
+    def test_udl_async_trait_interface_methods(self):
+        async def test():
+            traits = get_say_after_udl_traits()
+            t0 = now()
+            result1 = await traits[0].say_after(100, 'Alice')
+            result2 = await traits[1].say_after(100, 'Bob')
+            t1 = now()
+
+            self.assertEqual(result1, 'Hello, Alice!')
+            self.assertEqual(result2, 'Hello, Bob!')
+            t_delta = (t1 - t0).total_seconds()
+            self.assertGreater(t_delta, 0.2)
+
+        asyncio.run(test())
+
     def test_async_object_param(self):
         async def test():
             megaphone = new_megaphone()

--- a/fixtures/futures/tests/bindings/test_futures.swift
+++ b/fixtures/futures/tests/bindings/test_futures.swift
@@ -112,6 +112,44 @@ Task {
 	counter.leave()
 }
 
+// Test async trait interface methods
+counter.enter()
+
+Task {
+	let traits = getSayAfterTraits()
+
+	let t0 = Date()
+	let result1 = await traits[0].sayAfter(ms: 1000, who: "Alice")
+	let result2 = await traits[1].sayAfter(ms: 1000, who: "Bob")
+	let t1 = Date()
+
+	assert(result1 == "Hello, Alice!")
+	assert(result2 == "Hello, Bob!")
+	let tDelta = DateInterval(start: t0, end: t1)
+	assert(tDelta.duration > 2 && tDelta.duration < 2.1)
+
+	counter.leave()
+}
+
+// Test UDL-defined async trait interface methods
+counter.enter()
+
+Task {
+	let traits = getSayAfterUdlTraits()
+
+	let t0 = Date()
+	let result1 = await traits[0].sayAfter(ms: 1000, who: "Alice")
+	let result2 = await traits[1].sayAfter(ms: 1000, who: "Bob")
+	let t1 = Date()
+
+	assert(result1 == "Hello, Alice!")
+	assert(result2 == "Hello, Bob!")
+	let tDelta = DateInterval(start: t0, end: t1)
+	assert(tDelta.duration > 2 && tDelta.duration < 2.1)
+
+	counter.leave()
+}
+
 // Test async function returning an object
 counter.enter()
 

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -605,17 +605,19 @@ impl From<uniffi_meta::TraitMethodMetadata> for Method {
     fn from(meta: uniffi_meta::TraitMethodMetadata) -> Self {
         let ffi_name = meta.ffi_symbol_name();
         let checksum_fn_name = meta.checksum_symbol_name();
+        let is_async = meta.is_async;
         let return_type = meta.return_type.map(Into::into);
         let arguments = meta.inputs.into_iter().map(Into::into).collect();
         let ffi_func = FfiFunction {
             name: ffi_name,
+            is_async,
             ..FfiFunction::default()
         };
         Self {
             name: meta.name,
             object_name: meta.trait_name,
             object_module_path: meta.module_path,
-            is_async: false,
+            is_async,
             arguments,
             return_type,
             docstring: meta.docstring.clone(),

--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -6,7 +6,7 @@
 #[::uniffi::export_for_udl{% if obj.has_callback_interface() %}(with_foreign){% endif %}]
 pub trait r#{{ obj.name() }} {
     {%- for meth in obj.methods() %}
-    fn {% if meth.is_async() %}async {% endif %}r#{{ meth.name() }}(
+    {% if meth.is_async() %}async {% endif %}fn r#{{ meth.name() }}(
         {% if meth.takes_self_by_arc()%}self: Arc<Self>{% else %}&self{% endif %},
         {%- for arg in meth.arguments() %}
         r#{{ arg.name() }}: {% if arg.by_ref() %}&{% endif %}{{ arg.as_type().borrow()|type_rs }},

--- a/uniffi_macros/src/export/trait_interface.rs
+++ b/uniffi_macros/src/export/trait_interface.rs
@@ -87,12 +87,6 @@ pub(super) fn gen_trait_scaffolding(
         .into_iter()
         .map(|item| match item {
             ImplItem::Method(sig) => {
-                if sig.is_async {
-                    return Err(syn::Error::new(
-                        sig.span,
-                        "async trait methods are not supported",
-                    ));
-                }
                 let fn_args = ExportFnArgs {
                     async_runtime: None,
                 };


### PR DESCRIPTION
This was pretty easy, it mostly meant not hard coding that we don't support async methods and which order to apply `#[uniffi::export]` vs `#[async_trait::async_trait]`.

The next step is foreign-implemented traits.