### PR TITLE
`Error` creates Kotlin inheritance loop

### DIFF
--- a/fixtures/keywords/kotlin/src/keywords.udl
+++ b/fixtures/keywords/kotlin/src/keywords.udl
@@ -40,3 +40,8 @@ enum class {
 interface fun {
    class(u8 object);
 };
+
+[Error]
+interface Error {
+   class(u8 object);
+};

--- a/fixtures/keywords/kotlin/src/lib.rs
+++ b/fixtures/keywords/kotlin/src/lib.rs
@@ -56,4 +56,14 @@ pub enum fun {
     class { object: u8 },
 }
 
+// `FooError` is turned into `FooException`, so this enum will end up
+// being named just `Exception`. Without special care, this will clash
+// with `kotlin.Exception` class.
+#[allow(non_camel_case_types)]
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("class?")]
+    class { object: u8 },
+}
+
 uniffi::include_scaffolding!("keywords");

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Async.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Async.kt
@@ -12,7 +12,7 @@ internal object uniffiRustFutureContinuationCallbackImpl: UniffiRustFutureContin
     }
 }
 
-internal suspend fun<T, F, E: Exception> uniffiRustCallAsync(
+internal suspend fun<T, F, E: kotlin.Exception> uniffiRustCallAsync(
     rustFuture: Long,
     pollFunc: (Long, UniffiRustFutureContinuationCallback, Long) -> Unit,
     completeFunc: (Long, UniffiRustCallStatus) -> F,

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
@@ -4,7 +4,7 @@
 
 {% if e.is_flat() %}
 {%- call kt::docstring(e, 0) %}
-sealed class {{ type_name }}(message: String): Exception(message){% if contains_object_references %}, Disposable {% endif %} {
+sealed class {{ type_name }}(message: String): kotlin.Exception(message){% if contains_object_references %}, Disposable {% endif %} {
         {% for variant in e.variants() -%}
         {%- call kt::docstring(variant, 4) %}
         class {{ variant|error_variant_name }}(message: String) : {{ type_name }}(message)
@@ -16,7 +16,7 @@ sealed class {{ type_name }}(message: String): Exception(message){% if contains_
 }
 {%- else %}
 {%- call kt::docstring(e, 0) %}
-sealed class {{ type_name }}: Exception(){% if contains_object_references %}, Disposable {% endif %} {
+sealed class {{ type_name }}: kotlin.Exception(){% if contains_object_references %}, Disposable {% endif %} {
     {% for variant in e.variants() -%}
     {%- call kt::docstring(variant, 4) %}
     {%- let variant_name = variant|error_variant_name %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
@@ -34,7 +34,7 @@ internal open class UniffiRustCallStatus : Structure() {
     }
 }
 
-class InternalException(message: String) : Exception(message)
+class InternalException(message: String) : kotlin.Exception(message)
 
 // Each top-level error class has a companion object that can lift the error from the call status's rust buffer
 interface UniffiRustCallStatusErrorHandler<E> {
@@ -46,7 +46,7 @@ interface UniffiRustCallStatusErrorHandler<E> {
 // synchronize itself
 
 // Call a rust function that returns a Result<>.  Pass in the Error class companion that corresponds to the Err
-private inline fun <U, E: Exception> uniffiRustCallWithError(errorHandler: UniffiRustCallStatusErrorHandler<E>, callback: (UniffiRustCallStatus) -> U): U {
+private inline fun <U, E: kotlin.Exception> uniffiRustCallWithError(errorHandler: UniffiRustCallStatusErrorHandler<E>, callback: (UniffiRustCallStatus) -> U): U {
     var status = UniffiRustCallStatus();
     val return_value = callback(status)
     uniffiCheckCallStatus(errorHandler, status)
@@ -54,7 +54,7 @@ private inline fun <U, E: Exception> uniffiRustCallWithError(errorHandler: Uniff
 }
 
 // Check UniffiRustCallStatus and throw an error if the call wasn't successful
-private fun<E: Exception> uniffiCheckCallStatus(errorHandler: UniffiRustCallStatusErrorHandler<E>, status: UniffiRustCallStatus) {
+private fun<E: kotlin.Exception> uniffiCheckCallStatus(errorHandler: UniffiRustCallStatusErrorHandler<E>, status: UniffiRustCallStatus) {
     if (status.isSuccess()) {
         return
     } else if (status.isError()) {
@@ -93,7 +93,7 @@ internal inline fun<T> uniffiTraitInterfaceCall(
 ) {
     try {
         writeReturn(makeCall())
-    } catch(e: Exception) {
+    } catch(e: kotlin.Exception) {
         callStatus.code = UNIFFI_CALL_UNEXPECTED_ERROR
         callStatus.error_buf = {{ Type::String.borrow()|lower_fn }}(e.toString())
     }
@@ -107,7 +107,7 @@ internal inline fun<T, reified E: Throwable> uniffiTraitInterfaceCallWithError(
 ) {
     try {
         writeReturn(makeCall())
-    } catch(e: Exception) {
+    } catch(e: kotlin.Exception) {
         if (e is E) {
             callStatus.code = UNIFFI_CALL_ERROR
             callStatus.error_buf = lowerError(e)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -111,7 +111,7 @@
 
 {%- call kt::docstring(obj, 0) %}
 {% if (is_error) %}
-open class {{ impl_class_name }} : Exception, Disposable, AutoCloseable, {{ interface_name }} {
+open class {{ impl_class_name }} : kotlin.Exception, Disposable, AutoCloseable, {{ interface_name }} {
 {% else -%}
 open class {{ impl_class_name }}: Disposable, AutoCloseable, {{ interface_name }} {
 {%- endif %}


### PR DESCRIPTION
If a Rust enum is named `Error`, it becomes `Exception` in the generated Kotlin. The problem is that this class inherits from `Exception`, which I think it supposed to be a built-in Kotlin type:

```kotlin
sealed class Exception : Exception() {
    class Foo() : Exception() {
        override val message
            get() = ""
    }

    companion object ErrorHandler : UniffiRustCallStatusErrorHandler<Exception> {
        override fun lift(error_buf: RustBuffer.ByValue): Exception = FfiConverterTypeError.lift(error_buf)
    }
}
```

If I use `FooError` instead on the Rust side, the code above changes to `class FooException : Exception`.