### PR TITLE
Refactor FFI definition code

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -10,7 +10,7 @@ use std::fmt::Debug;
 
 use anyhow::{Context, Result};
 use askama::Template;
-use heck::{ToLowerCamelCase, ToUpperCamelCase};
+use heck::{ToLowerCamelCase, ToShoutySnakeCase, ToUpperCamelCase};
 use serde::{Deserialize, Serialize};
 
 use super::Bindings;
@@ -517,6 +517,11 @@ impl SwiftCodeOracle {
         format!("Uniffi{}", nm.to_upper_camel_case())
     }
 
+    /// Get the idiomatic Swift rendering of an if guard name
+    fn if_guard_name(&self, nm: &str) -> String {
+        format!("UNIFFI_FFIDEF_{}", nm.to_shouty_snake_case())
+    }
+
     fn ffi_type_label(&self, ffi_type: &FfiType) -> String {
         match ffi_type {
             FfiType::Int8 => "Int8".into(),
@@ -692,6 +697,11 @@ pub mod filters {
     /// Get the idiomatic Swift rendering of an FFI struct name
     pub fn ffi_struct_name(nm: &str) -> Result<String, askama::Error> {
         Ok(oracle().ffi_struct_name(nm))
+    }
+
+    /// Get the idiomatic Swift rendering of an if guard name
+    pub fn if_guard_name(nm: &str) -> Result<String, askama::Error> {
+        Ok(oracle().if_guard_name(nm))
     }
 
     /// Get the idiomatic Swift rendering of docstring


### PR DESCRIPTION
This was not quite a pure refactor, because some of the code generation for FFI definitions changed.  AFAICT, it should be equivalent far all current FFI definitions though.

Added the `FfiDefinition` enum, which can hold any type of FFI definition (struct, function, or callback function).  Added `ComponentInterface::ffi_definitions` to iterate over all of the definitions.  The reason for this is that FFI definitions can have complicated dependencies and some languages require that the dependencies come first in source order.  By defining a single function to output all definitons, we can ensure that they come out in the right order.

Factored out the Rust FFI return types calculation into its own function.  I want to use it in some other places.

Updated the codegen for FFI definitions:
  - Kotlin (most of these changes are to workaround JNA issues):
    - Make FFI structs open. 
    - If a FFI struct contains an FFI callback field, make that field nullable.
    - Add default field values.
    - Added `UniffiByValue` for passing structs by value
    - Added the `setValue` utility method
  - Swift: add an IF guard for FFI definitions.  That way we can introduce shared FFI structs without getting a name conflict.