### PR TITLE
Add Python return type for async functions

### DIFF
--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -101,6 +101,12 @@ pub async fn sleep(ms: u16) -> bool {
     true
 }
 
+/// Async function that sleeps with no return type
+#[uniffi::export]
+pub async fn sleep_no_return(ms: u16) {
+    TimerFuture::new(Duration::from_millis(ms.into())).await;
+}
+
 // Our error.
 #[derive(thiserror::Error, uniffi::Error, Debug)]
 pub enum MyError {

--- a/fixtures/futures/tests/bindings/test_futures.py
+++ b/fixtures/futures/tests/bindings/test_futures.py
@@ -178,5 +178,11 @@ class TestFutures(unittest.TestCase):
             await use_shared_resource(SharedResourceOptions(release_after_ms=0, timeout_ms=1000))
         asyncio.run(test())
 
+    def test_function_annotations(self):
+        async def test():
+            assert sleep.__annotations__ == {"ms": "int", "return": "bool"}
+            assert sleep_no_return.__annotations__ == {"ms": "int"}
+        asyncio.run(test())
+
 if __name__ == '__main__':
     unittest.main()

--- a/fixtures/futures/tests/bindings/test_futures.py
+++ b/fixtures/futures/tests/bindings/test_futures.py
@@ -181,7 +181,7 @@ class TestFutures(unittest.TestCase):
     def test_function_annotations(self):
         async def test():
             assert sleep.__annotations__ == {"ms": "int", "return": "bool"}
-            assert sleep_no_return.__annotations__ == {"ms": "int"}
+            assert sleep_no_return.__annotations__ == {"ms": "int", "return": None}
         asyncio.run(test())
 
 if __name__ == '__main__':

--- a/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
@@ -1,20 +1,18 @@
 {%- if func.is_async() %}
 
-def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}):
+{%- match func.return_type() -%}
+{%- when Some with (return_type) %}
+
+async def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}) -> "{{ return_type|type_name }}":
     {%- call py::docstring(func, 4) %}
     {%- call py::setup_args(func) %}
-    return _uniffi_rust_call_async(
+    return await _uniffi_rust_call_async(
         _UniffiLib.{{ func.ffi_func().name() }}({% call py::arg_list_lowered(func) %}),
         _UniffiLib.{{func.ffi_rust_future_poll(ci) }},
         _UniffiLib.{{func.ffi_rust_future_complete(ci) }},
         _UniffiLib.{{func.ffi_rust_future_free(ci) }},
         # lift function
-        {%- match func.return_type() %}
-        {%- when Some(return_type) %}
         {{ return_type|lift_fn }},
-        {%- when None %}
-        lambda val: None,
-        {% endmatch %}
         # Error FFI converter
         {%- match func.throws_type() %}
         {%- when Some(e) %}
@@ -23,6 +21,28 @@ def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}):
         None,
         {%- endmatch %}
     )
+
+{% when None %}
+
+async def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}):
+    {%- call py::docstring(func, 4) %}
+    {%- call py::setup_args(func) %}
+    return await _uniffi_rust_call_async(
+        _UniffiLib.{{ func.ffi_func().name() }}({% call py::arg_list_lowered(func) %}),
+        _UniffiLib.{{func.ffi_rust_future_poll(ci) }},
+        _UniffiLib.{{func.ffi_rust_future_complete(ci) }},
+        _UniffiLib.{{func.ffi_rust_future_free(ci) }},
+        # lift function
+        lambda val: None,
+        # Error FFI converter
+        {%- match func.throws_type() %}
+        {%- when Some(e) %}
+        {{ e|ffi_converter_name }},
+        {%- when None %}
+        None,
+        {%- endmatch %}
+    )
+{% endmatch %}
 
 {%- else %}
 {%- match func.return_type() -%}

--- a/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
@@ -2,29 +2,11 @@
 
 {%- match func.return_type() -%}
 {%- when Some with (return_type) %}
-
 async def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}) -> "{{ return_type|type_name }}":
-    {%- call py::docstring(func, 4) %}
-    {%- call py::setup_args(func) %}
-    return await _uniffi_rust_call_async(
-        _UniffiLib.{{ func.ffi_func().name() }}({% call py::arg_list_lowered(func) %}),
-        _UniffiLib.{{func.ffi_rust_future_poll(ci) }},
-        _UniffiLib.{{func.ffi_rust_future_complete(ci) }},
-        _UniffiLib.{{func.ffi_rust_future_free(ci) }},
-        # lift function
-        {{ return_type|lift_fn }},
-        # Error FFI converter
-        {%- match func.throws_type() %}
-        {%- when Some(e) %}
-        {{ e|ffi_converter_name }},
-        {%- when None %}
-        None,
-        {%- endmatch %}
-    )
-
 {% when None %}
+async def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}) -> None:
+{% endmatch %}
 
-async def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}):
     {%- call py::docstring(func, 4) %}
     {%- call py::setup_args(func) %}
     return await _uniffi_rust_call_async(
@@ -33,7 +15,12 @@ async def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}):
         _UniffiLib.{{func.ffi_rust_future_complete(ci) }},
         _UniffiLib.{{func.ffi_rust_future_free(ci) }},
         # lift function
+        {%- match func.return_type() %}
+        {%- when Some(return_type) %}
+        {{ return_type|lift_fn }},
+        {%- when None %}
         lambda val: None,
+        {% endmatch %}
         # Error FFI converter
         {%- match func.throws_type() %}
         {%- when Some(e) %}
@@ -42,7 +29,6 @@ async def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}):
         None,
         {%- endmatch %}
     )
-{% endmatch %}
 
 {%- else %}
 {%- match func.return_type() -%}
@@ -54,7 +40,7 @@ def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}) -> "{{ retur
     return {{ return_type|lift_fn }}({% call py::to_ffi_call(func) %})
 {% when None %}
 
-def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}):
+def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}) -> None:
     {%- call py::docstring(func, 4) %}
     {%- call py::setup_args(func) %}
     {% call py::to_ffi_call(func) %}


### PR DESCRIPTION
As discussed in #1970, uniffi currently doesn't put a return type on generated async functions in Python. 

This is my attempt at correcting the function signatures it generates. Because the diff is a bit bad, I'll summarize the changes:
- For async functions, match on if they have a return type
  a. If they do, add `async` to the front of the function, add the `-> ___` return type, and add `await` to the return statement.
  b. If they don't, still add `async` to the front of the function and `await` to the return.
- Remove the `match meth.return_type()` cases from the body of the function, as it's now being checked outside of the function

The changes are repeated in `macros.py` and `TopLevelFunctionTemplate.py`

`b.` technically could remain unchanged, but it seemed more correct to make the generated functions match each other.

Note that I'm by no means a Python expert, so please let me know if there's a more ergonomic/preferred way to accomplish all this.

