### PR TITLE
Fix so cargo_metadata isn't a dependency without the cargo_metadata feature

### DIFF
--- a/fixtures/benchmarks/Cargo.toml
+++ b/fixtures/benchmarks/Cargo.toml
@@ -20,7 +20,7 @@ criterion = "0.5.1"
 uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi_bindgen = {path = "../../uniffi_bindgen"}
+uniffi_bindgen = {path = "../../uniffi_bindgen", features = ["bindgen-tests"]}
 
 [[bench]]
 name = "benchmarks"

--- a/fixtures/benchmarks/benches/benchmarks.rs
+++ b/fixtures/benchmarks/benches/benchmarks.rs
@@ -6,7 +6,8 @@ use clap::Parser;
 use std::env;
 use uniffi_benchmarks::Args;
 use uniffi_bindgen::bindings::{
-    kotlin_run_script, python_run_script, swift_run_script, RunScriptOptions,
+    kotlin_test::run_script as kotlin_run_script, python_test::run_script as python_run_script,
+    swift_test::run_script as swift_run_script, RunScriptOptions,
 };
 
 fn main() {

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -39,7 +39,7 @@ bindgen = ["dep:uniffi_bindgen"]
 cli = [ "bindgen", "dep:clap", "dep:camino" ]
 # Support for running example/fixture tests for `uniffi-bindgen`.  You probably
 # don't need to enable this.
-bindgen-tests = [ "dep:uniffi_bindgen" ]
+bindgen-tests = [ "dep:uniffi_bindgen", "uniffi_bindgen/bindgen-tests" ]
 # Enable support for Tokio's futures.
 # This must still be opted into on a per-function basis using `#[uniffi::export(async_runtime = "tokio")]`.
 tokio = ["uniffi_core/tokio"]

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -8,13 +8,8 @@ pub use uniffi_macros::*;
 #[cfg(feature = "cli")]
 mod cli;
 #[cfg(feature = "bindgen-tests")]
-pub use uniffi_bindgen::bindings::kotlin_run_test;
-#[cfg(feature = "bindgen-tests")]
-pub use uniffi_bindgen::bindings::python_run_test;
-#[cfg(feature = "bindgen-tests")]
-pub use uniffi_bindgen::bindings::ruby_run_test;
-#[cfg(feature = "bindgen-tests")]
-pub use uniffi_bindgen::bindings::swift_run_test;
+pub use uniffi_bindgen::bindings::{kotlin_test, python_test, ruby_test, swift_test};
+
 #[cfg(feature = "bindgen")]
 pub use uniffi_bindgen::{
     bindings::{

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -12,8 +12,9 @@ keywords = ["ffi", "bindgen"]
 readme = "../README.md"
 
 [features]
-default = ["cargo_metadata"]
-cargo_metadata = ["dep:cargo_metadata"]
+default = ["cargo-metadata"]
+cargo-metadata = ["dep:cargo_metadata"]
+bindgen-tests = ["cargo-metadata", "dep:uniffi_testing"]
 
 [dependencies]
 anyhow = "1"
@@ -29,7 +30,7 @@ paste = "1.0"
 serde = { version = "1", features = ["derive"] }
 toml = "0.5"
 uniffi_meta = { path = "../uniffi_meta", version = "=0.28.0" }
-uniffi_testing = { path = "../uniffi_testing", version = "=0.28.0" }
+uniffi_testing = { path = "../uniffi_testing", version = "=0.28.0", optional = true }
 uniffi_udl = { path = "../uniffi_udl", version = "=0.28.0" }
 # Don't include the `unicode-linebreak` or `unicode-width` since that functionality isn't needed for
 # docstrings.

--- a/uniffi_bindgen/src/bindings/kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/mod.rs
@@ -11,8 +11,8 @@ use std::process::Command;
 
 mod gen_kotlin;
 use gen_kotlin::{generate_bindings, Config};
-mod test;
-pub use test::{run_script, run_test};
+#[cfg(feature = "bindgen-tests")]
+pub mod test;
 
 pub struct KotlinBindingGenerator;
 impl BindingGenerator for KotlinBindingGenerator {

--- a/uniffi_bindgen/src/bindings/mod.rs
+++ b/uniffi_bindgen/src/bindings/mod.rs
@@ -8,26 +8,28 @@
 //! along with some helpers for executing foreign language scripts or tests.
 
 mod kotlin;
-pub use kotlin::{
-    run_script as kotlin_run_script, run_test as kotlin_run_test, KotlinBindingGenerator,
-};
+pub use kotlin::KotlinBindingGenerator;
 mod python;
-pub use python::{
-    run_script as python_run_script, run_test as python_run_test, PythonBindingGenerator,
-};
+pub use python::PythonBindingGenerator;
 mod ruby;
-pub use ruby::{run_test as ruby_run_test, RubyBindingGenerator};
+pub use ruby::RubyBindingGenerator;
 mod swift;
-pub use swift::{
-    run_script as swift_run_script, run_test as swift_run_test, SwiftBindingGenerator,
+pub use swift::SwiftBindingGenerator;
+
+#[cfg(feature = "bindgen-tests")]
+pub use self::{
+    kotlin::test as kotlin_test, python::test as python_test, ruby::test as ruby_test,
+    swift::test as swift_test,
 };
 
+#[cfg(feature = "bindgen-tests")]
 /// Mode for the `run_script` function defined for each language
 #[derive(Clone, Debug)]
 pub struct RunScriptOptions {
     pub show_compiler_messages: bool,
 }
 
+#[cfg(feature = "bindgen-tests")]
 impl Default for RunScriptOptions {
     fn default() -> Self {
         Self {

--- a/uniffi_bindgen/src/bindings/python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/mod.rs
@@ -8,10 +8,10 @@ use anyhow::Result;
 use fs_err as fs;
 
 mod gen_python;
-mod test;
+#[cfg(feature = "bindgen-tests")]
+pub mod test;
 use crate::{Component, GenerationSettings};
 use gen_python::{generate_python_bindings, Config};
-pub use test::{run_script, run_test};
 
 pub struct PythonBindingGenerator;
 

--- a/uniffi_bindgen/src/bindings/ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/mod.rs
@@ -9,9 +9,9 @@ use anyhow::{Context, Result};
 use fs_err as fs;
 
 mod gen_ruby;
-mod test;
+#[cfg(feature = "bindgen-tests")]
+pub mod test;
 use gen_ruby::{Config, RubyWrapper};
-pub use test::run_test;
 
 pub struct RubyBindingGenerator;
 impl BindingGenerator for RubyBindingGenerator {

--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -36,8 +36,9 @@ use std::process::Command;
 
 mod gen_swift;
 use gen_swift::{generate_bindings, Config};
-mod test;
-pub use test::{run_script, run_test};
+
+#[cfg(feature = "bindgen-tests")]
+pub mod test;
 
 /// The Swift bindings generated from a [`crate::ComponentInterface`].
 ///

--- a/uniffi_bindgen/src/library_mode.rs
+++ b/uniffi_bindgen/src/library_mode.rs
@@ -145,7 +145,7 @@ impl CratePathMap {
     // TODO: we probably need external overrides passed in (maybe via
     // `config_file_override` - what are the semantics of that?)
     // Anyway: for now we just do this.
-    #[cfg(feature = "cargo_metadata")]
+    #[cfg(feature = "cargo-metadata")]
     fn new() -> Result<Self> {
         Ok(Self::from(
             cargo_metadata::MetadataCommand::new()
@@ -155,7 +155,7 @@ impl CratePathMap {
         ))
     }
 
-    #[cfg(not(feature = "cargo_metadata"))]
+    #[cfg(not(feature = "cargo-metadata"))]
     fn new() -> Result<Self> {
         Ok(Self::default())
     }
@@ -166,7 +166,7 @@ impl CratePathMap {
 }
 
 // all this to get a few paths!?
-#[cfg(feature = "cargo_metadata")]
+#[cfg(feature = "cargo-metadata")]
 impl From<cargo_metadata::Metadata> for CratePathMap {
     fn from(metadata: cargo_metadata::Metadata) -> Self {
         let paths: HashMap<String, Utf8PathBuf> = metadata

--- a/uniffi_macros/src/test.rs
+++ b/uniffi_macros/src/test.rs
@@ -30,16 +30,16 @@ pub(crate) fn build_foreign_language_testcases(tokens: TokenStream) -> TokenStre
             );
             let run_test = match test_file_pathbuf.extension() {
                 Some("kts") => quote! {
-                    ::uniffi::kotlin_run_test
+                    ::uniffi::kotlin_test::run_test
                 },
                 Some("swift") => quote! {
-                    ::uniffi::swift_run_test
+                    ::uniffi::swift_test::run_test
                 },
                 Some("py") => quote! {
-                    ::uniffi::python_run_test
+                    ::uniffi::python_test::run_test
                 },
                 Some("rb") => quote! {
-                    ::uniffi::ruby_run_test
+                    ::uniffi::ruby_test::run_test
                 },
                 _ => panic!("Unexpected extension for test script: {test_file_name}"),
             };


### PR DESCRIPTION
The `uniffi_test` crate unconditionally depends on `cargo_metadata`, and this will be difficult to change. This means that because `uniffi_test` is an unconditional dependency of `uniffi_bindgen`, the `cargo_metadata` feature doesn't actually prevent `uniffi_bindgen` from depending on `cargo_metadata`.

The top level `uniffi` create already has a feature `bindgen-tests`. This patch introduces a feature of the same name to `uniffi_bindgen`. Enabling that feature also enables the metadata feature. This means that if you do not enable either of these features you should be able to avoid `cargo_metadata`.

This patch also renames the new `cargo_metadata` feature to be `cargo-metadata` to be more consistent with our existing features and Rust feature naming in general.

This is on the path to trying to untangle the requirements for #2195, so I'd love feedback from @skeet70 - note that this doesn't actually fix the issue found there, but it's a step in the right direction. My intention is to push the actual execution of `cargo metadata` out to both the cli and to `uniffi_testing`, and this is a step in that direction.