### PR TITLE
Fix Python checking for invalid enum values.

### DIFF
--- a/fixtures/enum-types/src/lib.rs
+++ b/fixtures/enum-types/src/lib.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-enum Animal {
+pub enum Animal {
     Dog,
     Cat,
 }
@@ -36,6 +36,11 @@ pub enum AnimalLargeUInt {
 pub enum AnimalSignedInt {
     Dog = -3,
     Cat = -4,
+}
+
+#[uniffi::export]
+fn get_animal(a: Option<Animal>) -> Animal {
+    a.unwrap_or(Animal::Dog)
 }
 
 uniffi::include_scaffolding!("enum_types");

--- a/fixtures/enum-types/tests/bindings/test_enum_types.py
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.py
@@ -5,14 +5,22 @@
 import unittest
 from enum_types import *
 
-assert(Animal.DOG.value == 0)
-assert(Animal.CAT.value == 1)
+class TestErrorTypes(unittest.TestCase):
+    def test_animals(self):
+        self.assertEqual(Animal.DOG.value,  0)
+        self.assertEqual(Animal.CAT.value, 1)
+        self.assertEqual(get_animal(None), Animal.DOG)
+        with self.assertRaises(ValueError):
+            get_animal(1)
 
-assert(AnimalNoReprInt.DOG.value == 3)
-assert(AnimalNoReprInt.CAT.value == 4)
+        self.assertEqual(AnimalNoReprInt.DOG.value, 3)
+        self.assertEqual(AnimalNoReprInt.CAT.value, 4)
 
-assert(AnimalUInt.DOG.value == 3)
-assert(AnimalUInt.CAT.value == 4)
+        self.assertEqual(AnimalUInt.DOG.value, 3)
+        self.assertEqual(AnimalUInt.CAT.value, 4)
 
-assert(AnimalLargeUInt.DOG.value == (4294967295 + 3))
-assert(AnimalLargeUInt.CAT.value == (4294967295 + 4))
+        self.assertEqual(AnimalLargeUInt.DOG.value, (4294967295 + 3))
+        self.assertEqual(AnimalLargeUInt.CAT.value, (4294967295 + 4))
+
+if __name__=='__main__':
+    unittest.main()

--- a/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
@@ -103,6 +103,7 @@ class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
             {%- endfor %}
             return
         {%- endfor %}
+        raise ValueError(value)
         {%- endif %}
 
     @staticmethod


### PR DESCRIPTION
The generated Python code didn't raise an exception after checking all variants. Without the fix the new test fails with:

> enum_types.InternalError: Failed to convert arg 'a': not enough bytes remaining in buffer (0 < 4)

Also upgrades the test to a unittest.