### PR TITLE
Update toml dependency to latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
   # Our minimum supported rust version is specified here.
   prepare-rust-min-version:
     steps:
-      - run: rustup override set 1.66.0
+      - run: rustup override set 1.70.0
       - run: rustup update
   build-api-docs:
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +707,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +743,16 @@ checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1204,6 +1226,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,11 +1375,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2187,3 +2243,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+dependencies = [
+ "memchr",
+]

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -23,7 +23,7 @@ heck = "0.4"
 once_cell = "1.12"
 paste = "1.0"
 serde = { version = "1", features = ["derive"] }
-toml = "0.5"
+toml = "0.8"
 uniffi_meta = { path = "../uniffi_meta", version = "=0.26.1" }
 uniffi_testing = { path = "../uniffi_testing", version = "=0.26.1" }
 uniffi_udl = { path = "../uniffi_udl", version = "=0.26.1" }

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -354,8 +354,9 @@ fn crate_name_from_cargo_toml(udl_file: &Utf8Path) -> Result<String> {
     let file = guess_crate_root(udl_file)?.join("Cargo.toml");
     let cargo_toml_bytes =
         fs::read(file).context("Can't find Cargo.toml to determine the crate name")?;
-
-    let cargo_toml = toml::from_slice::<CargoToml>(&cargo_toml_bytes)?;
+    let cargo_toml_string =
+        String::from_utf8(cargo_toml_bytes).context("Could not UTF-8 decode Cargo.toml")?;
+    let cargo_toml = toml::from_str::<CargoToml>(&cargo_toml_string)?;
 
     let lib_crate_name = cargo_toml
         .lib

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -23,7 +23,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
 syn = { version = "2.0", features = ["full", "visit-mut"] }
-toml = "0.5.9"
+toml = "0.8"
 uniffi_build = { path = "../uniffi_build", version = "=0.26.1", optional = true }
 uniffi_meta = { path = "../uniffi_meta", version = "=0.26.1" }
 

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -46,8 +46,9 @@ pub fn mod_path() -> syn::Result<String> {
     static LIB_CRATE_MOD_PATH: Lazy<Result<String, String>> = Lazy::new(|| {
         let file = manifest_path()?;
         let cargo_toml_bytes = fs::read(file).map_err(|e| e.to_string())?;
-
-        let cargo_toml = toml::from_slice::<CargoToml>(&cargo_toml_bytes)
+        let cargo_toml_string = String::from_utf8(cargo_toml_bytes)
+            .map_err(|e| format!("Could not UTF-8 decode `Cargo.toml`: {e}"))?;
+        let cargo_toml = toml::from_str::<CargoToml>(&cargo_toml_string)
             .map_err(|e| format!("Failed to parse `Cargo.toml`: {e}"))?;
 
         let lib_crate_name = cargo_toml


### PR DESCRIPTION
I am in the process of vendoring UniFFI in AOSP, which means that I have to make it play nice with the existing crates found here:

  https://cs.android.com/android/platform/superproject/+/main:external/rust/crates/

Android tries to only vendor each crate in a single version, so it would be helpful for me if the toml dependency could be updated.

This updates the “Requires” version to 1.70. I believe this is okay since this version is below 1.74 which is what mozilla-central currently requires.