### PR TITLE
Allow for arbitrary BindingGenerator

### DIFF
--- a/fixtures/docstring-proc-macro/tests/test_generated_bindings.rs
+++ b/fixtures/docstring-proc-macro/tests/test_generated_bindings.rs
@@ -7,6 +7,7 @@ uniffi::build_foreign_language_testcases!(
 #[cfg(test)]
 mod tests {
     use uniffi_bindgen::bindings::TargetLanguage;
+    use uniffi_bindgen::BindingGeneratorDefault;
     use uniffi_testing::UniFFITestHelper;
 
     const DOCSTRINGS: &[&str] = &[
@@ -50,7 +51,10 @@ mod tests {
         uniffi_bindgen::library_mode::generate_bindings(
             &cdylib_path,
             None,
-            &[language],
+            &BindingGeneratorDefault {
+                target_languages: vec![language],
+                try_format_code: false,
+            },
             None,
             &out_dir,
             false,

--- a/fixtures/docstring/tests/test_generated_bindings.rs
+++ b/fixtures/docstring/tests/test_generated_bindings.rs
@@ -8,6 +8,7 @@ uniffi::build_foreign_language_testcases!(
 mod tests {
     use camino::Utf8PathBuf;
     use uniffi_bindgen::bindings::TargetLanguage;
+    use uniffi_bindgen::BindingGeneratorDefault;
     use uniffi_testing::UniFFITestHelper;
 
     const DOCSTRINGS: &[&str] = &[
@@ -48,7 +49,10 @@ mod tests {
         uniffi_bindgen::generate_bindings(
             &Utf8PathBuf::from("src/docstring.udl"),
             None,
-            vec![language],
+            BindingGeneratorDefault {
+                target_languages: vec![language],
+                try_format_code: false,
+            },
             Some(&out_dir),
             None,
             None,

--- a/fixtures/swift-bridging-header-compile/tests/clang.rs
+++ b/fixtures/swift-bridging-header-compile/tests/clang.rs
@@ -1,6 +1,6 @@
 use camino::Utf8PathBuf;
 use std::process::Command;
-use uniffi::TargetLanguage;
+use uniffi::SwiftBindingGenerator;
 use uniffi_testing::UniFFITestHelper;
 
 #[test]
@@ -14,7 +14,7 @@ fn clang() -> Result<(), anyhow::Error> {
     uniffi::generate_bindings(
         &Utf8PathBuf::from("src/swift-bridging-header-compile.udl"),
         None,
-        vec![TargetLanguage::Swift],
+        SwiftBindingGenerator,
         Some(&out_dir),
         None,
         None,

--- a/uniffi/src/cli.rs
+++ b/uniffi/src/cli.rs
@@ -5,6 +5,7 @@
 use camino::Utf8PathBuf;
 use clap::{Parser, Subcommand};
 use uniffi_bindgen::bindings::TargetLanguage;
+use uniffi_bindgen::BindingGeneratorDefault;
 
 // Structs to help our cmdline parsing. Note that docstrings below form part
 // of the "help" output.
@@ -102,7 +103,10 @@ pub fn run_main() -> anyhow::Result<()> {
                 uniffi_bindgen::library_mode::generate_bindings(
                     &source,
                     crate_name,
-                    &language,
+                    &BindingGeneratorDefault {
+                        target_languages: language,
+                        try_format_code: !no_format,
+                    },
                     config.as_deref(),
                     &out_dir,
                     !no_format,
@@ -111,7 +115,10 @@ pub fn run_main() -> anyhow::Result<()> {
                 uniffi_bindgen::generate_bindings(
                     &source,
                     config.as_deref(),
-                    language,
+                    BindingGeneratorDefault {
+                        target_languages: language,
+                        try_format_code: !no_format,
+                    },
                     out_dir.as_deref(),
                     lib_file.as_deref(),
                     crate_name.as_deref(),

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -17,8 +17,11 @@ pub use uniffi_bindgen::bindings::ruby::run_test as ruby_run_test;
 pub use uniffi_bindgen::bindings::swift::run_test as swift_run_test;
 #[cfg(feature = "bindgen")]
 pub use uniffi_bindgen::{
-    bindings::TargetLanguage, generate_bindings, generate_component_scaffolding,
-    generate_component_scaffolding_for_crate, print_repr,
+    bindings::kotlin::gen_kotlin::KotlinBindingGenerator,
+    bindings::python::gen_python::PythonBindingGenerator,
+    bindings::ruby::gen_ruby::RubyBindingGenerator,
+    bindings::swift::gen_swift::SwiftBindingGenerator, bindings::TargetLanguage, generate_bindings,
+    generate_component_scaffolding, generate_component_scaffolding_for_crate, print_repr,
 };
 #[cfg(feature = "build")]
 pub use uniffi_build::{generate_scaffolding, generate_scaffolding_for_crate};

--- a/uniffi_bindgen/src/bindings/kotlin/test.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/test.rs
@@ -2,10 +2,8 @@
 License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::{
-    bindings::{RunScriptOptions, TargetLanguage},
-    library_mode::generate_bindings,
-};
+use crate::bindings::TargetLanguage;
+use crate::{bindings::RunScriptOptions, library_mode::generate_bindings, BindingGeneratorDefault};
 use anyhow::{bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use std::env;
@@ -40,7 +38,10 @@ pub fn run_script(
     generate_bindings(
         &cdylib_path,
         None,
-        &[TargetLanguage::Kotlin],
+        &BindingGeneratorDefault {
+            target_languages: vec![TargetLanguage::Kotlin],
+            try_format_code: false,
+        },
         None,
         &out_dir,
         false,

--- a/uniffi_bindgen/src/bindings/python/test.rs
+++ b/uniffi_bindgen/src/bindings/python/test.rs
@@ -2,10 +2,8 @@
 License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::{
-    bindings::{RunScriptOptions, TargetLanguage},
-    library_mode::generate_bindings,
-};
+use crate::bindings::TargetLanguage;
+use crate::{bindings::RunScriptOptions, library_mode::generate_bindings, BindingGeneratorDefault};
 use anyhow::{Context, Result};
 use camino::Utf8Path;
 use std::env;
@@ -41,7 +39,10 @@ pub fn run_script(
     generate_bindings(
         &cdylib_path,
         None,
-        &[TargetLanguage::Python],
+        &BindingGeneratorDefault {
+            target_languages: vec![TargetLanguage::Python],
+            try_format_code: false,
+        },
         None,
         &out_dir,
         false,

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -2,15 +2,39 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use askama::Template;
+use camino::Utf8Path;
 use heck::{ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
 use std::collections::HashMap;
 
+use crate::bindings::ruby;
 use crate::interface::*;
-use crate::BindingsConfig;
+use crate::{BindingGenerator, BindingsConfig};
+
+pub struct RubyBindingGenerator;
+impl BindingGenerator for RubyBindingGenerator {
+    type Config = Config;
+
+    fn write_bindings(
+        &self,
+        ci: &ComponentInterface,
+        config: &Config,
+        out_dir: &Utf8Path,
+        try_format_code: bool,
+    ) -> Result<()> {
+        ruby::write_bindings(config, ci, out_dir, try_format_code)
+    }
+
+    fn check_library_path(&self, library_path: &Utf8Path, cdylib_name: Option<&str>) -> Result<()> {
+        if cdylib_name.is_none() {
+            bail!("Generate bindings for Ruby requires a cdylib, but {library_path} was given");
+        }
+        Ok(())
+    }
+}
 
 const RESERVED_WORDS: &[&str] = &[
     "alias", "and", "BEGIN", "begin", "break", "case", "class", "def", "defined?", "do", "else",

--- a/uniffi_bindgen/src/bindings/ruby/test.rs
+++ b/uniffi_bindgen/src/bindings/ruby/test.rs
@@ -4,6 +4,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 
 use crate::bindings::TargetLanguage;
 use crate::library_mode::generate_bindings;
+use crate::BindingGeneratorDefault;
 use anyhow::{bail, Context, Result};
 use camino::Utf8Path;
 use std::env;
@@ -37,7 +38,10 @@ pub fn test_script_command(
     generate_bindings(
         &cdylib_path,
         None,
-        &[TargetLanguage::Ruby],
+        &BindingGeneratorDefault {
+            target_languages: vec![TargetLanguage::Ruby],
+            try_format_code: false,
+        },
         None,
         &out_dir,
         false,

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -10,13 +10,15 @@ use std::fmt::Debug;
 
 use anyhow::{Context, Result};
 use askama::Template;
+use camino::Utf8Path;
 use heck::{ToLowerCamelCase, ToShoutySnakeCase, ToUpperCamelCase};
 use serde::{Deserialize, Serialize};
 
 use super::Bindings;
 use crate::backend::TemplateExpression;
+use crate::bindings::swift;
 use crate::interface::*;
-use crate::BindingsConfig;
+use crate::{BindingGenerator, BindingsConfig};
 
 mod callback_interface;
 mod compounds;
@@ -27,6 +29,29 @@ mod miscellany;
 mod object;
 mod primitives;
 mod record;
+
+pub struct SwiftBindingGenerator;
+impl BindingGenerator for SwiftBindingGenerator {
+    type Config = Config;
+
+    fn write_bindings(
+        &self,
+        ci: &ComponentInterface,
+        config: &Config,
+        out_dir: &Utf8Path,
+        try_format_code: bool,
+    ) -> Result<()> {
+        swift::write_bindings(config, ci, out_dir, try_format_code)
+    }
+
+    fn check_library_path(
+        &self,
+        _library_path: &Utf8Path,
+        _cdylib_name: Option<&str>,
+    ) -> Result<()> {
+        Ok(())
+    }
+}
 
 /// A trait tor the implementation.
 trait CodeType: Debug {

--- a/uniffi_bindgen/src/bindings/swift/test.rs
+++ b/uniffi_bindgen/src/bindings/swift/test.rs
@@ -2,10 +2,7 @@
 License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::{
-    bindings::{RunScriptOptions, TargetLanguage},
-    library_mode::generate_bindings,
-};
+use crate::{bindings::RunScriptOptions, library_mode::generate_bindings, BindingGeneratorDefault};
 use anyhow::{bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
@@ -14,6 +11,8 @@ use std::fs::{read_to_string, File};
 use std::io::Write;
 use std::process::{Command, Stdio};
 use uniffi_testing::UniFFITestHelper;
+
+use crate::bindings::TargetLanguage;
 
 /// Run Swift tests for a UniFFI test fixture
 pub fn run_test(tmp_dir: &str, fixture_name: &str, script_file: &str) -> Result<()> {
@@ -129,7 +128,10 @@ impl GeneratedSources {
         let sources = generate_bindings(
             cdylib_path,
             None,
-            &[TargetLanguage::Swift],
+            &BindingGeneratorDefault {
+                target_languages: vec![TargetLanguage::Swift],
+                try_format_code: false,
+            },
             None,
             out_dir,
             false,


### PR DESCRIPTION
De-couple TargetLanguage from the `generate_external_bindings` calls. This will allow 3rd-party BindingGenerators to use the methods.

I'm not 100% certain this is the way to go, and I'm very open to feedback. cc @bendk @mhammond

Related to https://github.com/mozilla/uniffi-rs/issues/299