### PR TITLE
Provide more external type information to `FfiType::RustBuffer`

### DIFF
--- a/uniffi/src/cli.rs
+++ b/uniffi/src/cli.rs
@@ -138,6 +138,7 @@ fn gen_library_mode(
     cfo: Option<&camino::Utf8Path>,
     out_dir: &camino::Utf8Path,
     fmt: bool,
+    no_deps: bool,
 ) -> anyhow::Result<()> {
     use uniffi_bindgen::library_mode::generate_bindings;
     for language in languages {
@@ -158,6 +159,7 @@ fn gen_library_mode(
                 cfo,
                 out_dir,
                 fmt,
+                no_deps,
             )?
             .len(),
             TargetLanguage::Python => generate_bindings(
@@ -167,6 +169,7 @@ fn gen_library_mode(
                 cfo,
                 out_dir,
                 fmt,
+                no_deps,
             )?
             .len(),
             TargetLanguage::Ruby => generate_bindings(
@@ -176,6 +179,7 @@ fn gen_library_mode(
                 cfo,
                 out_dir,
                 fmt,
+                no_deps,
             )?
             .len(),
             TargetLanguage::Swift => generate_bindings(
@@ -185,6 +189,7 @@ fn gen_library_mode(
                 cfo,
                 out_dir,
                 fmt,
+                no_deps,
             )?
             .len(),
         };
@@ -273,6 +278,7 @@ pub fn run_main() -> anyhow::Result<()> {
                     config.as_deref(),
                     &out_dir,
                     !no_format,
+                    true,
                 )?;
             } else {
                 gen_bindings(

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -431,8 +431,9 @@ impl KotlinCodeOracle {
             FfiType::Float64 => "Double".to_string(),
             FfiType::Handle => "Long".to_string(),
             FfiType::RustArcPtr(_) => "Pointer".to_string(),
-            FfiType::RustBuffer(maybe_suffix) => {
-                format!("RustBuffer{}", maybe_suffix.as_deref().unwrap_or_default())
+            FfiType::RustBuffer(maybe_external) => match maybe_external {
+                Some(external_meta) => format!("RustBuffer{}", external_meta.name),
+                None => "RustBuffer".to_string()
             }
             FfiType::RustCallStatus => "UniffiRustCallStatus.ByValue".to_string(),
             FfiType::ForeignBytes => "ForeignBytes.ByValue".to_string(),

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -433,8 +433,8 @@ impl KotlinCodeOracle {
             FfiType::RustArcPtr(_) => "Pointer".to_string(),
             FfiType::RustBuffer(maybe_external) => match maybe_external {
                 Some(external_meta) => format!("RustBuffer{}", external_meta.name),
-                None => "RustBuffer".to_string()
-            }
+                None => "RustBuffer".to_string(),
+            },
             FfiType::RustCallStatus => "UniffiRustCallStatus.ByValue".to_string(),
             FfiType::ForeignBytes => "ForeignBytes.ByValue".to_string(),
             FfiType::Callback(name) => self.ffi_callback_name(name),

--- a/uniffi_bindgen/src/bindings/kotlin/test.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/test.rs
@@ -42,6 +42,7 @@ pub fn run_script(
         None,
         &out_dir,
         false,
+        true,
     )?;
     let jar_file = build_jar(crate_name, &out_dir, options)?;
 

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -408,7 +408,9 @@ impl PythonCodeOracle {
                 FfiType::Float32 | FfiType::Float64 => "0.0".to_owned(),
                 FfiType::RustArcPtr(_) => "ctypes.c_void_p()".to_owned(),
                 FfiType::RustBuffer(maybe_external) => match maybe_external {
-                    Some(external_meta) => format!("_UniffiRustBuffer{}.default()", external_meta.name),
+                    Some(external_meta) => {
+                        format!("_UniffiRustBuffer{}.default()", external_meta.name)
+                    }
                     None => "_UniffiRustBuffer.default()".to_owned(),
                 },
                 _ => unimplemented!("FFI return type: {t:?}"),

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -377,8 +377,8 @@ impl PythonCodeOracle {
             FfiType::Float64 => "ctypes.c_double".to_string(),
             FfiType::Handle => "ctypes.c_uint64".to_string(),
             FfiType::RustArcPtr(_) => "ctypes.c_void_p".to_string(),
-            FfiType::RustBuffer(maybe_suffix) => match maybe_suffix {
-                Some(suffix) => format!("_UniffiRustBuffer{suffix}"),
+            FfiType::RustBuffer(maybe_external) => match maybe_external {
+                Some(external_meta) => format!("_UniffiRustBuffer{}", external_meta.name),
                 None => "_UniffiRustBuffer".to_string(),
             },
             FfiType::RustCallStatus => "_UniffiRustCallStatus".to_string(),
@@ -407,8 +407,8 @@ impl PythonCodeOracle {
                 | FfiType::Int64 => "0".to_owned(),
                 FfiType::Float32 | FfiType::Float64 => "0.0".to_owned(),
                 FfiType::RustArcPtr(_) => "ctypes.c_void_p()".to_owned(),
-                FfiType::RustBuffer(maybe_suffix) => match maybe_suffix {
-                    Some(suffix) => format!("_UniffiRustBuffer{suffix}.default()"),
+                FfiType::RustBuffer(maybe_external) => match maybe_external {
+                    Some(external_meta) => format!("_UniffiRustBuffer{}.default()", external_meta.name),
                     None => "_UniffiRustBuffer.default()".to_owned(),
                 },
                 _ => unimplemented!("FFI return type: {t:?}"),

--- a/uniffi_bindgen/src/bindings/python/test.rs
+++ b/uniffi_bindgen/src/bindings/python/test.rs
@@ -43,6 +43,7 @@ pub fn run_script(
         None,
         &out_dir,
         false,
+        true,
     )?;
 
     let pythonpath = env::var_os("PYTHONPATH").unwrap_or_else(|| OsString::from(""));

--- a/uniffi_bindgen/src/bindings/ruby/test.rs
+++ b/uniffi_bindgen/src/bindings/ruby/test.rs
@@ -40,6 +40,7 @@ pub fn test_script_command(
         None,
         &out_dir,
         false,
+        true,
     )?;
 
     let rubypath = env::var_os("RUBYLIB").unwrap_or_else(|| OsString::from(""));

--- a/uniffi_bindgen/src/bindings/swift/test.rs
+++ b/uniffi_bindgen/src/bindings/swift/test.rs
@@ -133,6 +133,7 @@ impl GeneratedSources {
             None,
             out_dir,
             false,
+            true,
         )?;
         let main_source = sources
             .iter()

--- a/uniffi_bindgen/src/interface/ffi.rs
+++ b/uniffi_bindgen/src/interface/ffi.rs
@@ -150,7 +150,7 @@ impl From<&Type> for FfiType {
             } => FfiType::RustBuffer(Some(ExternalMetadata {
                 name: name.clone(),
                 module_path: module_path.clone(),
-                namespace: namespace.clone()
+                namespace: namespace.clone(),
             })),
             Type::Custom { builtin, .. } => FfiType::from(builtin.as_ref()),
         }
@@ -161,7 +161,7 @@ impl From<&Type> for FfiType {
 pub struct ExternalMetadata {
     pub name: String,
     pub module_path: String,
-    pub namespace: String
+    pub namespace: String,
 }
 
 // Needed for rust scaffolding askama template

--- a/uniffi_bindgen/src/interface/ffi.rs
+++ b/uniffi_bindgen/src/interface/ffi.rs
@@ -43,7 +43,7 @@ pub enum FfiType {
     /// or pass it to someone that will.
     /// If the inner option is Some, it is the name of the external type. The bindings may need
     /// to use this name to import the correct RustBuffer for that type.
-    RustBuffer(Option<String>),
+    RustBuffer(Option<ExternalMetadata>),
     /// A borrowed reference to some raw bytes owned by foreign language code.
     /// The provider of this reference must keep it alive for the duration of the receiving call.
     ForeignBytes,
@@ -144,11 +144,24 @@ impl From<&Type> for FfiType {
             Type::External {
                 name,
                 kind: ExternalKind::DataClass,
+                module_path,
+                namespace,
                 ..
-            } => FfiType::RustBuffer(Some(name.clone())),
+            } => FfiType::RustBuffer(Some(ExternalMetadata {
+                name: name.clone(),
+                module_path: module_path.clone(),
+                namespace: namespace.clone()
+            })),
             Type::Custom { builtin, .. } => FfiType::from(builtin.as_ref()),
         }
     }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ExternalMetadata {
+    pub name: String,
+    pub module_path: String,
+    pub namespace: String
 }
 
 // Needed for rust scaffolding askama template

--- a/uniffi_bindgen/src/library_mode.rs
+++ b/uniffi_bindgen/src/library_mode.rs
@@ -149,7 +149,6 @@ impl CratePathMap {
     fn new() -> Result<Self> {
         Ok(Self::from(
             cargo_metadata::MetadataCommand::new()
-                .no_deps()
                 .exec()
                 .context("error running cargo metadata")?,
         ))

--- a/uniffi_testing/src/lib.rs
+++ b/uniffi_testing/src/lib.rs
@@ -159,7 +159,8 @@ fn get_cargo_metadata() -> Metadata {
 
 fn get_cargo_build_messages() -> Vec<Message> {
     let mut child = Command::new(env!("CARGO"))
-        .arg("build")
+        .arg("test")
+        .arg("--no-run")
         .arg("--message-format=json")
         .stdout(Stdio::piped())
         .spawn()


### PR DESCRIPTION
All the currently supported official languages support some form of aliasing so nothing output changes for them. For languages without aliasing (ie Java), this allows the fully qualified type name to be generated in place where necessary.

The `uniffi_testing` switch from `cargo build` to `cargo test --no-run` includes dev dependencies in the message tree, which is needed for external binding authors where the uniffi fixtures are included as dev dependencies (vs in the same workspace as they are here). Making `no_deps` during component discovery is for the same problem, deps are needed when discovering external `cdylibs` to test with.

[`uniffi-bindgen-java`](https://github.com/IronCoreLabs/uniffi-bindgen-java) does test these changes by its test suite running at all, this fixes a regression (from our POV) introduced in [this commit](https://github.com/mozilla/uniffi-rs/commit/4803eb4d6ff32fd51456be084b4797080860d24a). If there are tests I can write to cover both use cases (#2183 and ours), I can do it given direction.