### PR TITLE
Allow procmacro exported items to be renamed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### What's new?
 
+- Functions, methods and constructors exported by procmacros can be renamed for the forgeign bindings. See the procmaco manual section.
+
 - Rust trait interfaces can now have async functions.  See the futures manual section for details.
 
 ### What's fixed?

--- a/docs/manual/src/proc_macro/index.md
+++ b/docs/manual/src/proc_macro/index.md
@@ -138,6 +138,31 @@ fn do_something(foo: MyFooRef) {
 }
 ```
 
+### Renaming functions, methods and constructors
+
+A single exported function can specify an alternate name to be used by the bindings by specifying a `name` attribute.
+
+```rust
+#[uniffi::export(name = "something")]
+fn do_something() {
+}
+```
+will be exposed to foreign bindings as a namespace function `something()`
+
+You can also rename constructors and methods:
+```rust
+#[uniffi::export]
+impl Something {
+    // Set this as the default constructor by naming it `new`
+    #[uniffi::constructor(name = "new")]
+    fn make_new() -> Arc<Self> { ... }
+
+    // Expose this as `obj.something()`
+    #[uniffi::method(name = "something")]
+    fn do_something(&self) { }
+}
+```
+
 ## The `uniffi::Record` derive
 
 The `Record` derive macro exposes a `struct` with named fields over FFI. All types that are

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -304,4 +304,27 @@ pub fn join(parts: &[String], sep: &str) -> String {
     parts.join(sep)
 }
 
+// Custom names
+#[derive(uniffi::Object)]
+pub struct Renamed;
+
+// `renamed_new` becomes the default constructor because it's named `new`
+#[uniffi::export]
+impl Renamed {
+    #[uniffi::constructor(name = "new")]
+    fn renamed_new() -> Arc<Self> {
+        Arc::new(Self)
+    }
+
+    #[uniffi::method(name = "func")]
+    fn renamed_func(&self) -> bool {
+        true
+    }
+}
+
+#[uniffi::export(name = "rename_test")]
+fn renamed_rename_test() -> bool {
+    true
+}
+
 uniffi::include_scaffolding!("proc-macro");

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -20,6 +20,10 @@ assert obj.is_heavy() == MaybeBool.UNCERTAIN
 obj2 = Object()
 assert obj.is_other_heavy(obj2) == MaybeBool.UNCERTAIN
 
+robj = Renamed()
+assert(robj.func())
+assert(rename_test())
+
 trait_impl = obj.get_trait(None)
 assert trait_impl.concat_strings("foo", "bar") == "foobar"
 assert obj.get_trait(trait_impl).concat_strings("foo", "bar") == "foobar"

--- a/fixtures/uitests/tests/ui/export_attrs.rs
+++ b/fixtures/uitests/tests/ui/export_attrs.rs
@@ -35,4 +35,20 @@ pub enum Error {
     Oops,
 }
 
+// ctor and method attribute confusion.
+#[derive(uniffi::Object)]
+struct OtherAttrs;
+
+#[uniffi::export]
+impl OtherAttrs {
+    #[uniffi::constructor(foo = bar)]
+    fn one() {}
+}
+
+#[uniffi::export]
+impl OtherAttrs {
+    #[uniffi::method(foo)]
+    fn two() {}
+}
+
 uniffi_macros::setup_scaffolding!();

--- a/fixtures/uitests/tests/ui/export_attrs.stderr
+++ b/fixtures/uitests/tests/ui/export_attrs.stderr
@@ -41,3 +41,15 @@ error: attribute arguments are not currently recognized in this position
    |
 34 |     #[uniffi(flat_error)]
    |              ^^^^^^^^^^
+
+error: uniffi::constructor/method attribute `foo = bar` is not supported here.
+  --> tests/ui/export_attrs.rs:44:27
+   |
+44 |     #[uniffi::constructor(foo = bar)]
+   |                           ^^^
+
+error: uniffi::constructor/method attribute `foo` is not supported here.
+  --> tests/ui/export_attrs.rs:50:22
+   |
+50 |     #[uniffi::method(foo)]
+   |                      ^^^

--- a/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
@@ -17,6 +17,9 @@ class {{ impl_name }}:
         {%- call py::setup_args_extra_indent(cons) %}
         self._pointer = {% call py::to_ffi_call(cons) %}
 {%-     when None %}
+    {# no __init__ means simple construction without a pointer works, which can confuse #}
+    def __init__(self, *args, **kwargs):
+        raise ValueError("This class has no default constructor")
 {%- endmatch %}
 
     def __del__(self):

--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -40,7 +40,9 @@ pub(crate) fn expand_export(
     let metadata = ExportItem::new(item, all_args)?;
 
     match metadata {
-        ExportItem::Function { sig, args } => gen_fn_scaffolding(sig, &args, udl_mode),
+        ExportItem::Function { sig, args } => {
+            gen_fn_scaffolding(sig, &args.async_runtime, udl_mode)
+        }
         ExportItem::Impl {
             items,
             self_ident,
@@ -61,8 +63,12 @@ pub(crate) fn expand_export(
             let item_tokens: TokenStream = items
                 .into_iter()
                 .map(|item| match item {
-                    ImplItem::Constructor(sig) => gen_constructor_scaffolding(sig, &args, udl_mode),
-                    ImplItem::Method(sig) => gen_method_scaffolding(sig, &args, udl_mode),
+                    ImplItem::Constructor(sig) => {
+                        gen_constructor_scaffolding(sig, &args.async_runtime, udl_mode)
+                    }
+                    ImplItem::Method(sig) => {
+                        gen_method_scaffolding(sig, &args.async_runtime, udl_mode)
+                    }
                 })
                 .collect::<syn::Result<_>>()?;
             Ok(quote_spanned! { self_ident.span() => #item_tokens })

--- a/uniffi_macros/src/export/item.rs
+++ b/uniffi_macros/src/export/item.rs
@@ -43,7 +43,7 @@ impl ExportItem {
             syn::Item::Fn(item) => {
                 let args: ExportFnArgs = syn::parse(attr_args)?;
                 let docstring = extract_docstring(&item.attrs)?;
-                let sig = FnSignature::new_function(item.sig, docstring)?;
+                let sig = FnSignature::new_function(item.sig, args.name.clone(), docstring)?;
                 Ok(Self::Function { sig, args })
             }
             syn::Item::Impl(item) => Self::from_impl(item, attr_args),
@@ -106,12 +106,14 @@ impl ExportItem {
                     ImplItem::Constructor(FnSignature::new_constructor(
                         self_ident.clone(),
                         impl_fn.sig,
+                        attrs.name,
                         docstring,
                     )?)
                 } else {
                     ImplItem::Method(FnSignature::new_method(
                         self_ident.clone(),
                         impl_fn.sig,
+                        attrs.name,
                         docstring,
                     )?)
                 };
@@ -167,6 +169,7 @@ impl ExportItem {
                     ImplItem::Method(FnSignature::new_trait_method(
                         self_ident.clone(),
                         tim.sig,
+                        None,
                         i as u32,
                         docstring,
                     )?)

--- a/uniffi_macros/src/export/trait_interface.rs
+++ b/uniffi_macros/src/export/trait_interface.rs
@@ -9,9 +9,7 @@ use uniffi_meta::ObjectImpl;
 
 use crate::{
     export::{
-        attributes::{ExportFnArgs, ExportTraitArgs},
-        callback_interface, gen_method_scaffolding,
-        item::ImplItem,
+        attributes::ExportTraitArgs, callback_interface, gen_method_scaffolding, item::ImplItem,
     },
     object::interface_meta_static_var,
     util::{ident_to_string, tagged_impl_header},
@@ -86,12 +84,7 @@ pub(super) fn gen_trait_scaffolding(
     let impl_tokens: TokenStream = items
         .into_iter()
         .map(|item| match item {
-            ImplItem::Method(sig) => {
-                let fn_args = ExportFnArgs {
-                    async_runtime: None,
-                };
-                gen_method_scaffolding(sig, &fn_args, udl_mode)
-            }
+            ImplItem::Method(sig) => gen_method_scaffolding(sig, &None, udl_mode),
             _ => unreachable!("traits have no constructors"),
         })
         .collect::<syn::Result<_>>()?;

--- a/uniffi_macros/src/export/utrait.rs
+++ b/uniffi_macros/src/export/utrait.rs
@@ -6,7 +6,7 @@ use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use syn::ext::IdentExt;
 
-use super::{attributes::ExportFnArgs, gen_ffi_function};
+use super::gen_ffi_function;
 use crate::fnsig::FnSignature;
 use crate::util::extract_docstring;
 use uniffi_meta::UniffiTraitDiscriminants;
@@ -161,12 +161,17 @@ fn process_uniffi_trait_method(
     let docstring = extract_docstring(&item.attrs)?;
 
     let ffi_func = gen_ffi_function(
-        &FnSignature::new_method(self_ident.clone(), item.sig.clone(), docstring.clone())?,
-        &ExportFnArgs::default(),
+        &FnSignature::new_method(
+            self_ident.clone(),
+            item.sig.clone(),
+            None,
+            docstring.clone(),
+        )?,
+        &None,
         udl_mode,
     )?;
     // metadata for the method, which will be packed inside metadata for the trait.
     let method_meta =
-        FnSignature::new_method(self_ident.clone(), item.sig, docstring)?.metadata_expr()?;
+        FnSignature::new_method(self_ident.clone(), item.sig, None, docstring)?.metadata_expr()?;
     Ok((ffi_func, method_meta))
 }

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -380,3 +380,11 @@ pub fn generate_and_include_scaffolding(udl_file: TokenStream) -> TokenStream {
 pub fn constructor(_attrs: TokenStream, input: TokenStream) -> TokenStream {
     input
 }
+
+/// An attribute for methods.
+///
+/// Everything above applies here too.
+#[proc_macro_attribute]
+pub fn method(_attrs: TokenStream, input: TokenStream) -> TokenStream {
+    input
+}

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -250,6 +250,7 @@ pub mod kw {
     syn::custom_keyword!(flat_error);
     syn::custom_keyword!(None);
     syn::custom_keyword!(with_try_read);
+    syn::custom_keyword!(name);
     syn::custom_keyword!(non_exhaustive);
     syn::custom_keyword!(Debug);
     syn::custom_keyword!(Display);


### PR DESCRIPTION
Fixes #1753

While #1753 talks just about the constructor, I noticed that we already had the capability of using different names for exported items but just lacked a way to express that.