### PR TITLE
Update the BindingGenerator trait and remove BindingsConfig.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@
 
 ### What's changed?
 - The internal bindings generation has changed to make it friendlier for external language bindings.
-  However, this is likely to be a small **breaking change** for these bindings.
+  However, this a **breaking change** for these bindings.
   No consumers of any languages are impacted, only the maintainers of these language bindings.
-  ([#2066](https://github.com/mozilla/uniffi-rs/issues/2066))
+  ([#2066](https://github.com/mozilla/uniffi-rs/issues/2066)), ([#2094](https://github.com/mozilla/uniffi-rs/pull/2094))
 
 - The async runtime can be specified for constructors/methods, this will override the runtime specified at the impl block level.
 

--- a/uniffi/src/cli.rs
+++ b/uniffi/src/cli.rs
@@ -141,6 +141,14 @@ fn gen_library_mode(
 ) -> anyhow::Result<()> {
     use uniffi_bindgen::library_mode::generate_bindings;
     for language in languages {
+        // to help avoid mistakes we check the library is actually a cdylib, except
+        // for swift where static libs are often used to extract the metadata.
+        if !matches!(language, TargetLanguage::Swift) && !uniffi_bindgen::is_cdylib(library_path) {
+            anyhow::bail!(
+                "Generate bindings for {language} requires a cdylib, but {library_path} was given"
+            );
+        }
+
         // Type-bounds on trait implementations makes selecting between languages a bit tedious.
         match language {
             TargetLanguage::Kotlin => generate_bindings(

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -16,7 +16,6 @@ use serde::{Deserialize, Serialize};
 use crate::backend::TemplateExpression;
 
 use crate::interface::*;
-use crate::BindingsConfig;
 
 mod callback_interface;
 mod compounds;
@@ -72,13 +71,13 @@ trait CodeType: Debug {
 // config options to customize the generated Kotlin.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Config {
-    package_name: Option<String>,
-    cdylib_name: Option<String>,
+    pub(super) package_name: Option<String>,
+    pub(super) cdylib_name: Option<String>,
     generate_immutable_records: Option<bool>,
     #[serde(default)]
     custom_types: HashMap<String, CustomTypeConfig>,
     #[serde(default)]
-    external_packages: HashMap<String, String>,
+    pub(super) external_packages: HashMap<String, String>,
     #[serde(default)]
     android: bool,
     #[serde(default)]
@@ -119,29 +118,6 @@ impl Config {
     /// Whether to generate immutable records (`val` instead of `var`)
     pub fn generate_immutable_records(&self) -> bool {
         self.generate_immutable_records.unwrap_or(false)
-    }
-}
-
-impl BindingsConfig for Config {
-    fn update_from_ci(&mut self, ci: &ComponentInterface) {
-        self.package_name
-            .get_or_insert_with(|| format!("uniffi.{}", ci.namespace()));
-        self.cdylib_name
-            .get_or_insert_with(|| format!("uniffi_{}", ci.namespace()));
-    }
-
-    fn update_from_cdylib_name(&mut self, cdylib_name: &str) {
-        self.cdylib_name
-            .get_or_insert_with(|| cdylib_name.to_string());
-    }
-
-    fn update_from_dependency_configs(&mut self, config_map: HashMap<&str, &Self>) {
-        for (crate_name, config) in config_map {
-            if !self.external_packages.contains_key(crate_name) {
-                self.external_packages
-                    .insert(crate_name.to_string(), config.package_name());
-            }
-        }
     }
 }
 

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -16,7 +16,6 @@ use std::fmt::Debug;
 use crate::backend::TemplateExpression;
 
 use crate::interface::*;
-use crate::BindingsConfig;
 
 mod callback_interface;
 mod compounds;
@@ -112,7 +111,7 @@ static KEYWORDS: Lazy<HashSet<String>> = Lazy::new(|| {
 // Config options to customize the generated python.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Config {
-    cdylib_name: Option<String>,
+    pub(super) cdylib_name: Option<String>,
     #[serde(default)]
     custom_types: HashMap<String, CustomTypeConfig>,
     #[serde(default)]
@@ -145,18 +144,6 @@ impl Config {
             Some(value) if value.is_empty() => ns,
             Some(value) => format!("{value}.{ns}"),
         }
-    }
-}
-
-impl BindingsConfig for Config {
-    fn update_from_ci(&mut self, ci: &ComponentInterface) {
-        self.cdylib_name
-            .get_or_insert_with(|| format!("uniffi_{}", ci.namespace()));
-    }
-
-    fn update_from_cdylib_name(&mut self, cdylib_name: &str) {
-        self.cdylib_name
-            .get_or_insert_with(|| cdylib_name.to_string());
     }
 }
 

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -10,7 +10,6 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
 
 use crate::interface::*;
-use crate::BindingsConfig;
 
 const RESERVED_WORDS: &[&str] = &[
     "alias", "and", "BEGIN", "begin", "break", "case", "class", "def", "defined?", "do", "else",
@@ -82,7 +81,7 @@ pub fn canonical_name(t: &Type) -> String {
 // since the details of the underlying component are entirely determined by the `ComponentInterface`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Config {
-    cdylib_name: Option<String>,
+    pub(super) cdylib_name: Option<String>,
     cdylib_path: Option<String>,
 }
 
@@ -99,18 +98,6 @@ impl Config {
 
     pub fn cdylib_path(&self) -> String {
         self.cdylib_path.clone().unwrap_or_default()
-    }
-}
-
-impl BindingsConfig for Config {
-    fn update_from_ci(&mut self, ci: &ComponentInterface) {
-        self.cdylib_name
-            .get_or_insert_with(|| format!("uniffi_{}", ci.namespace()));
-    }
-
-    fn update_from_cdylib_name(&mut self, cdylib_name: &str) {
-        self.cdylib_name
-            .get_or_insert_with(|| cdylib_name.to_string());
     }
 }
 

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -18,7 +18,6 @@ use super::Bindings;
 use crate::backend::TemplateExpression;
 
 use crate::interface::*;
-use crate::BindingsConfig;
 
 mod callback_interface;
 mod compounds;
@@ -191,8 +190,8 @@ pub fn quote_arg_keyword(nm: String) -> String {
 /// since the details of the underlying component are entirely determined by the `ComponentInterface`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Config {
-    cdylib_name: Option<String>,
-    module_name: Option<String>,
+    pub(super) cdylib_name: Option<String>,
+    pub(super) module_name: Option<String>,
     ffi_module_name: Option<String>,
     ffi_module_filename: Option<String>,
     generate_module_map: Option<bool>,
@@ -273,20 +272,6 @@ impl Config {
     /// Whether to mark value types as 'Sendable'
     pub fn experimental_sendable_value_types(&self) -> bool {
         self.experimental_sendable_value_types.unwrap_or(false)
-    }
-}
-
-impl BindingsConfig for Config {
-    fn update_from_ci(&mut self, ci: &ComponentInterface) {
-        self.module_name
-            .get_or_insert_with(|| ci.namespace().into());
-        self.cdylib_name
-            .get_or_insert_with(|| format!("uniffi_{}", ci.namespace()));
-    }
-
-    fn update_from_cdylib_name(&mut self, cdylib_name: &str) {
-        self.cdylib_name
-            .get_or_insert_with(|| cdylib_name.to_string());
     }
 }
 

--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -4,7 +4,7 @@
 
 //! # Swift bindings backend for UniFFI
 //!
-//! This module generates Swift bindings from a [`ComponentInterface`] definition,
+//! This module generates Swift bindings from a [`crate::ComponentInterface`] definition,
 //! using Swift's builtin support for loading C header files.
 //!
 //! Conceptually, the generated bindings are split into two Swift modules, one for the low-level
@@ -17,7 +17,7 @@
 //!   * A Swift source file `example.swift` that imports the `exampleFFI` module and wraps it
 //!    to provide the higher-level Swift API.
 //!
-//! Most of the concepts in a [`ComponentInterface`] have an obvious counterpart in Swift,
+//! Most of the concepts in a [`crate::ComponentInterface`] have an obvious counterpart in Swift,
 //! with the details documented in inline comments where appropriate.
 //!
 //! To handle lifting/lowering/serializing types across the FFI boundary, the Swift code
@@ -29,9 +29,8 @@
 //!  * How to read from and write into a byte buffer.
 //!
 
-use crate::{BindingGenerator, ComponentInterface};
+use crate::{BindingGenerator, Component, GenerationSettings};
 use anyhow::Result;
-use camino::Utf8Path;
 use fs_err as fs;
 use std::process::Command;
 
@@ -40,7 +39,7 @@ use gen_swift::{generate_bindings, Config};
 mod test;
 pub use test::{run_script, run_test};
 
-/// The Swift bindings generated from a [`ComponentInterface`].
+/// The Swift bindings generated from a [`crate::ComponentInterface`].
 ///
 struct Bindings {
     /// The contents of the generated `.swift` file, as a string.
@@ -64,53 +63,66 @@ impl BindingGenerator for SwiftBindingGenerator {
         )
     }
 
+    fn update_component_configs(
+        &self,
+        settings: &GenerationSettings,
+        components: &mut Vec<Component<Self::Config>>,
+    ) -> Result<()> {
+        for c in &mut *components {
+            c.config
+                .module_name
+                .get_or_insert_with(|| c.ci.namespace().into());
+            c.config.cdylib_name.get_or_insert_with(|| {
+                settings
+                    .cdylib
+                    .clone()
+                    .unwrap_or_else(|| format!("uniffi_{}", c.ci.namespace()))
+            });
+        }
+        Ok(())
+    }
+
     /// Unlike other target languages, binding to Rust code from Swift involves more than just
     /// generating a `.swift` file. We also need to produce a `.h` file with the C-level API
     /// declarations, and a `.modulemap` file to tell Swift how to use it.
     fn write_bindings(
         &self,
-        ci: &ComponentInterface,
-        config: &Config,
-        out_dir: &Utf8Path,
-        try_format_code: bool,
+        settings: &GenerationSettings,
+        components: &[Component<Self::Config>],
     ) -> Result<()> {
-        let Bindings {
-            header,
-            library,
-            modulemap,
-        } = generate_bindings(config, ci)?;
+        for Component { ci, config, .. } in components {
+            let Bindings {
+                header,
+                library,
+                modulemap,
+            } = generate_bindings(config, ci)?;
 
-        let source_file = out_dir.join(format!("{}.swift", config.module_name()));
-        fs::write(&source_file, library)?;
+            let source_file = settings
+                .out_dir
+                .join(format!("{}.swift", config.module_name()));
+            fs::write(&source_file, library)?;
 
-        let header_file = out_dir.join(config.header_filename());
-        fs::write(header_file, header)?;
+            let header_file = settings.out_dir.join(config.header_filename());
+            fs::write(header_file, header)?;
 
-        if let Some(modulemap) = modulemap {
-            let modulemap_file = out_dir.join(config.modulemap_filename());
-            fs::write(modulemap_file, modulemap)?;
-        }
+            if let Some(modulemap) = modulemap {
+                let modulemap_file = settings.out_dir.join(config.modulemap_filename());
+                fs::write(modulemap_file, modulemap)?;
+            }
 
-        if try_format_code {
-            if let Err(e) = Command::new("swiftformat")
-                .arg(source_file.as_str())
-                .output()
-            {
-                println!(
-                    "Warning: Unable to auto-format {} using swiftformat: {e:?}",
-                    source_file.file_name().unwrap(),
-                );
+            if settings.try_format_code {
+                if let Err(e) = Command::new("swiftformat")
+                    .arg(source_file.as_str())
+                    .output()
+                {
+                    println!(
+                        "Warning: Unable to auto-format {} using swiftformat: {e:?}",
+                        source_file.file_name().unwrap(),
+                    );
+                }
             }
         }
 
-        Ok(())
-    }
-
-    fn check_library_path(
-        &self,
-        _library_path: &Utf8Path,
-        _cdylib_name: Option<&str>,
-    ) -> Result<()> {
         Ok(())
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/test.rs
+++ b/uniffi_bindgen/src/bindings/swift/test.rs
@@ -124,7 +124,7 @@ struct GeneratedSources {
 }
 
 impl GeneratedSources {
-    fn new(crate_name: &str, cdylib_path: &Utf8Path, out_dir: &Utf8Path) -> Result<Self> {
+    fn new(package_name: &str, cdylib_path: &Utf8Path, out_dir: &Utf8Path) -> Result<Self> {
         let sources = generate_bindings(
             cdylib_path,
             None,
@@ -135,7 +135,7 @@ impl GeneratedSources {
         )?;
         let main_source = sources
             .iter()
-            .find(|s| s.package.name == crate_name)
+            .find(|s| s.package_name.as_deref() == Some(package_name))
             .unwrap();
         let main_module = main_source.config.module_name();
         let modulemap_glob = glob(&out_dir.join("*.modulemap"))?;


### PR DESCRIPTION
This is a breaking change for BindingGenerators, and follows up on other breaking changes made for this release (#2078). Between them, it is intended to offer a better framework for binding generators for future versions and break unintentional coupling between uniffi_bindgen and the builtin bindings.

This patch updates the `BindingGenerator` trait to give binding generators more control over the binding generation process and to simplify the interactions between the generator and `uniffi_bindgen`.

The trait `BindingsConfig` has been removed and replaced with a new method on `BindingGenerator` which passes the generator the entire list of all `ComponentInterface` and `Config` objects to be used in the generation, which the generator can modify as necessary. The binding generator is also passed the entire list of items to generate rather than called once per item - this gives the generator more flexibility in how the items are generated.

A new `Component` struct has been introduced which holds all necessary information for a single crate/namespace, including the `ComponentInterface` and `Config`. These structs are passed to the `BindingGenerator`

Calling everyone with an interest in external binding generators - cc @heinrich5991 @SalvatoreT @arg0d @skeet70 @Lipt0nas. All feedback welcome, including where I went too far, or where I didn't go far enough - eg

* I was thinking a new `GenerationSettings` struct which held things like `out_dir`, `try_format_code`, `cdylib` etc to make the function argument lists smaller and to make future additions less of a breaking change (eg, a new option would not change signatures, but instead just add a new item to a struct). etc.
* I'm still not that happy with how each config is created, but don't have any ideas how to fix that. Trying to remove `Config` as a type param and use `toml::Value` directly doesn't seem particularly viable. I'd welcome ideas here.