### PR TITLE
Use Data(bytesNoCopy:size:deallocator:) for conversion between RustBuffer and Data

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/RustBufferTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RustBufferTemplate.swift
@@ -37,9 +37,11 @@ fileprivate extension ForeignBytes {
 
 fileprivate extension Data {
     init(rustBuffer: RustBuffer) {
-        // TODO: This copies the buffer. Can we read directly from a
-        // Rust buffer?
-        self.init(bytes: rustBuffer.data!, count: Int(rustBuffer.len))
+        self.init(
+            bytesNoCopy: rustBuffer.data!,
+            count: Int(rustBuffer.len),
+            deallocator: .none
+        )
     }
 }
 


### PR DESCRIPTION
This avoids unnecessary copies between FFI and Swift.

Tests are apparently entirely unaffected (i.e. no changes to their results) by this change. `deallocator` is set to `.none` since the `FfiConverterRustBuffer` extension function `lift(_:)` ensures deallocation on it's own.