### PR TITLE
Allow the binding generator to not depend on builtin bindings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
   ([#2073](https://github.com/mozilla/uniffi-rs/issues/2073))
 
 ### What's changed?
+- The internal bindings generation has changed to make it friendlier for external language bindings.
+  However, this is likely to be a small **breaking change** for these bindings.
+  No consumers of any languages are impacted, only the maintainers of these language bindings.
+  ([#2066](https://github.com/mozilla/uniffi-rs/issues/2066))
+
 - The async runtime can be specified for constructors/methods, this will override the runtime specified at the impl block level.
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.27.1...HEAD).

--- a/fixtures/benchmarks/benches/benchmarks.rs
+++ b/fixtures/benchmarks/benches/benchmarks.rs
@@ -5,7 +5,9 @@
 use clap::Parser;
 use std::env;
 use uniffi_benchmarks::Args;
-use uniffi_bindgen::bindings::{kotlin, python, swift, RunScriptOptions};
+use uniffi_bindgen::bindings::{
+    kotlin_run_script, python_run_script, swift_run_script, RunScriptOptions,
+};
 
 fn main() {
     let args = Args::parse();
@@ -18,7 +20,7 @@ fn main() {
     };
 
     if args.should_run_python() {
-        python::run_script(
+        python_run_script(
             std::env!("CARGO_TARGET_TMPDIR"),
             "uniffi-fixture-benchmarks",
             "benches/bindings/run_benchmarks.py",
@@ -29,7 +31,7 @@ fn main() {
     }
 
     if args.should_run_kotlin() {
-        kotlin::run_script(
+        kotlin_run_script(
             std::env!("CARGO_TARGET_TMPDIR"),
             "uniffi-fixture-benchmarks",
             "benches/bindings/run_benchmarks.kts",
@@ -40,7 +42,7 @@ fn main() {
     }
 
     if args.should_run_swift() {
-        swift::run_script(
+        swift_run_script(
             std::env!("CARGO_TARGET_TMPDIR"),
             "uniffi-fixture-benchmarks",
             "benches/bindings/run_benchmarks.swift",

--- a/fixtures/docstring-proc-macro/tests/test_generated_bindings.rs
+++ b/fixtures/docstring-proc-macro/tests/test_generated_bindings.rs
@@ -6,8 +6,7 @@ uniffi::build_foreign_language_testcases!(
 
 #[cfg(test)]
 mod tests {
-    use uniffi_bindgen::bindings::TargetLanguage;
-    use uniffi_bindgen::BindingGeneratorDefault;
+    use uniffi_bindgen::{bindings::*, BindingGenerator};
     use uniffi_testing::UniFFITestHelper;
 
     const DOCSTRINGS: &[&str] = &[
@@ -36,13 +35,16 @@ mod tests {
         "<docstring-variant-field>",
     ];
 
-    fn test_docstring(language: TargetLanguage, file_extension: &str) {
+    fn test_docstring<T: BindingGenerator>(gen: T, file_extension: &str) {
         let test_helper = UniFFITestHelper::new(std::env!("CARGO_PKG_NAME")).unwrap();
 
         let out_dir = test_helper
             .create_out_dir(
                 std::env!("CARGO_TARGET_TMPDIR"),
-                format!("test-docstring-proc-macro-{}", language),
+                format!(
+                    "test-docstring-proc-macro-{}",
+                    file_extension.to_string().replace('.', "")
+                ),
             )
             .unwrap();
 
@@ -51,10 +53,7 @@ mod tests {
         uniffi_bindgen::library_mode::generate_bindings(
             &cdylib_path,
             None,
-            &BindingGeneratorDefault {
-                target_languages: vec![language],
-                try_format_code: false,
-            },
+            &gen,
             None,
             &out_dir,
             false,
@@ -88,16 +87,16 @@ mod tests {
 
     #[test]
     fn test_docstring_kotlin() {
-        test_docstring(TargetLanguage::Kotlin, "kt");
+        test_docstring(KotlinBindingGenerator, "kt");
     }
 
     #[test]
     fn test_docstring_python() {
-        test_docstring(TargetLanguage::Python, "py");
+        test_docstring(PythonBindingGenerator, "py");
     }
 
     #[test]
     fn test_docstring_swift() {
-        test_docstring(TargetLanguage::Swift, "swift");
+        test_docstring(SwiftBindingGenerator, "swift");
     }
 }

--- a/fixtures/docstring/tests/test_generated_bindings.rs
+++ b/fixtures/docstring/tests/test_generated_bindings.rs
@@ -7,8 +7,7 @@ uniffi::build_foreign_language_testcases!(
 #[cfg(test)]
 mod tests {
     use camino::Utf8PathBuf;
-    use uniffi_bindgen::bindings::TargetLanguage;
-    use uniffi_bindgen::BindingGeneratorDefault;
+    use uniffi_bindgen::{bindings::*, BindingGenerator};
     use uniffi_testing::UniFFITestHelper;
 
     const DOCSTRINGS: &[&str] = &[
@@ -36,23 +35,23 @@ mod tests {
         "<docstring-record>",
     ];
 
-    fn test_docstring(language: TargetLanguage, file_extension: &str) {
+    fn test_docstring<T: BindingGenerator>(gen: T, file_extension: &str) {
         let test_helper = UniFFITestHelper::new(std::env!("CARGO_PKG_NAME")).unwrap();
 
         let out_dir = test_helper
             .create_out_dir(
                 std::env!("CARGO_TARGET_TMPDIR"),
-                format!("test-docstring-{}", language),
+                format!(
+                    "test-docstring-{}",
+                    file_extension.to_string().replace('.', "")
+                ),
             )
             .unwrap();
 
         uniffi_bindgen::generate_bindings(
             &Utf8PathBuf::from("src/docstring.udl"),
             None,
-            BindingGeneratorDefault {
-                target_languages: vec![language],
-                try_format_code: false,
-            },
+            gen,
             Some(&out_dir),
             None,
             None,
@@ -87,16 +86,16 @@ mod tests {
 
     #[test]
     fn test_docstring_kotlin() {
-        test_docstring(TargetLanguage::Kotlin, "kt");
+        test_docstring(KotlinBindingGenerator, "kt");
     }
 
     #[test]
     fn test_docstring_python() {
-        test_docstring(TargetLanguage::Python, "py");
+        test_docstring(PythonBindingGenerator, "py");
     }
 
     #[test]
     fn test_docstring_swift() {
-        test_docstring(TargetLanguage::Swift, "swift");
+        test_docstring(SwiftBindingGenerator, "swift");
     }
 }

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -8,20 +8,21 @@ pub use uniffi_macros::*;
 #[cfg(feature = "cli")]
 mod cli;
 #[cfg(feature = "bindgen-tests")]
-pub use uniffi_bindgen::bindings::kotlin::run_test as kotlin_run_test;
+pub use uniffi_bindgen::bindings::kotlin_run_test;
 #[cfg(feature = "bindgen-tests")]
-pub use uniffi_bindgen::bindings::python::run_test as python_run_test;
+pub use uniffi_bindgen::bindings::python_run_test;
 #[cfg(feature = "bindgen-tests")]
-pub use uniffi_bindgen::bindings::ruby::run_test as ruby_run_test;
+pub use uniffi_bindgen::bindings::ruby_run_test;
 #[cfg(feature = "bindgen-tests")]
-pub use uniffi_bindgen::bindings::swift::run_test as swift_run_test;
+pub use uniffi_bindgen::bindings::swift_run_test;
 #[cfg(feature = "bindgen")]
 pub use uniffi_bindgen::{
-    bindings::kotlin::gen_kotlin::KotlinBindingGenerator,
-    bindings::python::gen_python::PythonBindingGenerator,
-    bindings::ruby::gen_ruby::RubyBindingGenerator,
-    bindings::swift::gen_swift::SwiftBindingGenerator, bindings::TargetLanguage, generate_bindings,
-    generate_component_scaffolding, generate_component_scaffolding_for_crate, print_repr,
+    bindings::{
+        KotlinBindingGenerator, PythonBindingGenerator, RubyBindingGenerator,
+        SwiftBindingGenerator, TargetLanguage,
+    },
+    generate_bindings, generate_component_scaffolding, generate_component_scaffolding_for_crate,
+    print_repr,
 };
 #[cfg(feature = "build")]
 pub use uniffi_build::{generate_scaffolding, generate_scaffolding_for_crate};

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -7,16 +7,16 @@ use std::cell::RefCell;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt::Debug;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use askama::Template;
-use camino::Utf8Path;
+
 use heck::{ToLowerCamelCase, ToShoutySnakeCase, ToUpperCamelCase};
 use serde::{Deserialize, Serialize};
 
 use crate::backend::TemplateExpression;
-use crate::bindings::kotlin;
+
 use crate::interface::*;
-use crate::{BindingGenerator, BindingsConfig};
+use crate::BindingsConfig;
 
 mod callback_interface;
 mod compounds;
@@ -28,28 +28,6 @@ mod object;
 mod primitives;
 mod record;
 mod variant;
-
-pub struct KotlinBindingGenerator;
-impl BindingGenerator for KotlinBindingGenerator {
-    type Config = Config;
-
-    fn write_bindings(
-        &self,
-        ci: &ComponentInterface,
-        config: &Config,
-        out_dir: &Utf8Path,
-        try_format_code: bool,
-    ) -> Result<()> {
-        kotlin::write_bindings(config, ci, out_dir, try_format_code)
-    }
-
-    fn check_library_path(&self, library_path: &Utf8Path, cdylib_name: Option<&str>) -> Result<()> {
-        if cdylib_name.is_none() {
-            bail!("Generate bindings for Kotlin requires a cdylib, but {library_path} was given");
-        }
-        Ok(())
-    }
-}
 
 trait CodeType: Debug {
     /// The language specific label used to reference this type. This will be used in

--- a/uniffi_bindgen/src/bindings/kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/mod.rs
@@ -2,37 +2,60 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::{BindingGenerator, ComponentInterface};
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
 use std::process::Command;
 
-pub mod gen_kotlin;
-pub use gen_kotlin::{generate_bindings, Config};
+mod gen_kotlin;
+use gen_kotlin::{generate_bindings, Config};
 mod test;
-
-use super::super::interface::ComponentInterface;
 pub use test::{run_script, run_test};
 
-pub fn write_bindings(
-    config: &Config,
-    ci: &ComponentInterface,
-    out_dir: &Utf8Path,
-    try_format_code: bool,
-) -> Result<()> {
-    let mut kt_file = full_bindings_path(config, out_dir);
-    fs::create_dir_all(&kt_file)?;
-    kt_file.push(format!("{}.kt", ci.namespace()));
-    fs::write(&kt_file, generate_bindings(config, ci)?)?;
-    if try_format_code {
-        if let Err(e) = Command::new("ktlint").arg("-F").arg(&kt_file).output() {
-            println!(
-                "Warning: Unable to auto-format {} using ktlint: {e:?}",
-                kt_file.file_name().unwrap(),
+pub struct KotlinBindingGenerator;
+impl BindingGenerator for KotlinBindingGenerator {
+    type Config = Config;
+
+    fn new_config(&self, root_toml: &toml::Value) -> Result<Self::Config> {
+        Ok(
+            match root_toml.get("bindings").and_then(|b| b.get("kotlin")) {
+                Some(v) => v.clone().try_into()?,
+                None => Default::default(),
+            },
+        )
+    }
+
+    fn write_bindings(
+        &self,
+        ci: &ComponentInterface,
+        config: &Config,
+        out_dir: &Utf8Path,
+        try_format_code: bool,
+    ) -> Result<()> {
+        let mut kt_file = full_bindings_path(config, out_dir);
+        fs::create_dir_all(&kt_file)?;
+        kt_file.push(format!("{}.kt", ci.namespace()));
+        fs::write(&kt_file, generate_bindings(config, ci)?)?;
+        if try_format_code {
+            if let Err(e) = Command::new("ktlint").arg("-F").arg(&kt_file).output() {
+                println!(
+                    "Warning: Unable to auto-format {} using ktlint: {e:?}",
+                    kt_file.file_name().unwrap(),
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn check_library_path(&self, library_path: &Utf8Path, cdylib_name: Option<&str>) -> Result<()> {
+        if cdylib_name.is_none() {
+            anyhow::bail!(
+                "Generate bindings for Kotlin requires a cdylib, but {library_path} was given"
             );
         }
+        Ok(())
     }
-    Ok(())
 }
 
 fn full_bindings_path(config: &Config, out_dir: &Utf8Path) -> Utf8PathBuf {

--- a/uniffi_bindgen/src/bindings/kotlin/test.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/test.rs
@@ -2,8 +2,8 @@
 License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bindings::TargetLanguage;
-use crate::{bindings::RunScriptOptions, library_mode::generate_bindings, BindingGeneratorDefault};
+use crate::bindings::RunScriptOptions;
+use crate::library_mode::generate_bindings;
 use anyhow::{bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use std::env;
@@ -38,10 +38,7 @@ pub fn run_script(
     generate_bindings(
         &cdylib_path,
         None,
-        &BindingGeneratorDefault {
-            target_languages: vec![TargetLanguage::Kotlin],
-            try_format_code: false,
-        },
+        &super::KotlinBindingGenerator,
         None,
         &out_dir,
         false,

--- a/uniffi_bindgen/src/bindings/mod.rs
+++ b/uniffi_bindgen/src/bindings/mod.rs
@@ -8,16 +8,23 @@
 //! along with some helpers for executing foreign language scripts or tests.
 
 use anyhow::{bail, Result};
-use camino::Utf8Path;
-use serde::{Deserialize, Serialize};
+
 use std::fmt;
 
-use crate::interface::ComponentInterface;
-
-pub mod kotlin;
-pub mod python;
-pub mod ruby;
-pub mod swift;
+mod kotlin;
+pub use kotlin::{
+    run_script as kotlin_run_script, run_test as kotlin_run_test, KotlinBindingGenerator,
+};
+mod python;
+pub use python::{
+    run_script as python_run_script, run_test as python_run_test, PythonBindingGenerator,
+};
+mod ruby;
+pub use ruby::{run_test as ruby_run_test, RubyBindingGenerator};
+mod swift;
+pub use swift::{
+    run_script as swift_run_script, run_test as swift_run_test, SwiftBindingGenerator,
+};
 
 /// Enumeration of all foreign language targets currently supported by this crate.
 ///
@@ -87,39 +94,4 @@ impl TryFrom<String> for TargetLanguage {
     fn try_from(value: String) -> Result<Self> {
         TryFrom::try_from(value.as_str())
     }
-}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct Config {
-    #[serde(default)]
-    pub(crate) kotlin: kotlin::Config,
-    #[serde(default)]
-    pub(crate) swift: swift::Config,
-    #[serde(default)]
-    pub(crate) python: python::Config,
-    #[serde(default)]
-    pub(crate) ruby: ruby::Config,
-}
-
-/// Generate foreign language bindings from a compiled `uniffi` library.
-pub fn write_bindings(
-    config: &Config,
-    ci: &ComponentInterface,
-    out_dir: &Utf8Path,
-    language: TargetLanguage,
-    try_format_code: bool,
-) -> Result<()> {
-    match language {
-        TargetLanguage::Kotlin => {
-            kotlin::write_bindings(&config.kotlin, ci, out_dir, try_format_code)?
-        }
-        TargetLanguage::Swift => {
-            swift::write_bindings(&config.swift, ci, out_dir, try_format_code)?
-        }
-        TargetLanguage::Python => {
-            python::write_bindings(&config.python, ci, out_dir, try_format_code)?
-        }
-        TargetLanguage::Ruby => ruby::write_bindings(&config.ruby, ci, out_dir, try_format_code)?,
-    }
-    Ok(())
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use askama::Template;
-use camino::Utf8Path;
+
 use heck::{ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
@@ -14,9 +14,9 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt::Debug;
 
 use crate::backend::TemplateExpression;
-use crate::bindings::python;
+
 use crate::interface::*;
-use crate::{BindingGenerator, BindingsConfig};
+use crate::BindingsConfig;
 
 mod callback_interface;
 mod compounds;
@@ -27,29 +27,6 @@ mod miscellany;
 mod object;
 mod primitives;
 mod record;
-
-pub struct PythonBindingGenerator;
-
-impl BindingGenerator for PythonBindingGenerator {
-    type Config = Config;
-
-    fn write_bindings(
-        &self,
-        ci: &ComponentInterface,
-        config: &Config,
-        out_dir: &Utf8Path,
-        try_format_code: bool,
-    ) -> Result<()> {
-        python::write_bindings(config, ci, out_dir, try_format_code)
-    }
-
-    fn check_library_path(&self, library_path: &Utf8Path, cdylib_name: Option<&str>) -> Result<()> {
-        if cdylib_name.is_none() {
-            bail!("Generate bindings for Python requires a cdylib, but {library_path} was given");
-        }
-        Ok(())
-    }
-}
 
 /// A trait tor the implementation.
 trait CodeType: Debug {
@@ -181,8 +158,6 @@ impl BindingsConfig for Config {
         self.cdylib_name
             .get_or_insert_with(|| cdylib_name.to_string());
     }
-
-    fn update_from_dependency_configs(&mut self, _config_map: HashMap<&str, &Self>) {}
 }
 
 // Generate python bindings for the given ComponentInterface, as a string.

--- a/uniffi_bindgen/src/bindings/python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/mod.rs
@@ -8,30 +8,54 @@ use anyhow::Result;
 use camino::Utf8Path;
 use fs_err as fs;
 
-pub mod gen_python;
+mod gen_python;
 mod test;
 use super::super::interface::ComponentInterface;
-pub use gen_python::{generate_python_bindings, Config};
+use gen_python::{generate_python_bindings, Config};
 pub use test::{run_script, run_test};
 
-// Generate python bindings for the given ComponentInterface, in the given output directory.
-pub fn write_bindings(
-    config: &Config,
-    ci: &ComponentInterface,
-    out_dir: &Utf8Path,
-    try_format_code: bool,
-) -> Result<()> {
-    let py_file = out_dir.join(format!("{}.py", ci.namespace()));
-    fs::write(&py_file, generate_python_bindings(config, ci)?)?;
+pub struct PythonBindingGenerator;
 
-    if try_format_code {
-        if let Err(e) = Command::new("yapf").arg(&py_file).output() {
-            println!(
-                "Warning: Unable to auto-format {} using yapf: {e:?}",
-                py_file.file_name().unwrap(),
-            )
-        }
+impl crate::BindingGenerator for PythonBindingGenerator {
+    type Config = Config;
+
+    fn new_config(&self, root_toml: &toml::Value) -> Result<Self::Config> {
+        Ok(
+            match root_toml.get("bindings").and_then(|b| b.get("python")) {
+                Some(v) => v.clone().try_into()?,
+                None => Default::default(),
+            },
+        )
     }
 
-    Ok(())
+    fn write_bindings(
+        &self,
+        ci: &ComponentInterface,
+        config: &Config,
+        out_dir: &Utf8Path,
+        try_format_code: bool,
+    ) -> Result<()> {
+        let py_file = out_dir.join(format!("{}.py", ci.namespace()));
+        fs::write(&py_file, generate_python_bindings(config, ci)?)?;
+
+        if try_format_code {
+            if let Err(e) = Command::new("yapf").arg(&py_file).output() {
+                println!(
+                    "Warning: Unable to auto-format {} using yapf: {e:?}",
+                    py_file.file_name().unwrap(),
+                )
+            }
+        }
+
+        Ok(())
+    }
+
+    fn check_library_path(&self, library_path: &Utf8Path, cdylib_name: Option<&str>) -> Result<()> {
+        if cdylib_name.is_none() {
+            anyhow::bail!(
+                "Generate bindings for Python requires a cdylib, but {library_path} was given"
+            );
+        }
+        Ok(())
+    }
 }

--- a/uniffi_bindgen/src/bindings/python/test.rs
+++ b/uniffi_bindgen/src/bindings/python/test.rs
@@ -2,8 +2,8 @@
 License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bindings::TargetLanguage;
-use crate::{bindings::RunScriptOptions, library_mode::generate_bindings, BindingGeneratorDefault};
+use crate::bindings::RunScriptOptions;
+use crate::library_mode::generate_bindings;
 use anyhow::{Context, Result};
 use camino::Utf8Path;
 use std::env;
@@ -39,10 +39,7 @@ pub fn run_script(
     generate_bindings(
         &cdylib_path,
         None,
-        &BindingGeneratorDefault {
-            target_languages: vec![TargetLanguage::Python],
-            try_format_code: false,
-        },
+        &super::PythonBindingGenerator,
         None,
         &out_dir,
         false,

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -2,39 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use askama::Template;
-use camino::Utf8Path;
+
 use heck::{ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
-use std::collections::HashMap;
 
-use crate::bindings::ruby;
 use crate::interface::*;
-use crate::{BindingGenerator, BindingsConfig};
-
-pub struct RubyBindingGenerator;
-impl BindingGenerator for RubyBindingGenerator {
-    type Config = Config;
-
-    fn write_bindings(
-        &self,
-        ci: &ComponentInterface,
-        config: &Config,
-        out_dir: &Utf8Path,
-        try_format_code: bool,
-    ) -> Result<()> {
-        ruby::write_bindings(config, ci, out_dir, try_format_code)
-    }
-
-    fn check_library_path(&self, library_path: &Utf8Path, cdylib_name: Option<&str>) -> Result<()> {
-        if cdylib_name.is_none() {
-            bail!("Generate bindings for Ruby requires a cdylib, but {library_path} was given");
-        }
-        Ok(())
-    }
-}
+use crate::BindingsConfig;
 
 const RESERVED_WORDS: &[&str] = &[
     "alias", "and", "BEGIN", "begin", "break", "case", "class", "def", "defined?", "do", "else",
@@ -136,8 +112,6 @@ impl BindingsConfig for Config {
         self.cdylib_name
             .get_or_insert_with(|| cdylib_name.to_string());
     }
-
-    fn update_from_dependency_configs(&mut self, _config_map: HashMap<&str, &Self>) {}
 }
 
 #[derive(Template)]

--- a/uniffi_bindgen/src/bindings/ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/mod.rs
@@ -4,42 +4,62 @@
 
 use std::process::Command;
 
+use crate::{BindingGenerator, ComponentInterface};
 use anyhow::{Context, Result};
 use camino::Utf8Path;
 use fs_err as fs;
 
-pub mod gen_ruby;
+mod gen_ruby;
 mod test;
-pub use gen_ruby::{Config, RubyWrapper};
-pub use test::{run_test, test_script_command};
+use gen_ruby::{Config, RubyWrapper};
+pub use test::run_test;
 
-use super::super::interface::ComponentInterface;
+pub struct RubyBindingGenerator;
+impl BindingGenerator for RubyBindingGenerator {
+    type Config = Config;
 
-// Generate ruby bindings for the given ComponentInterface, in the given output directory.
-
-pub fn write_bindings(
-    config: &Config,
-    ci: &ComponentInterface,
-    out_dir: &Utf8Path,
-    try_format_code: bool,
-) -> Result<()> {
-    let rb_file = out_dir.join(format!("{}.rb", ci.namespace()));
-    fs::write(&rb_file, generate_ruby_bindings(config, ci)?)?;
-
-    if try_format_code {
-        if let Err(e) = Command::new("rubocop").arg("-A").arg(&rb_file).output() {
-            println!(
-                "Warning: Unable to auto-format {} using rubocop: {e:?}",
-                rb_file.file_name().unwrap(),
-            )
-        }
+    fn new_config(&self, root_toml: &toml::Value) -> Result<Self::Config> {
+        Ok(
+            match root_toml.get("bindings").and_then(|b| b.get("ruby")) {
+                Some(v) => v.clone().try_into()?,
+                None => Default::default(),
+            },
+        )
     }
 
-    Ok(())
+    fn write_bindings(
+        &self,
+        ci: &ComponentInterface,
+        config: &Config,
+        out_dir: &Utf8Path,
+        try_format_code: bool,
+    ) -> Result<()> {
+        let rb_file = out_dir.join(format!("{}.rb", ci.namespace()));
+        fs::write(&rb_file, generate_ruby_bindings(config, ci)?)?;
+
+        if try_format_code {
+            if let Err(e) = Command::new("rubocop").arg("-A").arg(&rb_file).output() {
+                println!(
+                    "Warning: Unable to auto-format {} using rubocop: {e:?}",
+                    rb_file.file_name().unwrap(),
+                )
+            }
+        }
+
+        Ok(())
+    }
+
+    fn check_library_path(&self, library_path: &Utf8Path, cdylib_name: Option<&str>) -> Result<()> {
+        if cdylib_name.is_none() {
+            anyhow::bail!(
+                "Generate bindings for Ruby requires a cdylib, but {library_path} was given"
+            );
+        }
+        Ok(())
+    }
 }
 
 // Generate ruby bindings for the given ComponentInterface, as a string.
-
 pub fn generate_ruby_bindings(config: &Config, ci: &ComponentInterface) -> Result<String> {
     use askama::Template;
     RubyWrapper::new(config.clone(), ci)

--- a/uniffi_bindgen/src/bindings/ruby/test.rs
+++ b/uniffi_bindgen/src/bindings/ruby/test.rs
@@ -2,9 +2,7 @@
 License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bindings::TargetLanguage;
 use crate::library_mode::generate_bindings;
-use crate::BindingGeneratorDefault;
 use anyhow::{bail, Context, Result};
 use camino::Utf8Path;
 use std::env;
@@ -38,10 +36,7 @@ pub fn test_script_command(
     generate_bindings(
         &cdylib_path,
         None,
-        &BindingGeneratorDefault {
-            target_languages: vec![TargetLanguage::Ruby],
-            try_format_code: false,
-        },
+        &super::RubyBindingGenerator,
         None,
         &out_dir,
         false,

--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -29,22 +29,20 @@
 //!  * How to read from and write into a byte buffer.
 //!
 
-use std::process::Command;
-
+use crate::{BindingGenerator, ComponentInterface};
 use anyhow::Result;
 use camino::Utf8Path;
 use fs_err as fs;
+use std::process::Command;
 
-pub mod gen_swift;
-pub use gen_swift::{generate_bindings, Config};
+mod gen_swift;
+use gen_swift::{generate_bindings, Config};
 mod test;
-
-use super::super::interface::ComponentInterface;
 pub use test::{run_script, run_test};
 
 /// The Swift bindings generated from a [`ComponentInterface`].
 ///
-pub struct Bindings {
+struct Bindings {
     /// The contents of the generated `.swift` file, as a string.
     library: String,
     /// The contents of the generated `.h` file, as a string.
@@ -53,45 +51,66 @@ pub struct Bindings {
     modulemap: Option<String>,
 }
 
-/// Write UniFFI component bindings for Swift as files on disk.
-///
-/// Unlike other target languages, binding to Rust code from Swift involves more than just
-/// generating a `.swift` file. We also need to produce a `.h` file with the C-level API
-/// declarations, and a `.modulemap` file to tell Swift how to use it.
-pub fn write_bindings(
-    config: &Config,
-    ci: &ComponentInterface,
-    out_dir: &Utf8Path,
-    try_format_code: bool,
-) -> Result<()> {
-    let Bindings {
-        header,
-        library,
-        modulemap,
-    } = generate_bindings(config, ci)?;
+pub struct SwiftBindingGenerator;
+impl BindingGenerator for SwiftBindingGenerator {
+    type Config = Config;
 
-    let source_file = out_dir.join(format!("{}.swift", config.module_name()));
-    fs::write(&source_file, library)?;
-
-    let header_file = out_dir.join(config.header_filename());
-    fs::write(header_file, header)?;
-
-    if let Some(modulemap) = modulemap {
-        let modulemap_file = out_dir.join(config.modulemap_filename());
-        fs::write(modulemap_file, modulemap)?;
+    fn new_config(&self, root_toml: &toml::Value) -> Result<Self::Config> {
+        Ok(
+            match root_toml.get("bindings").and_then(|b| b.get("swift")) {
+                Some(v) => v.clone().try_into()?,
+                None => Default::default(),
+            },
+        )
     }
 
-    if try_format_code {
-        if let Err(e) = Command::new("swiftformat")
-            .arg(source_file.as_str())
-            .output()
-        {
-            println!(
-                "Warning: Unable to auto-format {} using swiftformat: {e:?}",
-                source_file.file_name().unwrap(),
-            );
+    /// Unlike other target languages, binding to Rust code from Swift involves more than just
+    /// generating a `.swift` file. We also need to produce a `.h` file with the C-level API
+    /// declarations, and a `.modulemap` file to tell Swift how to use it.
+    fn write_bindings(
+        &self,
+        ci: &ComponentInterface,
+        config: &Config,
+        out_dir: &Utf8Path,
+        try_format_code: bool,
+    ) -> Result<()> {
+        let Bindings {
+            header,
+            library,
+            modulemap,
+        } = generate_bindings(config, ci)?;
+
+        let source_file = out_dir.join(format!("{}.swift", config.module_name()));
+        fs::write(&source_file, library)?;
+
+        let header_file = out_dir.join(config.header_filename());
+        fs::write(header_file, header)?;
+
+        if let Some(modulemap) = modulemap {
+            let modulemap_file = out_dir.join(config.modulemap_filename());
+            fs::write(modulemap_file, modulemap)?;
         }
+
+        if try_format_code {
+            if let Err(e) = Command::new("swiftformat")
+                .arg(source_file.as_str())
+                .output()
+            {
+                println!(
+                    "Warning: Unable to auto-format {} using swiftformat: {e:?}",
+                    source_file.file_name().unwrap(),
+                );
+            }
+        }
+
+        Ok(())
     }
 
-    Ok(())
+    fn check_library_path(
+        &self,
+        _library_path: &Utf8Path,
+        _cdylib_name: Option<&str>,
+    ) -> Result<()> {
+        Ok(())
+    }
 }

--- a/uniffi_bindgen/src/bindings/swift/test.rs
+++ b/uniffi_bindgen/src/bindings/swift/test.rs
@@ -2,7 +2,9 @@
 License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::{bindings::RunScriptOptions, library_mode::generate_bindings, BindingGeneratorDefault};
+use crate::bindings::RunScriptOptions;
+use crate::library_mode::generate_bindings;
+
 use anyhow::{bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
@@ -11,8 +13,6 @@ use std::fs::{read_to_string, File};
 use std::io::Write;
 use std::process::{Command, Stdio};
 use uniffi_testing::UniFFITestHelper;
-
-use crate::bindings::TargetLanguage;
 
 /// Run Swift tests for a UniFFI test fixture
 pub fn run_test(tmp_dir: &str, fixture_name: &str, script_file: &str) -> Result<()> {
@@ -128,10 +128,7 @@ impl GeneratedSources {
         let sources = generate_bindings(
             cdylib_path,
             None,
-            &BindingGeneratorDefault {
-                target_languages: vec![TargetLanguage::Swift],
-                try_format_code: false,
-            },
+            &super::SwiftBindingGenerator,
             None,
             out_dir,
             false,
@@ -140,7 +137,7 @@ impl GeneratedSources {
             .iter()
             .find(|s| s.package.name == crate_name)
             .unwrap();
-        let main_module = main_source.config.bindings.swift.module_name();
+        let main_module = main_source.config.module_name();
         let modulemap_glob = glob(&out_dir.join("*.modulemap"))?;
         let module_map = match modulemap_glob.len() {
             0 => bail!("No modulemap files found in {out_dir}"),


### PR DESCRIPTION
Previously there were internal `Config` details which only worked with
builtin bindings types. This leans in to the `BindingGenerator` trait
to make things less coupled with the builtin bindings and better
for external bindings.
