### PR TITLE
Create fixture proc-macro-no-implicit-prelude

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,6 +1785,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-fixture-proc-macro-no-implicit-prelude"
+version = "0.22.0"
+dependencies = [
+ "uniffi",
+]
+
+[[package]]
 name = "uniffi-fixture-regression-callbacks-omit-labels"
 version = "0.22.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
   "fixtures/keywords/swift",
   "fixtures/metadata",
   "fixtures/proc-macro",
+  "fixtures/proc-macro-no-implicit-prelude",
   "fixtures/regressions/enum-without-i32-helpers",
   "fixtures/regressions/fully-qualified-types",
   "fixtures/regressions/kotlin-experimental-unsigned-types",

--- a/fixtures/proc-macro-no-implicit-prelude/Cargo.toml
+++ b/fixtures/proc-macro-no-implicit-prelude/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "uniffi-fixture-proc-macro-no-implicit-prelude"
+version = "0.22.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+edition = "2018"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+name = "uniffi_proc_macro"
+crate-type = ["lib", "cdylib"]
+
+[features]
+default = ["myfeature"]
+myfeature = []
+
+[dependencies]
+# Add the "scaffolding-ffi-buffer-fns" feature to make sure things can build correctly
+uniffi = { workspace = true, features = ["scaffolding-ffi-buffer-fns"] }
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["build", "scaffolding-ffi-buffer-fns"] }
+
+[dev-dependencies]
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/proc-macro-no-implicit-prelude/Cargo.toml
+++ b/fixtures/proc-macro-no-implicit-prelude/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 [lib]
-name = "uniffi_proc_macro"
+name = "uniffi_proc_macro_nip"
 crate-type = ["lib", "cdylib"]
 
 [features]

--- a/fixtures/proc-macro-no-implicit-prelude/build.rs
+++ b/fixtures/proc-macro-no-implicit-prelude/build.rs
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    // generate_scaffolding would work here, but we use the _for_crate version for
+    // test coverage.
+    uniffi::generate_scaffolding_for_crate("src/proc-macro.udl", "uniffi_proc_macro").unwrap();
+}

--- a/fixtures/proc-macro-no-implicit-prelude/src/callback_interface.rs
+++ b/fixtures/proc-macro-no-implicit-prelude/src/callback_interface.rs
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use ::std::marker::Sized;
+
+use crate::{BasicError, Object, RecordWithBytes};
+
+#[::uniffi::export(callback_interface)]
+pub trait TestCallbackInterface {
+    fn do_nothing(&self);
+    fn add(&self, a: u32, b: u32) -> u32;
+    fn optional(&self, a: ::std::option::Option<u32>) -> u32;
+    fn with_bytes(&self, rwb: RecordWithBytes) -> ::std::vec::Vec<u8>;
+    fn try_parse_int(&self, value: ::std::string::String)
+        -> ::std::result::Result<u32, BasicError>;
+    fn callback_handler(&self, h: ::std::sync::Arc<Object>) -> u32;
+    fn get_other_callback_interface(&self) -> ::std::boxed::Box<dyn OtherCallbackInterface>;
+}
+
+#[::uniffi::export(callback_interface)]
+pub trait OtherCallbackInterface {
+    fn multiply(&self, a: u32, b: u32) -> u32;
+}

--- a/fixtures/proc-macro-no-implicit-prelude/src/lib.rs
+++ b/fixtures/proc-macro-no-implicit-prelude/src/lib.rs
@@ -1,0 +1,413 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#![no_implicit_prelude]
+
+// Let's not have the macros care about derive being shadowed in the macro namespace for now..
+use ::std::prelude::rust_2021::derive;
+// Required for now because `static-assertions` (used internally) macros assume it to be in scope.
+use ::std::marker::Sized;
+
+mod callback_interface;
+
+use callback_interface::TestCallbackInterface;
+
+#[derive(::uniffi::Record)]
+pub struct One {
+    inner: i32,
+}
+
+#[::uniffi::export]
+pub fn one_inner_by_ref(one: &One) -> i32 {
+    one.inner
+}
+
+#[derive(::uniffi::Record)]
+pub struct Two {
+    a: ::std::string::String,
+}
+
+#[derive(::uniffi::Record)]
+pub struct NestedRecord {
+    // This used to result in an error in bindings generation
+    user_type_in_builtin_generic: ::std::option::Option<Two>,
+}
+
+#[derive(::uniffi::Record)]
+pub struct Three {
+    obj: ::std::sync::Arc<Object>,
+}
+
+#[derive(::uniffi::Record, Debug, PartialEq)]
+pub struct RecordWithBytes {
+    some_bytes: ::std::vec::Vec<u8>,
+}
+
+// An object that's not used anywhere (ie, in records, function signatures, etc)
+// should not break things.
+#[derive(::uniffi::Object)]
+pub struct Unused;
+
+#[::uniffi::export]
+impl Unused {
+    #[::uniffi::constructor]
+    fn new() -> ::std::sync::Arc<Self> {
+        ::std::sync::Arc::new(Self)
+    }
+}
+
+#[::uniffi::export]
+pub trait Trait: ::std::marker::Send + ::std::marker::Sync {
+    // Test the absence of `with_foreign` by inputting reference arguments, which is
+    // incompatible with callback interfaces
+    #[allow(clippy::ptr_arg)]
+    fn concat_strings(&self, a: &str, b: &str) -> ::std::string::String;
+}
+
+struct TraitImpl {}
+
+impl Trait for TraitImpl {
+    fn concat_strings(&self, a: &str, b: &str) -> ::std::string::String {
+        ::std::format!("{a}{b}")
+    }
+}
+
+#[::uniffi::export(with_foreign)]
+pub trait TraitWithForeign: ::std::marker::Send + ::std::marker::Sync {
+    fn name(&self) -> ::std::string::String;
+}
+
+struct RustTraitImpl {}
+
+impl TraitWithForeign for RustTraitImpl {
+    fn name(&self) -> ::std::string::String {
+        use ::std::string::ToString;
+        "RustTraitImpl".to_string()
+    }
+}
+
+#[derive(::uniffi::Object)]
+pub struct Object;
+
+#[cfg_attr(feature = "myfeature", ::uniffi::export)]
+impl Object {
+    #[cfg_attr(feature = "myfeature", ::uniffi::constructor)]
+    fn new() -> ::std::sync::Arc<Self> {
+        ::std::sync::Arc::new(Self)
+    }
+
+    #[::uniffi::constructor]
+    fn named_ctor(arg: u32) -> Self {
+        _ = arg;
+        // This constructor returns Self directly.  UniFFI ensures that it's wrapped in an Arc
+        // before sending it across the FFI.
+        Self
+    }
+
+    fn is_heavy(&self) -> MaybeBool {
+        MaybeBool::Uncertain
+    }
+
+    fn is_other_heavy(&self, other: &Self) -> MaybeBool {
+        other.is_heavy()
+    }
+
+    fn get_trait(
+        &self,
+        inc: ::std::option::Option<::std::sync::Arc<dyn Trait>>,
+    ) -> ::std::sync::Arc<dyn Trait> {
+        inc.unwrap_or_else(|| ::std::sync::Arc::new(TraitImpl {}))
+    }
+
+    fn get_trait_with_foreign(
+        &self,
+        inc: ::std::option::Option<::std::sync::Arc<dyn TraitWithForeign>>,
+    ) -> ::std::sync::Arc<dyn TraitWithForeign> {
+        inc.unwrap_or_else(|| ::std::sync::Arc::new(RustTraitImpl {}))
+    }
+
+    fn take_error(&self, e: BasicError) -> u32 {
+        ::std::assert!(::std::matches!(e, BasicError::InvalidInput));
+        42
+    }
+}
+
+#[::uniffi::export]
+fn concat_strings_by_ref(t: &dyn Trait, a: &str, b: &str) -> ::std::string::String {
+    t.concat_strings(a, b)
+}
+
+#[::uniffi::export]
+fn make_one(inner: i32) -> One {
+    One { inner }
+}
+
+#[::uniffi::export]
+fn take_two(two: Two) -> ::std::string::String {
+    two.a
+}
+
+#[::uniffi::export]
+fn make_hashmap(k: i8, v: u64) -> ::std::collections::HashMap<i8, u64> {
+    ::std::convert::From::from([(k, v)])
+}
+
+#[::uniffi::export]
+fn return_hashmap(h: ::std::collections::HashMap<i8, u64>) -> ::std::collections::HashMap<i8, u64> {
+    h
+}
+
+#[::uniffi::export]
+fn take_record_with_bytes(rwb: RecordWithBytes) -> ::std::vec::Vec<u8> {
+    rwb.some_bytes
+}
+
+#[::uniffi::export]
+fn call_callback_interface(cb: ::std::boxed::Box<dyn TestCallbackInterface>) {
+    use ::std::{assert_eq, matches, option::Option::*, result::Result::*, string::ToString, vec};
+
+    cb.do_nothing();
+    assert_eq!(cb.add(1, 1), 2);
+    assert_eq!(cb.optional(Some(1)), 1);
+    assert_eq!(cb.optional(None), 0);
+    assert_eq!(
+        cb.with_bytes(RecordWithBytes {
+            some_bytes: vec![9, 8, 7],
+        }),
+        vec![9, 8, 7]
+    );
+    assert_eq!(Ok(10), cb.try_parse_int("10".to_string()));
+    assert_eq!(
+        Err(BasicError::InvalidInput),
+        cb.try_parse_int("ten".to_string())
+    );
+    assert!(matches!(
+        cb.try_parse_int("force-unexpected-error".to_string()),
+        Err(BasicError::UnexpectedError { .. }),
+    ));
+    assert_eq!(42, cb.callback_handler(Object::new()));
+
+    assert_eq!(6, cb.get_other_callback_interface().multiply(2, 3));
+}
+
+// Type that's defined in the UDL and not wrapped with #[::uniffi::export]
+pub struct Zero {
+    inner: ::std::string::String,
+}
+
+#[::uniffi::export]
+fn make_zero() -> Zero {
+    use ::std::borrow::ToOwned;
+    Zero {
+        inner: "ZERO".to_owned(),
+    }
+}
+
+#[::uniffi::export]
+fn make_record_with_bytes() -> RecordWithBytes {
+    RecordWithBytes {
+        some_bytes: ::std::vec![0, 1, 2, 3, 4],
+    }
+}
+
+#[derive(::uniffi::Enum)]
+pub enum MaybeBool {
+    True,
+    False,
+    Uncertain,
+}
+
+#[derive(::uniffi::Enum)]
+pub enum MixedEnum {
+    None,
+    String(::std::string::String),
+    Int(i64),
+    Both(::std::string::String, i64),
+    All { s: ::std::string::String, i: i64 },
+}
+
+#[::uniffi::export]
+fn get_mixed_enum(v: ::std::option::Option<MixedEnum>) -> MixedEnum {
+    v.unwrap_or(MixedEnum::Int(1))
+}
+
+#[repr(u8)]
+#[derive(::uniffi::Enum)]
+pub enum ReprU8 {
+    One = 1,
+    Three = 0x3,
+}
+
+#[::uniffi::export]
+fn enum_identity(value: MaybeBool) -> MaybeBool {
+    value
+}
+
+#[derive(::uniffi::Error, Debug, PartialEq, Eq)]
+pub enum BasicError {
+    InvalidInput,
+    OsError,
+    UnexpectedError { reason: ::std::string::String },
+}
+
+impl ::std::fmt::Display for BasicError {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        f.write_str(match self {
+            Self::InvalidInput => "InvalidInput",
+            Self::OsError => "OsError",
+            Self::UnexpectedError { .. } => "UnexpectedError",
+        })
+    }
+}
+
+impl ::std::error::Error for BasicError {}
+
+impl ::std::convert::From<::uniffi::UnexpectedUniFFICallbackError> for BasicError {
+    fn from(e: ::uniffi::UnexpectedUniFFICallbackError) -> Self {
+        Self::UnexpectedError { reason: e.reason }
+    }
+}
+
+#[::uniffi::export]
+fn always_fails() -> ::std::result::Result<(), BasicError> {
+    ::std::result::Result::Err(BasicError::OsError)
+}
+
+#[derive(Debug, ::uniffi::Error)]
+#[uniffi(flat_error)]
+#[non_exhaustive]
+pub enum FlatError {
+    InvalidInput,
+
+    // Inner types that aren't FFI-convertible, as well as unnamed fields,
+    // are allowed for flat errors
+    OsError(::std::io::Error),
+}
+
+impl ::std::fmt::Display for FlatError {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            Self::InvalidInput => f.write_str("Invalid input"),
+            Self::OsError(e) => ::std::write!(f, "OS error: {e}"),
+        }
+    }
+}
+
+#[::uniffi::export]
+impl Object {
+    fn do_stuff(&self, times: u32) -> ::std::result::Result<(), FlatError> {
+        match times {
+            0 => ::std::result::Result::Err(FlatError::InvalidInput),
+            _ => {
+                // do stuff
+                ::std::result::Result::Ok(())
+            }
+        }
+    }
+}
+
+// defined in UDL.
+fn get_one(one: ::std::option::Option<One>) -> One {
+    one.unwrap_or(One { inner: 0 })
+}
+
+fn get_bool(b: ::std::option::Option<MaybeBool>) -> MaybeBool {
+    b.unwrap_or(MaybeBool::Uncertain)
+}
+
+fn get_object(o: ::std::option::Option<::std::sync::Arc<Object>>) -> ::std::sync::Arc<Object> {
+    o.unwrap_or_else(Object::new)
+}
+
+fn get_trait(o: ::std::option::Option<::std::sync::Arc<dyn Trait>>) -> ::std::sync::Arc<dyn Trait> {
+    o.unwrap_or_else(|| ::std::sync::Arc::new(TraitImpl {}))
+}
+
+fn get_trait_with_foreign(
+    o: ::std::option::Option<::std::sync::Arc<dyn TraitWithForeign>>,
+) -> ::std::sync::Arc<dyn TraitWithForeign> {
+    o.unwrap_or_else(|| ::std::sync::Arc::new(RustTraitImpl {}))
+}
+
+#[derive(Default)]
+struct Externals {
+    one: ::std::option::Option<One>,
+    bool: ::std::option::Option<MaybeBool>,
+}
+
+fn get_externals(e: ::std::option::Option<Externals>) -> Externals {
+    e.unwrap_or_default()
+}
+
+#[::uniffi::export]
+pub fn join(parts: &[::std::string::String], sep: &str) -> ::std::string::String {
+    parts.join(sep)
+}
+
+// Custom names
+#[derive(::uniffi::Object)]
+pub struct Renamed;
+
+// `renamed_new` becomes the default constructor because it's named `new`
+#[::uniffi::export]
+impl Renamed {
+    #[::uniffi::constructor(name = "new")]
+    fn renamed_new() -> ::std::sync::Arc<Self> {
+        ::std::sync::Arc::new(Self)
+    }
+
+    #[::uniffi::method(name = "func")]
+    fn renamed_func(&self) -> bool {
+        true
+    }
+}
+
+#[::uniffi::export(name = "rename_test")]
+fn renamed_rename_test() -> bool {
+    true
+}
+
+/// Test defaults on Records
+#[derive(::uniffi::Record)]
+pub struct RecordWithDefaults {
+    no_default_string: ::std::string::String,
+    #[uniffi(default = true)]
+    boolean: bool,
+    #[uniffi(default = 42)]
+    integer: i32,
+    #[uniffi(default = 4.2)]
+    float_var: f64,
+    #[uniffi(default=[])]
+    vec: ::std::vec::Vec<bool>,
+    #[uniffi(default=None)]
+    opt_vec: ::std::option::Option<::std::vec::Vec<bool>>,
+    #[uniffi(default = Some(42))]
+    opt_integer: ::std::option::Option<i32>,
+}
+
+/// Test defaults on top-level functions
+#[::uniffi::export(default(num = 21))]
+fn double_with_default(num: i32) -> i32 {
+    num + num
+}
+
+/// Test defaults on constructors / methods
+#[derive(::uniffi::Object)]
+pub struct ObjectWithDefaults {
+    num: i32,
+}
+
+#[::uniffi::export]
+impl ObjectWithDefaults {
+    #[::uniffi::constructor(default(num = 30))]
+    fn new(num: i32) -> Self {
+        Self { num }
+    }
+
+    #[::uniffi::method(default(other = 12))]
+    fn add_to_num(&self, other: i32) -> i32 {
+        self.num + other
+    }
+}
+
+::uniffi::include_scaffolding!("proc-macro");

--- a/fixtures/proc-macro-no-implicit-prelude/src/proc-macro.udl
+++ b/fixtures/proc-macro-no-implicit-prelude/src/proc-macro.udl
@@ -1,0 +1,36 @@
+// Use this to test that types defined in the UDL can be used in the proc-macros
+dictionary Zero {
+    string inner;
+};
+
+// And all of these for the opposite - proc-macro types used in UDL.
+[Rust="record"]
+typedef extern One;
+
+[Rust="enum"]
+typedef extern MaybeBool;
+
+[Rust="interface"]
+typedef extern Object;
+
+[Rust="trait"]
+typedef extern Trait;
+
+[Rust="trait_with_foreign"]
+typedef extern TraitWithForeign;
+
+// Then stuff defined here but referencing the imported types.
+dictionary Externals {
+    One? one;
+    MaybeBool? bool;
+};
+
+// Namespace different from crate name.
+namespace proc_macro {
+    One get_one(One? one);
+    MaybeBool get_bool(MaybeBool? b);
+    Object get_object(Object? o);
+    Trait get_trait(Trait? t);
+    TraitWithForeign get_trait_with_foreign(TraitWithForeign? t);
+    Externals get_externals(Externals? e);
+};

--- a/fixtures/proc-macro-no-implicit-prelude/uniffi.toml
+++ b/fixtures/proc-macro-no-implicit-prelude/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.kotlin]
+package_name = "uniffi.fixture.proc_macro"

--- a/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
+++ b/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
@@ -16,7 +16,7 @@ note: required by a bound in `_::{closure#0}::assert_impl_all`
   |
   | #[::uniffi::udl_derive(Object)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
-  = note: this error originates in the macro `uniffi::deps::static_assertions::assert_impl_all` which comes from the expansion of the attribute macro `::uniffi::udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `::uniffi::deps::static_assertions::assert_impl_all` which comes from the expansion of the attribute macro `::uniffi::udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Cell<u32>` cannot be shared between threads safely
  --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
@@ -55,7 +55,7 @@ note: required by a bound in `_::{closure#0}::assert_impl_all`
    |
 26 | #[derive(uniffi::Object)]
    |          ^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
-   = note: this error originates in the macro `uniffi::deps::static_assertions::assert_impl_all` which comes from the expansion of the derive macro `uniffi::Object` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `::uniffi::deps::static_assertions::assert_impl_all` which comes from the expansion of the derive macro `uniffi::Object` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Cell<u32>` cannot be shared between threads safely
   --> tests/ui/interface_not_sync_and_send.rs:27:12

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -36,24 +36,24 @@ mod filters {
             Type::Float32 => "f32".into(),
             Type::Float64 => "f64".into(),
             Type::Boolean => "bool".into(),
-            Type::String => "String".into(),
-            Type::Bytes => "Vec<u8>".into(),
-            Type::Timestamp => "std::time::SystemTime".into(),
-            Type::Duration => "std::time::Duration".into(),
+            Type::String => "::std::string::String".into(),
+            Type::Bytes => "::std::vec::Vec<u8>".into(),
+            Type::Timestamp => "::std::time::SystemTime".into(),
+            Type::Duration => "::std::time::Duration".into(),
             Type::Enum { name, .. } | Type::Record { name, .. } => format!("r#{name}"),
             Type::Object { name, imp, .. } => {
-                format!("std::sync::Arc<{}>", imp.rust_name_for(name))
+                format!("::std::sync::Arc<{}>", imp.rust_name_for(name))
             }
             Type::CallbackInterface { name, .. } => format!("Box<dyn r#{name}>"),
             Type::Optional { inner_type } => {
-                format!("std::option::Option<{}>", type_rs(inner_type)?)
+                format!("::std::option::Option<{}>", type_rs(inner_type)?)
             }
             Type::Sequence { inner_type } => format!("std::vec::Vec<{}>", type_rs(inner_type)?),
             Type::Map {
                 key_type,
                 value_type,
             } => format!(
-                "std::collections::HashMap<{}, {}>",
+                "::std::collections::HashMap<{}, {}>",
                 type_rs(key_type)?,
                 type_rs(value_type)?
             ),

--- a/uniffi_core/src/ffi/callbackinterface.rs
+++ b/uniffi_core/src/ffi/callbackinterface.rs
@@ -195,7 +195,7 @@ macro_rules! convert_unexpected_error {
             fn get_converter(&self) -> $crate::UnexpectedUniFFICallbackErrorConverterSpecialized;
         }
 
-        impl<T: Into<$ty>> GetConverterSpecialized for T {
+        impl<T: ::std::convert::Into<$ty>> GetConverterSpecialized for T {
             fn get_converter(&self) -> $crate::UnexpectedUniFFICallbackErrorConverterSpecialized {
                 $crate::UnexpectedUniFFICallbackErrorConverterSpecialized
             }

--- a/uniffi_core/src/ffi_converter_traits.rs
+++ b/uniffi_core/src/ffi_converter_traits.rs
@@ -541,7 +541,7 @@ macro_rules! derive_ffi_traits {
             type ReturnType = <Self as $crate::Lower<$ut>>::FfiType;
 
             fn lower_return(obj: Self) -> $crate::deps::anyhow::Result<Self::ReturnType, $crate::RustBuffer> {
-                Ok(<Self as $crate::Lower<$ut>>::lower(obj))
+                ::std::result::Result::Ok(<Self as $crate::Lower<$ut>>::lower(obj))
             }
         }
     };

--- a/uniffi_core/src/lib.rs
+++ b/uniffi_core/src/lib.rs
@@ -176,7 +176,7 @@ macro_rules! ffi_converter_rust_buffer_lift_and_lower {
             let mut buf = vec.as_slice();
             let value = <Self as $crate::FfiConverter<$uniffi_tag>>::try_read(&mut buf)?;
             match $crate::deps::bytes::Buf::remaining(&buf) {
-                0 => Ok(value),
+                0 => ::std::result::Result::Ok(value),
                 n => $crate::deps::anyhow::bail!(
                     "junk data left in buffer after lifting (count: {n})",
                 ),

--- a/uniffi_macros/src/custom.rs
+++ b/uniffi_macros/src/custom.rs
@@ -41,7 +41,7 @@ pub(crate) fn expand_ffi_converter_custom_type(
                 #lower(#from_custom(obj))
             }
 
-            fn try_lift(v: Self::FfiType) -> uniffi::Result<#ident> {
+            fn try_lift(v: Self::FfiType) -> ::uniffi::Result<#ident> {
                 #into_custom(#try_lift(v)?)
             }
 
@@ -49,7 +49,7 @@ pub(crate) fn expand_ffi_converter_custom_type(
                 #write(#from_custom(obj), buf);
             }
 
-            fn try_read(buf: &mut &[u8]) -> uniffi::Result<#ident> {
+            fn try_read(buf: &mut &[u8]) -> ::uniffi::Result<#ident> {
                 #into_custom(#try_read(buf)?)
             }
 
@@ -85,8 +85,8 @@ fn custom_ffi_type_converter(ident: &Ident, builtin: &Path) -> syn::Result<Token
         impl crate::UniffiCustomTypeConverter for #ident {
             type Builtin = #builtin;
 
-            fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
-                Ok(#ident(val))
+            fn into_custom(val: Self::Builtin) -> ::uniffi::Result<Self> {
+                ::std::result::Result::Ok(#ident(val))
             }
 
             fn from_custom(obj: Self) -> Self::Builtin {

--- a/uniffi_macros/src/enum_.rs
+++ b/uniffi_macros/src/enum_.rs
@@ -211,7 +211,7 @@ fn enum_or_error_ffi_converter_impl(
         .collect();
     if item.is_non_exhaustive() {
         write_match_arms.push(quote! {
-            _ => panic!("Unexpected variant in non-exhaustive enum"),
+            _ => ::std::panic!("Unexpected variant in non-exhaustive enum"),
         })
     }
     let write_impl = quote! {
@@ -238,7 +238,7 @@ fn enum_or_error_ffi_converter_impl(
     let try_read_impl = quote! {
         ::uniffi::check_remaining(buf, 4)?;
 
-        Ok(match ::uniffi::deps::bytes::Buf::get_i32(buf) {
+        ::std::result::Result::Ok(match ::uniffi::deps::bytes::Buf::get_i32(buf) {
             #(#try_read_match_arms)*
             v => ::uniffi::deps::anyhow::bail!(#error_format_string, v),
         })

--- a/uniffi_macros/src/error.rs
+++ b/uniffi_macros/src/error.rs
@@ -88,7 +88,7 @@ fn flat_error_ffi_converter_impl(item: &EnumItem, options: &DeriveOptions) -> To
             .collect();
         if item.is_non_exhaustive() {
             match_arms.push(quote! {
-                _ => panic!("Unexpected variant in non-exhaustive enum"),
+                _ => ::std::panic!("Unexpected variant in non-exhaustive enum"),
             })
         }
 
@@ -127,7 +127,7 @@ fn flat_error_ffi_converter_impl(item: &EnumItem, options: &DeriveOptions) -> To
                 type FfiType = ::uniffi::RustBuffer;
 
                 fn try_read(buf: &mut &[::std::primitive::u8]) -> ::uniffi::deps::anyhow::Result<Self> {
-                    Ok(match ::uniffi::deps::bytes::Buf::get_i32(buf) {
+                    ::std::result::Result::Ok(match ::uniffi::deps::bytes::Buf::get_i32(buf) {
                         #(#match_arms)*
                         v => ::uniffi::deps::anyhow::bail!("Invalid #ident enum value: {}", v),
                     })
@@ -152,11 +152,11 @@ fn flat_error_ffi_converter_impl(item: &EnumItem, options: &DeriveOptions) -> To
                 type FfiType = ::uniffi::RustBuffer;
 
                 fn try_read(buf: &mut &[::std::primitive::u8]) -> ::uniffi::deps::anyhow::Result<Self> {
-                    panic!("Can't lift flat errors")
+                    ::std::panic!("Can't lift flat errors")
                 }
 
                 fn try_lift(v: ::uniffi::RustBuffer) -> ::uniffi::deps::anyhow::Result<Self> {
-                    panic!("Can't lift flat errors")
+                    ::std::panic!("Can't lift flat errors")
                 }
             }
         }

--- a/uniffi_macros/src/export/callback_interface.rs
+++ b/uniffi_macros/src/export/callback_interface.rs
@@ -150,11 +150,11 @@ pub fn ffi_converter_callback_interface_impl(
             type FfiType = u64;
 
             fn try_lift(v: Self::FfiType) -> ::uniffi::deps::anyhow::Result<Self> {
-                Ok(::std::boxed::Box::new(<#trait_impl_ident>::new(v)))
+                ::std::result::Result::Ok(::std::boxed::Box::new(<#trait_impl_ident>::new(v)))
             }
 
             fn try_read(buf: &mut &[u8]) -> ::uniffi::deps::anyhow::Result<Self> {
-                use uniffi::deps::bytes::Buf;
+                use ::uniffi::deps::bytes::Buf;
                 ::uniffi::check_remaining(buf, 8)?;
                 #try_lift_self(buf.get_u64())
             }
@@ -222,7 +222,7 @@ fn gen_method_impl(sig: &FnSignature, vtable_cell: &Ident) -> syn::Result<TokenS
         Ok(quote! {
             fn #ident(#self_param, #(#params),*) -> #return_ty {
                 let vtable = #vtable_cell.get();
-                let mut uniffi_call_status = ::uniffi::RustCallStatus::default();
+                let mut uniffi_call_status: ::uniffi::RustCallStatus = ::std::default::Default::default();
                 let mut uniffi_return_value: #lift_return_type = ::uniffi::FfiDefault::ffi_default();
                 (vtable.#ident)(self.handle, #(#lower_exprs,)* &mut uniffi_return_value, &mut uniffi_call_status);
                 #lift_foreign_return(uniffi_return_value, uniffi_call_status)

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -144,9 +144,13 @@ impl ScaffoldingBits {
             // pointer.
             quote! {
                 {
-                    let boxed_foreign_arc = unsafe { Box::from_raw(uniffi_self_lowered as *mut ::std::sync::Arc<dyn #self_ident>) };
+                    let boxed_foreign_arc = unsafe {
+                        ::std::boxed::Box::from_raw(
+                            uniffi_self_lowered as *mut ::std::sync::Arc<dyn #self_ident>,
+                        )
+                    };
                     // Take a clone for our own use.
-                    Ok(*boxed_foreign_arc)
+                    ::std::result::Result::Ok(*boxed_foreign_arc)
                 }
             }
         } else {
@@ -155,8 +159,10 @@ impl ScaffoldingBits {
 
         let lift_closure = sig.lift_closure(Some(quote! {
             match #try_lift_self {
-                Ok(v) => v,
-                Err(e) => return Err(("self", e))
+                ::std::result::Result::Ok(v) => v,
+                ::std::result::Result::Err(e) => {
+                    return ::std::result::Result::Err(("self", e));
+                }
             }
         }));
         let call_params = sig.rust_call_params(true);
@@ -260,11 +266,11 @@ pub(super) fn gen_ffi_function(
                 let uniffi_lift_args = #lift_closure;
                 ::uniffi::rust_call(call_status, || {
                     #lower_return(match uniffi_lift_args() {
-                        Ok(uniffi_args) => {
+                        ::std::result::Result::Ok(uniffi_args) => {
                             let uniffi_result = #rust_fn_call;
                             #convert_result
                         }
-                        Err((arg_name, anyhow_error)) => {
+                        ::std::result::Result::Err((arg_name, anyhow_error)) => {
                             #handle_failed_lift(arg_name, anyhow_error)
                         },
                     })
@@ -288,7 +294,7 @@ pub(super) fn gen_ffi_function(
                 ::uniffi::deps::log::debug!(#name);
                 let uniffi_lift_args = #lift_closure;
                 match uniffi_lift_args() {
-                    Ok(uniffi_args) => {
+                    ::std::result::Result::Ok(uniffi_args) => {
                         ::uniffi::rust_future_new::<_, #return_ty, _>(
                             async move {
                                 let uniffi_result = #future_expr.await;
@@ -297,7 +303,7 @@ pub(super) fn gen_ffi_function(
                             crate::UniFfiTag
                         )
                     },
-                    Err((arg_name, anyhow_error)) => {
+                    ::std::result::Result::Err((arg_name, anyhow_error)) => {
                         ::uniffi::rust_future_new::<_, #return_ty, _>(
                             async move { #handle_failed_lift(arg_name, anyhow_error) },
                             crate::UniFfiTag,
@@ -332,7 +338,7 @@ fn ffi_buffer_scaffolding_fn(
             ) {
                 let mut arg_buf = unsafe { ::std::slice::from_raw_parts(arg_ptr, ::uniffi::ffi_buffer_size!(#(#type_list),*)) };
                 let mut return_buf = unsafe { ::std::slice::from_raw_parts_mut(return_ptr, ::uniffi::ffi_buffer_size!(#return_type, ::uniffi::RustCallStatus)) };
-                let mut out_status = ::uniffi::RustCallStatus::default();
+                let mut out_status: ::uniffi::RustCallStatus = ::std::default::Default::default();
 
                 let return_value = #fn_ident(
                     #(

--- a/uniffi_macros/src/export/utrait.rs
+++ b/uniffi_macros/src/export/utrait.rs
@@ -103,14 +103,14 @@ pub(crate) fn expand_uniffi_trait_export(
                 let method_eq = quote! {
                     fn uniffi_trait_eq_eq(&self, other: &#self_ident) -> bool {
                         use ::std::cmp::PartialEq;
-                        uniffi::deps::static_assertions::assert_impl_all!(#self_ident: PartialEq); // This object has a trait method which requires `PartialEq` be implemented.
+                        ::uniffi::deps::static_assertions::assert_impl_all!(#self_ident: PartialEq); // This object has a trait method which requires `PartialEq` be implemented.
                         PartialEq::eq(self, other)
                     }
                 };
                 let method_ne = quote! {
                     fn uniffi_trait_eq_ne(&self, other: &#self_ident) -> bool {
                         use ::std::cmp::PartialEq;
-                        uniffi::deps::static_assertions::assert_impl_all!(#self_ident: PartialEq); // This object has a trait method which requires `PartialEq` be implemented.
+                        ::uniffi::deps::static_assertions::assert_impl_all!(#self_ident: PartialEq); // This object has a trait method which requires `PartialEq` be implemented.
                         PartialEq::ne(self, other)
                     }
                 };

--- a/uniffi_macros/src/fnsig.rs
+++ b/uniffi_macros/src/fnsig.rs
@@ -159,14 +159,16 @@ impl FnSignature {
             let name = &arg.name;
             quote! {
                 match #try_lift(#ident) {
-                    Ok(v) => v,
-                    Err(e) => return Err((#name, e)),
+                    ::std::result::Result::Ok(v) => v,
+                    ::std::result::Result::Err(e) => {
+                        return ::std::result::Result::Err((#name, e))
+                    }
                 }
             }
         });
         let all_lifts = self_lift.into_iter().chain(arg_lifts);
         quote! {
-            move || Ok((
+            move || ::std::result::Result::Ok((
                 #(#all_lifts,)*
             ))
         }

--- a/uniffi_macros/src/object.rs
+++ b/uniffi_macros/src/object.rs
@@ -67,9 +67,9 @@ pub fn expand_object(input: DeriveInput, options: DeriveOptions) -> syn::Result<
             ptr: *const ::std::ffi::c_void,
             call_status: &mut ::uniffi::RustCallStatus
         ) -> *const ::std::ffi::c_void {
-            uniffi::rust_call(call_status, || {
+            ::uniffi::rust_call(call_status, || {
                 unsafe { ::std::sync::Arc::increment_strong_count(ptr) };
-                Ok(ptr)
+                ::std::result::Result::Ok(ptr)
             })
         }
 
@@ -79,13 +79,13 @@ pub fn expand_object(input: DeriveInput, options: DeriveOptions) -> syn::Result<
             ptr: *const ::std::ffi::c_void,
             call_status: &mut ::uniffi::RustCallStatus
         ) {
-            uniffi::rust_call(call_status, || {
+            ::uniffi::rust_call(call_status, || {
                 assert!(!ptr.is_null());
                 let ptr = ptr.cast::<#ident>();
                 unsafe {
                     ::std::sync::Arc::decrement_strong_count(ptr);
                 }
-                Ok(())
+                ::std::result::Result::Ok(())
             });
         }
 
@@ -119,7 +119,9 @@ fn interface_impl(object: &ObjectItem, options: &DeriveOptions) -> TokenStream {
         // if they are not, but unfortunately it fails with an unactionably obscure error message.
         // By asserting the requirement explicitly, we help Rust produce a more scrutable error message
         // and thus help the user debug why the requirement isn't being met.
-        uniffi::deps::static_assertions::assert_impl_all!(#ident: ::core::marker::Sync, ::core::marker::Send);
+        ::uniffi::deps::static_assertions::assert_impl_all!(
+            #ident: ::core::marker::Sync, ::core::marker::Send
+        );
 
         #[doc(hidden)]
         #[automatically_derived]
@@ -148,7 +150,7 @@ fn interface_impl(object: &ObjectItem, options: &DeriveOptions) -> TokenStream {
             /// When lifting, we receive an owned `Arc` that the foreign language code cloned.
             fn try_lift(v: Self::FfiType) -> ::uniffi::Result<::std::sync::Arc<Self>> {
                 let v = v as *const #ident;
-                Ok(unsafe { ::std::sync::Arc::<Self>::from_raw(v) })
+                ::std::result::Result::Ok(unsafe { ::std::sync::Arc::<Self>::from_raw(v) })
             }
 
             /// When writing as a field of a complex structure, make a clone and transfer ownership
@@ -159,9 +161,9 @@ fn interface_impl(object: &ObjectItem, options: &DeriveOptions) -> TokenStream {
             /// Safety: when freeing the resulting pointer, the foreign-language code must
             /// call the destructor function specific to the type `T`. Calling the destructor
             /// function for other types may lead to undefined behaviour.
-            fn write(obj: ::std::sync::Arc<Self>, buf: &mut Vec<u8>) {
+            fn write(obj: ::std::sync::Arc<Self>, buf: &mut ::std::vec::Vec<u8>) {
                 ::uniffi::deps::static_assertions::const_assert!(::std::mem::size_of::<*const ::std::ffi::c_void>() <= 8);
-                ::uniffi::deps::bytes::BufMut::put_u64(buf, #lower_arc(obj) as u64);
+                ::uniffi::deps::bytes::BufMut::put_u64(buf, #lower_arc(obj) as ::std::primitive::u64);
             }
 
             /// When reading as a field of a complex structure, we receive a "borrow" of the `Arc`

--- a/uniffi_macros/src/record.rs
+++ b/uniffi_macros/src/record.rs
@@ -94,7 +94,7 @@ fn record_ffi_converter_impl(
             }
 
             fn try_read(buf: &mut &[::std::primitive::u8]) -> ::uniffi::deps::anyhow::Result<Self> {
-                Ok(Self { #try_read_fields })
+                ::std::result::Result::Ok(Self { #try_read_fields })
             }
 
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_RECORD)

--- a/uniffi_macros/src/setup_scaffolding.rs
+++ b/uniffi_macros/src/setup_scaffolding.rs
@@ -36,7 +36,7 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
         #[allow(clippy::missing_safety_doc, missing_docs)]
         #[doc(hidden)]
         #[no_mangle]
-        pub extern "C" fn #ffi_contract_version_ident() -> u32 {
+        pub extern "C" fn #ffi_contract_version_ident() -> ::std::primitive::u32 {
             #UNIFFI_CONTRACT_VERSION
         }
 
@@ -45,13 +45,15 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
         ///
         /// See `uniffi_bindgen::macro_metadata` for how this is used.
 
-        const #namespace_const_ident: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::NAMESPACE)
-            .concat_str(#module_path)
-            .concat_str(#namespace);
+        const #namespace_const_ident: ::uniffi::MetadataBuffer =
+            ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::NAMESPACE)
+                .concat_str(#module_path)
+                .concat_str(#namespace);
 
         #[doc(hidden)]
         #[no_mangle]
-        pub static #namespace_static_ident: [u8; #namespace_const_ident.size] = #namespace_const_ident.into_array();
+        pub static #namespace_static_ident: [::std::primitive::u8; #namespace_const_ident.size] =
+            #namespace_const_ident.into_array();
 
         // Everybody gets basic buffer support, since it's needed for passing complex types over the FFI.
         //
@@ -60,29 +62,42 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
         #[allow(clippy::missing_safety_doc, missing_docs)]
         #[doc(hidden)]
         #[no_mangle]
-        pub extern "C" fn #ffi_rustbuffer_alloc_ident(size: u64, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
-            uniffi::ffi::uniffi_rustbuffer_alloc(size, call_status)
+        pub extern "C" fn #ffi_rustbuffer_alloc_ident(
+            size: ::std::primitive::u64,
+            call_status: &mut ::uniffi::RustCallStatus,
+        ) -> ::uniffi::RustBuffer {
+            ::uniffi::ffi::uniffi_rustbuffer_alloc(size, call_status)
         }
 
         #[allow(clippy::missing_safety_doc, missing_docs)]
         #[doc(hidden)]
         #[no_mangle]
-        pub unsafe extern "C" fn #ffi_rustbuffer_from_bytes_ident(bytes: uniffi::ForeignBytes, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
-            uniffi::ffi::uniffi_rustbuffer_from_bytes(bytes, call_status)
+        pub unsafe extern "C" fn #ffi_rustbuffer_from_bytes_ident(
+            bytes: ::uniffi::ForeignBytes,
+            call_status: &mut ::uniffi::RustCallStatus,
+        ) -> ::uniffi::RustBuffer {
+            ::uniffi::ffi::uniffi_rustbuffer_from_bytes(bytes, call_status)
         }
 
         #[allow(clippy::missing_safety_doc, missing_docs)]
         #[doc(hidden)]
         #[no_mangle]
-        pub unsafe extern "C" fn #ffi_rustbuffer_free_ident(buf: uniffi::RustBuffer, call_status: &mut uniffi::RustCallStatus) {
-            uniffi::ffi::uniffi_rustbuffer_free(buf, call_status);
+        pub unsafe extern "C" fn #ffi_rustbuffer_free_ident(
+            buf: ::uniffi::RustBuffer,
+            call_status: &mut ::uniffi::RustCallStatus,
+        ) {
+            ::uniffi::ffi::uniffi_rustbuffer_free(buf, call_status);
         }
 
         #[allow(clippy::missing_safety_doc, missing_docs)]
         #[doc(hidden)]
         #[no_mangle]
-        pub unsafe extern "C" fn #ffi_rustbuffer_reserve_ident(buf: uniffi::RustBuffer, additional: u64, call_status: &mut uniffi::RustCallStatus) -> uniffi::RustBuffer {
-            uniffi::ffi::uniffi_rustbuffer_reserve(buf, additional, call_status)
+        pub unsafe extern "C" fn #ffi_rustbuffer_reserve_ident(
+            buf: ::uniffi::RustBuffer,
+            additional: ::std::primitive::u64,
+            call_status: &mut ::uniffi::RustCallStatus,
+        ) -> ::uniffi::RustBuffer {
+            ::uniffi::ffi::uniffi_rustbuffer_reserve(buf, additional, call_status)
         }
 
         #ffi_rust_future_scaffolding_fns
@@ -121,7 +136,9 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
         #[doc(hidden)]
         pub trait UniffiCustomTypeConverter {
             type Builtin;
-            fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> where Self: Sized;
+            fn into_custom(val: Self::Builtin) -> ::uniffi::Result<Self>
+            where
+                Self: ::std::marker::Sized;
             fn from_custom(obj: Self) -> Self::Builtin;
         }
     })

--- a/uniffi_macros/src/test.rs
+++ b/uniffi_macros/src/test.rs
@@ -30,16 +30,16 @@ pub(crate) fn build_foreign_language_testcases(tokens: TokenStream) -> TokenStre
             );
             let run_test = match test_file_pathbuf.extension() {
                 Some("kts") => quote! {
-                    uniffi::kotlin_run_test
+                    ::uniffi::kotlin_run_test
                 },
                 Some("swift") => quote! {
-                    uniffi::swift_run_test
+                    ::uniffi::swift_run_test
                 },
                 Some("py") => quote! {
-                    uniffi::python_run_test
+                    ::uniffi::python_run_test
                 },
                 Some("rb") => quote! {
-                    uniffi::ruby_run_test
+                    ::uniffi::ruby_run_test
                 },
                 _ => panic!("Unexpected extension for test script: {test_file_name}"),
             };
@@ -51,7 +51,7 @@ pub(crate) fn build_foreign_language_testcases(tokens: TokenStream) -> TokenStre
             quote! {
                 #maybe_ignore
                 #[test]
-                fn #test_name () -> uniffi::deps::anyhow::Result<()> {
+                fn #test_name () -> ::uniffi::deps::anyhow::Result<()> {
                     #run_test(
                         std::env!("CARGO_TARGET_TMPDIR"),
                         std::env!("CARGO_PKG_NAME"),


### PR DESCRIPTION
This is what I was talking about in #2177. I think you weren't missing anything @mhammond, it's a bunch of boilerplate so I put it in a new fixture instead of `proc-macro`. It's a copy of that one though.

Note that there is still the language prelude that is _not_ disabled by this attribute (which contains primitive types such as `u8` and I think `str` as well, plus lots of macros like `#[align]`, `#[allow]`, `#[automatically_derived]`, ...). Because some of these things can nevertheless be shadowed, this test doesn't catch all potential name confusions within macro code. It it pretty good at it though, as you can see in the first commit 😄 (the few `::std::primitive` insertions were drive-by improvements and not steered by error messages)