### PR TITLE
Fix Python error name regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### What's fixed?
 
 - `uniffi.toml` of crates without a `lib` type where ignored in 0.28.1
+- Python: Fixed a bug when enum/error names were not proper camel case (HTMLError instead of HtmlError).
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.28.1...HEAD).
 

--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -36,6 +36,9 @@ namespace coverall {
     Getters test_round_trip_through_rust(Getters getters);
     void test_round_trip_through_foreign(Getters getters);
 
+    // Always throws an InvalidHTML error
+    [Throws=HTMLError]
+    void validate_html(string source);
 };
 
 dictionary SimpleDict {
@@ -295,3 +298,10 @@ interface ISecond {
 };
 
 dictionary EmptyStruct {};
+
+// Error class with a controversial camel case.  This can cause errors if we don't consistently
+// convert the name.
+[Error]
+enum HTMLError {
+    "InvalidHTML"
+};

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -606,4 +606,14 @@ impl ISecond {
 
 pub struct EmptyStruct;
 
+#[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
+pub enum HTMLError {
+    #[error("InvalidHTML")]
+    InvalidHTML,
+}
+
+pub fn validate_html(_source: String) -> Result<(), HTMLError> {
+    Err(HTMLError::InvalidHTML)
+}
+
 uniffi::include_scaffolding!("coverall");

--- a/fixtures/coverall/tests/bindings/test_coverall.kts
+++ b/fixtures/coverall/tests/bindings/test_coverall.kts
@@ -541,6 +541,17 @@ Coveralls("using_fakes_with_real_objects_crashes").use { coveralls ->
     assert(exception != null)
 }
 
+Coveralls("HtmlError").use { coveralls ->
+    var exception: Throwable? = null
+    try {
+        validateHtml("test")
+    } catch (e: HtmlException.InvalidHtml) {
+        exception = e
+    }
+    assert(exception != null)
+}
+
+
 // This is from an earlier GC test; ealier, we made 1000 new objects.
 // By now, the GC has had time to clean up, and now we should see 0 alive.
 // (hah! Wishful-thinking there ;)

--- a/fixtures/coverall/tests/bindings/test_coverall.py
+++ b/fixtures/coverall/tests/bindings/test_coverall.py
@@ -454,5 +454,9 @@ class TraitsTest(unittest.TestCase):
         self.assertEqual(traits[0].concat("cow", "boy"), "cowboy")
         self.assertEqual(traits[1].concat("cow", "boy"), "cowboy")
 
+    def test_html_error(self):
+        with self.assertRaises(HtmlError):
+            validate_html("test")
+
 if __name__=='__main__':
     unittest.main()

--- a/fixtures/coverall/tests/bindings/test_coverall.rb
+++ b/fixtures/coverall/tests/bindings/test_coverall.rb
@@ -259,4 +259,10 @@ class TestCoverall < Test::Unit::TestCase
     assert_equal coveralls.reverse("123").encoding, Encoding::BINARY
   end
 
+  def test_html_error
+    assert_raise Coverall::HtmlError::InvalidHtml do
+      Coverall.validate_html("test")
+    end
+  end
+
 end

--- a/fixtures/coverall/tests/bindings/test_coverall.swift
+++ b/fixtures/coverall/tests/bindings/test_coverall.swift
@@ -479,3 +479,13 @@ do {
     assert(stringUtils[0].concat(a: "cow", b: "boy") == "cowboy")
     assert(stringUtils[1].concat(a: "cow", b: "boy") == "cowboy")
 }
+
+// Test HTMLError
+do {
+    try validateHtml(source: "test")
+    fatalError("should have thrown")
+} catch HtmlError.InvalidHtml {
+    // Expected
+} catch {
+    fatalError("Unexpected error: \(error)")
+}

--- a/uniffi_bindgen/src/bindings/python/gen_python/callback_interface.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/callback_interface.rs
@@ -22,7 +22,7 @@ impl CodeType for CallbackInterfaceCodeType {
     }
 
     fn canonical_name(&self) -> String {
-        format!("CallbackInterface{}", self.id)
+        format!("Type{}", self.type_label())
     }
 
     fn literal(&self, _literal: &Literal) -> String {

--- a/uniffi_bindgen/src/bindings/python/gen_python/custom.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/custom.rs
@@ -21,6 +21,6 @@ impl CodeType for CustomCodeType {
     }
 
     fn canonical_name(&self) -> String {
-        format!("Type{}", self.name)
+        format!("Type{}", self.type_label())
     }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/enum_.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/enum_.rs
@@ -22,7 +22,7 @@ impl CodeType for EnumCodeType {
     }
 
     fn canonical_name(&self) -> String {
-        format!("Type{}", self.id)
+        format!("Type{}", self.type_label())
     }
 
     fn literal(&self, literal: &Literal) -> String {

--- a/uniffi_bindgen/src/bindings/python/gen_python/error.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/error.rs
@@ -22,7 +22,7 @@ impl CodeType for ErrorCodeType {
     }
 
     fn canonical_name(&self) -> String {
-        format!("Type{}", self.id)
+        format!("Type{}", self.type_label())
     }
 
     fn literal(&self, _literal: &Literal) -> String {

--- a/uniffi_bindgen/src/bindings/python/gen_python/external.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/external.rs
@@ -21,6 +21,6 @@ impl CodeType for ExternalCodeType {
     }
 
     fn canonical_name(&self) -> String {
-        format!("Type{}", self.name)
+        format!("Type{}", self.type_label())
     }
 }

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -519,6 +519,10 @@ impl VisitMut for PythonCodeOracle {
         //TODO: Renaming the function name in wrapper.py is not currently tested
         function.rename(self.fn_name(function.name()));
     }
+
+    fn visit_error_name(&self, name: &mut String) {
+        *name = self.class_name(name);
+    }
 }
 
 trait AsCodeType {

--- a/uniffi_bindgen/src/bindings/python/gen_python/object.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/object.rs
@@ -22,7 +22,7 @@ impl CodeType for ObjectCodeType {
     }
 
     fn canonical_name(&self) -> String {
-        format!("Type{}", self.id)
+        format!("Type{}", self.type_label())
     }
 
     fn literal(&self, _literal: &Literal) -> String {

--- a/uniffi_bindgen/src/bindings/python/gen_python/record.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/record.rs
@@ -22,7 +22,7 @@ impl CodeType for RecordCodeType {
     }
 
     fn canonical_name(&self) -> String {
-        format!("Type{}", self.id)
+        format!("Type{}", self.type_label())
     }
 
     fn literal(&self, _literal: &Literal) -> String {

--- a/uniffi_bindgen/src/interface/visit_mut.rs
+++ b/uniffi_bindgen/src/interface/visit_mut.rs
@@ -131,6 +131,15 @@ impl ComponentInterface {
                 }
             }
         }
+
+        self.errors = self
+            .errors
+            .drain()
+            .map(|mut name| {
+                visitor.visit_error_name(&mut name);
+                name
+            })
+            .collect()
     }
 
     fn fix_record_keys_after_rename(&mut self) {

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -225,6 +225,11 @@ pub trait VisitMut {
     /// naming conventions.
     fn visit_type(&self, type_: &mut Type);
 
+    /// Go through each error name in the interface and adjust it to language specific naming
+    /// conventions.  The new name must match the name of the Enum/Object definition after it's
+    /// visited.
+    fn visit_error_name(&self, name: &mut String);
+
     /// Go through each `Method` of an `Object` and
     /// adjust it to language specific naming conventions.
     fn visit_method(&self, method: &mut Method);


### PR DESCRIPTION
I hit this one when trying to upgrade application-services to 0.28.1.  It's kind of surprising that this is the first we're hearing of it, but I guess the Python bindings users are a minority.