### PR TITLE
Simplify path in bindings tests

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/test.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/test.rs
@@ -33,9 +33,9 @@ pub fn run_script(
     args: Vec<String>,
     options: &RunScriptOptions,
 ) -> Result<()> {
-    let script_path = Utf8Path::new(".").join(script_file);
+    let script_path = Utf8Path::new(script_file);
     let test_helper = UniFFITestHelper::new(crate_name)?;
-    let out_dir = test_helper.create_out_dir(tmp_dir, &script_path)?;
+    let out_dir = test_helper.create_out_dir(tmp_dir, script_path)?;
     let cdylib_path = test_helper.copy_cdylib_to_out_dir(&out_dir)?;
     generate_bindings(
         &cdylib_path,

--- a/uniffi_bindgen/src/bindings/python/test.rs
+++ b/uniffi_bindgen/src/bindings/python/test.rs
@@ -34,7 +34,7 @@ pub fn run_script(
     args: Vec<String>,
     _options: &RunScriptOptions,
 ) -> Result<()> {
-    let script_path = Utf8Path::new(".").join(script_file).canonicalize_utf8()?;
+    let script_path = Utf8Path::new(script_file).canonicalize_utf8()?;
     let test_helper = UniFFITestHelper::new(crate_name)?;
     let out_dir = test_helper.create_out_dir(tmp_dir, &script_path)?;
     let cdylib_path = test_helper.copy_cdylib_to_out_dir(&out_dir)?;

--- a/uniffi_bindgen/src/bindings/ruby/test.rs
+++ b/uniffi_bindgen/src/bindings/ruby/test.rs
@@ -30,7 +30,7 @@ pub fn test_script_command(
     fixture_name: &str,
     script_file: &str,
 ) -> Result<Command> {
-    let script_path = Utf8Path::new(".").join(script_file).canonicalize_utf8()?;
+    let script_path = Utf8Path::new(script_file).canonicalize_utf8()?;
     let test_helper = UniFFITestHelper::new(fixture_name)?;
     let out_dir = test_helper.create_out_dir(tmp_dir, &script_path)?;
     let cdylib_path = test_helper.copy_cdylib_to_out_dir(&out_dir)?;

--- a/uniffi_bindgen/src/bindings/swift/test.rs
+++ b/uniffi_bindgen/src/bindings/swift/test.rs
@@ -36,7 +36,7 @@ pub fn run_script(
     args: Vec<String>,
     options: &RunScriptOptions,
 ) -> Result<()> {
-    let script_path = Utf8Path::new(".").join(script_file).canonicalize_utf8()?;
+    let script_path = Utf8Path::new(script_file).canonicalize_utf8()?;
     let test_helper = UniFFITestHelper::new(crate_name)?;
     let out_dir = test_helper.create_out_dir(tmp_dir, &script_path)?;
     let cdylib_path = test_helper.copy_cdylib_to_out_dir(&out_dir)?;


### PR DESCRIPTION
Joining “.” with anything ought to be the same as using anything directly.