### PR TITLE
Make panic section more precise for `RustBuffer::len`

### DIFF
--- a/uniffi_core/src/ffi/rustbuffer.rs
+++ b/uniffi_core/src/ffi/rustbuffer.rs
@@ -100,7 +100,8 @@ impl RustBuffer {
     /// # Panics
     ///
     /// Panics if called on an invalid struct obtained from foreign-language code,
-    /// in which the `len` field is negative.
+    /// in which the `len` field is larger than what `u32` can represent and the
+    /// platform has `usize` being `u32` or smaller.
     pub fn len(&self) -> usize {
         self.len
             .try_into()


### PR DESCRIPTION
The panic condition seems to be a mismatch between the foregin code and the size of `usize` on the platform.