### PR TITLE
Fix the documentation around references

### DIFF
--- a/docs/manual/src/proc_macro/index.md
+++ b/docs/manual/src/proc_macro/index.md
@@ -107,7 +107,7 @@ Arguments and receivers can also be references to these types, for example:
 ```rust
 // Input data types as references
 #[uniffi::export]
-fn process_data(a: &MyRecord, b: &MyEnum, c: Option<&MyRecord>) {
+fn process_data(a: &MyRecord, b: &MyEnum, c: &Option<MyRecord>) {
     ...
 }
 


### PR DESCRIPTION
`Option<&T>` was never supported as far as I can tell.  I added some tests on top of e10a7f95d6b5bd8b4788d8f0eb77aea20dfb655b, where that documentation was added and it didn't work.

See https://github.com/mozilla/uniffi-rs/issues/2149 for some more discussion around this.