### PR TITLE
Do not ignore uniffi.toml for crates without a lib type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Added the `GenerationSettings::mode` field.  This can be ignored in most cases, it's currently only used by Swift.
 
+### What's fixed?
+
+- `uniffi.toml` of crates without a `lib` type where ignored in 0.28.1
+
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.28.1...HEAD).
 
 ## v0.28.1 (backend crates: v0.28.1) - (_2024-08-09_)

--- a/uniffi_bindgen/src/cargo_metadata.rs
+++ b/uniffi_bindgen/src/cargo_metadata.rs
@@ -44,11 +44,20 @@ impl From<Metadata> for CrateConfigSupplier {
             .packages
             .iter()
             .flat_map(|p| {
-                p.targets.iter().filter(|t| t.is_lib()).filter_map(|t| {
-                    p.manifest_path
-                        .parent()
-                        .map(|p| (t.name.replace('-', "_"), p.to_owned()))
-                })
+                p.targets
+                    .iter()
+                    .filter(|t| {
+                        !t.is_bin()
+                            && !t.is_example()
+                            && !t.is_test()
+                            && !t.is_bench()
+                            && !t.is_custom_build()
+                    })
+                    .filter_map(|t| {
+                        p.manifest_path
+                            .parent()
+                            .map(|p| (t.name.replace('-', "_"), p.to_owned()))
+                    })
             })
             .collect();
         Self { paths }


### PR DESCRIPTION
See https://github.com/mozilla/uniffi-rs/pull/2175/files#r1749374986. That PR added a filter on `cargo_metadata`'s `is_lib`. While it makes sense to ignore non-library targets here, `is_lib` only returns `true` if the crate has the `lib` type, but not e.g. for `staticlib`, `cdylib` etc. In that case none of the targets match and the crate's `uniffi.toml` gets ignored.