### PR TITLE
Removing cargo use

### DIFF
--- a/uniffi/src/cli.rs
+++ b/uniffi/src/cli.rs
@@ -108,6 +108,12 @@ enum Commands {
 
         /// Path to the UDL file, or cdylib if `library-mode` is specified
         source: Utf8PathBuf,
+
+        #[clap(long)]
+        package_name: Option<String>,
+        
+        #[clap(long)]
+        crate_root: Option<Utf8PathBuf>,
     },
 
     /// Generate Rust scaffolding code
@@ -138,6 +144,8 @@ fn gen_library_mode(
     cfo: Option<&camino::Utf8Path>,
     out_dir: &camino::Utf8Path,
     fmt: bool,
+    package_name: Option<String>,
+    crate_root: Option<&camino::Utf8Path>,
 ) -> anyhow::Result<()> {
     use uniffi_bindgen::library_mode::generate_bindings;
     for language in languages {
@@ -158,6 +166,8 @@ fn gen_library_mode(
                 cfo,
                 out_dir,
                 fmt,
+                package_name.clone(),
+                crate_root,
             )?
             .len(),
             TargetLanguage::Python => generate_bindings(
@@ -167,6 +177,8 @@ fn gen_library_mode(
                 cfo,
                 out_dir,
                 fmt,
+                package_name.clone(),
+                crate_root,
             )?
             .len(),
             TargetLanguage::Ruby => generate_bindings(
@@ -176,6 +188,8 @@ fn gen_library_mode(
                 cfo,
                 out_dir,
                 fmt,
+                package_name.clone(),
+                crate_root,
             )?
             .len(),
             TargetLanguage::Swift => generate_bindings(
@@ -185,6 +199,8 @@ fn gen_library_mode(
                 cfo,
                 out_dir,
                 fmt,
+                package_name.clone(),
+                crate_root,
             )?
             .len(),
         };
@@ -257,6 +273,8 @@ pub fn run_main() -> anyhow::Result<()> {
             source,
             crate_name,
             library_mode,
+            package_name,
+            crate_root,
         } => {
             if library_mode {
                 if lib_file.is_some() {
@@ -273,6 +291,8 @@ pub fn run_main() -> anyhow::Result<()> {
                     config.as_deref(),
                     &out_dir,
                     !no_format,
+                    package_name,
+                    crate_root.as_deref(),
                 )?;
             } else {
                 gen_bindings(

--- a/uniffi_bindgen/src/bindings/kotlin/test.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/test.rs
@@ -42,6 +42,8 @@ pub fn run_script(
         None,
         &out_dir,
         false,
+        None,
+        None,
     )?;
     let jar_file = build_jar(crate_name, &out_dir, options)?;
 

--- a/uniffi_bindgen/src/bindings/python/test.rs
+++ b/uniffi_bindgen/src/bindings/python/test.rs
@@ -43,6 +43,8 @@ pub fn run_script(
         None,
         &out_dir,
         false,
+        None,
+        None,
     )?;
 
     let pythonpath = env::var_os("PYTHONPATH").unwrap_or_else(|| OsString::from(""));

--- a/uniffi_bindgen/src/bindings/ruby/test.rs
+++ b/uniffi_bindgen/src/bindings/ruby/test.rs
@@ -40,6 +40,8 @@ pub fn test_script_command(
         None,
         &out_dir,
         false,
+        None,
+        None,
     )?;
 
     let rubypath = env::var_os("RUBYLIB").unwrap_or_else(|| OsString::from(""));

--- a/uniffi_bindgen/src/bindings/swift/test.rs
+++ b/uniffi_bindgen/src/bindings/swift/test.rs
@@ -132,6 +132,8 @@ impl GeneratedSources {
             None,
             out_dir,
             false,
+            None,
+            None,
         )?;
         let main_source = sources
             .iter()


### PR DESCRIPTION
This removes the use of `cargo` in `library_mode`, in order to support systems that do not have `cargo` available. It also removes the requirement that the project for which bindings are being generated have a `Cargo.toml` in the root. 

This also removes reading UDL files in `library_mode`'s `find_components`; it was not necessary for our test cases so far, and this code had more complex use of the data extracted from `cargo metadata`. 

This is a first attempt at addressing #2151; it is a bit hacky, particularly in the `find_components` and the addition of command-line arguments to pass in the package root and crate name (which was metadata previously extracted with `cargo metadata`).

Would appreciate any thoughts on how to improve this implementation of `cargo`-free `library_mode`. Thanks!