### PR TITLE
RustFuture: fix memory leak

### DIFF
--- a/uniffi_core/src/ffi/rustfuture/mod.rs
+++ b/uniffi_core/src/ffi/rustfuture/mod.rs
@@ -122,7 +122,7 @@ pub unsafe fn rust_future_free<ReturnType, UT>(handle: Handle)
 where
     dyn RustFutureFfi<ReturnType>: HandleAlloc<UT>,
 {
-    <dyn RustFutureFfi<ReturnType> as HandleAlloc<UT>>::get_arc(handle).ffi_free()
+    <dyn RustFutureFfi<ReturnType> as HandleAlloc<UT>>::consume_handle(handle).ffi_free()
 }
 
 // Derive HandleAlloc for dyn RustFutureFfi<T> for all FFI return types


### PR DESCRIPTION
Currently, `rust_future_free` doesn't properly release memory, leading to a memory leak. This happens because `get_arc` increases the reference count of RustFuture without decreasing it afterward. By using `consume_handle` we do not increase it anymore before giving the ownership to `ffi_free`.

I have tested this fix in my project and confirmed that it resolves the memory leak. Let me know if I missed something.

