### PR TITLE
Split up ScaffoldingBits.params

### DIFF
--- a/uniffi_macros/src/export/callback_interface.rs
+++ b/uniffi_macros/src/export/callback_interface.rs
@@ -47,10 +47,11 @@ pub(super) fn trait_impl(
     let vtable_fields = methods.iter()
         .map(|sig| {
             let ident = &sig.ident;
-            let params = sig.scaffolding_params();
+            let param_names = sig.scaffolding_param_names();
+            let param_types = sig.scaffolding_param_types();
             let lift_return = sig.lift_return_impl();
             quote! {
-                #ident: extern "C" fn(handle: u64, #(#params,)* &mut #lift_return::ReturnType, &mut ::uniffi::RustCallStatus),
+                #ident: extern "C" fn(handle: u64, #(#param_names: #param_types,)* &mut #lift_return::ReturnType, &mut ::uniffi::RustCallStatus),
             }
         });
 

--- a/uniffi_macros/src/fnsig.rs
+++ b/uniffi_macros/src/fnsig.rs
@@ -211,8 +211,18 @@ impl FnSignature {
     }
 
     /// Scaffolding parameters expressions for each of our arguments
-    pub fn scaffolding_params(&self) -> impl Iterator<Item = TokenStream> + '_ {
-        self.args.iter().map(NamedArg::scaffolding_param)
+    pub fn scaffolding_param_names(&self) -> impl Iterator<Item = TokenStream> + '_ {
+        self.args.iter().map(|a| {
+            let ident = &a.ident;
+            quote! { #ident }
+        })
+    }
+
+    pub fn scaffolding_param_types(&self) -> impl Iterator<Item = TokenStream> + '_ {
+        self.args.iter().map(|a| {
+            let lift_impl = a.lift_impl();
+            quote! { #lift_impl::FfiType }
+        })
     }
 
     /// Generate metadata items for this function
@@ -510,13 +520,6 @@ impl NamedArg {
         let ident = &self.ident;
         let ty = &self.ty;
         quote! { #ident: #ty }
-    }
-
-    /// Generate the scaffolding parameter for this Arg
-    pub(crate) fn scaffolding_param(&self) -> TokenStream {
-        let ident = &self.ident;
-        let lift_impl = self.lift_impl();
-        quote! { #ident: #lift_impl::FfiType }
     }
 
     pub(crate) fn arg_metadata(&self) -> TokenStream {


### PR DESCRIPTION
This is a refactor to enable some future work.  By tracking the parameter names and types separately we get some extra flexibility, for example iterating over the types only.