### PR TITLE
Add test for custom_newtype Python error

### DIFF
--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -382,4 +382,24 @@ impl ObjectWithDefaults {
     }
 }
 
+pub struct CustomNewtype(pub String);
+uniffi::custom_newtype!(CustomNewtype, String);
+
+// This newtype contains another newtype and alphabetically comes before it,
+// so forward references are required for generating valid Python.
+pub struct ASecondCustomNewtype(pub CustomNewtype);
+uniffi::custom_newtype!(ASecondCustomNewtype, CustomNewtype);
+
+#[derive(uniffi::Object)]
+pub struct ObjectWithNewtype {
+    pub str: ASecondCustomNewtype,
+}
+#[uniffi::export]
+impl ObjectWithNewtype {
+    #[uniffi::constructor]
+    fn new(str: ASecondCustomNewtype) -> Self {
+        Self { str }
+    }
+}
+
 uniffi::include_scaffolding!("proc-macro");


### PR DESCRIPTION
This PR is expected to fail in its current state as a way to demonstrate a possible error in generated Python when using custom newtypes.

Please feel free to close or edit as needed.