### PR TITLE
Swift: Enable error types to be named `Error`

### DIFF
--- a/fixtures/error-types/src/lib.rs
+++ b/fixtures/error-types/src/lib.rs
@@ -142,14 +142,14 @@ fn return_proc_error(e: String) -> Arc<ProcErrorInterface> {
 
 // Enums have good coverage elsewhere, but simple coverage here is good.
 #[derive(thiserror::Error, uniffi::Error, Debug)]
-pub enum EnumError {
+pub enum Error {
     #[error("Oops")]
     Oops,
 }
 
 #[uniffi::export]
-fn oops_enum() -> Result<(), EnumError> {
-    Err(EnumError::Oops)
+fn oops_enum() -> Result<(), Error> {
+    Err(Error::Oops)
 }
 
 uniffi::include_scaffolding!("error_types");

--- a/fixtures/error-types/tests/bindings/test.swift
+++ b/fixtures/error-types/tests/bindings/test.swift
@@ -16,3 +16,5 @@ do {
 let e = getError(message: "the error")
 assert(String(describing: e) == "the error")
 assert(String(reflecting: e) == "ErrorInterface { e: the error }")
+assert(Error.self is Swift.Error.Type)
+assert(Error.self != Swift.Error.self)

--- a/uniffi_bindgen/src/bindings/swift/templates/Async.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Async.swift
@@ -9,7 +9,7 @@ fileprivate func uniffiRustCallAsync<F, T>(
     completeFunc: (UInt64, UnsafeMutablePointer<RustCallStatus>) -> F,
     freeFunc: (UInt64) -> (),
     liftFunc: (F) throws -> T,
-    errorHandler: ((RustBuffer) throws -> Error)?
+    errorHandler: ((RustBuffer) throws -> Swift.Error)?
 ) async throws -> T {
     // Make sure to call uniffiEnsureInitialized() since future creation doesn't have a
     // RustCallStatus param, so doesn't use makeRustCall()

--- a/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
@@ -83,4 +83,4 @@ public struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
 {% if !contains_object_references %}
 extension {{ type_name }}: Equatable, Hashable {}
 {% endif %}
-extension {{ type_name }}: Error { }
+extension {{ type_name }}: Swift.Error { }

--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -23,7 +23,7 @@ open class {{ impl_class_name }}:
     {%-    endmatch %}
     {%- endfor %}
     {%- if is_error %}
-    Error,
+    Swift.Error,
     {% endif %}
     {{ protocol_name }} {
     fileprivate let pointer: UnsafeMutableRawPointer!


### PR DESCRIPTION
Solves https://github.com/mozilla/uniffi-rs/issues/2079

This PR makes it possible to name a type `Error` at let it be exported into Swift. It is is a quite simple PR which adds `Swift.` disambiguation.