### PR TITLE
docs(kotlin): mention `AttachCurrentThread`

### DIFF
--- a/docs/manual/src/kotlin/gradle.md
+++ b/docs/manual/src/kotlin/gradle.md
@@ -61,7 +61,13 @@ dependencies {
 }
 ```
 
+> ## Attention
+>
+> It's highly recommend to call `AttachCurrentThread` when native threads startup, for example, using `jni-rs`'s [attach_current_thread_permanently].
+> Otherwise, JNA will attach & detach java thread in every uniffi's callback when calling from a rust thread.
+
 [JNA]: https://github.com/java-native-access/jna
+[attach_current_thread_permanently]: https://docs.rs/jni/latest/jni/struct.JavaVM.html#method.attach_current_thread_permanently
 
 ## Coroutines dependency
 

--- a/docs/manual/src/kotlin/gradle.md
+++ b/docs/manual/src/kotlin/gradle.md
@@ -63,7 +63,7 @@ dependencies {
 
 ## Advise on rust->java interop
 
-It's highly recommend to call `AttachCurrentThread` when spawning a rust thread, and in that thread we need to call java functions, maybe through uniffi's foreign interface. Otherwise, [JNA] has to attach and detach java thread into native thread in every function call, which is obviously a heavy operation.
+It's highly recommend to call `AttachCurrentThread` when spawning a rust thread, and in that thread we need to call java functions, maybe through uniffi's foreign interface. Otherwise, [JNA] has to attach and detach a java thread into the native thread in every function call, which is a heavy operation.
 
 ```rust
 static VM: once_cell::sync::OnceCell<jni::JavaVM> = once_cell::sync::OnceCell::new();

--- a/docs/manual/src/kotlin/gradle.md
+++ b/docs/manual/src/kotlin/gradle.md
@@ -83,7 +83,7 @@ pub extern "system" fn java_init(
 tokio::runtime::Builder::new_multi_thread().on_thread_start(|| {
     let vm = VM.get().expect("init java vm");
     vm.attach_current_thread_permanently().unwrap();
-})
+}).build().unwrap();
 ```
 
 [JNA]: https://github.com/java-native-access/jna

--- a/docs/manual/src/kotlin/gradle.md
+++ b/docs/manual/src/kotlin/gradle.md
@@ -65,8 +65,6 @@ dependencies {
 
 It's highly recommend to call `AttachCurrentThread` when spawning a rust thread, and in that thread we need to call java functions, maybe through uniffi's foreign interface. Otherwise, [JNA] has to attach and detach java thread into native thread in every function call, which is obviously a heavy operation.
 
-For example, if we're using tokio, and we'll call uniffi's callback in the tokio worker threads:
-
 ```rust
 static VM: once_cell::sync::OnceCell<jni::JavaVM> = once_cell::sync::OnceCell::new();
 
@@ -81,7 +79,7 @@ pub extern "system" fn java_init(
     _ = VM.set(vm);
 }
 
-// create tokio runtime manually
+// take tokio for example, and we need to call uniffi's callback in the tokio worker threads -
 tokio::runtime::Builder::new_multi_thread().on_thread_start(|| {
     let vm = VM.get().expect("init java vm");
     vm.attach_current_thread_permanently().unwrap();

--- a/docs/manual/src/kotlin/gradle.md
+++ b/docs/manual/src/kotlin/gradle.md
@@ -89,7 +89,6 @@ tokio::runtime::Builder::new_multi_thread().on_thread_start(|| {
 ```
 
 [JNA]: https://github.com/java-native-access/jna
-[attach_current_thread_permanently]: https://docs.rs/jni/latest/jni/struct.JavaVM.html#method.attach_current_thread_permanently
 
 ## Coroutines dependency
 


### PR DESCRIPTION
discovered in https://github.com/rustls/rustls-platform-verifier/pull/63#issuecomment-2125127857

It will help uniffi's callback performance.