### PR TITLE
Adding the `LowerError` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [[UnreleasedUniFFIVersion]] (backend crates: [[UnreleasedBackendVersion]]) - (_[[ReleaseDate]]_)
 
+### What's new?
+
+- Objects error types can now be as `Result<>` error type without wrapping them in `Arc<>`.
+
 ### What's fixed?
 - Custom Type names are now treated as type names by all bindings. This means if they will work if they happen to be
   keywords in the language. There's a very small risk of this being a breaking change if you used a type name which

--- a/docs/manual/src/udl/errors.md
+++ b/docs/manual/src/udl/errors.md
@@ -83,9 +83,9 @@ impl From<anyhow::Error> for MyError {
 You can't yet use `anyhow` directly in your exposed functions - you need a wrapper:
 
 ```rs
-fn oops() -> Result<(), Arc<MyError>> {
+fn oops() -> Result<(), MyError> {
     let e = anyhow::Error::msg("oops");
-    Err(Arc::new(e.into()))
+    Err(e.into())
 }
 ```
 then in Python:

--- a/fixtures/error-types/src/error_types.udl
+++ b/fixtures/error-types/src/error_types.udl
@@ -2,6 +2,9 @@ namespace error_types {
     [Throws=ErrorInterface]
     void oops();
 
+    [Throws=ErrorInterface]
+    void oops_nowrap();
+
     ErrorInterface get_error(string message);
 
     [Throws=RichError]

--- a/fixtures/error-types/src/lib.rs
+++ b/fixtures/error-types/src/lib.rs
@@ -27,13 +27,22 @@ impl From<anyhow::Error> for ErrorInterface {
     }
 }
 
-// must do explicit conversion...
+// Test an interface as the error type
 fn oops() -> Result<(), Arc<ErrorInterface>> {
+    // must do explicit conversion to convert anyhow::Error into ErrorInterface
     Err(Arc::new(
         anyhow::Error::msg("oops")
             .context("because uniffi told me so")
             .into(),
     ))
+}
+
+// Like `oops`, but let UniFFI handle wrapping the interface with an arc
+fn oops_nowrap() -> Result<(), ErrorInterface> {
+    // must do explicit conversion to convert anyhow::Error into ErrorInterface
+    Err(anyhow::Error::msg("oops")
+        .context("because uniffi told me so")
+        .into())
 }
 
 #[uniffi::export]

--- a/fixtures/error-types/tests/bindings/test.kts
+++ b/fixtures/error-types/tests/bindings/test.kts
@@ -15,6 +15,15 @@ try {
 }
 
 try {
+    oopsNowrap()
+    throw RuntimeException("Should have failed")
+} catch (e: ErrorInterface) {
+    assert(e.toString() == "because uniffi told me so\n\nCaused by:\n    oops")
+    assert(e.chain().size == 2)
+    assert(e.link(0U) == "because uniffi told me so")
+}
+
+try {
     toops()
     throw RuntimeException("Should have failed")
 } catch (e: ErrorTrait) {

--- a/fixtures/error-types/tests/bindings/test.py
+++ b/fixtures/error-types/tests/bindings/test.py
@@ -14,6 +14,13 @@ class TestErrorTypes(unittest.TestCase):
         except ErrorInterface as e:
            self.assertEqual(str(e), "because uniffi told me so\n\nCaused by:\n    oops")
 
+    def test_normal_catch_with_implit_arc_wrapping(self):
+        try:
+            oops_nowrap()
+            self.fail("must fail")
+        except ErrorInterface as e:
+           self.assertEqual(str(e), "because uniffi told me so\n\nCaused by:\n    oops")
+
     def test_error_interface(self):
         with self.assertRaises(ErrorInterface) as cm:
             oops()

--- a/fixtures/error-types/tests/bindings/test.swift
+++ b/fixtures/error-types/tests/bindings/test.swift
@@ -5,6 +5,12 @@ do {
 } catch let e as ErrorInterface {
     assert(String(describing: e) == "because uniffi told me so\n\nCaused by:\n    oops")
 }
+do {
+    try oopsNowrap()
+    fatalError("Should have thrown")
+} catch let e as ErrorInterface {
+    assert(String(describing: e) == "because uniffi told me so\n\nCaused by:\n    oops")
+}
 
 do {
     try toops()

--- a/uniffi_core/src/lib.rs
+++ b/uniffi_core/src/lib.rs
@@ -46,7 +46,7 @@ pub mod metadata;
 pub use ffi::*;
 pub use ffi_converter_traits::{
     ConvertError, FfiConverter, FfiConverterArc, HandleAlloc, Lift, LiftRef, LiftReturn, Lower,
-    LowerReturn, TypeId,
+    LowerError, LowerReturn, TypeId,
 };
 pub use metadata::*;
 

--- a/uniffi_macros/src/error.rs
+++ b/uniffi_macros/src/error.rs
@@ -60,7 +60,7 @@ fn flat_error_ffi_converter_impl(item: &EnumItem, options: &DeriveOptions) -> To
     let lower_impl_spec = options.ffi_impl_header("Lower", ident);
     let lift_impl_spec = options.ffi_impl_header("Lift", ident);
     let type_id_impl_spec = options.ffi_impl_header("TypeId", ident);
-    let derive_ffi_traits = options.derive_ffi_traits(ident, &["ConvertError"]);
+    let derive_ffi_traits = options.derive_ffi_traits(ident, &["LowerError", "ConvertError"]);
     let mod_path = match mod_path() {
         Ok(p) => p,
         Err(e) => return e.into_compile_error(),

--- a/uniffi_macros/src/ffiops.rs
+++ b/uniffi_macros/src/ffiops.rs
@@ -67,6 +67,13 @@ pub fn lower_return(ty: impl ToTokens) -> TokenStream {
     }
 }
 
+/// Lower error function
+pub fn lower_error(ty: impl ToTokens) -> TokenStream {
+    quote! {
+        <#ty as ::uniffi::LowerError<crate::UniFfiTag>>::lower_error
+    }
+}
+
 /// Lift return type
 pub fn lift_return_type(ty: impl ToTokens) -> TokenStream {
     quote! {


### PR DESCRIPTION
This specifies how types are lowered when they are the `E` side of `Result<T, E>`.  The main reason for the trait is that it lets us specialize the handling for interfaces by auto-wrapping the value in an Arc.

This makes using interfaces as errors much more ergonomic.

Also, replace the `Error` bound on the `E` types with `Display + Debug`. I just found out that `anyhow::Error` doesn't actually implement `Error` for some obscure reason.