### PR TITLE
Allow errors to be tuple enums.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Swift errors now provide `localizedDescription` ([#2116](https://github.com/mozilla/uniffi-rs/pull/2116))
 
+- Procmacros support tuple-errors (ie, enums used as errors can be tuple-enums.)
+
 ### What's fixed?
 - Custom Type names are now treated as type names by all bindings. This means if they will work if they happen to be
   keywords in the language. There's a very small risk of this being a breaking change if you used a type name which

--- a/docs/manual/src/proc_macro/index.md
+++ b/docs/manual/src/proc_macro/index.md
@@ -409,9 +409,8 @@ pub enum MyError {
         index: u32,
         size: u32,
     }
-    Generic {
-        message: String,
-    }
+    // tuple-enums work.
+    Generic(String),
 }
 
 #[uniffi::export]
@@ -423,8 +422,7 @@ fn do_thing() -> Result<(), MyError> {
 You can also use the helper attribute `#[uniffi(flat_error)]` to expose just the variants but none of the fields.
 In this case the error will be serialized using Rust's `ToString` trait
 and will be accessible as the only field on each of the variants.
-For flat errors your variants can have unnamed fields,
-and the types of the fields don't need to implement any special traits.
+The types of the fields can be any UniFFI supported type and don't need to implement any special traits.
 
 ```rust
 #[derive(uniffi::Error)]

--- a/fixtures/error-types/src/lib.rs
+++ b/fixtures/error-types/src/lib.rs
@@ -154,11 +154,50 @@ fn return_proc_error(e: String) -> Arc<ProcErrorInterface> {
 pub enum Error {
     #[error("Oops")]
     Oops,
+    #[error("Value: {value}")]
+    Value { value: String },
+    #[error("IntValue: {value}")]
+    IntValue { value: u16 },
 }
 
 #[uniffi::export]
-fn oops_enum() -> Result<(), Error> {
-    Err(Error::Oops)
+fn oops_enum(i: u16) -> Result<(), Error> {
+    if i == 0 {
+        Err(Error::Oops)
+    } else if i == 1 {
+        Err(Error::Value {
+            value: "value".to_string(),
+        })
+    } else if i == 2 {
+        Err(Error::IntValue { value: i })
+    } else {
+        panic!("unknown variant {i}")
+    }
+}
+
+// tuple enum as an error.
+#[derive(thiserror::Error, uniffi::Error, Debug)]
+pub enum TupleError {
+    #[error("Oops")]
+    Oops(String),
+    #[error("Value {0}")]
+    Value(u16),
+}
+
+#[uniffi::export]
+fn oops_tuple(i: u16) -> Result<(), TupleError> {
+    if i == 0 {
+        Err(TupleError::Oops("oops".to_string()))
+    } else if i == 1 {
+        Err(TupleError::Value(i))
+    } else {
+        panic!("unknown variant {i}")
+    }
+}
+
+#[uniffi::export(default(t = None))]
+fn get_tuple(t: Option<TupleError>) -> TupleError {
+    t.unwrap_or_else(|| TupleError::Oops("oops".to_string()))
 }
 
 uniffi::include_scaffolding!("error_types");

--- a/fixtures/error-types/tests/bindings/test.kts
+++ b/fixtures/error-types/tests/bindings/test.kts
@@ -47,6 +47,41 @@ try {
     assert(e.toString() == "RichError: \"oh no\"")
 }
 
+try {
+    oopsEnum(0u)
+    throw RuntimeException("Should have failed")
+} catch (e: Exception) {
+    assert(e.toString() == "uniffi.error_types.Exception${'$'}Oops: ")
+}
+
+try {
+    oopsEnum(1u)
+    throw RuntimeException("Should have failed")
+} catch (e: Exception) {
+    assert(e.toString() == "uniffi.error_types.Exception${'$'}Value: value=value")
+}
+
+try {
+    oopsEnum(2u)
+    throw RuntimeException("Should have failed")
+} catch (e: Exception) {
+    assert(e.toString() == "uniffi.error_types.Exception${'$'}IntValue: value=2")
+}
+
+try {
+    oopsTuple(0u)
+    throw RuntimeException("Should have failed")
+} catch (e: TupleException) {
+    assert(e.toString() == "uniffi.error_types.TupleException${'$'}Oops: v1=oops")
+}
+
+try {
+    oopsTuple(1u)
+    throw RuntimeException("Should have failed")
+} catch (e: TupleException) {
+    assert(e.toString() == "uniffi.error_types.TupleException${'$'}Value: v1=1")
+}
+
 runBlocking {
     try {
         aoops()

--- a/fixtures/error-types/tests/bindings/test.py
+++ b/fixtures/error-types/tests/bindings/test.py
@@ -80,5 +80,38 @@ class TestErrorTypes(unittest.TestCase):
         self.assertEqual(cm.exception.message(), "eek")
         self.assertEqual(str(cm.exception), "ProcErrorInterface(eek)")
 
+    def test_enum_error(self):
+        with self.assertRaises(Error) as cm:
+            oops_enum(0)
+        # This doesn't seem ideal?
+        self.assertEqual(str(cm.exception), "")
+        self.assertEqual(repr(cm.exception), "Error.Oops()")
+
+    def test_enum_error_value(self):
+        with self.assertRaises(Error) as cm:
+            oops_enum(1)
+        self.assertEqual(str(cm.exception), "value='value'")
+        self.assertEqual(repr(cm.exception), "Error.Value(value='value')")
+
+    def test_enum_error_int_value(self):
+        with self.assertRaises(Error) as cm:
+            oops_enum(2)
+        self.assertEqual(str(cm.exception), "value=2")
+        self.assertEqual(repr(cm.exception), "Error.IntValue(value=2)")
+
+    def test_tuple_error(self):
+        r = get_tuple()
+        self.assertEqual(repr(r), "TupleError.Oops('oops')")
+        # self.assertEqual(get_tuple(r), r)
+        with self.assertRaises(TupleError) as cm:
+            oops_tuple(0)
+        self.assertEqual(str(cm.exception), "'oops'")
+        self.assertEqual(repr(cm.exception), "TupleError.Oops('oops')")
+
+        with self.assertRaises(TupleError) as cm:
+            oops_tuple(1)
+        self.assertEqual(str(cm.exception), "1")
+        self.assertEqual(repr(cm.exception), "TupleError.Value(1)")
+
 if __name__=='__main__':
     unittest.main()

--- a/fixtures/error-types/tests/bindings/test.swift
+++ b/fixtures/error-types/tests/bindings/test.swift
@@ -19,7 +19,7 @@ do {
 }
 
 do {
-    try oopsEnum()
+    try oopsEnum(i: 0)
     fatalError("Should have thrown")
 } catch let e as Error {
     assert(e == Error.Oops)
@@ -27,12 +27,48 @@ do {
     assert(String(reflecting: e) == "error_types.Error.Oops")
 }
 do {
-    try oopsEnum()
+    try oopsEnum(i: 0)
     fatalError("Should have thrown")
 } catch {
     assert(String(describing: error) == "Oops")
     assert(String(reflecting: error) == "error_types.Error.Oops")
     assert(error.localizedDescription == "error_types.Error.Oops")
+}
+
+do {
+    try oopsEnum(i: 1)
+    fatalError("Should have thrown")
+} catch {
+    assert(String(describing: error) == "Value(value: \"value\")")
+    assert(String(reflecting: error) == "error_types.Error.Value(value: \"value\")")
+    assert(error.localizedDescription == "error_types.Error.Value(value: \"value\")")
+}
+
+do {
+    try oopsEnum(i: 2)
+    fatalError("Should have thrown")
+} catch {
+    assert(String(describing: error) == "IntValue(value: 2)")
+    assert(String(reflecting: error) == "error_types.Error.IntValue(value: 2)")
+    assert(error.localizedDescription == "error_types.Error.IntValue(value: 2)")
+}
+
+do {
+    try oopsTuple(i: 0)
+    fatalError("Should have thrown")
+} catch {
+    assert(String(describing: error) == "Oops(\"oops\")")
+    assert(String(reflecting: error) == "error_types.TupleError.Oops(\"oops\")")
+    assert(error.localizedDescription == "error_types.TupleError.Oops(\"oops\")")
+}
+
+do {
+    try oopsTuple(i: 1)
+    fatalError("Should have thrown")
+} catch {
+    assert(String(describing: error) == "Value(1)")
+    assert(String(reflecting: error) == "error_types.TupleError.Value(1)")
+    assert(error.localizedDescription == "error_types.TupleError.Value(1)")
 }
 
 do {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
@@ -23,11 +23,11 @@ sealed class {{ type_name }}: kotlin.Exception(){% if contains_object_references
     class {{ variant_name }}(
         {% for field in variant.fields() -%}
         {%- call kt::docstring(field, 8) %}
-        val {{ field.name()|var_name }}: {{ field|type_name(ci) }}{% if loop.last %}{% else %}, {% endif %}
+        val {% call kt::field_name(field, loop.index) %}: {{ field|type_name(ci) }}{% if loop.last %}{% else %}, {% endif %}
         {% endfor -%}
     ) : {{ type_name }}() {
         override val message
-            get() = "{%- for field in variant.fields() %}{{ field.name()|var_name|unquote }}=${ {{field.name()|var_name }} }{% if !loop.last %}, {% endif %}{% endfor %}"
+            get() = "{%- for field in variant.fields() %}{% call kt::field_name_unquoted(field, loop.index) %}=${ {% call kt::field_name(field, loop.index) %} }{% if !loop.last %}, {% endif %}{% endfor %}"
     }
     {% endfor %}
 
@@ -88,7 +88,7 @@ public object {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
                 4UL
                 {%- for field in variant.fields() %}
-                + {{ field|allocation_size_fn }}(value.{{ field.name()|var_name }})
+                + {{ field|allocation_size_fn }}(value.{% call kt::field_name(field, loop.index) %})
                 {%- endfor %}
             )
             {%- endfor %}
@@ -102,7 +102,7 @@ public object {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }
             is {{ type_name }}.{{ variant|error_variant_name }} -> {
                 buf.putInt({{ loop.index }})
                 {%- for field in variant.fields() %}
-                {{ field|write_fn }}(value.{{ field.name()|var_name }}, buf)
+                {{ field|write_fn }}(value.{% call kt::field_name(field, loop.index) %}, buf)
                 {%- endfor %}
                 Unit
             }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -132,6 +132,14 @@ v{{- field_num -}}
 {%- endif -%}
 {%- endmacro %}
 
+{% macro field_name_unquoted(field, field_num) %}
+{%- if field.name().is_empty() -%}
+v{{- field_num -}}
+{%- else -%}
+{{ field.name()|var_name|unquote }}
+{%- endif -%}
+{%- endmacro %}
+
  // Macro for destroying fields
 {%- macro destroy_fields(member) %}
     {%- for field in member.fields() %}

--- a/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
@@ -27,7 +27,7 @@ class {{ type_name }}:
     {%-  if variant.has_nameless_fields() %}
         def __init__(self, *values):
             if len(values) != {{ variant.fields().len() }}:
-                raise TypeError(f"Expected a tuple of len {{ variant.fields().len() }}, found len {len(values)}")
+                raise TypeError(f"Expected {{ variant.fields().len() }} arguments, found {len(values)}")
         {%- for field in variant.fields() %}
             if not isinstance(values[{{ loop.index0 }}], {{ field|type_name }}):
                 raise TypeError(f"unexpected type for tuple element {{ loop.index0 }} - expected '{{ field|type_name }}', got '{type(values[{{ loop.index0 }}])}'")

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -708,6 +708,11 @@ pub mod filters {
         Ok(quote_general_keyword(oracle().enum_variant_name(nm)))
     }
 
+    /// Like enum_variant_swift_quoted, but a class name.
+    pub fn error_variant_swift_quoted(nm: &str) -> Result<String, askama::Error> {
+        Ok(quote_general_keyword(oracle().class_name(nm)))
+    }
+
     /// Get the idiomatic Swift rendering of an FFI callback function name
     pub fn ffi_callback_name(nm: &str) -> Result<String, askama::Error> {
         Ok(oracle().ffi_callback_name(nm))

--- a/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
@@ -37,9 +37,13 @@ public struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
         {% else %}
 
         {% for variant in e.variants() %}
-        case {{ loop.index }}: return .{{ variant.name()|class_name }}{% if variant.has_fields() -%}(
+        case {{ loop.index }}: return .{{ variant.name()|error_variant_swift_quoted }}{% if variant.has_fields() %}(
             {% for field in variant.fields() -%}
+            {%-     if variant.has_nameless_fields() -%}
+            try {{ field|read_fn }}(from: &buf)
+            {%-     else -%}
             {{ field.name()|var_name }}: try {{ field|read_fn }}(from: &buf)
+            {%-     endif -%}
             {%- if !loop.last %}, {% endif %}
             {% endfor -%}
         ){% endif -%}
@@ -64,10 +68,10 @@ public struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
 
         {% for variant in e.variants() %}
         {% if variant.has_fields() %}
-        case let .{{ variant.name()|class_name }}({% for field in variant.fields() %}{{ field.name()|var_name }}{%- if loop.last -%}{%- else -%},{%- endif -%}{% endfor %}):
+        case let .{{ variant.name()|error_variant_swift_quoted }}({% for field in variant.fields() %}{%- call swift::field_name(field, loop.index) -%}{%- if loop.last -%}{%- else -%},{%- endif -%}{% endfor %}):
             writeInt(&buf, Int32({{ loop.index }}))
             {% for field in variant.fields() -%}
-            {{ field|write_fn }}({{ field.name()|var_name }}, into: &buf)
+            {{ field|write_fn }}({% call swift::field_name(field, loop.index) %}, into: &buf)
             {% endfor -%}
         {% else %}
         case .{{ variant.name()|class_name }}:


### PR DESCRIPTION
Follows on from #2004 which allowed tuple enums in plain enums, it's now possible to use tuple enums for errors.