### PR TITLE
Remove the unicode-linebreak / unicode-width dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,8 +1353,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 dependencies = [
  "smawk",
- "unicode-linebreak",
- "unicode-width",
 ]
 
 [[package]]
@@ -1466,12 +1464,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
-name = "unicode-linebreak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
 name = "unicode-normalization"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,12 +1471,6 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "uniffi"

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -28,4 +28,6 @@ uniffi_meta = { path = "../uniffi_meta", version = "=0.27.2" }
 uniffi_testing = { path = "../uniffi_testing", version = "=0.27.2" }
 uniffi_udl = { path = "../uniffi_udl", version = "=0.27.2" }
 clap = { version = "4", default-features = false, features = ["std", "derive"], optional = true }
-textwrap = "0.16"
+# Don't include the `unicode-linebreak` or `unicode-width` since that functionality isn't needed for
+# docstrings.
+textwrap = { version = "0.16", features=["smawk"], default-features = false }

--- a/uniffi_udl/Cargo.toml
+++ b/uniffi_udl/Cargo.toml
@@ -13,6 +13,8 @@ readme = "../README.md"
 [dependencies]
 anyhow = "1"
 weedle2 = { version = "5.0.0", path = "../weedle2" }
-textwrap = "0.16"
+# Don't include the `unicode-linebreak` or `unicode-width` since that functionality isn't needed for
+# docstrings.
+textwrap = { version = "0.16", features=["smawk"], default-features = false }
 uniffi_meta = { path = "../uniffi_meta", version = "=0.27.2" }
 uniffi_testing = { path = "../uniffi_testing", version = "=0.27.2" }


### PR DESCRIPTION
Cherry-picking https://github.com/mozilla/uniffi-rs/commit/8a6948dcdef725d2d559c82b141dd7c38f145db9 into the 0.27.x branch.  I should have done with before 0.27.2, but I forget.  My new plan is to make an 0.27.3 release for it.

Docstrings rarely have unicode characters so these are not adding much value.  They present an issue for the downstream moz-central crate (https://bugzilla.mozilla.org/show_bug.cgi?id=1894888), so let's remove them.

