### PR TITLE
Remove the oneshot dependency (#1736)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 
 - The async runtime can be specified for constructors/methods, this will override the runtime specified at the impl block level.
 
+- Removed the dependency on the `oneshot' crate (https://github.com/mozilla/uniffi-rs/issues/1736)
+
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.27.1...HEAD).
 
 ## v0.27.1 (backend crates: v0.27.1) - (_2024-04-03_)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,12 +1002,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "oneshot-uniffi"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c548d5c78976f6955d72d0ced18c48ca07030f7a1d4024529fedd7c1c01b29c"
-
-[[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,7 +1964,6 @@ dependencies = [
  "camino",
  "log",
  "once_cell",
- "oneshot-uniffi",
  "paste",
  "static_assertions",
 ]

--- a/uniffi_core/Cargo.toml
+++ b/uniffi_core/Cargo.toml
@@ -19,10 +19,6 @@ bytes = "1.3"
 camino = "1.0.8"
 log = "0.4"
 once_cell = "1.10.0"
-# Use the `oneshot-uniffi` crate to get our `oneshot` dependency.
-# That crate is a fork of `oneshot` that removes the `loom` target/dependency, which makes it easier to vendor UniFFI into the mozilla-central repository.
-# Enable "async" so that receivers implement Future, no need for "std" since we don't block on them.
-oneshot = { package = "oneshot-uniffi", version = "0.1.6", features = ["async"] }
 # Regular dependencies
 paste = "1.0"
 static_assertions = "1.1.0"

--- a/uniffi_core/src/lib.rs
+++ b/uniffi_core/src/lib.rs
@@ -42,6 +42,7 @@ pub mod ffi;
 mod ffi_converter_impls;
 mod ffi_converter_traits;
 pub mod metadata;
+mod oneshot;
 
 #[cfg(feature = "scaffolding-ffi-buffer-fns")]
 pub use ffi::ffiserialize::FfiBufferElement;
@@ -60,7 +61,6 @@ pub mod deps {
     pub use async_compat;
     pub use bytes;
     pub use log;
-    pub use oneshot;
     pub use static_assertions;
 }
 

--- a/uniffi_core/src/oneshot.rs
+++ b/uniffi_core/src/oneshot.rs
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Implements a simple oneshot channel.
+//!
+//! We used to use the `oneshot` crate for this, but the dependency was hard to manage
+//! (https://github.com/mozilla/uniffi-rs/issues/1736)
+//!
+//! This implementation is less efficient, but the difference is probably negligible for most
+//! use-cases involving UniFFI.
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::{Context, Poll, Waker},
+};
+
+pub struct Sender<T>(Arc<Mutex<OneshotInner<T>>>);
+pub struct Receiver<T>(Arc<Mutex<OneshotInner<T>>>);
+
+struct OneshotInner<T> {
+    value: Option<T>,
+    waker: Option<Waker>,
+}
+
+pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
+    let arc = Arc::new(Mutex::new(OneshotInner {
+        value: None,
+        waker: None,
+    }));
+    (Sender(arc.clone()), Receiver(arc))
+}
+
+impl<T> Sender<T> {
+    /// Send a value to the receiver
+    pub fn send(self, value: T) {
+        let mut inner = self.0.lock().unwrap();
+        inner.value = Some(value);
+        if let Some(waker) = inner.waker.take() {
+            waker.wake();
+        }
+    }
+
+    /// Convert a Sender into a raw pointer
+    ///
+    /// from_raw must be called with this pointer or else the sender will leak
+    pub fn into_raw(self) -> *const () {
+        Arc::into_raw(self.0) as *const ()
+    }
+
+    /// Convert a raw pointer back to a Sender
+    ///
+    /// # Safety
+    ///
+    /// `raw_ptr` must have come from into_raw().  Once a pointer is passed into `from_raw` it must
+    /// not be used again.
+    pub unsafe fn from_raw(raw_ptr: *const ()) -> Self {
+        Self(Arc::from_raw(raw_ptr as *const Mutex<OneshotInner<T>>))
+    }
+}
+
+impl<T> Future for Receiver<T> {
+    type Output = T;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut inner = self.0.lock().unwrap();
+        match inner.value.take() {
+            Some(v) => Poll::Ready(v),
+            None => {
+                inner.waker = Some(cx.waker().clone());
+                Poll::Pending
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implemented our own oneshot channel using a Mutex.  It's not quite as efficient as the `oneshot` one, but I think it should be fine for our purposes.  My gut feeling is that the loss of overhead is neglibable compared the other existing overhead that UniFFI adds.

The API of the new oneshot is basically the same, except send/recv are not failable.