### PR TITLE
Fix for Mach-O symbol extraction

### DIFF
--- a/uniffi_bindgen/src/macro_metadata/extract.rs
+++ b/uniffi_bindgen/src/macro_metadata/extract.rs
@@ -99,8 +99,13 @@ pub fn extract_from_macho(macho: MachO<'_>, file_data: &[u8]) -> anyhow::Result<
         //   - Has type=N_SECT (it's regular data as opposed to something like
         //     "undefined" or "indirect")
         //   - Has a metadata symbol name
-        if nlist.is_global() && nlist.get_type() == symbols::N_SECT && is_metadata_symbol(name) {
-            let section = &sections[nlist.n_sect];
+        if nlist.is_global()
+            && nlist.get_type() == symbols::N_SECT
+            && is_metadata_symbol(name)
+            && nlist.n_sect != goblin::mach::symbols::NO_SECT as usize
+        {
+            let section = &sections[nlist.n_sect - 1];
+
             // `nlist.n_value` is an address, so we can calculating the offset inside the section
             // using the difference between that and `section.addr`
             let offset = section.offset as usize + nlist.n_value as usize - section.addr as usize;


### PR DESCRIPTION
The `n_sect` field is 1-based with `0` meaning `NO_SECT` meaning the symbol is not present in any section in the library.  This change fixes the index mismatch.

Reference: https://github.com/aidansteele/osx-abi-macho-file-format-reference#nlist_64, 

The code was mostly working before because of the way we calculate the offset (https://github.com/mozilla/uniffi-rs/blob/2e3b59cf6dbcb46983028b08afc6e0ee51183f2e/uniffi_bindgen/src/macro_metadata/extract.rs#L106).  Because of this, even if we were off by one when picking the section, things would still work as long as the two sections involved lined up correctly.

Thanks to 0c0w3 for pointing this out and sending me the patch.