### PR TITLE
Adding changelog entries for merges since 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 ## [[UnreleasedUniFFIVersion]] (backend crates: [[UnreleasedBackendVersion]]) - (_[[ReleaseDate]]_)
 
+### What's new?
+
+- Lift errors will not cause an abort when `panic=abort` is set.
+- Added the `cargo_metadata` feature, which is on by default.  In some cases, this can be disabled
+  for better compatibility with projects that don't use cargo.
+
+### What's changed?
+- Kotlin will use the more efficient Enum.entries property instead of Enum.values() when possible
+
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.28.0...HEAD).
 
 ## v0.28.0 (backend crates: v0.28.0) - (_2024-06-11_)


### PR DESCRIPTION
I'm hoping to do a 0.28.1 release and these would be good to have in it.

I also considered adding an entry for the work that @mgeisler has been doing, but I couldn't think of a good wording for that.  @mgeisler do you have any suggestions for changelog entry text?