### PR TITLE
Prevent Swift objects' `deinit` from trying to free a nil pointer when subclassed for mocking

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -63,6 +63,10 @@ open class {{ impl_class_name }}:
     {%- endmatch %}
 
     deinit {
+        guard let pointer = pointer else {
+            return
+        }
+
         try! rustCall { {{ obj.ffi_object_free().name() }}(pointer, $0) }
     }
 


### PR DESCRIPTION
It seems that #1918 and implicitly #1975 missed one important aspect when opening up classes for mocking:
- the current deinit implementation shouldn't be called for mocked/subclassed objects because the internal `pointer` is nil in those cases and doing so will result in a `Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value`
- deinit is also not overridable in Swift so this is not something that can be worked around downstream

This PR attempts to fix the problem by introducing a guard to check that `pointer` is not nil before trying to free it.