### PR TITLE
Rename kotlin uniffiRustFutureContinuationCallback to uniffiRustFutureContinuationCallbackImpl

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/Async.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Async.kt
@@ -6,7 +6,7 @@ internal const val UNIFFI_RUST_FUTURE_POLL_MAYBE_READY = 1.toByte()
 internal val uniffiContinuationHandleMap = UniffiHandleMap<CancellableContinuation<Byte>>()
 
 // FFI type for Rust future continuations
-internal object uniffiRustFutureContinuationCallback: UniffiRustFutureContinuationCallback {
+internal object uniffiRustFutureContinuationCallbackImpl: UniffiRustFutureContinuationCallback {
     override fun callback(data: Long, pollResult: Byte) {
         uniffiContinuationHandleMap.remove(data).resume(pollResult)
     }
@@ -25,7 +25,7 @@ internal suspend fun<T, F, E: Exception> uniffiRustCallAsync(
             val pollResult = suspendCancellableCoroutine<Byte> { continuation ->
                 pollFunc(
                     rustFuture,
-                    uniffiRustFutureContinuationCallback,
+                    uniffiRustFutureContinuationCallbackImpl,
                     uniffiContinuationHandleMap.insert(continuation)
                 )
             }


### PR DESCRIPTION
Fixes https://github.com/mozilla/uniffi-rs/issues/1995

I'm not exactly sure why but certain java runtimes can't distinguish between `uniffiRustFutureContinuationCallback` and `UniffiRustFutureContinuationCallback`. the issue manifests in various ways but I was getting `java.lang.NoClassDefFoundError`:

```
java.lang.NoClassDefFoundError: uniffi/<crate>/uniffiRustFutureContinuationCallback (wrong name: uniffi/<crate>/UniffiRustFutureContinuationCallback)
```

I patched in this version of uniffi and verified that it's fixed