### PR TITLE
Demonstrate passing a hashmap to a procmacro function.

### DIFF
--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -144,7 +144,6 @@ fn make_hashmap(k: i8, v: u64) -> HashMap<i8, u64> {
     HashMap::from([(k, v)])
 }
 
-// XXX - fails to call this from python - https://github.com/mozilla/uniffi-rs/issues/1774
 #[uniffi::export]
 fn return_hashmap(h: HashMap<i8, u64>) -> HashMap<i8, u64> {
     h

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -42,9 +42,8 @@ assert(make_zero().inner == "ZERO")
 assert(make_record_with_bytes().some_bytes == bytes([0, 1, 2, 3, 4]))
 
 assert(make_hashmap(1, 2) == {1: 2})
-# fails with AttributeError!? - https://github.com/mozilla/uniffi-rs/issues/1774
-# d = {1, 2}
-# assert(return_hashmap(d) == d)
+d = {1: 2}
+assert(return_hashmap(d) == d)
 
 assert(join(["a", "b", "c"], ":") == "a:b:c")
 


### PR DESCRIPTION
#1774 said it doesn't work but it does if you pass the correct type