### PR TITLE
Kotlin: use `Enum.entries` instead of `Enum.values()`

### DIFF
--- a/docs/manual/src/kotlin/configuration.md
+++ b/docs/manual/src/kotlin/configuration.md
@@ -4,16 +4,16 @@ The generated Kotlin modules can be configured using a `uniffi.toml` configurati
 
 ## Available options
 
-| Configuration name           | Default  | Description |
-|------------------------------| -------  |------------ |
-| `package_name`               |  `uniffi` | The Kotlin package name - ie, the value used in the `package` statement at the top of generated files. |
+| Configuration name           | Default                  | Description |
+|------------------------------|--------------------------|------------ |
+| `package_name`               | `uniffi`                 | The Kotlin package name - ie, the value used in the `package` statement at the top of generated files. |
 | `cdylib_name`                | `uniffi_{namespace}`[^1] | The name of the compiled Rust library containing the FFI implementation (not needed when using `generate --library`). |
-| `generate_immutable_records` | `false` | Whether to generate records with immutable fields (`val` instead of `var`). |
-| `custom_types`               | | A map which controls how custom types are exposed to Kotlin. See the [custom types section of the manual](../udl/custom_types.md#custom-types-in-the-bindings-code)|
-| `external_packages`          | | A map of packages to be used for the specified external crates. The key is the Rust crate name, the value is the Kotlin package which will be used referring to types in that crate. See the [external types section of the manual](../udl/ext_types_external.md#kotlin)
-| `android`                    | `false` | Used to toggle on Android specific optimizations
-| `android_cleaner`            | `android` | Use the [`android.system.SystemCleaner`](https://developer.android.com/reference/android/system/SystemCleaner) instead of [`java.lang.ref.Cleaner`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/ref/Cleaner.html). Fallback in both instances is the one shipped with JNA.
-| `use_enum_entries`           | `false` | Uses `EnumClass.entries` instead of `EnumClass.values()` in the bindings, which is more efficient as it reuses the same list instance every time. Note this is only available since Kotlin 1.9.0
+| `generate_immutable_records` | `false`                  | Whether to generate records with immutable fields (`val` instead of `var`). |
+| `custom_types`               |                          | A map which controls how custom types are exposed to Kotlin. See the [custom types section of the manual](../udl/custom_types.md#custom-types-in-the-bindings-code)|
+| `external_packages`          |                          | A map of packages to be used for the specified external crates. The key is the Rust crate name, the value is the Kotlin package which will be used referring to types in that crate. See the [external types section of the manual](../udl/ext_types_external.md#kotlin)
+| `android`                    | `false`                  | Used to toggle on Android specific optimizations
+| `android_cleaner`            | `android`                | Use the [`android.system.SystemCleaner`](https://developer.android.com/reference/android/system/SystemCleaner) instead of [`java.lang.ref.Cleaner`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/ref/Cleaner.html). Fallback in both instances is the one shipped with JNA.
+| `kotlin_target_version`      | `"x.y.z"`                | When provided, it will enable features in the bindings supported for this version. The build process will fail if an invalid format is used.
 
 ## Example
 

--- a/docs/manual/src/kotlin/configuration.md
+++ b/docs/manual/src/kotlin/configuration.md
@@ -4,15 +4,16 @@ The generated Kotlin modules can be configured using a `uniffi.toml` configurati
 
 ## Available options
 
-| Configuration name | Default  | Description |
-| ------------------ | -------  |------------ |
-| `package_name`     |  `uniffi` | The Kotlin package name - ie, the value used in the `package` statement at the top of generated files. |
-| `cdylib_name`      | `uniffi_{namespace}`[^1] | The name of the compiled Rust library containing the FFI implementation (not needed when using `generate --library`). |
+| Configuration name           | Default  | Description |
+|------------------------------| -------  |------------ |
+| `package_name`               |  `uniffi` | The Kotlin package name - ie, the value used in the `package` statement at the top of generated files. |
+| `cdylib_name`                | `uniffi_{namespace}`[^1] | The name of the compiled Rust library containing the FFI implementation (not needed when using `generate --library`). |
 | `generate_immutable_records` | `false` | Whether to generate records with immutable fields (`val` instead of `var`). |
-| `custom_types`      | | A map which controls how custom types are exposed to Kotlin. See the [custom types section of the manual](../udl/custom_types.md#custom-types-in-the-bindings-code)|
-| `external_packages` | | A map of packages to be used for the specified external crates. The key is the Rust crate name, the value is the Kotlin package which will be used referring to types in that crate. See the [external types section of the manual](../udl/ext_types_external.md#kotlin)
-| `android` | `false` | Used to toggle on Android specific optimizations
-| `android_cleaner` | `android` | Use the [`android.system.SystemCleaner`](https://developer.android.com/reference/android/system/SystemCleaner) instead of [`java.lang.ref.Cleaner`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/ref/Cleaner.html). Fallback in both instances is the one shipped with JNA.
+| `custom_types`               | | A map which controls how custom types are exposed to Kotlin. See the [custom types section of the manual](../udl/custom_types.md#custom-types-in-the-bindings-code)|
+| `external_packages`          | | A map of packages to be used for the specified external crates. The key is the Rust crate name, the value is the Kotlin package which will be used referring to types in that crate. See the [external types section of the manual](../udl/ext_types_external.md#kotlin)
+| `android`                    | `false` | Used to toggle on Android specific optimizations
+| `android_cleaner`            | `android` | Use the [`android.system.SystemCleaner`](https://developer.android.com/reference/android/system/SystemCleaner) instead of [`java.lang.ref.Cleaner`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/ref/Cleaner.html). Fallback in both instances is the one shipped with JNA.
+| `use_enum_entries`           | `false` | Uses `EnumClass.entries` instead of `EnumClass.values()` in the bindings, which is more efficient as it reuses the same list instance every time. Note this is only available since Kotlin 1.9.0
 
 ## Example
 

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -82,11 +82,17 @@ pub struct Config {
     android: bool,
     #[serde(default)]
     android_cleaner: Option<bool>,
+    #[serde(default)]
+    use_enum_entries: bool,
 }
 
 impl Config {
     pub(crate) fn android_cleaner(&self) -> bool {
         self.android_cleaner.unwrap_or(self.android)
+    }
+
+    pub(crate) fn use_enum_entries(&self) -> bool {
+        self.use_enum_entries
     }
 }
 

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -102,10 +102,9 @@ impl Config {
         self.kotlin_target_version
             .clone()
             .map(|v| {
-                Version::parse(&v).expect(&format!(
-                    "Provided Kotlin target version is not valid: {}",
-                    v
-                ))
+                Version::parse(&v).unwrap_or_else(|_| {
+                    panic!("Provided Kotlin target version is not valid: {}", v)
+                })
             })
             .unwrap_or(Version::new(0, 0, 0))
     }

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -10,7 +10,6 @@ use std::fmt::Debug;
 use anyhow::{Context, Result};
 use askama::Template;
 use cargo_metadata::semver::Version;
-use glob::Pattern;
 use heck::{ToLowerCamelCase, ToShoutySnakeCase, ToUpperCamelCase};
 use serde::{Deserialize, Serialize};
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
@@ -29,7 +29,7 @@ enum class {{ type_name }}(val value: {{ variant_discr_type|type_name(ci) }}) {
 
 public object {{ e|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
     override fun read(buf: ByteBuffer) = try {
-        {{ type_name }}.values()[buf.getInt() - 1]
+        {{ type_name }}.entries[buf.getInt() - 1]
     } catch (e: IndexOutOfBoundsException) {
         throw RuntimeException("invalid enum value, something is very wrong!!", e)
     }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
@@ -29,7 +29,11 @@ enum class {{ type_name }}(val value: {{ variant_discr_type|type_name(ci) }}) {
 
 public object {{ e|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
     override fun read(buf: ByteBuffer) = try {
+        {% if config.use_enum_entries() %}
         {{ type_name }}.entries[buf.getInt() - 1]
+        {% else -%}
+        {{ type_name }}.values()[buf.getInt() - 1]
+        {%- endif %}
     } catch (e: IndexOutOfBoundsException) {
         throw RuntimeException("invalid enum value, something is very wrong!!", e)
     }


### PR DESCRIPTION
Since Kotlin `1.9`, the `.entries` property is generated at build time for enum classes. Unlike `Enum.values()`, this property doesn't instantiate a new array with every enum case every time it's used, instead a single List instance is reused.

This should improve performance a tiny bit for Kotlin bindings. However, note this will only be supported since Kotlin 1.9, I don't know if there is a min version the project wants to support.