### PR TITLE
Remove unused and incorrect defaults in Kotlin and Swift.

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -99,20 +99,19 @@ pub struct CustomTypeConfig {
 }
 
 impl Config {
+    // We insist someone has already configured us - any defaults we supply would be wrong.
     pub fn package_name(&self) -> String {
-        if let Some(package_name) = &self.package_name {
-            package_name.clone()
-        } else {
-            "uniffi".into()
-        }
+        self.package_name
+            .as_ref()
+            .expect("package name should have been set in update_component_configs")
+            .clone()
     }
 
     pub fn cdylib_name(&self) -> String {
-        if let Some(cdylib_name) = &self.cdylib_name {
-            cdylib_name.clone()
-        } else {
-            "uniffi".into()
-        }
+        self.cdylib_name
+            .as_ref()
+            .expect("cdylib name should have been set in update_component_configs")
+            .clone()
     }
 
     /// Whether to generate immutable records (`val` instead of `var`)

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -211,11 +211,12 @@ pub struct CustomTypeConfig {
 
 impl Config {
     /// The name of the Swift module containing the high-level foreign-language bindings.
+    /// Panics if the module name hasn't been configured.
     pub fn module_name(&self) -> String {
-        match self.module_name.as_ref() {
-            Some(name) => name.clone(),
-            None => "uniffi".into(),
-        }
+        self.module_name
+            .as_ref()
+            .expect("module name should have been set in update_component_configs")
+            .clone()
     }
 
     /// The name of the lower-level C module containing the FFI declarations.


### PR DESCRIPTION
Both bindings supply a default for package_name/cdylib which is different to the default actually and unconditionally applied.

(I found this commit from a while ago and dusted it off - I think less confusion is good.)