### PR TITLE
Use typing.get_type_hints() in python type tests

### DIFF
--- a/fixtures/futures/tests/bindings/test_futures.py
+++ b/fixtures/futures/tests/bindings/test_futures.py
@@ -2,6 +2,7 @@ from futures import *
 import unittest
 from datetime import datetime
 import asyncio
+import typing
 
 def now():
     return datetime.now()
@@ -210,8 +211,8 @@ class TestFutures(unittest.TestCase):
 
     def test_function_annotations(self):
         async def test():
-            assert sleep.__annotations__ == {"ms": "int", "return": "bool"}
-            assert sleep_no_return.__annotations__ == {"ms": "int", "return": None}
+            self.assertEqual(typing.get_type_hints(sleep) , {"ms": int, "return": bool})
+            self.assertEqual(typing.get_type_hints(sleep_no_return), {"ms": int, "return": type(None)})
         asyncio.run(test())
 
 if __name__ == '__main__':

--- a/fixtures/simple-fns/tests/bindings/test_simple_fns.py
+++ b/fixtures/simple-fns/tests/bindings/test_simple_fns.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from uniffi_simple_fns import *
+import typing
 
 assert get_string() == "String created by Rust"
 assert get_int() == 1289
@@ -17,7 +18,7 @@ assert set_contains(a_set, "bar")
 assert not set_contains(a_set, "baz")
 
 assert hash_map_identity({"a": "b"}) == {"a": "b"}
-assert hash_map_identity.__annotations__ == {
-    "h": "'dict[str, str]'",
-    "return": "'dict[str, str]'",
+assert typing.get_type_hints(hash_map_identity) == {
+    "h": dict[str, str],
+    "return": dict[str, str],
 }


### PR DESCRIPTION
edit: As @badboy points out, we probably do want strings - sorry about that. It turns out `typing.get_type_hints()` does the magic we need to make the tests sane and able to check against actual types.