### PR TITLE
Swift: Make it possible to mark value types as `Sendable` with `sendable_value_types` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 
 - Proc-macro record defaults now support empty vecs and Some values.
 
+- Swift: Records and Enums without object references can now be made `Sendable` Swift,
+  by opting in to new Configuration `experimental_sendable_value_types` in `uniffi.toml`.
+
 ### What's fixed?
  
 - Fixed a memory leak in callback interface handling.

--- a/docs/manual/src/swift/configuration.md
+++ b/docs/manual/src/swift/configuration.md
@@ -4,17 +4,20 @@ The generated Swift module can be configured using a `uniffi.toml` configuration
 
 ## Available options
 
-| Configuration name | Default  | Description |
-| ------------------ | -------  |------------ |
-| `cdylib_name`      | `uniffi_{namespace}`[^1] | The name of the compiled Rust library containing the FFI implementation (not needed when using `generate --library`). |
-| `module_name`      | `{namespace}`[^1] | The name of the Swift module containing the high-level foreign-language bindings. |
-| `ffi_module_name`  | `{module_name}FFI` | The name of the lower-level C module containing the FFI declarations. |
-| `ffi_module_filename` | `{ffi_module_name}` | The filename stem for the lower-level C module containing the FFI declarations. |
-| `generate_module_map` | `true` | Whether to generate a `.modulemap` file for the lower-level C module with FFI declarations. |
-| `omit_argument_labels` | `false` | Whether to omit argument labels in Swift function definitions. |
-| `generate_immutable_records` | `false` | Whether to generate records with immutable fields (`let` instead of `var`). |
-| `custom_types`      | | A map which controls how custom types are exposed to Swift. See the [custom types section of the manual](../udl/custom_types.md#custom-types-in-the-bindings-code)|
+The configurations prefixed with `experimental_` should be regarded as unstable and
+more likely to change than other configurations.
 
+| Configuration name                  | Default                  | Description                                                                                                                                                        |
+| ----------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `cdylib_name`                       | `uniffi_{namespace}`[^1] | The name of the compiled Rust library containing the FFI implementation (not needed when using `generate --library`).                                              |
+| `module_name`                       | `{namespace}`[^1]        | The name of the Swift module containing the high-level foreign-language bindings.                                                                                  |
+| `ffi_module_name`                   | `{module_name}FFI`       | The name of the lower-level C module containing the FFI declarations.                                                                                              |
+| `ffi_module_filename`               | `{ffi_module_name}`      | The filename stem for the lower-level C module containing the FFI declarations.                                                                                    |
+| `generate_module_map`               | `true`                   | Whether to generate a `.modulemap` file for the lower-level C module with FFI declarations.                                                                        |
+| `omit_argument_labels`              | `false`                  | Whether to omit argument labels in Swift function definitions.                                                                                                     |
+| `generate_immutable_records`        | `false`                  | Whether to generate records with immutable fields (`let` instead of `var`).                                                                                        |
+| `experimental_sendable_value_types` | `false`                  | Whether to mark value types as `Sendable'.                                                                                                                         |
+| `custom_types`                      |                          | A map which controls how custom types are exposed to Swift. See the [custom types section of the manual](../udl/custom_types.md#custom-types-in-the-bindings-code) |
 
 [^1]: `namespace` is the top-level namespace from your UDL file.
 

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -221,6 +221,7 @@ pub struct Config {
     generate_module_map: Option<bool>,
     omit_argument_labels: Option<bool>,
     generate_immutable_records: Option<bool>,
+    experimental_sendable_value_types: Option<bool>,
     #[serde(default)]
     custom_types: HashMap<String, CustomTypeConfig>,
 }
@@ -290,6 +291,11 @@ impl Config {
     /// Whether to generate immutable records (`let` instead of `var`)
     pub fn generate_immutable_records(&self) -> bool {
         self.generate_immutable_records.unwrap_or(false)
+    }
+
+    /// Whether to mark value types as 'Sendable'
+    pub fn experimental_sendable_value_types(&self) -> bool {
+        self.experimental_sendable_value_types.unwrap_or(false)
     }
 }
 

--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -75,5 +75,6 @@ public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> RustBuff
 }
 
 {% if !contains_object_references %}
+{% if config.experimental_sendable_value_types() %}extension {{ type_name }}: Sendable {} {% endif %}
 extension {{ type_name }}: Equatable, Hashable {}
 {% endif %}

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -16,6 +16,7 @@ public struct {{ type_name }} {
 }
 
 {% if !contains_object_references %}
+{% if config.experimental_sendable_value_types() %}extension {{ type_name }}: Sendable {} {% endif %}
 extension {{ type_name }}: Equatable, Hashable {
     public static func ==(lhs: {{ type_name }}, rhs: {{ type_name }}) -> Bool {
         {%- for field in rec.fields() %}


### PR DESCRIPTION
Make it possible to mark Swift value types as [`Sendable`](https://developer.apple.com/documentation/swift/sendable) - which is needed for Swift 6.

* Add new config for Swift: `sendable_value_types` (false by default)
* which if true (`sendable_value_types: true`) will mark:
  - (`[uniffi::Record]`) Swift `struct`s which does not contain object references as `Sendable`
  - (`[uniffi::Enum]`) Swift `enums`s which does not contain object references as `Sendable`

This will make it possible for Swift devs to [skip having to add `@unchecked Sendable` all over the place](https://github.com/search?q=repo%3Aradixdlt%2Fsargon%20%40unchecked%20Sendable&type=code)

I was unable to add a meaningful fixture though, since it is not possible to "unit test" this. The only way to "test" it is to ensure that compilation fails... which would be possible if:
* I could [enable Strict Concurrency check](https://www.swift.org/documentation/concurrency/)...
*  ... AND change warnings => errors. 
* ...[here is a failed attempt to do so](https://github.com/Sajjon/uniffi-rs/pull/1/files) - the problem is I can't seem to be able to pass `strict-concurrency=complete` to `swiftc` for bindgen test.

# Alternatives to consider
AND/OR we can add a different set of (Swift only) config flags: `frozen_struct` and `frozen_enum` (or simply `frozen_value_types`) - because types marked `@frozen` [automatically becomes `Sendable`](https://developer.apple.com/documentation/swift/sendable#Sendable-Structures-and-Enumerations), but I think it valuable to not have to mark a value type as `@frozen` just to get `Sendable`. I can do another PR for the `@frozen` annotation if you'd like?