### PR TITLE
Add more functionality to get_custom_type_aliases sorting

### DIFF
--- a/fixtures/ext-types/custom-types/src/lib.rs
+++ b/fixtures/ext-types/custom-types/src/lib.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 // A trivial guid, declared as `[Custom]` in the UDL.
 pub struct Guid(pub String);
 
@@ -134,6 +136,23 @@ uniffi::custom_newtype!(ANestedOuid, Ouid);
 #[uniffi::export]
 fn get_nested_ouid(nouid: Option<ANestedOuid>) -> ANestedOuid {
     nouid.unwrap_or_else(|| ANestedOuid(Ouid("ANestedOuid".to_string())))
+}
+
+// Dependent types that are nested deeper inside of other types
+// need to also be taken into account when ordering aliases.
+#[derive(PartialEq, Eq, Hash)]
+pub struct StringWrapper(pub String);
+uniffi::custom_newtype!(StringWrapper, String);
+
+pub struct IntWrapper(pub u32);
+uniffi::custom_newtype!(IntWrapper, u32);
+
+pub struct MapUsingStringWrapper(pub HashMap<StringWrapper, IntWrapper>);
+uniffi::custom_newtype!(MapUsingStringWrapper, HashMap<StringWrapper, IntWrapper>);
+
+#[uniffi::export]
+fn get_map_using_string_wrapper(maybe_map: Option<MapUsingStringWrapper>) -> MapUsingStringWrapper {
+    maybe_map.unwrap_or_else(|| MapUsingStringWrapper(HashMap::new()))
 }
 
 // And custom types around other objects.

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -284,10 +284,10 @@ impl<'a> TypeRenderer<'a> {
         let mut ordered = vec![];
         for type_ in self.ci.iter_types() {
             if let Type::Custom { name, builtin, .. } = type_ {
-                match ordered
-                    .iter()
-                    .position(|x: &(&str, &Type)| *name == x.1.as_codetype().type_label())
-                {
+                match ordered.iter().position(|x: &(&str, &Type)| {
+                    x.1.iter_types()
+                        .any(|nested_type| *name == nested_type.as_codetype().type_label())
+                }) {
                     // This 'name' appears as a builtin, so we must insert our type first.
                     Some(pos) => ordered.insert(pos, (name, builtin)),
                     // Otherwise at the end.


### PR DESCRIPTION
I tried to consume the change from #2075 today and noticed that it didn't cover my use case, where a type alias is used as the key for a HashMap which also is an alias. I added a test showing this and made a change to the sorting algorithm to fix this. 

The current algorithm for ordering type aliases is: "if the typename I'm inserting into the sorted list _is the type_ for something already in the list, put this item in front of it".

My proposed new algorithm is: "if the typename I'm inserting into the sorted list is _included in the nested types_ for something already in the list, put this item in front of it". 