### PR TITLE
Make `RustBuffer::from_raw_parts` comment more precise

### DIFF
--- a/uniffi_core/src/ffi/rustbuffer.rs
+++ b/uniffi_core/src/ffi/rustbuffer.rs
@@ -81,7 +81,7 @@ impl RustBuffer {
     /// # Safety
     ///
     /// You must ensure that the raw parts uphold the documented invariants of this class.
-    pub unsafe fn from_raw_parts(data: *mut u8, len: u64, capacity: u64) -> Self {
+    pub(crate) unsafe fn from_raw_parts(data: *mut u8, len: u64, capacity: u64) -> Self {
         Self {
             capacity,
             len,

--- a/uniffi_core/src/ffi/rustbuffer.rs
+++ b/uniffi_core/src/ffi/rustbuffer.rs
@@ -78,9 +78,6 @@ impl RustBuffer {
 
     /// Creates a `RustBuffer` from its constituent fields.
     ///
-    /// This is intended mainly as an internal convenience function and should not
-    /// be used outside of this module.
-    ///
     /// # Safety
     ///
     /// You must ensure that the raw parts uphold the documented invariants of this class.


### PR DESCRIPTION
The method is used from outside of this module, so the comment seems unnecessary: the method should either be private or it should be public.