### PR TITLE
Introduce `mike` to the doc generation process.

### DIFF
--- a/docs/manual/src/README.md
+++ b/docs/manual/src/README.md
@@ -1,0 +1,61 @@
+# The docs for the "manual".
+
+The manual is what we publish to https://mozilla.github.io/uniffi-rs/ and
+is generated from the content in this directory.
+
+This README is not published as part of the docs - but almost everything
+else in this directory is. This document describes how that publishing
+works.
+
+* This repo uses `mkdocs` - but **we must never deploy using that tool**.
+  Deploying using mkdocs will publish into the root of the site, **damaging
+  the versioning system we have in place.**
+
+* We use a [`mike`](https://github.com/jimporter/mike) to manage
+  the `mkdocs` build process and the deployment - it deploys to a versioned
+  (eg, `./0.27`) directory and manages aliases (eg, `latest`) on the site.
+
+* There are various HTML redirects and symlinks keeping things together. These
+  are maintained by hand. See also any docs related scripts in `./tools`.
+
+To put it another way: we never deploy the entire site, but instead use `mike`
+to deploy just a single version.
+
+## How to deploy a specific version.
+
+While the main branch is published as a version called `next` by CI, the
+steps to publish a specific version must be performed manually for now.
+
+* Ensure you have the release branch checked out.
+
+* Prepare your Python environment by executing:
+> pip install -r tools/requirements_docs.txt
+
+* From the root of your checkout, execute:
+> mike deploy 0.XX latest --update-aliases --push
+
+If you leave out `--push` your local `gh-pages` branch will be changed but it will not
+be pushed, which can be helpful if you want to check the result. You can later push
+the branch normally.
+
+`--update-aliases` is only strictly necessary if this is the first time a
+new version has been pushed and you want it to be the new "latest" version.
+
+## Layout of the published site
+The layout of the published pages is:
+
+* `./versions.json` is a file maintained by `mike` and used in the generated
+  html as a version selector.
+
+* `./next` is the directory where `mike` publishes the docs on currrent git `main`.
+
+* `./0.27`, `./0.28` etc are directories where `mike` publishes released versions.
+
+* `./latest` is a symlink managed by `mike` which points to the most recently released version.
+
+The other content is managed manually by the UniFFI maintainers by directly editing the `gh-pages` branch:
+
+* Other `*.html` files are the entry-points to our docs which existed before we versioned the docs.
+  They have been replaced with redirects to `0.27` - ie, `./Motivation.html` is content which redirects to `0.27/Motivation.html`.
+
+* `./index.html` is a little shim that redirects to `./latest`.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -56,12 +56,19 @@ Steps:
 1. Create a PR with the changes and get it approved
 
 1. Publish the new release:
-  * Run `cargo login` if you're not already logged in
-  * Run `./tools/publish-release.sh`
+    * Run `cargo login` if you're not already logged in
+    * Run `./tools/publish-release.sh`
 
 1. Push the tag: `git push v{MAJOR}.{MINOR}.{PATCH}`
 
 1. Create a PR to merge the changes back to the main branch
+
+1. Publish the docs for the new version. See the [README](../manual/src/README.md) for details, but the short version is:
+    * Execute `pip install -r tools/requirements_docs.txt`
+    * Execute `mike deploy {MAJOR}.{MINOR} latest --update-aliases --push`
+    * Wait for the deployment fairies.
+    * Visit https://mozilla.github.io/uniffi-rs and make sure this new version shows
+      up in the version selector and is correctly treated as the latest.
 
 ## Why avoid breaking changes for the uniffi crate?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ docs_dir: docs/manual/src
 site_dir:  'target/rendered-docs'
 repo_url: 'https://github.com/mozilla/uniffi-rs'
 use_directory_urls: false
+exclude_docs: "README.md"
 
 theme:
   name: 'material'
@@ -19,6 +20,14 @@ theme:
 markdown_extensions:
   - pymdownx.superfences
   - pymdownx.highlight
+
+extra:
+  version:
+    provider: mike
+
+plugins:
+  # otherwise a no-op docs build ends with a diff to sitemap.xml.gz
+  - no-sitemap
 
 # This lists all the files that become part of the documentation
 nav:

--- a/tools/make_old_docs_symlinks.py
+++ b/tools/make_old_docs_symlinks.py
@@ -1,0 +1,84 @@
+# Make redirects for our old html files relative to the root to version specific content.
+# See also ../docs/manual/src/README.md
+#
+# This is a "migration" script, so not run regularly and not by CI,
+#
+# We used to publish the entire site in the "root" - ie, we had/have
+# `./Motiviation.html` - but we've moved to a versioned site, so this page is now
+# at, eg, `./0.XX/Motiviation.html`.
+# This script locates all such HTML files and replaces them with HTML which redirects
+# to 0.27.
+#
+# Note:
+# * We don't want a symlink as we want the browser to see the actual new URL.
+# * We pin the redirects to 0.27 to try and be more future-proof for future doc refactors.
+#   It could be run again to update to a later version.
+#
+# It is designed to be run on a directory with the `gh-pages` branch checked out,
+# and the result is then checked in and pushed.
+
+import argparse
+import os
+
+paths = r"""
+    ./Motivation.md
+    ./Getting_started.md
+    ./tutorial/Prerequisites.md ./tutorial/udl_file.md ./tutorial/Rust_scaffolding.md ./tutorial/foreign_language_bindings.md
+    ./udl_file_spec.md ./udl/namespace.md ./udl/builtin_types.md ./udl/enumerations.md ./udl/structs.md
+    ./udl/functions.md ./udl/errors.md ./udl/interfaces.md ./udl/callback_interfaces.md ./udl/ext_types.md
+    ./udl/ext_types_external.md ./udl/custom_types.md ./udl/docstrings.md
+    ./proc_macro/index.md
+    ./futures.md
+    ./bindings.md
+    ./foreign_traits.md
+    ./kotlin/configuration.md ./kotlin/gradle.md ./kotlin/lifetimes.md
+    ./swift/overview.md ./swift/configuration.md ./swift/module.md ./swift/xcode.md
+    ./python/configuration.md
+    ./internals/design_principles.md ./internals/crates.md ./internals/lifting_and_lowering.md
+    ./internals/object_references.md ./internals/rendering_foreign_bindings.md"""
+
+redirect_template = r"""
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting.</title>
+  <noscript>
+    <meta http-equiv="refresh" content="1; url={target}/{path}" />
+  </noscript>
+  <script>
+    window.location.replace("{target}/{path}" + window.location.hash);
+  </script>
+</head>
+<body>
+  Redirecting to <a href="{target}/{path}">{target}/{path}</a>...
+</body>
+</html>
+"""
+
+def redirects(args):
+    target = "0.27"
+    for spec in paths.split():
+        path = os.path.splitext(os.path.normpath(spec))[0] + ".html"
+        fq = os.path.join(args.target, path)
+        if os.path.exists(fq):
+            new_content = redirect_template.format(path=path, target=target)
+            open(fq, "w").write(new_content)
+            print("Updated", path)
+        else:
+            print("html file does not exist:", path)
+
+def main():
+    parser = argparse.ArgumentParser(description='UniFFI docs redirect helper')
+
+    subparsers = parser.add_subparsers(required=True)
+
+    parser_redirect = subparsers.add_parser('redirects', help='check redirects etc')
+    parser_redirect.set_defaults(func=redirects)
+    parser_redirect.add_argument('--target', type=str, required=True)
+
+    args = parser.parse_args()
+    args.func(args)
+
+if __name__=='__main__':
+    main()

--- a/tools/requirements_docs.txt
+++ b/tools/requirements_docs.txt
@@ -1,4 +1,6 @@
+mike==2.1.1
 mkdocs==1.6.0
 mkdocs-material==9.5.22
+mkdocs-no-sitemap-plugin=0.0.1
 pygments==2.18.0
 pymdown-extensions==10.8.1


### PR DESCRIPTION
This causes the version selector to be rendered into the pages, however they will not be shown until we actually deploy version information.

Includes a script to help generate redirects for all our "old" pages.

On the path to #2016. Actual deployment using this system to follow once these are landed.