### PR TITLE
Kotlin: Switch to JNA direct mapping

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -319,7 +319,7 @@ impl<'a> KotlinWrapper<'a> {
             .iter_local_types()
             .map(|t| KotlinCodeOracle.find(t))
             .filter_map(|ct| ct.initialization_fn())
-            .map(|fn_name| format!("{fn_name}(lib)"));
+            .map(|fn_name| format!("{fn_name}(this)"));
 
         // Also call global initialization function for any external type we use.
         // For example, we need to make sure that all callback interface vtables are registered
@@ -765,7 +765,7 @@ mod filters {
     ) -> Result<String, askama::Error> {
         let ffi_func = callable.ffi_rust_future_poll(ci);
         Ok(format!(
-            "{{ future, callback, continuation -> UniffiLib.INSTANCE.{ffi_func}(future, callback, continuation) }}"
+            "{{ future, callback, continuation -> UniffiLib.{ffi_func}(future, callback, continuation) }}"
         ))
     }
 
@@ -774,7 +774,7 @@ mod filters {
         ci: &ComponentInterface,
     ) -> Result<String, askama::Error> {
         let ffi_func = callable.ffi_rust_future_complete(ci);
-        let call = format!("UniffiLib.INSTANCE.{ffi_func}(future, continuation)");
+        let call = format!("UniffiLib.{ffi_func}(future, continuation)");
         // May need to convert the RustBuffer from our package to the RustBuffer of the external package
         let call = match callable.return_type() {
             Some(return_type) if ci.is_external(return_type) => {
@@ -797,9 +797,7 @@ mod filters {
         ci: &ComponentInterface,
     ) -> Result<String, askama::Error> {
         let ffi_func = callable.ffi_rust_future_free(ci);
-        Ok(format!(
-            "{{ future -> UniffiLib.INSTANCE.{ffi_func}(future) }}"
-        ))
+        Ok(format!("{{ future -> UniffiLib.{ffi_func}(future) }}"))
     }
 
     /// Remove the "`" chars we put around function/variable names

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -208,7 +208,7 @@ open class {{ impl_class_name }}: Disposable, AutoCloseable, {{ interface_name }
                 return;
             }
             uniffiRustCall { status ->
-                UniffiLib.INSTANCE.{{ obj.ffi_object_free().name() }}(handle, status)
+                UniffiLib.{{ obj.ffi_object_free().name() }}(handle, status)
             }
         }
     }
@@ -221,7 +221,7 @@ open class {{ impl_class_name }}: Disposable, AutoCloseable, {{ interface_name }
             throw InternalException("uniffiCloneHandle() called on NoHandle object");
         }
         return uniffiRustCall() { status ->
-            UniffiLib.INSTANCE.{{ obj.ffi_object_clone().name() }}(handle, status)
+            UniffiLib.{{ obj.ffi_object_clone().name() }}(handle, status)
         }
     }
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
@@ -25,7 +25,7 @@ open class RustBuffer : Structure() {
     companion object {
         internal fun alloc(size: ULong = 0UL) = uniffiRustCall() { status ->
             // Note: need to convert the size to a `Long` value to make this work with JVM.
-            UniffiLib.INSTANCE.{{ ci.ffi_rustbuffer_alloc().name() }}(size.toLong(), status)
+            UniffiLib.{{ ci.ffi_rustbuffer_alloc().name() }}(size.toLong(), status)
         }.also {
             if(it.data == null) {
                throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
@@ -41,7 +41,7 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = uniffiRustCall() { status ->
-            UniffiLib.INSTANCE.{{ ci.ffi_rustbuffer_free().name() }}(buf, status)
+            UniffiLib.{{ ci.ffi_rustbuffer_free().name() }}(buf, status)
         }
     }
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -26,7 +26,7 @@
     {%- else %}
     uniffiRustCall()
     {%- endmatch %} { _status ->
-    UniffiLib.INSTANCE.{{ func.ffi_func().name() }}(
+    UniffiLib.{{ func.ffi_func().name() }}(
     {%- match func.self_type() %}
     {%- when Some(Type::Object { .. }) %}
         it,
@@ -72,13 +72,13 @@
     uniffiRustCallAsync(
 {%- if callable.self_type().is_some() %}
         callWithHandle { uniffiHandle ->
-            UniffiLib.INSTANCE.{{ callable.ffi_func().name() }}(
+            UniffiLib.{{ callable.ffi_func().name() }}(
                 uniffiHandle,
                 {% call arg_list_lowered(callable) %}
             )
         },
 {%- else %}
-        UniffiLib.INSTANCE.{{ callable.ffi_func().name() }}({% call arg_list_lowered(callable) %}),
+        UniffiLib.{{ callable.ffi_func().name() }}({% call arg_list_lowered(callable) %}),
 {%- endif %}
         {{ callable|async_poll(ci) }},
         {{ callable|async_complete(ci) }},


### PR DESCRIPTION
According to https://github.com/java-native-access/jna/blob/master/www/DirectMapping.md direct mapping can improve performance substantially, maybe even that of custom JNI. Given we know all methods it's easy to switch it all over.

Note that I have not run any actual benchmark to see how it helps.