### PR TITLE
Move cargo_metadata execution out to the edges (ie, to the cli)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### What's new?
 
+- A new bindgen command line option `--metadata-no-deps` is available to avoid processing
+  cargo_metadata for all dependencies.
+
 - Objects error types can now be as `Result<>` error type without wrapping them in `Arc<>`.
 
 - Swift errors now provide `localizedDescription` ([#2116](https://github.com/mozilla/uniffi-rs/pull/2116))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,6 +1475,7 @@ version = "0.28.0"
 dependencies = [
  "anyhow",
  "camino",
+ "cargo_metadata",
  "clap",
  "trybuild",
  "uniffi_bindgen",
@@ -1626,6 +1627,7 @@ dependencies = [
 name = "uniffi-fixture-docstring-proc-macro"
 version = "0.22.0"
 dependencies = [
+ "cargo_metadata",
  "glob",
  "thiserror",
  "uniffi",

--- a/fixtures/docstring-proc-macro/Cargo.toml
+++ b/fixtures/docstring-proc-macro/Cargo.toml
@@ -11,6 +11,7 @@ name = "uniffi_fixture_docstring_proc_macro"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
+cargo_metadata = { version = "0.15" }
 thiserror = "1.0"
 uniffi = { path = "../../uniffi" }
 

--- a/fixtures/docstring-proc-macro/tests/test_generated_bindings.rs
+++ b/fixtures/docstring-proc-macro/tests/test_generated_bindings.rs
@@ -50,10 +50,19 @@ mod tests {
 
         let cdylib_path = test_helper.copy_cdylib_to_out_dir(&out_dir).unwrap();
 
+        let config_supplier = {
+            use uniffi_bindgen::cargo_metadata::CrateConfigSupplier;
+            let metadata = cargo_metadata::MetadataCommand::new()
+                .exec()
+                .expect("error running cargo metadata");
+            CrateConfigSupplier::from(metadata)
+        };
+
         uniffi_bindgen::library_mode::generate_bindings(
             &cdylib_path,
             None,
             &gen,
+            &config_supplier,
             None,
             &out_dir,
             false,

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -21,19 +21,22 @@ uniffi_core = { path = "../uniffi_core", version = "=0.28.0" }
 uniffi_macros = { path = "../uniffi_macros", version = "=0.28.0" }
 anyhow = "1"
 camino = { version = "1.0.8", optional = true }
+cargo_metadata = { version = "0.15", optional = true }
 clap = { version = "4", features = ["cargo", "std", "derive"], optional = true }
 
 [dev-dependencies]
 trybuild = "1"
 
 [features]
-default = []
+default = ["cargo-metadata"]
 # Support for features needed by the `build.rs` script. Enable this in your
 # `build-dependencies`.
 build = [ "dep:uniffi_build" ]
 # Support for `uniffi_bindgen::{generate_bindings, generate_component_scaffolding}`.
 # Enable this feature for your `uniffi-bindgen` binaries if you don't need the full CLI.
 bindgen = ["dep:uniffi_bindgen"]
+cargo-metadata = ["dep:cargo_metadata", "uniffi_bindgen?/cargo-metadata"]
+
 # Support for `uniffi_bindgen_main()`. Enable this feature for your
 # `uniffi-bindgen` binaries.
 cli = [ "bindgen", "dep:clap", "dep:camino" ]

--- a/uniffi_bindgen/src/bindings/kotlin/test.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/test.rs
@@ -3,6 +3,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::bindings::RunScriptOptions;
+use crate::cargo_metadata::CrateConfigSupplier;
 use crate::library_mode::generate_bindings;
 use anyhow::{bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -35,10 +36,12 @@ pub fn run_script(
     let test_helper = UniFFITestHelper::new(crate_name)?;
     let out_dir = test_helper.create_out_dir(tmp_dir, script_path)?;
     let cdylib_path = test_helper.copy_cdylib_to_out_dir(&out_dir)?;
+
     generate_bindings(
         &cdylib_path,
         None,
         &super::KotlinBindingGenerator,
+        &CrateConfigSupplier::from(test_helper.cargo_metadata()),
         None,
         &out_dir,
         false,

--- a/uniffi_bindgen/src/bindings/python/test.rs
+++ b/uniffi_bindgen/src/bindings/python/test.rs
@@ -3,6 +3,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::bindings::RunScriptOptions;
+use crate::cargo_metadata::CrateConfigSupplier;
 use crate::library_mode::generate_bindings;
 use anyhow::{Context, Result};
 use camino::Utf8Path;
@@ -40,6 +41,7 @@ pub fn run_script(
         &cdylib_path,
         None,
         &super::PythonBindingGenerator,
+        &CrateConfigSupplier::from(test_helper.cargo_metadata()),
         None,
         &out_dir,
         false,

--- a/uniffi_bindgen/src/bindings/ruby/test.rs
+++ b/uniffi_bindgen/src/bindings/ruby/test.rs
@@ -2,6 +2,7 @@
 License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::cargo_metadata::CrateConfigSupplier;
 use crate::library_mode::generate_bindings;
 use anyhow::{bail, Context, Result};
 use camino::Utf8Path;
@@ -37,6 +38,7 @@ pub fn test_script_command(
         &cdylib_path,
         None,
         &super::RubyBindingGenerator,
+        &CrateConfigSupplier::from(test_helper.cargo_metadata()),
         None,
         &out_dir,
         false,

--- a/uniffi_bindgen/src/cargo_metadata.rs
+++ b/uniffi_bindgen/src/cargo_metadata.rs
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Helpers for data returned by cargo_metadata. Note that this doesn't
+//! execute cargo_metadata, just parses its output.
+
+use anyhow::{bail, Context};
+use camino::Utf8PathBuf;
+use cargo_metadata::Metadata;
+use std::{collections::HashMap, fs};
+
+use crate::BindgenCrateConfigSupplier;
+
+#[derive(Debug, Clone, Default)]
+pub struct CrateConfigSupplier {
+    paths: HashMap<String, Utf8PathBuf>,
+}
+
+impl BindgenCrateConfigSupplier for CrateConfigSupplier {
+    fn get_toml(&self, crate_name: &str) -> anyhow::Result<Option<toml::value::Table>> {
+        let toml = self.paths.get(crate_name).map(|p| p.join("uniffi.toml"));
+        crate::load_toml_file(toml.as_deref())
+    }
+
+    fn get_udl(&self, crate_name: &str, udl_name: &str) -> anyhow::Result<String> {
+        let path = self
+            .paths
+            .get(crate_name)
+            .context(format!("No path known to UDL files for '{crate_name}'"))?
+            .join("src")
+            .join(format!("{udl_name}.udl"));
+        if path.exists() {
+            Ok(fs::read_to_string(path)?)
+        } else {
+            bail!(format!("No UDL file found at '{path}'"));
+        }
+    }
+}
+
+impl From<Metadata> for CrateConfigSupplier {
+    fn from(metadata: Metadata) -> Self {
+        let paths: HashMap<String, Utf8PathBuf> = metadata
+            .packages
+            .iter()
+            .flat_map(|p| {
+                p.targets.iter().filter(|t| t.is_lib()).filter_map(|t| {
+                    p.manifest_path
+                        .parent()
+                        .map(|p| (t.name.replace('-', "_"), p.to_owned()))
+                })
+            })
+            .collect();
+        Self { paths }
+    }
+}

--- a/uniffi_bindgen/src/library_mode.rs
+++ b/uniffi_bindgen/src/library_mode.rs
@@ -16,11 +16,11 @@
 ///   - UniFFI can figure out the package/module names for each crate, eliminating the external
 ///     package maps.
 use crate::{
-    load_initial_config, macro_metadata, BindingGenerator, Component, ComponentInterface,
-    GenerationSettings, Result,
+    macro_metadata, overridden_config_value, BindgenCrateConfigSupplier, BindingGenerator,
+    Component, ComponentInterface, GenerationSettings, Result,
 };
-use anyhow::{bail, Context};
-use camino::{Utf8Path, Utf8PathBuf};
+use anyhow::bail;
+use camino::Utf8Path;
 use std::{collections::HashMap, fs};
 use uniffi_meta::{
     create_metadata_groups, fixup_external_type, group_metadata, Metadata, MetadataGroup,
@@ -37,17 +37,17 @@ pub fn generate_bindings<T: BindingGenerator + ?Sized>(
     library_path: &Utf8Path,
     crate_name: Option<String>,
     binding_generator: &T,
+    config_supplier: &dyn BindgenCrateConfigSupplier,
     config_file_override: Option<&Utf8Path>,
     out_dir: &Utf8Path,
     try_format_code: bool,
 ) -> Result<Vec<Component<T::Config>>> {
-    let path_map = CratePathMap::new()?;
-    let mut components = find_components(&path_map, library_path)?
+    let mut components = find_components(config_supplier, library_path)?
         .into_iter()
         .map(|ci| {
-            let crate_root = path_map.get_path(ci.crate_name());
-            let config = binding_generator
-                .new_config(&load_initial_config(crate_root, config_file_override)?)?;
+            let crate_toml = config_supplier.get_toml(ci.crate_name())?;
+            let toml_value = overridden_config_value(crate_toml, config_file_override)?;
+            let config = binding_generator.new_config(&toml_value)?;
             Ok(Component { ci, config })
         })
         .collect::<Result<Vec<_>>>()?;
@@ -91,7 +91,7 @@ pub fn calc_cdylib_name(library_path: &Utf8Path) -> Option<&str> {
 }
 
 fn find_components(
-    crates: &CratePathMap,
+    config_supplier: &dyn BindgenCrateConfigSupplier,
     library_path: &Utf8Path,
 ) -> Result<Vec<ComponentInterface>> {
     let items = macro_metadata::extract_from_library(library_path)?;
@@ -104,9 +104,7 @@ fn find_components(
 
     for group in metadata_groups.values() {
         let crate_name = group.namespace.crate_name.clone();
-        let path = crates.get_path(&crate_name);
-
-        if let Some(mut metadata_group) = load_udl_metadata(group, path, &crate_name)? {
+        if let Some(mut metadata_group) = load_udl_metadata(group, &crate_name, config_supplier)? {
             // fixup the items.
             metadata_group.items = metadata_group
                 .items
@@ -135,59 +133,10 @@ fn find_components(
         .collect()
 }
 
-#[derive(Debug, Clone, Default)]
-struct CratePathMap {
-    // path on disk where we will find the crate's source.
-    paths: HashMap<String, Utf8PathBuf>,
-}
-
-impl CratePathMap {
-    // TODO: we probably need external overrides passed in (maybe via
-    // `config_file_override` - what are the semantics of that?)
-    // Anyway: for now we just do this.
-    #[cfg(feature = "cargo-metadata")]
-    fn new() -> Result<Self> {
-        Ok(Self::from(
-            cargo_metadata::MetadataCommand::new()
-                .no_deps()
-                .exec()
-                .context("error running cargo metadata")?,
-        ))
-    }
-
-    #[cfg(not(feature = "cargo-metadata"))]
-    fn new() -> Result<Self> {
-        Ok(Self::default())
-    }
-
-    fn get_path(&self, crate_name: &str) -> Option<&Utf8Path> {
-        self.paths.get(crate_name).map(|p| p.as_path())
-    }
-}
-
-// all this to get a few paths!?
-#[cfg(feature = "cargo-metadata")]
-impl From<cargo_metadata::Metadata> for CratePathMap {
-    fn from(metadata: cargo_metadata::Metadata) -> Self {
-        let paths: HashMap<String, Utf8PathBuf> = metadata
-            .packages
-            .iter()
-            .flat_map(|p| {
-                p.targets.iter().filter(|t| t.is_lib()).filter_map(|t| {
-                    p.manifest_path
-                        .parent()
-                        .map(|p| (t.name.replace('-', "_"), p.to_owned()))
-                })
-            })
-            .collect();
-        Self { paths }
-    }
-}
-
 fn load_udl_metadata(
     group: &MetadataGroup,
-    crate_root: Option<&Utf8Path>,
     crate_name: &str,
+    config_supplier: &dyn BindgenCrateConfigSupplier,
 ) -> Result<Option<MetadataGroup>> {
     let udl_items = group
         .items
@@ -197,10 +146,9 @@ fn load_udl_metadata(
             _ => None,
         })
         .collect::<Vec<_>>();
+    // We only support 1 UDL file per crate, for no good reason!
     match udl_items.len() {
-        // No UDL files, load directly from the group
         0 => Ok(None),
-        // Found a UDL file, use it to load the CI, then add the MetadataGroup
         1 => {
             if udl_items[0].module_path != crate_name {
                 bail!(
@@ -209,18 +157,9 @@ fn load_udl_metadata(
                     crate_name
                 );
             }
-            let ci_name = &udl_items[0].file_stub;
-            let ci_path = crate_root
-                .context(format!("No path known to '{ci_name}.udl'"))?
-                .join("src")
-                .join(format!("{ci_name}.udl"));
-            if ci_path.exists() {
-                let udl = fs::read_to_string(ci_path)?;
-                let udl_group = uniffi_udl::parse_udl(&udl, crate_name)?;
-                Ok(Some(udl_group))
-            } else {
-                bail!("{ci_path} not found");
-            }
+            let udl = config_supplier.get_udl(crate_name, &udl_items[0].file_stub)?;
+            let udl_group = uniffi_udl::parse_udl(&udl, crate_name)?;
+            Ok(Some(udl_group))
         }
         n => bail!("{n} UDL files found for {crate_name}"),
     }

--- a/uniffi_testing/src/lib.rs
+++ b/uniffi_testing/src/lib.rs
@@ -149,6 +149,10 @@ impl UniFFITestHelper {
     pub fn crate_name(&self) -> &str {
         &self.crate_name
     }
+
+    pub fn cargo_metadata(&self) -> Metadata {
+        CARGO_METADATA.clone()
+    }
 }
 
 fn get_cargo_metadata() -> Metadata {


### PR DESCRIPTION
This continues the cargo_metadata feature work but making the execution of cargo_metadata the resonsibility of the uniffi_bindgen callers rather that executing it implicitly. This means the CLI, which in-turn means the top-level uniffi crate also gets a `cargo-metadata` feature.

This reverts what we did to fix #2183 - by making `no_deps` the default, it means we will be unable to support reuse of UniFFI components, because it means we only support all components being in the same workspace. While this is a common use-case, it's not the only use-case we want to support. So grabbing all dependencies from cargo_metadata is again the default, but there's a new command-line option to avoid it.

It also replaces some of #2195.

@skeet70, does this make sense to you? Please feel free to bikeshed the names, I'm not particularly happy with them - and anything else.