### PR TITLE
mkdocs: Use pymdown-extensions to get syntax highlighting in the docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,7 @@ commands:
             sudo apt-get update -qq
             sudo apt-get install -qy --no-install-recommends python3-pip
             sudo apt-get clean
-            pip install mkdocs
-            pip install mkdocs-material
+            pip install -r tools/requirements_docs.txt
 
   # Our policy for updating rust versions is at https://github.com/mozilla/uniffi-rs/tree/main/docs/policies/rust-versions.md
   # See also rust-toolchain.toml in the root of this repo, which is used to specify our official target version.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,10 +15,10 @@ theme:
   name: 'material'
   language: 'en'
 
-# XXX - not getting highlighting in, eg, ```rust``` blocks???
-# tried this :(
-# markdown_extensions:
-#  - codehilite
+# This also enables code highlighting
+markdown_extensions:
+  - pymdownx.superfences
+  - pymdownx.highlight
 
 # This lists all the files that become part of the documentation
 nav:

--- a/tools/requirements_docs.txt
+++ b/tools/requirements_docs.txt
@@ -1,0 +1,4 @@
+mkdocs==1.6.0
+mkdocs-material==9.5.22
+pygments==2.18.0
+pymdown-extensions==10.8.1


### PR DESCRIPTION
Fixes #2106