### PR TITLE
Stop building and publishing Rust API docs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,9 +121,6 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - prepare-rust-target-version
-      - build-api-docs
-      - run: cp -r ./target/doc ./docs/manual/src/internals/api
       - install-mkdocs
       - run: python -m mkdocs build
       - gh-pages/deploy:

--- a/docs/manual/src/internals/crates.md
+++ b/docs/manual/src/internals/crates.md
@@ -2,25 +2,34 @@
 
 The code for UniFFI is organized into the following crates:
 
-- **[`./uniffi_bindgen`](./api/uniffi_bindgen/index.html):** This is the source for the `uniffi-bindgen` executable and is where
-  most of the logic for the UniFFI tool lives. Its contents include:
-    - **[`./uniffi_bindgen/src/interface/`](./api/uniffi_bindgen/interface/index.html):** The logic for parsing `.udl` files
-      into an in-memory representation called [`ComponentInterface`](./api/uniffi_bindgen/interface/struct.ComponentInterface.html),
+- **`./uniffi`** ([docs.rs](https://docs.rs/uniffi/latest), [source](https://github.com/mozilla/uniffi-rs/tree/main/uniffi)): The main entry-point to UniFFI - almost all consumers should be able to use facilities expored by this module.
+
+- **`./uniffi_bindgen`** ([docs.rs](https://docs.rs/uniffi_bindgen/latest), [source](https://github.com/mozilla/uniffi-rs/tree/main/uniffi_bindgen)): The the source for the `uniffi-bindgen` executable and is where
+  most of the logic for the foreign bindings generation lives. Its contents include:
+    - **[`./uniffi_bindgen/src/interface/`](https://github.com/mozilla/uniffi-rs/tree/main/uniffi_bindgen/src/interface):** Converting `uniffi_meta` types into an in-memory representation called [`ComponentInterface`](https://docs.rs/uniffi_bindgen/latest/uniffi_bindgen/interface/struct.ComponentInterface.html),
       from which we can generate code for different languages.
-    - **[`./uniffi_bindgen/src/scaffolding`](./api/uniffi_bindgen/scaffolding/index.html):** This module turns a
-      [`ComponentInterface`](./api/uniffi_bindgen/interface/struct.ComponentInterface.html) into *Rust scaffolding*, the code that
-      wraps the user-provided Rust code and exposes it via a C-compatible FFI layer.
-    - **[`./uniffi_bindgen/src/bindings/`](./api/uniffi_bindgen/bindings/index.html):** This module turns a
-      [`ComponentInterface`](./api/uniffi_bindgen/interface/struct.ComponentInterface.html) into *foreign-language bindings*,
-      the code that can load the FFI layer exposed by the scaffolding and expose it as a
-      higher-level API in a target language. There is a sub-module for each supported language.
-- **[`./uniffi`](./api/uniffi/index.html):** This is a run-time support crate that is used by the generated Rust scaffolding. It
-  controls how values of various types are passed back-and-forth over the FFI layer, by means of the
-  [`FfiConverter`](./api/uniffi/trait.FfiConverter.html) trait.
-- **[`./uniffi_build`](./api/uniffi_build/index.html):** This is a small hook to run `uniffi-bindgen` from the `build.rs` script
-  of a UniFFI component, in order to automatically generate the Rust scaffolding as part of its build process.
-- **[`./uniffi_macros`](./api/uniffi_macros/index.html):** This contains some helper macros that UniFFI components can use to
-  simplify loading the generated scaffolding, and executing foreign-language tests.
+    - **[`./uniffi_bindgen/src/scaffolding`](https://github.com/mozilla/uniffi-rs/tree/main/uniffi_bindgen/src/scaffolding):** This module generates `.rs` files for the parts of the 
+      [`ComponentInterface`](https://docs.rs/uniffi_bindgen/latest/uniffi_bindgen/interface/struct.ComponentInterface.html) defined in UDL
+    - **[`./uniffi_bindgen/src/bindings/`](https://github.com/mozilla/uniffi-rs/tree/main/uniffi_bindgen/src/bindings):** This module turns a
+      [`ComponentInterface`](https://docs.rs/uniffi_bindgen/latest/uniffi_bindgen/interface/struct.ComponentInterface.html) into *foreign-language bindings*,
+      the code that can load the FFI layer exposed by Rust and expose it as a
+      higher-level API in a target language. There is a sub-module for each internally supported language.
+
+- **`./uniffi_meta`**([docs.rs](https://docs.rs/uniffi_meta/latest), [source](https://github.com/mozilla/uniffi-rs/tree/main/uniffi_meta)):
+The types used to represent the metadata used to describe the `ComponentInterface` used to generate the Rust scaffolding and the foreign bindings.
+
+- **`./uniffi_udl`**([docs.rs](https://docs.rs/uniffi_udl/latest), [source](https://github.com/mozilla/uniffi-rs/tree/main/uniffi_udl)) :
+The parsing of UDL files, turning them into `uniffi_meta` types.
+
+- **`./uniffi_build`**([docs.rs](https://docs.rs/uniffi_build/latest), [source](https://github.com/mozilla/uniffi-rs/tree/main/uniffi_build)):
+A small hook to run `uniffi-bindgen` from the `build.rs` script
+of a UniFFI component, in order to automatically generate the Rust scaffolding as part of its build process.
+
+- **`./uniffi_macros`**([docs.rs](https://docs.rs/uniffi_macros/latest), [source](https://github.com/mozilla/uniffi-rs/tree/main/uniffi_macros)):
+Contains the proc_macro support, which does much of the heavy-lifting for defining the Rust FFI.
+
 - **[`./examples`](https://github.com/mozilla/uniffi-rs/tree/main/examples):**
-  This contains code examples that you can use to explore the code generation
-  process.
+Contains code examples demonstrating the capabilites and code generation process.
+
+- **[`./fixtures`](https://github.com/mozilla/uniffi-rs/tree/main/fixtures):**
+Our test suite.

--- a/docs/manual/src/swift/overview.md
+++ b/docs/manual/src/swift/overview.md
@@ -41,4 +41,4 @@ in order to reduce the compiled code size, while distributing their Swift wrappe
 individual modules.
 
 For more technical details on how the bindings work internally, please see the
-[module documentation](../internals/api/uniffi_bindgen/bindings/swift/index.html)
+[module documentation](https://docs.rs/uniffi_bindgen/latest/uniffi_bindgen/bindings/swift/index.html)


### PR DESCRIPTION
The generation of these docs generates a lot of churn in the gh-pages branch - even when nothing has changed - so instead we skip building and publishing them and link to the generated pages on docs.rs.

This will mean that once versioned docs land, most doc publish jobs will be no-ops.