### PR TITLE
Make log crate dependency and logging an optional feature

### DIFF
--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -37,6 +37,8 @@ build = [ "dep:uniffi_build" ]
 bindgen = ["dep:uniffi_bindgen"]
 cargo-metadata = ["dep:cargo_metadata", "uniffi_bindgen?/cargo-metadata"]
 
+log = ["uniffi_macros/log", "uniffi_core/log"]
+
 # Support for `uniffi_bindgen_main()`. Enable this feature for your
 # `uniffi-bindgen` binaries.
 cli = [ "bindgen", "dep:clap", "dep:camino" ]

--- a/uniffi_core/Cargo.toml
+++ b/uniffi_core/Cargo.toml
@@ -16,7 +16,7 @@ readme = "../README.md"
 anyhow = "1"
 async-compat = { version = "0.2.1", optional = true }
 bytes = "1.3"
-log = "0.4"
+log = { version = "0.4", optional = true }
 once_cell = "1.10.0"
 # Regular dependencies
 paste = "1.0"
@@ -24,6 +24,8 @@ static_assertions = "1.1.0"
 
 [features]
 default = []
+
+log = ["dep:log"]
 
 # Enable support for Tokio's futures.
 # This must still be opted into on a per-function basis using `#[uniffi::export(async_runtime = "tokio")]`.

--- a/uniffi_core/src/ffi/rustcalls.rs
+++ b/uniffi_core/src/ffi/rustcalls.rs
@@ -204,6 +204,7 @@ where
                 } else {
                     "Unknown panic!".to_string()
                 };
+                #[cfg(feature = "log")]
                 log::error!("Caught a panic calling rust code: {:?}", message);
                 <String as Lower<UniFfiTag>>::lower(message)
             }));

--- a/uniffi_core/src/ffi/rustfuture/future.rs
+++ b/uniffi_core/src/ffi/rustfuture/future.rs
@@ -157,6 +157,7 @@ where
                 }
             }
         } else {
+            #[cfg(feature = "log")]
             log::error!("poll with neither future nor result set");
             true
         }

--- a/uniffi_core/src/ffi/rustfuture/scheduler.rs
+++ b/uniffi_core/src/ffi/rustfuture/scheduler.rs
@@ -44,6 +44,7 @@ impl Scheduler {
         match self {
             Self::Empty => *self = Self::Set(callback, data),
             Self::Set(old_callback, old_data) => {
+                #[cfg(feature = "log")]
                 log::error!(
                     "store: observed `Self::Set` state.  Is poll() being called from multiple threads at once?"
                 );

--- a/uniffi_core/src/lib.rs
+++ b/uniffi_core/src/lib.rs
@@ -60,6 +60,7 @@ pub mod deps {
     #[cfg(feature = "tokio")]
     pub use async_compat;
     pub use bytes;
+    #[cfg(feature = "log")]
     pub use log;
     pub use static_assertions;
 }

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -29,6 +29,7 @@ uniffi_meta = { path = "../uniffi_meta", version = "=0.28.1" }
 
 [features]
 default = []
+log = []
 # Enable the generate_and_include_scaffolding! macro
 trybuild = [ "dep:uniffi_build" ]
 # Generate extra scaffolding functions that use FfiBuffer to pass arguments and return values

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -262,6 +262,7 @@ pub(super) fn gen_ffi_function(
                 #(#param_names: #param_types,)*
                 call_status: &mut ::uniffi::RustCallStatus,
             ) -> #ffi_return_ty {
+                #[cfg(feature = "log")]
                 ::uniffi::deps::log::debug!(#name);
                 let uniffi_lift_args = #lift_closure;
                 ::uniffi::rust_call(call_status, || {
@@ -291,6 +292,7 @@ pub(super) fn gen_ffi_function(
             #[doc(hidden)]
             #[no_mangle]
             pub extern "C" fn #ffi_ident(#(#param_names: #param_types,)*) -> ::uniffi::Handle {
+                #[cfg(feature = "log")]
                 ::uniffi::deps::log::debug!(#name);
                 let uniffi_lifted_args = (#lift_closure)();
                 ::uniffi::rust_future_new::<_, #return_ty, _>(


### PR DESCRIPTION
Addresses #2224 - even disabled logging can have overhead depending with some backends, and in very high frequency calls, generates unacceptable overhead and log-spam.

Those tests that can run without `kotlinc` installed pass.

I cannot verify that it is problem-free until I backport it to `0.26.1` as using `0.28.1` with my code fails at build time, with or without the patch, as follows:
```
thread 'main' panicked at /Users/tim/.cargo/git/checkouts/uniffi-rs-cc388e82c08ac837/ddc23a3/uniffi/src/lib.rs:30:21:
called `Result::unwrap()` on an `Err` value: Failed to extract data from archive member `curve.curve.e27b66861dd0975a-cgu.0.rcgu.o`

Caused by:
    Constructor return type must be Arc<Self>
```

Note this patch **entirely** removes the `log` dependency - both call logging and panic logging.  If that seems like overkill, it could probably be split into two flags, one to remove logging entirely, and one just to remove FFI-call logging.
