### PR TITLE
Upgrade oneshot to 0.1.6

### DIFF
--- a/uniffi_core/Cargo.toml
+++ b/uniffi_core/Cargo.toml
@@ -22,7 +22,7 @@ once_cell = "1.10.0"
 # Use the `oneshot-uniffi` crate to get our `oneshot` dependency.
 # That crate is a fork of `oneshot` that removes the `loom` target/dependency, which makes it easier to vendor UniFFI into the mozilla-central repository.
 # Enable "async" so that receivers implement Future, no need for "std" since we don't block on them.
-oneshot = { package = "oneshot-uniffi", version = "0.1.5", features = ["async"] }
+oneshot = { package = "oneshot-uniffi", version = "0.1.6", features = ["async"] }
 # Regular dependencies
 paste = "1.0"
 static_assertions = "1.1.0"


### PR DESCRIPTION
I added contributed a new feature for this one to convert between `Sender` and a raw pointer.  I want to use this to handle foreign-implemented async trait methods.