### PR TITLE
Use fully-qualified names to the stdlib's `core` library

### DIFF
--- a/uniffi_core/src/ffi/ffiserialize.rs
+++ b/uniffi_core/src/ffi/ffiserialize.rs
@@ -81,7 +81,7 @@ pub trait FfiSerialize: Sized {
     fn write(buf: &mut &mut [FfiBufferElement], value: Self) {
         Self::put(buf, value);
         // Lifetime dance taken from `bytes::BufMut`
-        let (_, new_buf) = core::mem::take(buf).split_at_mut(Self::SIZE);
+        let (_, new_buf) = ::core::mem::take(buf).split_at_mut(Self::SIZE);
         *buf = new_buf;
     }
 }

--- a/uniffi_meta/src/types.rs
+++ b/uniffi_meta/src/types.rs
@@ -146,7 +146,7 @@ impl Type {
 }
 
 // A trait so various things can turn into a type.
-pub trait AsType: core::fmt::Debug {
+pub trait AsType: ::core::fmt::Debug {
     fn as_type(&self) -> Type;
 }
 


### PR DESCRIPTION
Fixes #2127