### PR TITLE
Factor out FFI converter operations

### DIFF
--- a/uniffi_macros/src/custom.rs
+++ b/uniffi_macros/src/custom.rs
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::util::{derive_all_ffi_traits, ident_to_string, mod_path, tagged_impl_header};
+use crate::{
+    ffiops,
+    util::{derive_all_ffi_traits, ident_to_string, mod_path, tagged_impl_header},
+};
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use syn::Path;
@@ -18,6 +21,14 @@ pub(crate) fn expand_ffi_converter_custom_type(
     let derive_ffi_traits = derive_all_ffi_traits(ident, udl_mode);
     let name = ident_to_string(ident);
     let mod_path = mod_path()?;
+    let from_custom = quote! { <#ident as crate::UniffiCustomTypeConverter>::from_custom };
+    let into_custom = quote! { <#ident as crate::UniffiCustomTypeConverter>::into_custom };
+    let lower_type = ffiops::lower_type(builtin);
+    let lower = ffiops::lower(builtin);
+    let write = ffiops::write(builtin);
+    let try_lift = ffiops::try_lift(builtin);
+    let try_read = ffiops::try_read(builtin);
+    let type_id_meta = ffiops::type_id_meta(builtin);
 
     Ok(quote! {
         #[automatically_derived]
@@ -25,27 +36,27 @@ pub(crate) fn expand_ffi_converter_custom_type(
             // Note: the builtin type needs to implement both `Lower` and `Lift'.  We use the
             // `Lower` trait to get the associated type `FfiType` and const `TYPE_ID_META`.  These
             // can't differ between `Lower` and `Lift`.
-            type FfiType = <#builtin as ::uniffi::Lower<crate::UniFfiTag>>::FfiType;
+            type FfiType = #lower_type;
             fn lower(obj: #ident ) -> Self::FfiType {
-                <#builtin as ::uniffi::Lower<crate::UniFfiTag>>::lower(<#ident as crate::UniffiCustomTypeConverter>::from_custom(obj))
+                #lower(#from_custom(obj))
             }
 
             fn try_lift(v: Self::FfiType) -> uniffi::Result<#ident> {
-                <#ident as crate::UniffiCustomTypeConverter>::into_custom(<#builtin as ::uniffi::Lift<crate::UniFfiTag>>::try_lift(v)?)
+                #into_custom(#try_lift(v)?)
             }
 
             fn write(obj: #ident, buf: &mut Vec<u8>) {
-                <#builtin as ::uniffi::Lower<crate::UniFfiTag>>::write(<#ident as crate::UniffiCustomTypeConverter>::from_custom(obj), buf);
+                #write(#from_custom(obj), buf);
             }
 
             fn try_read(buf: &mut &[u8]) -> uniffi::Result<#ident> {
-                <#ident as crate::UniffiCustomTypeConverter>::into_custom(<#builtin as ::uniffi::Lift<crate::UniFfiTag>>::try_read(buf)?)
+                #into_custom(#try_read(buf)?)
             }
 
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_CUSTOM)
                 .concat_str(#mod_path)
                 .concat_str(#name)
-                .concat(<#builtin as ::uniffi::TypeId<crate::UniFfiTag>>::TYPE_ID_META);
+                .concat(#type_id_meta);
         }
 
         #derive_ffi_traits

--- a/uniffi_macros/src/export/callback_interface.rs
+++ b/uniffi_macros/src/export/callback_interface.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     export::ImplItem,
+    ffiops,
     fnsig::{FnKind, FnSignature, ReceiverArg},
     util::{
         create_metadata_items, derive_ffi_traits, ident_to_string, mod_path, tagged_impl_header,
@@ -44,33 +45,32 @@ pub(super) fn trait_impl(
         })
         .collect::<syn::Result<Vec<_>>>()?;
 
-    let vtable_fields = methods.iter()
-        .map(|sig| {
-            let ident = &sig.ident;
-            let param_names = sig.scaffolding_param_names();
-            let param_types = sig.scaffolding_param_types();
-            let lift_return = sig.lift_return_impl();
-            if !sig.is_async {
-                quote! {
-                    #ident: extern "C" fn(
-                        uniffi_handle: u64,
-                        #(#param_names: #param_types,)*
-                        uniffi_out_return: &mut #lift_return::ReturnType,
-                        uniffi_out_call_status: &mut ::uniffi::RustCallStatus,
-                    ),
-                }
-            } else {
-                quote! {
-                    #ident: extern "C" fn(
-                        uniffi_handle: u64,
-                        #(#param_names: #param_types,)*
-                        uniffi_future_callback: ::uniffi::ForeignFutureCallback<#lift_return::ReturnType>,
-                        uniffi_callback_data: u64,
-                        uniffi_out_return: &mut ::uniffi::ForeignFuture,
-                    ),
-                }
+    let vtable_fields = methods.iter().map(|sig| {
+        let ident = &sig.ident;
+        let param_names = sig.scaffolding_param_names();
+        let param_types = sig.scaffolding_param_types();
+        let lift_return_type = ffiops::lift_return_type(&sig.return_ty);
+        if !sig.is_async {
+            quote! {
+                #ident: extern "C" fn(
+                    uniffi_handle: u64,
+                    #(#param_names: #param_types,)*
+                    uniffi_out_return: &mut #lift_return_type,
+                    uniffi_out_call_status: &mut ::uniffi::RustCallStatus,
+                ),
             }
-        });
+        } else {
+            quote! {
+                #ident: extern "C" fn(
+                    uniffi_handle: u64,
+                    #(#param_names: #param_types,)*
+                    uniffi_future_callback: ::uniffi::ForeignFutureCallback<#lift_return_type>,
+                    uniffi_callback_data: u64,
+                    uniffi_out_return: &mut ::uniffi::ForeignFuture,
+                ),
+            }
+        }
+    });
 
     let trait_impl_methods = methods
         .iter()
@@ -141,6 +141,7 @@ pub fn ffi_converter_callback_interface_impl(
         Ok(p) => p,
         Err(e) => return e.into_compile_error(),
     };
+    let try_lift_self = ffiops::try_lift(quote! { Self });
 
     quote! {
         #[doc(hidden)]
@@ -155,7 +156,7 @@ pub fn ffi_converter_callback_interface_impl(
             fn try_read(buf: &mut &[u8]) -> ::uniffi::deps::anyhow::Result<Self> {
                 use uniffi::deps::bytes::Buf;
                 ::uniffi::check_remaining(buf, 8)?;
-                <Self as ::uniffi::Lift<crate::UniFfiTag>>::try_lift(buf.get_u64())
+                #try_lift_self(buf.get_u64())
             }
         }
 
@@ -209,21 +210,22 @@ fn gen_method_impl(sig: &FnSignature, vtable_cell: &Ident) -> syn::Result<TokenS
 
     let params = sig.params();
     let lower_exprs = sig.args.iter().map(|a| {
-        let lower_impl = a.lower_impl();
+        let lower = ffiops::lower(&a.ty);
         let ident = &a.ident;
-        quote! { #lower_impl::lower(#ident) }
+        quote! { #lower(#ident) }
     });
 
-    let lift_return = sig.lift_return_impl();
+    let lift_return_type = ffiops::lift_return_type(&sig.return_ty);
+    let lift_foreign_return = ffiops::lift_foreign_return(&sig.return_ty);
 
     if !is_async {
         Ok(quote! {
             fn #ident(#self_param, #(#params),*) -> #return_ty {
                 let vtable = #vtable_cell.get();
                 let mut uniffi_call_status = ::uniffi::RustCallStatus::new();
-                let mut uniffi_return_value: #lift_return::ReturnType = ::uniffi::FfiDefault::ffi_default();
+                let mut uniffi_return_value: #lift_return_type = ::uniffi::FfiDefault::ffi_default();
                 (vtable.#ident)(self.handle, #(#lower_exprs,)* &mut uniffi_return_value, &mut uniffi_call_status);
-                #lift_return::lift_foreign_return(uniffi_return_value, uniffi_call_status)
+                #lift_foreign_return(uniffi_return_value, uniffi_call_status)
             }
         })
     } else {

--- a/uniffi_macros/src/ffiops.rs
+++ b/uniffi_macros/src/ffiops.rs
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Functions, types and expressions to handle FFI operations.
+//!
+//! This module leverages the various traits defined in `uniffi_core::ffi_converter_traits` to provide functionality to the rest of `uniffi_macros`.
+//! Keeping this layer separate makes it easier to handle changes to those traits.
+//! See `uniffi_core::ffi_converter_traits` for the meaning of these functions.
+
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+
+// Lower type
+pub fn lower_type(ty: impl ToTokens) -> TokenStream {
+    quote! {
+        <#ty as ::uniffi::Lower<crate::UniFfiTag>>::FfiType
+    }
+}
+
+// Lower function
+pub fn lower(ty: impl ToTokens) -> TokenStream {
+    quote! {
+        <#ty as ::uniffi::Lower<crate::UniFfiTag>>::lower
+    }
+}
+
+// Lift type
+pub fn lift_type(ty: impl ToTokens) -> TokenStream {
+    quote! {
+        <#ty as ::uniffi::Lift<crate::UniFfiTag>>::FfiType
+    }
+}
+
+// Lift function
+pub fn try_lift(ty: impl ToTokens) -> TokenStream {
+    quote! {
+        <#ty as ::uniffi::Lift<crate::UniFfiTag>>::try_lift
+    }
+}
+
+/// Write function
+pub fn write(ty: impl ToTokens) -> TokenStream {
+    quote! {
+        <#ty as ::uniffi::Lower<crate::UniFfiTag>>::write
+    }
+}
+
+/// Read function
+pub fn try_read(ty: impl ToTokens) -> TokenStream {
+    quote! {
+        <#ty as ::uniffi::Lift<crate::UniFfiTag>>::try_read
+    }
+}
+
+/// Lower return type
+pub fn lower_return_type(ty: impl ToTokens) -> TokenStream {
+    quote! {
+        <#ty as ::uniffi::LowerReturn<crate::UniFfiTag>>::ReturnType
+    }
+}
+
+/// Lower return function
+pub fn lower_return(ty: impl ToTokens) -> TokenStream {
+    quote! {
+        <#ty as ::uniffi::LowerReturn<crate::UniFfiTag>>::lower_return
+    }
+}
+
+/// Lift return type
+pub fn lift_return_type(ty: impl ToTokens) -> TokenStream {
+    quote! {
+        <#ty as ::uniffi::LiftReturn<crate::UniFfiTag>>::ReturnType
+    }
+}
+
+/// Lift foreign return function
+pub fn lift_foreign_return(ty: impl ToTokens) -> TokenStream {
+    quote! {
+        <#ty as ::uniffi::LiftReturn<crate::UniFfiTag>>::lift_foreign_return
+    }
+}
+
+/// Handle failed lift function
+pub fn lower_return_handle_failed_lift(ty: impl ToTokens) -> TokenStream {
+    quote! {
+        <#ty as ::uniffi::LowerReturn<crate::UniFfiTag>>::handle_failed_lift
+    }
+}
+
+/// LiftRef type
+pub fn lift_ref_type(ty: impl ToTokens) -> TokenStream {
+    quote! { <#ty as ::uniffi::LiftRef<crate::UniFfiTag>>::LiftType }
+}
+
+/// Lower into rust buffer function
+pub fn lower_into_rust_buffer(ty: impl ToTokens) -> TokenStream {
+    quote! {
+        <#ty as ::uniffi::Lower<crate::UniFfiTag>>::lower_into_rust_buffer
+    }
+}
+
+/// Lift from rust buffer function
+pub fn try_lift_from_rust_buffer(ty: impl ToTokens) -> TokenStream {
+    quote! {
+        <#ty as ::uniffi::Lift<crate::UniFfiTag>>::try_lift_from_rust_buffer
+    }
+}
+
+/// Expression for the TYPE_ID_META value for a type
+pub fn type_id_meta(ty: impl ToTokens) -> TokenStream {
+    quote! {
+        <#ty as ::uniffi::TypeId<crate::UniFfiTag>>::TYPE_ID_META
+    }
+}

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -20,6 +20,7 @@ mod default;
 mod enum_;
 mod error;
 mod export;
+mod ffiops;
 mod fnsig;
 mod object;
 mod record;

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::ffiops;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote, ToTokens};
 use std::path::{Path as StdPath, PathBuf};
@@ -77,14 +78,14 @@ pub fn mod_path() -> syn::Result<String> {
 
 pub fn try_read_field(f: &syn::Field) -> TokenStream {
     let ident = &f.ident;
-    let ty = &f.ty;
+    let try_read = ffiops::try_read(&f.ty);
 
     match ident {
         Some(ident) => quote! {
-            #ident: <#ty as ::uniffi::Lift<crate::UniFfiTag>>::try_read(buf)?,
+            #ident: #try_read(buf)?,
         },
         None => quote! {
-            <#ty as ::uniffi::Lift<crate::UniFfiTag>>::try_read(buf)?,
+            #try_read(buf)?,
         },
     }
 }


### PR DESCRIPTION
Put these all in one module in preparation of updating how this code works. I'm hoping to rework custom type handling and also drop the `UniFfiTag` param. By factoring these into their own module and away from the specific usages, future changes like that should be easier to understand.

I think there are no functional changes here. In a couple places I replaced `FfiConverterArc<Self>` with `SomeFfiTrait<Arc<Self>>`, but those should be equivalent.