### PR TITLE
Allow enum variants etc to be Kotlin type names

### DIFF
--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -212,7 +212,7 @@ pub enum MaybeBool {
 #[derive(uniffi::Enum)]
 pub enum MixedEnum {
     None,
-    Str(String),
+    String(String),
     Int(i64),
     Both(String, i64),
     All { s: String, i: i64 },

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
@@ -90,7 +90,7 @@ callCallbackInterface(KtTestCallbackInterface())
 
 assert(getMixedEnum(null) == MixedEnum.Int(1))
 assert(getMixedEnum(MixedEnum.None) == MixedEnum.None)
-assert(getMixedEnum(MixedEnum.Str("hello")) == MixedEnum.Str("hello"))
+assert(getMixedEnum(MixedEnum.String("hello")) == MixedEnum.String("hello"))
 
 val e = getMixedEnum(null)
 if (e is MixedEnum.Int) {

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -119,9 +119,9 @@ assert(ReprU8.THREE.value == 3)
 
 assert(get_mixed_enum(None) == MixedEnum.INT(1))
 assert(get_mixed_enum(MixedEnum.NONE()) == MixedEnum.NONE())
-assert(get_mixed_enum(MixedEnum.STR("hello")) == MixedEnum.STR("hello"))
-assert(MixedEnum.STR("hello")[0] == "hello")
-assert(str(MixedEnum.STR("hello")) == "MixedEnum.STR('hello',)")
+assert(get_mixed_enum(MixedEnum.STRING("hello")) == MixedEnum.STRING("hello"))
+assert(MixedEnum.STRING("hello")[0] == "hello")
+assert(str(MixedEnum.STRING("hello")) == "MixedEnum.STRING('hello',)")
 
 assert(MixedEnum.BOTH("hello", 1)[0] == "hello")
 assert(MixedEnum.BOTH("hello", 1)[1] == 1)

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
@@ -102,9 +102,9 @@ callCallbackInterface(cb: SwiftTestCallbackInterface())
 
 assert(getMixedEnum(v: nil) == .int(1))
 assert(getMixedEnum(v: MixedEnum.none) == .none)
-assert(getMixedEnum(v: MixedEnum.str("hello")) == .str("hello"))
-switch MixedEnum.str("hello") {
-    case let .str(s):
+assert(getMixedEnum(v: MixedEnum.string("hello")) == .string("hello"))
+switch MixedEnum.string("hello") {
+    case let .string(s):
         assert(s == "hello")
     default:
         assert(false)

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/primitives.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/primitives.rs
@@ -56,7 +56,7 @@ macro_rules! impl_code_type_for_primitive {
 
             impl CodeType for $T  {
                 fn type_label(&self, _ci: &ComponentInterface) -> String {
-                    $class_name.into()
+                    format!("kotlin.{}", $class_name)
                 }
 
                 fn canonical_name(&self) -> String {


### PR DESCRIPTION
Fixes #1853