### PR TITLE
Handle::from_raw() and HandleAlloc::clone_handle()/consume_handle() are all unsafe.

### DIFF
--- a/uniffi_core/src/ffi/ffiserialize.rs
+++ b/uniffi_core/src/ffi/ffiserialize.rs
@@ -275,7 +275,7 @@ mod test {
             rust_buffer.len(),
             rust_buffer.capacity(),
         );
-        let handle = Handle::from_raw(101).unwrap();
+        let handle = unsafe { Handle::from_raw(101).unwrap() };
         let rust_call_status = RustCallStatus::default();
         let rust_call_status_error_buf = &rust_call_status.error_buf;
         let orig_rust_call_status_buffer_data = (

--- a/uniffi_core/src/ffi/handle.rs
+++ b/uniffi_core/src/ffi/handle.rs
@@ -28,7 +28,9 @@ impl Handle {
         self.0 as *const T
     }
 
-    pub fn from_raw(raw: u64) -> Option<Self> {
+    /// # Safety
+    /// The raw value must be a valid handle as described above.
+    pub unsafe fn from_raw(raw: u64) -> Option<Self> {
         if raw == 0 {
             None
         } else {


### PR DESCRIPTION
Fixes #2164