### PR TITLE
Make the proc-macro constructor error more precise

### DIFF
--- a/uniffi_meta/src/reader.rs
+++ b/uniffi_meta/src/reader.rs
@@ -259,7 +259,7 @@ impl<'a> MetadataReader<'a> {
                     Type::Object { name, imp: ObjectImpl::Struct, .. } if name == &self_name
                 )
             })
-            .context("Constructor return type must be Arc<Self>")?;
+            .context("Constructor return type must be Self or Arc<Self>")?;
 
         Ok(ConstructorMetadata {
             module_path,


### PR DESCRIPTION
Since #1672 was merged, we support both `Arc<Self>` and `Self` return types.

This fixes the confusing error message that we're discussing in #2051