### PR TITLE
Make `uniffi_build` optional in `uniffi_macros`

### DIFF
--- a/fixtures/uitests/Cargo.toml
+++ b/fixtures/uitests/Cargo.toml
@@ -11,7 +11,7 @@ name = "uniffi_uitests"
 
 [dependencies]
 uniffi = { workspace = true }
-uniffi_macros = {path = "../../uniffi_macros"}
+uniffi_macros = { path = "../../uniffi_macros", features = ["trybuild"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -22,7 +22,7 @@ goblin = "0.8"
 heck = "0.4"
 once_cell = "1.12"
 paste = "1.0"
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 toml = "0.5"
 uniffi_meta = { path = "../uniffi_meta", version = "=0.26.1" }
 uniffi_testing = { path = "../uniffi_testing", version = "=0.26.1" }

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -24,11 +24,13 @@ quote = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
 syn = { version = "2.0", features = ["full", "visit-mut"] }
 toml = "0.5.9"
-uniffi_build = { path = "../uniffi_build", version = "=0.26.1" }
+uniffi_build = { path = "../uniffi_build", version = "=0.26.1", optional = true }
 uniffi_meta = { path = "../uniffi_meta", version = "=0.26.1" }
 
 [features]
 default = []
+# Enable the generate_and_include_scaffolding! macro
+trybuild = [ "dep:uniffi_build" ]
 # Enable extra features that require a nightly compiler:
 # * Add the full module path of exported items to FFI metadata instead of just the crate name.
 #   This may be used by language backends to generate nested module structures in the future.

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -21,7 +21,7 @@ fs-err = "2.7.0"
 once_cell = "1.10.0"
 proc-macro2 = "1.0"
 quote = "1.0"
-serde = "1.0.136"
+serde = { version = "1.0.136", features = ["derive"] }
 syn = { version = "2.0", features = ["full", "visit-mut"] }
 toml = "0.5.9"
 uniffi_build = { path = "../uniffi_build", version = "=0.26.1" }

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -6,6 +6,7 @@
 
 //! Macros for `uniffi`.
 
+#[cfg(feature = "trybuild")]
 use camino::Utf8Path;
 use proc_macro::TokenStream;
 use quote::quote;
@@ -343,6 +344,7 @@ pub fn use_udl_object(tokens: TokenStream) -> TokenStream {
 /// uniffi_macros::generate_and_include_scaffolding!("path/to/my/interface.udl");
 /// ```
 #[proc_macro]
+#[cfg(feature = "trybuild")]
 pub fn generate_and_include_scaffolding(udl_file: TokenStream) -> TokenStream {
     let udl_file = syn::parse_macro_input!(udl_file as LitStr);
     let udl_file_string = udl_file.value();


### PR DESCRIPTION
As far as I can see, the dependency on uniffi_build is not needed for the macros used by regular clients of UniFFI — it is only used to create a convenience macro for the UI tests.

I named the new feature “trybuild” after the description of the macro. Please let me know if you have preferences for a better name.

The overall goal here is to minimize the number of crates I need to vendor to use UniFFI — I’m hoping to get away with checking in the generated target language sources, so I’m currently focusing on the dependencies in the rest of the code base.