### PR TITLE
Test callback lifetime

### DIFF
--- a/fixtures/callbacks/tests/bindings/test_callbacks.kts
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.kts
@@ -141,3 +141,11 @@ listOf(1, 2).forEach { v ->
     assert(expected == observed) { "callback is sent on construction: $expected != $observed" }
 }
 rustStringifier.destroy()
+
+// `stringifier` must remain valid after `rustStringifier2` drops the reference
+val stringifier = StoredKotlinStringifier()
+val rustStringifier1 = RustStringifier(stringifier)
+val rustStringifier2 = RustStringifier(stringifier)
+assert("kotlin: 123" == rustStringifier2.fromSimpleType(123))
+rustStringifier2.destroy()
+assert("kotlin: 123" == rustStringifier1.fromSimpleType(123))

--- a/fixtures/callbacks/tests/bindings/test_callbacks.py
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.py
@@ -130,4 +130,14 @@ class TestCallbackErrors(unittest.TestCase):
             rust_getters.get_option(callback, "unexpected-error", True)
         self.assertEqual(cm.exception.reason, repr(ValueError("unexpected value")))
 
+class TestCallbackLifetime(unittest.TestCase):
+    def test_callback_reference_does_not_invalidate_other_references(self):
+        # `stringifier` must remain valid after `rust_stringifier_2` drops the reference
+        stringifier = StoredPythonStringifier()
+        rust_stringifier_1 = RustStringifier(stringifier)
+        rust_stringifier_2 = RustStringifier(stringifier)
+        assert("python: 123" == rust_stringifier_2.from_simple_type(123))
+        del rust_stringifier_2
+        assert("python: 123" == rust_stringifier_1.from_simple_type(123))
+
 unittest.main()

--- a/fixtures/callbacks/tests/bindings/test_callbacks.swift
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.swift
@@ -103,6 +103,16 @@ do {
         assert(expected == observed, "callback is sent on construction: \(expected) != \(observed)")
     }
 
+    do {
+        // `stringifier` must remain valid after `rustStringifier2` drops the reference
+        let stringifier = StoredSwiftStringifier()
+        let rustStringifier1 = RustStringifier(callback: stringifier)
+        do {
+            let rustStringifier2 = RustStringifier(callback: stringifier)
+            assert("swift: 123" == rustStringifier2.fromSimpleType(value: 123))
+        }
+        assert("swift: 123" == rustStringifier1.fromSimpleType(value: 123))
+    }
 
     // 3. Error handling
     do {


### PR DESCRIPTION
Added test to ensure callback references are counted correctly. We are just now discovering that callback references are counted incorrect in v0.25.0 for Kotlin, C#, and Go.