### PR TITLE
Add type hints to Python dict

### DIFF
--- a/fixtures/simple-fns/src/lib.rs
+++ b/fixtures/simple-fns/src/lib.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 pub type MyHashSet = Mutex<HashSet<String>>;
@@ -20,6 +20,11 @@ fn get_int() -> i32 {
 #[uniffi::export]
 fn string_identity(s: String) -> String {
     s
+}
+
+#[uniffi::export]
+fn hash_map_identity(h: HashMap<String, String>) -> HashMap<String, String> {
+    h
 }
 
 #[uniffi::export]

--- a/fixtures/simple-fns/tests/bindings/test_simple_fns.py
+++ b/fixtures/simple-fns/tests/bindings/test_simple_fns.py
@@ -15,3 +15,9 @@ add_to_set(a_set, "bar")
 assert set_contains(a_set, "foo")
 assert set_contains(a_set, "bar")
 assert not set_contains(a_set, "baz")
+
+assert hash_map_identity({"a": "b"}) == {"a": "b"}
+assert hash_map_identity.__annotations__ == {
+    "h": "'dict[str, str]'",
+    "return": "'dict[str, str]'",
+}

--- a/uniffi_bindgen/src/bindings/python/gen_python/compounds.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/compounds.rs
@@ -3,7 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::CodeType;
-use crate::backend::{Literal, Type};
+use crate::{
+    backend::{Literal, Type},
+    bindings::python::gen_python::AsCodeType,
+};
 
 #[derive(Debug)]
 pub struct OptionalCodeType {
@@ -88,7 +91,11 @@ impl MapCodeType {
 
 impl CodeType for MapCodeType {
     fn type_label(&self) -> String {
-        "dict".to_string()
+        format!(
+            "dict[{}, {}]",
+            self.key.as_codetype().type_label(),
+            self.value.as_codetype().type_label()
+        )
     }
 
     fn canonical_name(&self) -> String {

--- a/uniffi_bindgen/src/bindings/python/templates/wrapper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/wrapper.py
@@ -15,6 +15,7 @@
 # compile the rust component. The easiest way to ensure this is to bundle the Python
 # helpers directly inline like we're doing here.
 
+from __future__ import annotations
 import os
 import sys
 import ctypes


### PR DESCRIPTION
This adds type hints to Python dicts.

I couldn't find official documentation indicating what Python versions uniffi supports, so I wrote it to support 3.8+ as that's the oldest version not EOL.

In 3.8, the correct way to do this would be `typing.Dict[X, Y]`. Then in 3.9, support was added for `dict[X, Y]` and the original way was deprecated. By importing `from __future__ import annotations`, we can support the current way on 3.8 as well.