### PR TITLE
Allow enum discriminants to be signed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### What's new?
 
+- Enums created with proc macros can now produce literals for variants in Kotlin and Swift. See
+[the section on enum proc-macros](https://mozilla.github.io/uniffi-rs/proc_macro/index.html#the-uniffienum-derive) for more information.
+
 - Objects can be errors - anywhere you can specify an enum error object you can specify
   an `Arc<Object>` - see [the manual](https://mozilla.github.io/uniffi-rs/udl/errors.html).
 
@@ -44,11 +47,6 @@
 - Fixed a memory leak in callback interface handling.
 
 [All changes in v0.26.1](https://github.com/mozilla/uniffi-rs/compare/v0.26.0...v0.26.1).
-
-### What's new?
-
-- Enums created with proc macros can now produce literals for variants in Kotlin and Swift bindings specifically for unsigned types.. See
-[the section on enum proc-macros](https://mozilla.github.io/uniffi-rs/proc_macro/index.html#the-uniffienum-derive) for more information.
 
 ## v0.26.0 (backend crates: v0.26.0) - (_2024-01-23_)
 

--- a/docs/manual/src/proc_macro/index.md
+++ b/docs/manual/src/proc_macro/index.md
@@ -214,7 +214,7 @@ pub enum MyEnum {
 
 Variant discriminants are accepted by the macro but how they are used depends on the bindings.
 
-Currently only `unsigned integer` variant discriminants are passed through to the foreign bindings. For example this enum:
+For example this enum:
 
 ```rust
 #[derive(uniffi::Enum)]
@@ -228,13 +228,13 @@ would give you in Kotlin & Swift:
 
 ```swift
 // kotlin
-enum class MyEnum {   
+enum class MyEnum {
     FOO,
     BAR;
     companion object
 }
-// swift 
-public enum MyEnum {    
+// swift
+public enum MyEnum {
     case foo
     case bar
 }

--- a/fixtures/enum-types/src/lib.rs
+++ b/fixtures/enum-types/src/lib.rs
@@ -29,13 +29,14 @@ pub enum AnimalLargeUInt {
     Cat = 4294967299, // u32::MAX as u64 + 4
 }
 
-// Signed is currently NOT supported but included to ensure we don't break
-// things for current users of the enum proc-macro
 #[repr(i8)]
-#[derive(uniffi::Enum)]
+#[derive(Debug, uniffi::Enum)]
 pub enum AnimalSignedInt {
     Dog = -3,
-    Cat = -4,
+    Cat = -2,
+    Koala,   // -1
+    Wallaby, // 0
+    Wombat,  // 1
 }
 
 #[uniffi::export]
@@ -44,3 +45,15 @@ fn get_animal(a: Option<Animal>) -> Animal {
 }
 
 uniffi::include_scaffolding!("enum_types");
+
+#[cfg(test)]
+mod test {
+    use crate::AnimalSignedInt;
+
+    #[test]
+    fn check_signed() {
+        assert_eq!(AnimalSignedInt::Koala as i8, -1);
+        assert_eq!(AnimalSignedInt::Wallaby as i8, 0);
+        assert_eq!(AnimalSignedInt::Wombat as i8, 1);
+    }
+}

--- a/fixtures/enum-types/tests/bindings/test_enum_types.kts
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.kts
@@ -10,3 +10,6 @@ assert(AnimalUInt.CAT.value == 4.toUByte())
 
 assert(AnimalLargeUInt.DOG.value == 4294967298.toULong())
 assert(AnimalLargeUInt.CAT.value == 4294967299.toULong())
+
+// could check `value == (-3).toByte()` but that's ugly :)
+assert(AnimalSignedInt.DOG.value + 3 == 0)

--- a/fixtures/enum-types/tests/bindings/test_enum_types.py
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.py
@@ -19,8 +19,14 @@ class TestErrorTypes(unittest.TestCase):
         self.assertEqual(AnimalUInt.DOG.value, 3)
         self.assertEqual(AnimalUInt.CAT.value, 4)
 
-        self.assertEqual(AnimalLargeUInt.DOG.value, (4294967295 + 3))
-        self.assertEqual(AnimalLargeUInt.CAT.value, (4294967295 + 4))
+        self.assertEqual(AnimalLargeUInt.DOG.value, 4294967295 + 3)
+        self.assertEqual(AnimalLargeUInt.CAT.value, 4294967295 + 4)
+
+        self.assertEqual(AnimalSignedInt.DOG.value, -3)
+        self.assertEqual(AnimalSignedInt.CAT.value, -2)
+        self.assertEqual(AnimalSignedInt.KOALA.value, -1)
+        self.assertEqual(AnimalSignedInt.WALLABY.value, 0)
+        self.assertEqual(AnimalSignedInt.WOMBAT.value, 1)
 
 if __name__=='__main__':
     unittest.main()

--- a/fixtures/enum-types/tests/bindings/test_enum_types.swift
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.swift
@@ -10,3 +10,5 @@ assert(AnimalUInt.cat.rawValue == 4)
 
 assert(AnimalLargeUInt.dog.rawValue == 4294967298)
 assert(AnimalLargeUInt.cat.rawValue == 4294967299)
+
+assert(AnimalSignedInt.dog.rawValue == -3)

--- a/fixtures/uitests/tests/ui/enum_discriminants.rs
+++ b/fixtures/uitests/tests/ui/enum_discriminants.rs
@@ -1,0 +1,9 @@
+fn main() {} /* empty main required by `trybuild` */
+
+#[repr(u64)]
+#[derive(uniffi::Enum)]
+pub enum EnumExpr {
+    V = 1 + 1,
+}
+
+uniffi_macros::setup_scaffolding!();

--- a/fixtures/uitests/tests/ui/enum_discriminants.stderr
+++ b/fixtures/uitests/tests/ui/enum_discriminants.stderr
@@ -1,0 +1,5 @@
+error: UniFFI disciminant values must be a literal
+ --> tests/ui/enum_discriminants.rs:6:9
+  |
+6 |     V = 1 + 1,
+  |         ^^^^^

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -628,6 +628,7 @@ pub mod filters {
         let literal = e.variant_discr(*index).expect("invalid index");
         match literal {
             LiteralMetadata::UInt(v, _, _) => Ok(v.to_string()),
+            LiteralMetadata::Int(v, _, _) => Ok(v.to_string()),
             _ => unreachable!("expected an UInt!"),
         }
     }

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -277,6 +277,9 @@ impl LiteralMetadata {
     pub fn new_uint(v: u64) -> Self {
         LiteralMetadata::UInt(v, Radix::Decimal, Type::UInt64)
     }
+    pub fn new_int(v: i64) -> Self {
+        LiteralMetadata::Int(v, Radix::Decimal, Type::Int64)
+    }
 }
 
 // Represent the radix of integer literal values.


### PR DESCRIPTION
Also now generates an error rather then silently ignoring when a discriminant value is an expression or anything else we can't handle.