### PR TITLE
Remove unused camino dependency from uniffi_core.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,7 +1969,6 @@ dependencies = [
  "anyhow",
  "async-compat",
  "bytes",
- "camino",
  "log",
  "once_cell",
  "paste",

--- a/uniffi_core/Cargo.toml
+++ b/uniffi_core/Cargo.toml
@@ -16,7 +16,6 @@ readme = "../README.md"
 anyhow = "1"
 async-compat = { version = "0.2.1", optional = true }
 bytes = "1.3"
-camino = "1.0.8"
 log = "0.4"
 once_cell = "1.10.0"
 # Regular dependencies


### PR DESCRIPTION
It seems like it's not used by `uniffi_core` but causes `camino` to be include as transitive dependency when crate relies on `uniffi`.