### PR TITLE
Record metadata for a struct implementing a trait.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 
 - Removed the [old and outdated diplomat comparison](https://github.com/mozilla/uniffi-rs/blob/69ecfbd7fdf587a4ab24d1234e2d6afb8a496581/docs/diplomat-and-macros.md) doc
 
+- Proc-macros recognise when you are exporting an `impl Trait for Struct` block.
+  Python supports this by generating an inheritance hierarcy to reflect that.
+  [#2204](https://github.com/mozilla/uniffi-rs/pull/2204)
+
 ### What's fixed?
 
 - `uniffi.toml` of crates without a `lib` type where ignored in 0.28.1

--- a/docs/manual/src/proc_macro/index.md
+++ b/docs/manual/src/proc_macro/index.md
@@ -138,6 +138,33 @@ fn do_something(foo: MyFooRef) {
 }
 ```
 
+### Structs implementing traits.
+
+You can declare that an object implements a trait. For example:
+
+```
+#[uniffi::export]
+trait MyTrait { .. }
+
+#[derive(uniffi::Object)]
+struct MyObject {}
+
+#[uniffi::export]
+impl MyObject {
+    // ... some methods
+}
+
+#[uniffi::export]
+impl MyTrait for MyObject {
+    // ... the trait methods.
+}
+```
+
+This will mean the bindings are able to use both the methods declared directly on `MyObject`
+but also be able to be used when a `MyTrait` is required.
+
+Not all bindings support this.
+
 ### Default values
 
 Exported functions/methods can have default values using the `default` argument of the attribute macro that wraps them.

--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -260,7 +260,7 @@ interface NodeTrait {
     string name(); // The name of the this node
 
     /// Takes an `Arc<Self>` and stores it our parent node, dropping any existing / reference. Note
-    //you can create circular references with this.
+    /// you can create circular references with this.
     void set_parent(NodeTrait? parent);
 
     /// Returns what was previously set via `set_parent()`, or null.

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -312,7 +312,7 @@ fn create_some_dict() -> SimpleDict {
         float64: 0.0,
         maybe_float64: Some(1.0),
         coveralls: Some(Arc::new(Coveralls::new("some_dict".to_string()))),
-        test_trait: Some(Arc::new(traits::Trait2::default())),
+        test_trait: Some(Arc::new(traits::Node::default())),
     }
 }
 

--- a/fixtures/keywords/kotlin/src/lib.rs
+++ b/fixtures/keywords/kotlin/src/lib.rs
@@ -16,12 +16,25 @@ impl r#break {
 
 #[allow(non_camel_case_types)]
 trait r#continue {
-    fn r#return(&self, v: r#return) -> r#return;
-    fn r#continue(&self) -> Option<Box<dyn r#continue>>;
-    fn r#break(&self, _v: Option<Arc<r#break>>) -> HashMap<u8, Arc<r#break>>;
-    fn r#while(&self, _v: Vec<r#while>) -> r#while;
-    fn class(&self, _v: HashMap<u8, Vec<class>>) -> Option<HashMap<u8, Vec<class>>>;
+    fn r#return(&self, _v: r#return) -> r#return {
+        unimplemented!()
+    }
+    fn r#continue(&self) -> Option<Box<dyn r#continue>> {
+        unimplemented!()
+    }
+    fn r#break(&self, _v: Option<Arc<r#break>>) -> HashMap<u8, Arc<r#break>> {
+        unimplemented!()
+    }
+    fn r#while(&self, _v: Vec<r#while>) -> r#while {
+        unimplemented!()
+    }
+    fn class(&self, _v: HashMap<u8, Vec<class>>) -> Option<HashMap<u8, Vec<class>>> {
+        unimplemented!()
+    }
 }
+
+#[uniffi::export]
+impl r#continue for r#break {}
 
 #[allow(non_camel_case_types)]
 pub struct r#return {

--- a/fixtures/keywords/rust/src/lib.rs
+++ b/fixtures/keywords/rust/src/lib.rs
@@ -23,12 +23,29 @@ impl r#break {
 
 #[allow(non_camel_case_types)]
 pub trait r#continue {
-    fn r#return(&self, v: r#return) -> r#return;
-    fn r#continue(&self) -> Option<Box<dyn r#continue>>;
-    fn r#break(&self, _v: Option<Arc<r#break>>) -> HashMap<u8, Arc<r#break>>;
-    fn r#while(&self, _v: Vec<r#while>) -> r#while;
-    fn r#yield(&self, _v: HashMap<u8, Vec<r#yield>>) -> Option<HashMap<u8, Vec<r#yield>>>;
+    fn r#return(&self, _v: r#return) -> r#return {
+        unimplemented!()
+    }
+    fn r#continue(&self) -> Option<Box<dyn r#continue>> {
+        unimplemented!()
+    }
+    fn r#break(&self, _v: Option<Arc<r#break>>) -> HashMap<u8, Arc<r#break>> {
+        unimplemented!()
+    }
+    fn r#while(&self, _v: Vec<r#while>) -> r#while {
+        unimplemented!()
+    }
+    fn r#yield(&self, _v: HashMap<u8, Vec<r#yield>>) -> Option<HashMap<u8, Vec<r#yield>>> {
+        unimplemented!()
+    }
 }
+
+#[allow(non_camel_case_types)]
+#[derive(uniffi::Object)]
+pub struct r#in {}
+
+#[uniffi::export]
+impl r#continue for r#in {}
 
 #[allow(non_camel_case_types)]
 #[derive(Debug)]

--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -92,6 +92,14 @@ pub trait Logger {
     fn log(&self, message: String);
 }
 
+#[derive(uniffi::Object)]
+pub struct RealLogger {}
+
+#[uniffi::export]
+impl Logger for RealLogger {
+    fn log(&self, _message: String) {}
+}
+
 pub use calc::Calculator;
 pub use error::FlatError;
 pub use person::Person;
@@ -858,6 +866,32 @@ mod test_function_metadata {
                     UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_METHOD_LOGGER_LOG.checksum(),
                 ),
                 docstring: None,
+            },
+        );
+    }
+
+    #[test]
+    fn test_trait_object_impl() {
+        check_metadata(
+            &UNIFFI_META_UNIFFI_FIXTURE_METADATA_INTERFACE_REALLOGGER,
+            ObjectMetadata {
+                module_path: "uniffi_fixture_metadata".into(),
+                name: "RealLogger".into(),
+                imp: ObjectImpl::Struct,
+                docstring: None,
+            },
+        );
+
+        check_metadata(
+            &UNIFFI_META_UNIFFI_FIXTURE_METADATA_OBJECT_TRAIT_IMPL_REALLOGGER_LOGGER,
+            ObjectTraitImplMetadata {
+                ty: Type::Object {
+                    module_path: "uniffi_fixture_metadata".into(),
+                    name: "RealLogger".into(),
+                    imp: ObjectImpl::Struct,
+                },
+                trait_name: "Logger".into(),
+                tr_module_path: None,
             },
         );
     }

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -81,6 +81,27 @@ impl TraitWithForeign for RustTraitImpl {
     }
 }
 
+// A public struct implementing a public trait.
+#[derive(uniffi::Object)]
+pub struct StructWithTrait {
+    name: String,
+}
+
+#[uniffi::export]
+impl StructWithTrait {
+    #[uniffi::constructor]
+    fn new(name: String) -> Self {
+        Self { name }
+    }
+}
+
+#[uniffi::export]
+impl Trait for StructWithTrait {
+    fn concat_strings(&self, a: &str, b: &str) -> String {
+        format!("{}: {a}{b}", self.name)
+    }
+}
+
 #[derive(uniffi::Object)]
 pub struct Object;
 

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -30,6 +30,8 @@ assert isinstance(trait_impl, Trait)
 assert trait_impl.concat_strings("foo", "bar") == "foobar"
 assert obj.get_trait(trait_impl).concat_strings("foo", "bar") == "foobar"
 assert concat_strings_by_ref(trait_impl, "foo", "bar") == "foobar"
+assert issubclass(StructWithTrait, Trait)
+assert StructWithTrait("me").concat_strings("foo", "bar") == "me: foobar"
 
 trait_impl2 = obj.get_trait_with_foreign(None)
 # This is an instance of `TraitWithForeignImpl` - `TraitWithForeign` is used primarily for subclassing.

--- a/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
@@ -25,7 +25,7 @@
 {%- if ci.is_name_used_as_error(name) %}
 class {{ impl_name }}(Exception):
 {%- else %}
-class {{ impl_name }}:
+class {{ impl_name }}({% for t in obj.trait_impls() %}{{ t.trait_name }},{% endfor %}):
 {%- endif %}
     {%- call py::docstring(obj, 4) %}
     _pointer: ctypes.c_void_p

--- a/uniffi_bindgen/src/bindings/python/templates/Types.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Types.py
@@ -67,9 +67,6 @@
 {%- when Type::Record { name, module_path } %}
 {%- include "RecordTemplate.py" %}
 
-{%- when Type::Object { name, module_path, imp } %}
-{%- include "ObjectTemplate.py" %}
-
 {%- when Type::Timestamp %}
 {%- include "TimestampHelper.py" %}
 
@@ -94,6 +91,18 @@
 {%- when Type::External { name, module_path, namespace, kind, tagged } %}
 {%- include "ExternalTemplate.py" %}
 
+{%- else %}
+{%- endmatch %}
+{%- endfor %}
+
+# objects.
+{%- for type_ in self.iter_sorted_object_types() %}
+{%- match type_ %}
+{%- when Type::Object { name, module_path, imp } %}
+{%-     let type_name = type_|type_name %}
+{%-     let ffi_converter_name = type_|ffi_converter_name %}
+{%-     let canonical_type_name = type_|canonical_name %}
+{%-     include "ObjectTemplate.py" %}
 {%- else %}
 {%- endmatch %}
 {%- endfor %}

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -73,8 +73,8 @@ pub use ffi::{
 };
 pub use uniffi_meta::Radix;
 use uniffi_meta::{
-    ConstructorMetadata, LiteralMetadata, NamespaceMetadata, ObjectMetadata, TraitMethodMetadata,
-    UniffiTraitMetadata, UNIFFI_CONTRACT_VERSION,
+    ConstructorMetadata, LiteralMetadata, NamespaceMetadata, ObjectMetadata,
+    ObjectTraitImplMetadata, TraitMethodMetadata, UniffiTraitMetadata, UNIFFI_CONTRACT_VERSION,
 };
 pub type Literal = LiteralMetadata;
 
@@ -960,6 +960,24 @@ impl ComponentInterface {
         } else {
             self.add_method_meta(meta)?;
         }
+        Ok(())
+    }
+
+    pub(super) fn add_object_trait_impl(
+        &mut self,
+        trait_impl: ObjectTraitImplMetadata,
+    ) -> Result<()> {
+        let object = trait_impl
+            .ty
+            .name()
+            .and_then(|n| get_object(&mut self.objects, n))
+            .ok_or_else(|| {
+                anyhow!(
+                    "add_object_trait_impl: object {:?} not found",
+                    &trait_impl.ty
+                )
+            })?;
+        object.trait_impls.push(trait_impl);
         Ok(())
     }
 

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -58,7 +58,7 @@
 //! ```
 
 use anyhow::Result;
-use uniffi_meta::Checksum;
+use uniffi_meta::{Checksum, ObjectTraitImplMetadata};
 
 use super::callbacks;
 use super::ffi::{FfiArgument, FfiCallbackFunction, FfiFunction, FfiStruct, FfiType};
@@ -91,6 +91,9 @@ pub struct Object {
     // a regular method (albeit with a generated name)
     // XXX - this should really be a HashSet, but not enough transient types support hash to make it worthwhile now.
     pub(super) uniffi_traits: Vec<UniffiTrait>,
+    // These are traits described in our CI which this object has declared it implements.
+    // This allows foreign bindings to implement things like inheritance or whatever makes sense for them.
+    pub(super) trait_impls: Vec<ObjectTraitImplMetadata>,
     // We don't include the FfiFuncs in the hash calculation, because:
     //  - it is entirely determined by the other fields,
     //    so excluding it is safe.
@@ -174,6 +177,15 @@ impl Object {
 
     pub fn uniffi_traits(&self) -> Vec<&UniffiTrait> {
         self.uniffi_traits.iter().collect()
+    }
+
+    pub fn trait_impls(&self) -> Vec<&ObjectTraitImplMetadata> {
+        self.trait_impls.iter().collect()
+    }
+
+    // used by bindings for renaming.
+    pub fn trait_impls_mut(&mut self) -> &mut Vec<ObjectTraitImplMetadata> {
+        &mut self.trait_impls
     }
 
     pub fn ffi_object_clone(&self) -> &FfiFunction {
@@ -316,6 +328,7 @@ impl From<uniffi_meta::ObjectMetadata> for Object {
             constructors: Default::default(),
             methods: Default::default(),
             uniffi_traits: Default::default(),
+            trait_impls: Default::default(),
             ffi_func_clone: FfiFunction {
                 name: ffi_clone_name,
                 ..Default::default()

--- a/uniffi_bindgen/src/macro_metadata/ci.rs
+++ b/uniffi_bindgen/src/macro_metadata/ci.rs
@@ -103,6 +103,9 @@ fn add_item_to_ci(iface: &mut ComponentInterface, item: Metadata) -> anyhow::Res
         Metadata::UniffiTrait(meta) => {
             iface.add_uniffitrait_meta(meta)?;
         }
+        Metadata::ObjectTraitImpl(meta) => {
+            iface.add_object_trait_impl(meta)?;
+        }
         Metadata::CallbackInterface(meta) => {
             iface.types.add_known_type(&Type::CallbackInterface {
                 module_path: meta.module_path.clone(),

--- a/uniffi_core/src/metadata.rs
+++ b/uniffi_core/src/metadata.rs
@@ -24,7 +24,7 @@
 //! `uniffi_bindgen::macro_metadata` contains the code to read the metadata from a library file.
 //! `fixtures/metadata` has the tests.
 
-/// Metadata constants, make sure to keep this in sync with copy in `uniffi_meta::reader`
+/// Metadata constants, make sure to keep this in sync with copy in `uniffi_meta::metadata::codes`
 pub mod codes {
     // Top-level metadata item codes
     pub const FUNC: u8 = 0;
@@ -40,6 +40,7 @@ pub mod codes {
     pub const UNIFFI_TRAIT: u8 = 11;
     pub const TRAIT_INTERFACE: u8 = 12;
     pub const CALLBACK_TRAIT_INTERFACE: u8 = 13;
+    pub const OBJECT_TRAIT_IMPL: u8 = 14;
     pub const UNKNOWN: u8 = 255;
 
     // Type codes

--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -19,7 +19,7 @@ use self::{
         gen_constructor_scaffolding, gen_ffi_function, gen_fn_scaffolding, gen_method_scaffolding,
     },
 };
-use crate::util::{ident_to_string, mod_path};
+use crate::util::{create_metadata_items, ident_to_string, mod_path};
 pub use attributes::{AsyncRuntime, DefaultMap, ExportFnArgs};
 pub use callback_interface::ffi_converter_callback_interface_impl;
 
@@ -48,6 +48,7 @@ pub(crate) fn expand_export(
             items,
             self_ident,
             args,
+            trait_,
         } => {
             if let Some(rt) = &args.async_runtime {
                 if items
@@ -76,7 +77,27 @@ pub(crate) fn expand_export(
                     }
                 })
                 .collect::<syn::Result<_>>()?;
-            Ok(quote_spanned! { self_ident.span() => #item_tokens })
+            let trait_impl_tokens = trait_.map(|t| {
+                let object_name = ident_to_string(&self_ident);
+                // TODO: parse trait path?
+                let trait_name = ident_to_string(t.get_ident().expect("not a simple trait path"));
+                let trait_path = "";
+                let metadata_expr = quote! {
+                    ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::OBJECT_TRAIT_IMPL)
+                        .concat(::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_INTERFACE))
+                        .concat_str(#mod_path)
+                        .concat_str(#object_name)
+                        .concat_str(#trait_name)
+                        .concat_str(#trait_path)
+                };
+                create_metadata_items(
+                    "object_trait_impl",
+                    &format!("{object_name}_{trait_name}"),
+                    metadata_expr,
+                    None,
+                )
+            });
+            Ok(quote_spanned! { self_ident.span() => #item_tokens #trait_impl_tokens })
         }
         ExportItem::Trait {
             items,

--- a/uniffi_macros/src/export/item.rs
+++ b/uniffi_macros/src/export/item.rs
@@ -22,6 +22,7 @@ pub(super) enum ExportItem {
         self_ident: Ident,
         items: Vec<ImplItem>,
         args: ExportImplArgs,
+        trait_: Option<syn::Path>,
     },
     Trait {
         self_ident: Ident,
@@ -126,6 +127,7 @@ impl ExportItem {
             items,
             self_ident: self_ident.to_owned(),
             args,
+            trait_: item.trait_.map(|t| t.1),
         })
     }
 

--- a/uniffi_meta/src/metadata.rs
+++ b/uniffi_meta/src/metadata.rs
@@ -23,7 +23,7 @@ pub mod codes {
     pub const UNIFFI_TRAIT: u8 = 11;
     pub const TRAIT_INTERFACE: u8 = 12;
     pub const CALLBACK_TRAIT_INTERFACE: u8 = 13;
-    //pub const UNKNOWN: u8 = 255;
+    pub const OBJECT_TRAIT_IMPL: u8 = 14;
 
     // Type codes
     pub const TYPE_U8: u8 = 0;

--- a/uniffi_meta/src/types.rs
+++ b/uniffi_meta/src/types.rs
@@ -144,14 +144,28 @@ impl Type {
         Box::new(std::iter::once(self).chain(nested_types))
     }
 
-    pub fn name(&self) -> Option<String> {
+    pub fn name(&self) -> Option<&str> {
         match self {
-            Type::Object { name, .. } => Some(name.to_string()),
-            Type::Record { name, .. } => Some(name.to_string()),
-            Type::Enum { name, .. } => Some(name.to_string()),
-            Type::External { name, .. } => Some(name.to_string()),
-            Type::Custom { name, .. } => Some(name.to_string()),
+            Type::Object { name, .. } => Some(name),
+            Type::Record { name, .. } => Some(name),
+            Type::Enum { name, .. } => Some(name),
+            Type::External { name, .. } => Some(name),
+            Type::Custom { name, .. } => Some(name),
             Type::Optional { inner_type } | Type::Sequence { inner_type } => inner_type.name(),
+            _ => None,
+        }
+    }
+
+    pub fn module_path(&self) -> Option<&str> {
+        match self {
+            Type::Object { module_path, .. } => Some(module_path),
+            Type::Record { module_path, .. } => Some(module_path),
+            Type::Enum { module_path, .. } => Some(module_path),
+            Type::External { module_path, .. } => Some(module_path),
+            Type::Custom { module_path, .. } => Some(module_path),
+            Type::Optional { inner_type } | Type::Sequence { inner_type } => {
+                inner_type.module_path()
+            }
             _ => None,
         }
     }
@@ -170,7 +184,7 @@ impl Type {
     pub fn rename_recursive(&mut self, name_transformer: &impl Fn(&str) -> String) {
         // Rename the current type if it has a name
         if let Some(name) = self.name() {
-            self.rename(name_transformer(&name));
+            self.rename(name_transformer(name));
         }
 
         // Recursively rename nested types


### PR DESCRIPTION
Record metadata for a struct implementing a trait.

```
#[uniffi::export]
impl MyTrait for MyObject { ... }
```

Previously worked as it ignored `MyTrait`. This adds new metadata to record it,
allowing foreign bindings to implement things like inheritance.

Includes Python generating an inheritance chain to reflect this relationship.

This will not generate correct code if a struct declares more than 1 trait,
and there's some undesirable re-wrapping when traits from these objects gets
passed back and forward, but seems to work surprisingly well.

On the path to #2196.
