### PR TITLE
Change log level of methods name logged in Scaffolding

### DIFF
--- a/fixtures/regressions/logging-callback-interface/Cargo.toml
+++ b/fixtures/regressions/logging-callback-interface/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "uniffi-fixture-logging-callback-interface"
 edition = "2021"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>", "Viktor Jansson <v.l.jansson@gmail.com>"]
 version = "0.22.0"
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/logging-callback-interface/src/lib.rs
+++ b/fixtures/regressions/logging-callback-interface/src/lib.rs
@@ -6,7 +6,7 @@ use std::sync::{Once, RwLock};
 
 // Logger trait that the foreign code implements
 pub trait Logger: Sync + Send {
-    fn log_message(&self, message: String);
+    fn log_message(&self, message: String, level: String);
 }
 
 // Logger struct that implements the `log::Log` trait.
@@ -21,7 +21,7 @@ impl log::Log for RustLogger {
 
     fn log(&self, record: &log::Record<'_>) {
         if let Some(foreign_logger) = &*self.0.read().unwrap() {
-            foreign_logger.log_message(record.args().to_string());
+            foreign_logger.log_message(record.args().to_string(), record.level().to_string());
         }
     }
 
@@ -32,7 +32,7 @@ fn init() {
     static ONCE: Once = Once::new();
     ONCE.call_once(|| {
         log::set_logger(&RUST_LOGGER).expect("Error in install_logger()");
-        log::set_max_level(log::LevelFilter::Debug);
+        log::set_max_level(log::LevelFilter::Trace);
     });
 }
 
@@ -41,8 +41,20 @@ pub fn install_logger(logger: Box<dyn Logger>) {
     *RUST_LOGGER.0.write().unwrap() = Some(logger);
 }
 
-pub fn log_something() {
-    log::warn!("something");
+pub fn log_foo_at_warn() {
+    log::warn!("foo");
+}
+
+pub fn log_bar_at_info() {
+    log::info!("bar");
+}
+
+pub fn set_log_level_to_debug() {
+    log::set_max_level(log::LevelFilter::Debug)
+}
+
+pub fn log_buzz_at_error() {
+    log::error!("buzz");
 }
 
 uniffi::include_scaffolding!("test");

--- a/fixtures/regressions/logging-callback-interface/src/test.udl
+++ b/fixtures/regressions/logging-callback-interface/src/test.udl
@@ -1,8 +1,11 @@
 namespace regression_logging_callback_interface {
   void install_logger(Logger logger);
-  void log_something();
+  void log_foo_at_warn();
+  void log_bar_at_info();
+  void set_log_level_to_debug();
+  void log_buzz_at_error();
 };
 
 callback interface Logger {
-    void log_message(string message);
+    void log_message(string message, string level);
 };

--- a/fixtures/regressions/logging-callback-interface/tests/bindings/test.py
+++ b/fixtures/regressions/logging-callback-interface/tests/bindings/test.py
@@ -5,16 +5,34 @@ class Logger:
     def __init__(self):
         self.messages = []
 
-    def log_message(self, message):
-        self.messages.append(message)
+    def log_message(self, message, level):
+        self.messages.append((message, level))
 
 class TestLoggingCallbackInterface(unittest.TestCase):
     def test_log(self):
         logger = Logger()
         regression_logging_callback_interface.install_logger(logger)
         self.assertEqual(logger.messages, [])
-        regression_logging_callback_interface.log_something()
-        self.assertIn("something", logger.messages)
+        expected = [
+            # Invoke fn `log_foo_at_warn`, UniFFI internals logs its name at Level::TRACE
+            ("log_foo_at_warn", "TRACE"), 
+            # `log_foo_at_warn`'s body logs "foo" at Level::WARN
+            ("foo", "WARN"),
+            # Invoke fn `log_bar_at_info`, UniFFI internals logs its name at Level::TRACE
+            ("log_bar_at_info", "TRACE"), 
+            # `log_bar_at_info`'s body logs "bar" at Level::INFO
+            ("bar", "INFO"),
+            # Invoke fn `set_log_level_to_debug`, UniFFI internals logs its name at Level::TRACE
+            ("set_log_level_to_debug", "TRACE"), 
+            # N.B. `("log_buzz_at_error", "TRACE")` is filtered out since max level is DEBUG
+            # `log_buzz_at_error`'s body logs "buzz" at Level::ERROR
+            ("buzz", "ERROR"),
+        ]
+        regression_logging_callback_interface.log_foo_at_warn()
+        regression_logging_callback_interface.log_bar_at_info()
+        regression_logging_callback_interface.set_log_level_to_debug()
+        regression_logging_callback_interface.log_buzz_at_error()
+        self.assertEqual(logger.messages, expected) 
 
 if __name__=='__main__':
     unittest.main()

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -256,7 +256,7 @@ pub(super) fn gen_ffi_function(
                 #(#param_names: #param_types,)*
                 call_status: &mut ::uniffi::RustCallStatus,
             ) -> #ffi_return_ty {
-                ::uniffi::deps::log::debug!(#name);
+                ::uniffi::deps::log::trace!(#name);
                 let uniffi_lift_args = #lift_closure;
                 ::uniffi::rust_call(call_status, || {
                     #lower_return(match uniffi_lift_args() {
@@ -285,7 +285,7 @@ pub(super) fn gen_ffi_function(
             #[doc(hidden)]
             #[no_mangle]
             pub extern "C" fn #ffi_ident(#(#param_names: #param_types,)*) -> ::uniffi::Handle {
-                ::uniffi::deps::log::debug!(#name);
+                ::uniffi::deps::log::trace!(#name);
                 let uniffi_lift_args = #lift_closure;
                 match uniffi_lift_args() {
                     Ok(uniffi_args) => {


### PR DESCRIPTION
Fixes #1702 

Change the log level to trace for method names logged by UniFFI internals when FFI calls into Rust. 

Augmented existing logging tests in Python, asserting that the changed level works as intended.

Let me know if you want me to put the tests in a **new** fixture instead of recycling an existing one.
