### PR TITLE
Bugfix: Enum with associated value generates non compiling Kotlin code

### DIFF
--- a/fixtures/enum-types/src/lib.rs
+++ b/fixtures/enum-types/src/lib.rs
@@ -39,6 +39,31 @@ pub enum AnimalSignedInt {
     Wombat,  // 1
 }
 
+#[derive(uniffi::Record)]
+pub struct AnimalRecord {
+    value: u8,
+}
+
+#[derive(uniffi::Object)]
+pub struct AnimalObject {
+    pub value: AnimalRecord,
+}
+
+use std::sync::Arc;
+// Adding an enum with a Associated Type that is a exported Arc<Object> with a exported Record field.
+// This is done to check for compilation errors.
+#[derive(uniffi::Enum)]
+pub(crate) enum AnimalAssociatedType {
+    Dog(Arc<AnimalObject>),
+    Cat,
+}
+
+#[derive(uniffi::Enum)]
+pub(crate) enum AnimalNamedAssociatedType {
+    Dog { value: Arc<AnimalObject> },
+    Cat,
+}
+
 #[uniffi::export]
 fn get_animal(a: Option<Animal>) -> Animal {
     a.unwrap_or(Animal::Dog)

--- a/fixtures/enum-types/tests/bindings/test_enum_types.kts
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.kts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import uniffi.enum_types.*
-
+import kotlin.reflect.full.functions
 
 assert(AnimalUInt.DOG.value == 3.toUByte())
 assert(AnimalUInt.CAT.value == 4.toUByte())
@@ -13,3 +13,11 @@ assert(AnimalLargeUInt.CAT.value == 4294967299.toULong())
 
 // could check `value == (-3).toByte()` but that's ugly :)
 assert(AnimalSignedInt.DOG.value + 3 == 0)
+
+// Assert that no destroy() function is created for simple Enum
+val simpleCat: Animal = Animal.CAT
+assert(simpleCat::class.functions.find { it.name == "destroy" } == null)
+
+// Assert that destroy() function is created for Enum with variants containing fields
+val cat: AnimalAssociatedType = AnimalAssociatedType.Cat
+assert(cat::class.functions.find { it.name == "destroy" } != null)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -134,10 +134,15 @@ v{{- field_num -}}
 
 // Macro for destroying fields
 {%- macro destroy_fields(member) %}
-    Disposable.destroy(
     {%- for field in member.fields() %}
-        this.{{ field.name()|var_name }}{%- if !loop.last %}, {% endif -%}
-    {% endfor -%})
+        {%- if field.name().is_empty() %} 
+            // No Label
+        {% else %}
+            Disposable.destroy(
+            this.{{ field.name()|var_name }}{%- if !loop.last %}, {% endif -%}
+            )
+        {% endif %}
+    {% endfor -%}
 {%- endmacro -%}
 
 {%- macro docstring_value(maybe_docstring, indent_spaces) %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -132,16 +132,10 @@ v{{- field_num -}}
 {%- endif -%}
 {%- endmacro %}
 
-// Macro for destroying fields
+ // Macro for destroying fields
 {%- macro destroy_fields(member) %}
     {%- for field in member.fields() %}
-            Disposable.destroy(
-        {%- if field.name().is_empty() %} 
-            this.{%- call field_name(field, loop.index) -%}
-        {% else %}
-            this.{{ field.name()|var_name }}{%- if !loop.last %}, {% endif -%}
-        {% endif %}
-            )
+        Disposable.destroy(this.{%- call field_name(field, loop.index) -%})
     {% endfor -%}
 {%- endmacro -%}
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -135,13 +135,13 @@ v{{- field_num -}}
 // Macro for destroying fields
 {%- macro destroy_fields(member) %}
     {%- for field in member.fields() %}
-        {%- if field.name().is_empty() %} 
-            // No Label
-        {% else %}
             Disposable.destroy(
+        {%- if field.name().is_empty() %} 
+            this.{%- call field_name(field, loop.index) -%}
+        {% else %}
             this.{{ field.name()|var_name }}{%- if !loop.last %}, {% endif -%}
-            )
         {% endif %}
+            )
     {% endfor -%}
 {%- endmacro -%}
 


### PR DESCRIPTION
As reported in issue #2089 there is a bug generating non-compiling Kotlin code. This happens when exporting a Enum with an associated value that is a `Arc<Object>`. This led to non-compiling Kotlin code:

```
    Disposable.destroy(
        this.``)
```

I recreated this by adding a Enum in fixtures and got the same compile-time error:

```
#[derive(uniffi::Enum)]
pub(crate) enum AnimalAssociatedType {
    Dog(Arc<AnimalObject>),
    Cat,
}
```

This issue was caused by the `destroy_fields` macro. Previously there was no checks if the `field.name()` was empty leading to the macro creating empty methods in cases where some fields had a name and some didn't.

I added a check for `field.name().is_empty()` and in such cases no `destroy` method will be generated by the macro.

No additional tests were added since this was a compile time error that was mitigated by these changes.