### PR TITLE
Combine ExportedImplFnArgs and ExportFnArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [[UnreleasedUniFFIVersion]] (backend crates: [[UnreleasedBackendVersion]]) - (_[[ReleaseDate]]_)
 
+### What's changed
+
+- The async runtime can be specified for constructors/methods, this will override the runtime specified at the impl block level.
+
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.27.0...HEAD).
 
 ## v0.27.0 (backend crates: v0.27.0) - (_2024-03-26_)

--- a/fixtures/uitests/tests/ui/export_attrs.stderr
+++ b/fixtures/uitests/tests/ui/export_attrs.stderr
@@ -18,7 +18,7 @@ error: uniffi::export attribute `callback_interface` is not supported here.
 14 | #[uniffi::export(callback_interface)]
    |                  ^^^^^^^^^^^^^^^^^^
 
-error: uniffi::export attribute `with_foreign` is not supported here.
+error: attribute `with_foreign` is not supported here.
   --> tests/ui/export_attrs.rs:17:18
    |
 17 | #[uniffi::export(with_foreign)]
@@ -42,13 +42,13 @@ error: attribute arguments are not currently recognized in this position
 34 |     #[uniffi(flat_error)]
    |              ^^^^^^^^^^
 
-error: uniffi::constructor/method attribute `foo = bar` is not supported here.
+error: attribute `foo = bar` is not supported here.
   --> tests/ui/export_attrs.rs:44:27
    |
 44 |     #[uniffi::constructor(foo = bar)]
    |                           ^^^
 
-error: uniffi::constructor/method attribute `foo` is not supported here.
+error: attribute `foo` is not supported here.
   --> tests/ui/export_attrs.rs:50:22
    |
 50 |     #[uniffi::method(foo)]

--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -20,7 +20,7 @@ use self::{
     },
 };
 use crate::util::{ident_to_string, mod_path};
-pub use attributes::{DefaultMap, ExportFnArgs, ExportedImplFnArgs};
+pub use attributes::{AsyncRuntime, DefaultMap, ExportFnArgs};
 pub use callback_interface::ffi_converter_callback_interface_impl;
 
 // TODO(jplatte): Ensure no generics, …
@@ -42,7 +42,7 @@ pub(crate) fn expand_export(
 
     match metadata {
         ExportItem::Function { sig, args } => {
-            gen_fn_scaffolding(sig, &args.async_runtime, udl_mode)
+            gen_fn_scaffolding(sig, args.async_runtime.as_ref(), udl_mode)
         }
         ExportItem::Impl {
             items,
@@ -65,10 +65,14 @@ pub(crate) fn expand_export(
                 .into_iter()
                 .map(|item| match item {
                     ImplItem::Constructor(sig) => {
-                        gen_constructor_scaffolding(sig, &args.async_runtime, udl_mode)
+                        let async_runtime =
+                            sig.async_runtime.clone().or(args.async_runtime.clone());
+                        gen_constructor_scaffolding(sig, async_runtime.as_ref(), udl_mode)
                     }
                     ImplItem::Method(sig) => {
-                        gen_method_scaffolding(sig, &args.async_runtime, udl_mode)
+                        let async_runtime =
+                            sig.async_runtime.clone().or(args.async_runtime.clone());
+                        gen_method_scaffolding(sig, async_runtime.as_ref(), udl_mode)
                     }
                 })
                 .collect::<syn::Result<_>>()?;

--- a/uniffi_macros/src/export/item.rs
+++ b/uniffi_macros/src/export/item.rs
@@ -8,8 +8,7 @@ use proc_macro2::{Ident, Span};
 use quote::ToTokens;
 
 use super::attributes::{
-    ExportFnArgs, ExportImplArgs, ExportStructArgs, ExportTraitArgs, ExportedImplFnArgs,
-    ExportedImplFnAttributes,
+    ExportFnArgs, ExportImplArgs, ExportStructArgs, ExportTraitArgs, ExportedImplFnAttributes,
 };
 use crate::util::extract_docstring;
 use uniffi_meta::UniffiTraitDiscriminants;
@@ -170,7 +169,7 @@ impl ExportItem {
                     ImplItem::Method(FnSignature::new_trait_method(
                         self_ident.clone(),
                         tim.sig,
-                        ExportedImplFnArgs::default(),
+                        ExportFnArgs::default(),
                         i as u32,
                         docstring,
                     )?)

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -11,7 +11,7 @@ use crate::fnsig::{FnKind, FnSignature};
 
 pub(super) fn gen_fn_scaffolding(
     sig: FnSignature,
-    ar: &Option<AsyncRuntime>,
+    ar: Option<&AsyncRuntime>,
     udl_mode: bool,
 ) -> syn::Result<TokenStream> {
     if sig.receiver.is_some() {
@@ -41,7 +41,7 @@ pub(super) fn gen_fn_scaffolding(
 
 pub(super) fn gen_constructor_scaffolding(
     sig: FnSignature,
-    ar: &Option<AsyncRuntime>,
+    ar: Option<&AsyncRuntime>,
     udl_mode: bool,
 ) -> syn::Result<TokenStream> {
     if sig.receiver.is_some() {
@@ -63,7 +63,7 @@ pub(super) fn gen_constructor_scaffolding(
 
 pub(super) fn gen_method_scaffolding(
     sig: FnSignature,
-    ar: &Option<AsyncRuntime>,
+    ar: Option<&AsyncRuntime>,
     udl_mode: bool,
 ) -> syn::Result<TokenStream> {
     let scaffolding_func = if sig.receiver.is_none() {
@@ -210,7 +210,7 @@ impl ScaffoldingBits {
 /// `rust_fn` is the Rust function to call.
 pub(super) fn gen_ffi_function(
     sig: &FnSignature,
-    ar: &Option<AsyncRuntime>,
+    ar: Option<&AsyncRuntime>,
     udl_mode: bool,
 ) -> syn::Result<TokenStream> {
     let ScaffoldingBits {

--- a/uniffi_macros/src/export/trait_interface.rs
+++ b/uniffi_macros/src/export/trait_interface.rs
@@ -84,7 +84,7 @@ pub(super) fn gen_trait_scaffolding(
     let impl_tokens: TokenStream = items
         .into_iter()
         .map(|item| match item {
-            ImplItem::Method(sig) => gen_method_scaffolding(sig, &None, udl_mode),
+            ImplItem::Method(sig) => gen_method_scaffolding(sig, None, udl_mode),
             _ => unreachable!("traits have no constructors"),
         })
         .collect::<syn::Result<_>>()?;

--- a/uniffi_macros/src/export/utrait.rs
+++ b/uniffi_macros/src/export/utrait.rs
@@ -7,7 +7,7 @@ use quote::quote;
 use syn::ext::IdentExt;
 
 use super::gen_ffi_function;
-use crate::export::ExportedImplFnArgs;
+use crate::export::ExportFnArgs;
 use crate::fnsig::FnSignature;
 use crate::util::extract_docstring;
 use uniffi_meta::UniffiTraitDiscriminants;
@@ -165,17 +165,17 @@ fn process_uniffi_trait_method(
         &FnSignature::new_method(
             self_ident.clone(),
             item.sig.clone(),
-            ExportedImplFnArgs::default(),
+            ExportFnArgs::default(),
             docstring.clone(),
         )?,
-        &None,
+        None,
         udl_mode,
     )?;
     // metadata for the method, which will be packed inside metadata for the trait.
     let method_meta = FnSignature::new_method(
         self_ident.clone(),
         item.sig,
-        ExportedImplFnArgs::default(),
+        ExportFnArgs::default(),
         docstring,
     )?
     .metadata_expr()?;


### PR DESCRIPTION
These were basically the same, so using 1 struct simplifies the code.

The one difference was that ExportFnArgs allowed an async runtime to be specified.  Now that the 2 are merged, it's possible to specify an async runtime for constructors/methods.  If present that runtime will override the one specified in the impl attribute.