### PR TITLE
Don't panic for try_lift errors

### DIFF
--- a/uniffi_core/src/ffi/rustfuture/mod.rs
+++ b/uniffi_core/src/ffi/rustfuture/mod.rs
@@ -12,7 +12,7 @@ use scheduler::*;
 #[cfg(test)]
 mod tests;
 
-use crate::{derive_ffi_traits, Handle, HandleAlloc, LowerReturn, RustCallStatus};
+use crate::{derive_ffi_traits, Handle, HandleAlloc, LiftArgsError, LowerReturn, RustCallStatus};
 
 /// Result code for [rust_future_poll].  This is passed to the continuation function.
 #[repr(i8)]
@@ -42,7 +42,7 @@ where
     // since it will move between threads for an indeterminate amount of time as the foreign
     // executor calls polls it and the Rust executor wakes it.  It does not need to by `Sync`,
     // since we synchronize all access to the values.
-    F: Future<Output = T> + Send + 'static,
+    F: Future<Output = Result<T, LiftArgsError>> + Send + 'static,
     // T is the output of the Future.  It needs to implement [LowerReturn].  Also it must be Send +
     // 'static for the same reason as F.
     T: LowerReturn<UT> + Send + 'static,

--- a/uniffi_core/src/ffi/rustfuture/tests.rs
+++ b/uniffi_core/src/ffi/rustfuture/tests.rs
@@ -13,7 +13,7 @@ use crate::{test_util::TestError, Lift, RustBuffer, RustCallStatusCode};
 
 // Sender/Receiver pair that we use for testing
 struct Channel {
-    result: Option<Result<String, TestError>>,
+    result: Option<Result<Result<String, TestError>, LiftArgsError>>,
     waker: Option<Waker>,
 }
 
@@ -29,7 +29,21 @@ impl Sender {
 
     fn send(&self, value: Result<String, TestError>) {
         let mut inner = self.0.lock().unwrap();
-        if inner.result.replace(value).is_some() {
+        if inner.result.replace(Ok(value)).is_some() {
+            panic!("value already sent");
+        }
+        if let Some(waker) = &inner.waker {
+            waker.wake_by_ref();
+        }
+    }
+
+    fn send_lift_args_error(&self, arg_name: &'static str, error: anyhow::Error) {
+        let mut inner = self.0.lock().unwrap();
+        if inner
+            .result
+            .replace(Err(LiftArgsError { arg_name, error }))
+            .is_some()
+        {
             panic!("value already sent");
         }
         if let Some(waker) = &inner.waker {
@@ -41,12 +55,15 @@ impl Sender {
 struct Receiver(Arc<Mutex<Channel>>);
 
 impl Future for Receiver {
-    type Output = Result<String, TestError>;
+    type Output = Result<Result<String, TestError>, LiftArgsError>;
 
-    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Result<String, TestError>> {
+    fn poll(
+        self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Result<Result<String, TestError>, LiftArgsError>> {
         let mut inner = self.0.lock().unwrap();
-        match &inner.result {
-            Some(v) => Poll::Ready(v.clone()),
+        match inner.result.take() {
+            Some(v) => Poll::Ready(v),
             None => {
                 inner.waker = Some(context.waker().clone());
                 Poll::Pending
@@ -136,6 +153,29 @@ fn test_error() {
     )
 }
 
+#[test]
+fn test_lift_args_error() {
+    let (sender, rust_future) = channel();
+
+    let continuation_result = poll(&rust_future);
+    assert_eq!(continuation_result.get(), None);
+    sender.send_lift_args_error("arg0", anyhow::anyhow!("Invalid handle"));
+    assert_eq!(continuation_result.get(), Some(&RustFuturePoll::MaybeReady));
+
+    let continuation_result = poll(&rust_future);
+    assert_eq!(continuation_result.get(), Some(&RustFuturePoll::Ready));
+
+    let (_, call_status) = complete(rust_future);
+    assert_eq!(call_status.code, RustCallStatusCode::UnexpectedError);
+    assert_eq!(
+        <String as Lift<crate::UniFfiTag>>::try_lift(ManuallyDrop::into_inner(
+            call_status.error_buf
+        ))
+        .unwrap(),
+        "Failed to convert arg 'arg0': Invalid handle",
+    )
+}
+
 // Once `complete` is called, the inner future should be released, even if wakers still hold a
 // reference to the RustFuture
 #[test]
@@ -203,7 +243,7 @@ fn test_wake_during_poll() {
             Poll::Pending
         } else {
             // The second time we're polled, we're ready
-            Poll::Ready("All done".to_owned())
+            Poll::Ready(Ok("All done".to_owned()))
         }
     });
     let rust_future: Arc<dyn RustFutureFfi<RustBuffer>> = RustFuture::new(future, crate::UniFfiTag);

--- a/uniffi_macros/src/object.rs
+++ b/uniffi_macros/src/object.rs
@@ -185,7 +185,7 @@ fn interface_impl(object: &ObjectItem, options: &DeriveOptions) -> TokenStream {
         unsafe #lower_return_impl_spec {
             type ReturnType = #lower_return_type_arc;
 
-            fn lower_return(obj: Self) -> ::std::result::Result<Self::ReturnType, ::uniffi::RustBuffer> {
+            fn lower_return(obj: Self) -> ::std::result::Result<Self::ReturnType, ::uniffi::RustCallError> {
                 #lower_return_arc(::std::sync::Arc::new(obj))
             }
         }


### PR DESCRIPTION
This avoids crashing for consumers that set panic=abort (Firefox).

- Updated the Err type for `rust_call`.  The closure can now return an internal error.  The only way to signal an internal error before was to panic.
- Reworked the `LowerReturn` trait and the future code to work with the new system.
- Added a type for argument lift errors, this makes the rustfuture signatures nicer.