### PR TITLE
Hide internal classes generated docs

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/BooleanHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/BooleanHelper.kt
@@ -1,3 +1,6 @@
+/**
+ * @suppress
+ */
 public object FfiConverterBoolean: FfiConverter<Boolean, Byte> {
     override fun lift(value: Byte): Boolean {
         return value.toInt() != 0

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ByteArrayHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ByteArrayHelper.kt
@@ -1,3 +1,6 @@
+/**
+ * @suppress
+ */
 public object FfiConverterByteArray: FfiConverterRustBuffer<ByteArray> {
     override fun read(buf: ByteBuffer): ByteArray {
         val len = buf.getInt()

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceRuntime.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceRuntime.kt
@@ -6,6 +6,9 @@ internal const val UNIFFI_CALLBACK_SUCCESS = 0
 internal const val UNIFFI_CALLBACK_ERROR = 1
 internal const val UNIFFI_CALLBACK_UNEXPECTED_ERROR = 2
 
+/**
+ * @suppress
+ */
 public abstract class FfiConverterCallbackInterface<CallbackInterface: Any>: FfiConverter<CallbackInterface, Long> {
     internal val handleMap = UniffiHandleMap<CallbackInterface>()
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceTemplate.kt
@@ -9,5 +9,9 @@
 {% include "Interface.kt" %}
 {% include "CallbackInterfaceImpl.kt" %}
 
-// The ffiConverter which transforms the Callbacks in to handles to pass to Rust.
+/**
+ * The ffiConverter which transforms the Callbacks in to handles to pass to Rust.
+ *
+ * @suppress
+ */
 public object {{ ffi_converter_name }}: FfiConverterCallbackInterface<{{ interface_name }}>()

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CustomTypeTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CustomTypeTemplate.kt
@@ -33,6 +33,9 @@ public typealias {{ type_name }} = {{ concrete_type_name }}
 {%- else %}
 {%- endmatch %}
 
+/**
+ * @suppress
+ */
 public object {{ ffi_converter_name }}: FfiConverter<{{ type_name }}, {{ ffi_type_name }}> {
     override fun lift(value: {{ ffi_type_name }}): {{ type_name }} {
         val builtinValue = {{ builtin|lift_fn }}(value)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/DurationHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/DurationHelper.kt
@@ -1,3 +1,6 @@
+/**
+ * @suppress
+ */
 public object FfiConverterDuration: FfiConverterRustBuffer<java.time.Duration> {
     override fun read(buf: ByteBuffer): java.time.Duration {
         // Type mismatch (should be u64) but we check for overflow/underflow below

--- a/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
@@ -27,6 +27,9 @@ enum class {{ type_name }}(val value: {{ variant_discr_type|type_name(ci) }}) {
 }
 {% endmatch %}
 
+/**
+ * @suppress
+ */
 public object {{ e|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
     override fun read(buf: ByteBuffer) = try {
         {% if config.use_enum_entries() %}
@@ -84,6 +87,9 @@ sealed class {{ type_name }}{% if contains_object_references %}: Disposable {% e
     companion object
 }
 
+/**
+ * @suppress
+ */
 public object {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }}>{
     override fun read(buf: ByteBuffer): {{ type_name }} {
         return when(buf.getInt()) {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ErrorTemplate.kt
@@ -54,6 +54,9 @@ sealed class {{ type_name }}: kotlin.Exception(){% if contains_object_references
 }
 {%- endif %}
 
+/**
+ * @suppress
+ */
 public object {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }}> {
     override fun read(buf: ByteBuffer): {{ type_name }} {
         {% if e.is_flat() %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/FfiConverterTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/FfiConverterTemplate.kt
@@ -1,7 +1,11 @@
-// The FfiConverter interface handles converter types to and from the FFI
-//
-// All implementing objects should be public to support external types.  When a
-// type is external we need to import it's FfiConverter.
+/**
+ * The FfiConverter interface handles converter types to and from the FFI
+ *
+ * All implementing objects should be public to support external types.  When a
+ * type is external we need to import it's FfiConverter.
+ *
+ * @suppress
+ */
 public interface FfiConverter<KotlinType, FfiType> {
     // Convert an FFI type to a Kotlin type
     fun lift(value: FfiType): KotlinType
@@ -64,7 +68,11 @@ public interface FfiConverter<KotlinType, FfiType> {
     }
 }
 
-// FfiConverter that uses `RustBuffer` as the FfiType
+/**
+ * FfiConverter that uses `RustBuffer` as the FfiType
+ *
+ * @suppress
+ */
 public interface FfiConverterRustBuffer<KotlinType>: FfiConverter<KotlinType, RustBuffer.ByValue> {
     override fun lift(value: RustBuffer.ByValue) = liftFromRustBuffer(value)
     override fun lower(value: KotlinType) = lowerIntoRustBuffer(value)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Float32Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Float32Helper.kt
@@ -1,3 +1,6 @@
+/**
+ * @suppress
+ */
 public object FfiConverterFloat: FfiConverter<Float, Float> {
     override fun lift(value: Float): Float {
         return value

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Float64Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Float64Helper.kt
@@ -1,3 +1,6 @@
+/**
+ * @suppress
+ */
 public object FfiConverterDouble: FfiConverter<Double, Double> {
     override fun lift(value: Double): Double {
         return value

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
@@ -36,7 +36,11 @@ internal open class UniffiRustCallStatus : Structure() {
 
 class InternalException(message: String) : kotlin.Exception(message)
 
-// Each top-level error class has a companion object that can lift the error from the call status's rust buffer
+/**
+ * Each top-level error class has a companion object that can lift the error from the call status's rust buffer
+ *
+ * @suppress
+ */
 interface UniffiRustCallStatusErrorHandler<E> {
     fun lift(error_buf: RustBuffer.ByValue): E;
 }
@@ -73,7 +77,11 @@ private fun<E: kotlin.Exception> uniffiCheckCallStatus(errorHandler: UniffiRustC
     }
 }
 
-// UniffiRustCallStatusErrorHandler implementation for times when we don't expect a CALL_ERROR
+/**
+ * UniffiRustCallStatusErrorHandler implementation for times when we don't expect a CALL_ERROR
+ *
+ * @suppress
+ */
 object UniffiNullRustCallStatusErrorHandler: UniffiRustCallStatusErrorHandler<InternalException> {
     override fun lift(error_buf: RustBuffer.ByValue): InternalException {
         RustBuffer.free(error_buf)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Int16Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Int16Helper.kt
@@ -1,3 +1,6 @@
+/**
+ * @suppress
+ */
 public object FfiConverterShort: FfiConverter<Short, Short> {
     override fun lift(value: Short): Short {
         return value

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Int32Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Int32Helper.kt
@@ -1,3 +1,6 @@
+/**
+ * @suppress
+ */
 public object FfiConverterInt: FfiConverter<Int, Int> {
     override fun lift(value: Int): Int {
         return value

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Int64Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Int64Helper.kt
@@ -1,3 +1,6 @@
+/**
+ * @suppress
+ */
 public object FfiConverterLong: FfiConverter<Long, Long> {
     override fun lift(value: Long): Long {
         return value

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Int8Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Int8Helper.kt
@@ -1,3 +1,6 @@
+/**
+ * @suppress
+ */
 public object FfiConverterByte: FfiConverter<Byte, Byte> {
     override fun lift(value: Byte): Byte {
         return value

--- a/uniffi_bindgen/src/bindings/kotlin/templates/MapTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/MapTemplate.kt
@@ -1,5 +1,9 @@
 {%- let key_type_name = key_type|type_name(ci) %}
 {%- let value_type_name = value_type|type_name(ci) %}
+
+/**
+ * @suppress
+ */
 public object {{ ffi_converter_name }}: FfiConverterRustBuffer<Map<{{ key_type_name }}, {{ value_type_name }}>> {
     override fun read(buf: ByteBuffer): Map<{{ key_type_name }}, {{ value_type_name }}> {
         val len = buf.getInt()

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectCleanerHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectCleanerHelper.kt
@@ -1,10 +1,14 @@
 
-// The cleaner interface for Object finalization code to run.
-// This is the entry point to any implementation that we're using.
-//
-// The cleaner registers objects and returns cleanables, so now we are
-// defining a `UniffiCleaner` with a `UniffiClenaer.Cleanable` to abstract the
-// different implmentations available at compile time.
+/**
+ * The cleaner interface for Object finalization code to run.
+ * This is the entry point to any implementation that we're using.
+ *
+ * The cleaner registers objects and returns cleanables, so now we are
+ * defining a `UniffiCleaner` with a `UniffiClenaer.Cleanable` to abstract the
+ * different implmentations available at compile time.
+ *
+ * @suppress
+ */
 interface UniffiCleaner {
     interface Cleanable {
         fun clean()

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -262,6 +262,9 @@ open class {{ impl_class_name }}: Disposable, AutoCloseable, {{ interface_name }
 {% include "CallbackInterfaceImpl.kt" %}
 {%- endif %}
 
+/**
+ * @suppress
+ */
 public object {{ ffi_converter_name }}: FfiConverter<{{ type_name }}, Pointer> {
     {%- if obj.has_callback_interface() %}
     internal val handleMap = UniffiHandleMap<{{ type_name }}>()

--- a/uniffi_bindgen/src/bindings/kotlin/templates/OptionalTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/OptionalTemplate.kt
@@ -1,5 +1,8 @@
 {%- let inner_type_name = inner_type|type_name(ci) %}
 
+/**
+ * @suppress
+ */
 public object {{ ffi_converter_name }}: FfiConverterRustBuffer<{{ inner_type_name }}?> {
     override fun read(buf: ByteBuffer): {{ inner_type_name }}? {
         if (buf.get().toInt() == 0) {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
@@ -36,6 +36,9 @@ class {{ type_name }} {
 }
 {%- endif %}
 
+/**
+ * @suppress
+ */
 public object {{ rec|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
     override fun read(buf: ByteBuffer): {{ type_name }} {
         {%- if rec.has_fields() %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
@@ -2,6 +2,9 @@
 // A rust-owned buffer is represented by its capacity, its current length, and a
 // pointer to the underlying data.
 
+/**
+ * @suppress
+ */
 @Structure.FieldOrder("capacity", "len", "data")
 open class RustBuffer : Structure() {
     // Note: `capacity` and `len` are actually `ULong` values, but JVM only supports signed values.
@@ -54,6 +57,8 @@ open class RustBuffer : Structure() {
  * Required for callbacks taking in an out pointer.
  *
  * Size is the sum of all values in the struct.
+ *
+ * @suppress
  */
 class RustBufferByReference : ByReference(16) {
     /**
@@ -88,7 +93,7 @@ class RustBufferByReference : ByReference(16) {
 // completeness.
 
 @Structure.FieldOrder("len", "data")
-open class ForeignBytes : Structure() {
+internal open class ForeignBytes : Structure() {
     @JvmField var len: Int = 0
     @JvmField var data: Pointer? = null
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/SequenceTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/SequenceTemplate.kt
@@ -1,5 +1,8 @@
 {%- let inner_type_name = inner_type|type_name(ci) %}
 
+/**
+ * @suppress
+ */
 public object {{ ffi_converter_name }}: FfiConverterRustBuffer<List<{{ inner_type_name }}>> {
     override fun read(buf: ByteBuffer): List<{{ inner_type_name }}> {
         val len = buf.getInt()

--- a/uniffi_bindgen/src/bindings/kotlin/templates/StringHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/StringHelper.kt
@@ -1,3 +1,6 @@
+/**
+ * @suppress
+ */
 public object FfiConverterString: FfiConverter<String, RustBuffer.ByValue> {
     // Note: we don't inherit from FfiConverterRustBuffer, because we use a
     // special encoding when lowering/lifting.  We can use `RustBuffer.len` to

--- a/uniffi_bindgen/src/bindings/kotlin/templates/TimestampHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/TimestampHelper.kt
@@ -1,3 +1,6 @@
+/**
+ * @suppress
+ */
 public object FfiConverterTimestamp: FfiConverterRustBuffer<java.time.Instant> {
     override fun read(buf: ByteBuffer): java.time.Instant {
         val seconds = buf.getLong()

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
@@ -18,6 +18,9 @@ interface Disposable {
     }
 }
 
+/**
+ * @suppress
+ */
 inline fun <T : Disposable?, R> T.use(block: (T) -> R) =
     try {
         block(this)
@@ -30,7 +33,11 @@ inline fun <T : Disposable?, R> T.use(block: (T) -> R) =
         }
     }
 
-/** Used to instantiate an interface without an actual pointer, for fakes in tests, mostly. */
+/** 
+ * Used to instantiate an interface without an actual pointer, for fakes in tests, mostly.
+ *
+ * @suppress
+ * */
 object NoPointer
 
 {%- for type_ in ci.iter_types() %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/UInt16Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/UInt16Helper.kt
@@ -1,3 +1,6 @@
+/**
+ * @suppress
+ */
 public object FfiConverterUShort: FfiConverter<UShort, Short> {
     override fun lift(value: Short): UShort {
         return value.toUShort()

--- a/uniffi_bindgen/src/bindings/kotlin/templates/UInt32Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/UInt32Helper.kt
@@ -1,3 +1,6 @@
+/**
+ * @suppress
+ */
 public object FfiConverterUInt: FfiConverter<UInt, Int> {
     override fun lift(value: Int): UInt {
         return value.toUInt()

--- a/uniffi_bindgen/src/bindings/kotlin/templates/UInt64Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/UInt64Helper.kt
@@ -1,3 +1,6 @@
+/**
+ * @suppress
+ */
 public object FfiConverterULong: FfiConverter<ULong, Long> {
     override fun lift(value: Long): ULong {
         return value.toULong()

--- a/uniffi_bindgen/src/bindings/kotlin/templates/UInt8Helper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/UInt8Helper.kt
@@ -1,3 +1,6 @@
+/**
+ * @suppress
+ */
 public object FfiConverterUByte: FfiConverter<UByte, Byte> {
     override fun lift(value: Byte): UByte {
         return value.toUByte()

--- a/uniffi_bindgen/src/bindings/swift/templates/BooleanHelper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/BooleanHelper.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterBool : FfiConverter {
     typealias FfiType = Int8
     typealias SwiftType = Bool

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
@@ -12,27 +12,45 @@
 {% include "CallbackInterfaceImpl.swift" %}
 
 // FfiConverter protocol for callback interfaces
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct {{ ffi_converter_name }} {
     fileprivate static var handleMap = UniffiHandleMap<{{ type_name }}>()
 }
 
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 extension {{ ffi_converter_name }} : FfiConverter {
     typealias SwiftType = {{ type_name }}
     typealias FfiType = UInt64
 
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     public static func lift(_ handle: UInt64) throws -> SwiftType {
         try handleMap.get(handle: handle)
     }
 
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
         let handle: UInt64 = try readInt(&buf)
         return try lift(handle)
     }
 
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     public static func lower(_ v: SwiftType) -> UInt64 {
         return handleMap.insert(obj: v)
     }
 
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     public static func write(_ v: SwiftType, into buf: inout [UInt8]) {
         writeInt(&buf, lower(v))
     }

--- a/uniffi_bindgen/src/bindings/swift/templates/CustomType.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CustomType.swift
@@ -7,6 +7,10 @@
  * is needed because the UDL type name is used in function/method signatures.
  */
 public typealias {{ type_name }} = {{ builtin|type_name }}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 public struct FfiConverterType{{ name }}: FfiConverter {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> {{ type_name }} {
         return try {{ builtin|read_fn }}(from: &buf)
@@ -46,6 +50,9 @@ public typealias {{ type_name }} = {{ concrete_type_name }}
 {%- else %}
 {%- endmatch %}
 
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 public struct FfiConverterType{{ name }}: FfiConverter {
     {#- Custom type config supplied, use it to convert the builtin type #}
 
@@ -76,10 +83,16 @@ public struct FfiConverterType{{ name }}: FfiConverter {
 We always write these public functions just incase the type is used as
 an external type by another crate.
 #}
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 public func FfiConverterType{{ name }}_lift(_ value: {{ ffi_type_name }}) throws -> {{ type_name }} {
     return try FfiConverterType{{ name }}.lift(value)
 }
 
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 public func FfiConverterType{{ name }}_lower(_ value: {{ type_name }}) -> {{ ffi_type_name }} {
     return FfiConverterType{{ name }}.lower(value)
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/DataHelper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/DataHelper.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterData: FfiConverterRustBuffer {
     typealias SwiftType = Data
 

--- a/uniffi_bindgen/src/bindings/swift/templates/DurationHelper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/DurationHelper.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterDuration: FfiConverterRustBuffer {
     typealias SwiftType = TimeInterval
 

--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -22,6 +22,9 @@ public enum {{ type_name }} : {{ variant_discr_type|type_name }} {
 }
 {% endmatch %}
 
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 public struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
     typealias SwiftType = {{ type_name }}
 
@@ -66,10 +69,16 @@ public struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
 We always write these public functions just in case the enum is used as
 an external type by another crate.
 #}
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 public func {{ ffi_converter_name }}_lift(_ buf: RustBuffer) throws -> {{ type_name }} {
     return try {{ ffi_converter_name }}.lift(buf)
 }
 
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> RustBuffer {
     return {{ ffi_converter_name }}.lower(value)
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
@@ -19,6 +19,9 @@ public enum {{ type_name }} {
 }
 
 
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 public struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
     typealias SwiftType = {{ type_name }}
 

--- a/uniffi_bindgen/src/bindings/swift/templates/Float32Helper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Float32Helper.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterFloat: FfiConverterPrimitive {
     typealias FfiType = Float
     typealias SwiftType = Float

--- a/uniffi_bindgen/src/bindings/swift/templates/Float64Helper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Float64Helper.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterDouble: FfiConverterPrimitive {
     typealias FfiType = Double
     typealias SwiftType = Double

--- a/uniffi_bindgen/src/bindings/swift/templates/Int16Helper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Int16Helper.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterInt16: FfiConverterPrimitive {
     typealias FfiType = Int16
     typealias SwiftType = Int16

--- a/uniffi_bindgen/src/bindings/swift/templates/Int32Helper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Int32Helper.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterInt32: FfiConverterPrimitive {
     typealias FfiType = Int32
     typealias SwiftType = Int32

--- a/uniffi_bindgen/src/bindings/swift/templates/Int64Helper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Int64Helper.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterInt64: FfiConverterPrimitive {
     typealias FfiType = Int64
     typealias SwiftType = Int64

--- a/uniffi_bindgen/src/bindings/swift/templates/Int8Helper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Int8Helper.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterInt8: FfiConverterPrimitive {
     typealias FfiType = Int8
     typealias SwiftType = Int8

--- a/uniffi_bindgen/src/bindings/swift/templates/MapTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/MapTemplate.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
     public static func write(_ value: {{ type_name }}, into buf: inout [UInt8]) {
         let len = Int32(value.count)

--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -28,7 +28,10 @@ open class {{ impl_class_name }}:
     {{ protocol_name }} {
     fileprivate let pointer: UnsafeMutableRawPointer!
 
-    // Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     public struct NoPointer {
         public init() {}
     }
@@ -45,10 +48,16 @@ open class {{ impl_class_name }}:
     //
     // - Warning:
     //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     public init(noPointer: NoPointer) {
         self.pointer = nil
     }
 
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { {{ obj.ffi_object_clone().name() }}(self.pointer, $0) }
     }
@@ -118,6 +127,9 @@ open class {{ impl_class_name }}:
 {% include "CallbackInterfaceImpl.swift" %}
 {%- endif %}
 
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 public struct {{ ffi_converter_name }}: FfiConverter {
     {%- if obj.has_callback_interface() %}
     fileprivate static var handleMap = UniffiHandleMap<{{ type_name }}>()
@@ -169,6 +181,9 @@ extension {{ type_name }}: Foundation.LocalizedError {
 }
 
 {# Due to some mismatches in the ffi converter mechanisms, errors are a RustBuffer holding a pointer #}
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 public struct {{ ffi_converter_name }}__as_error: FfiConverterRustBuffer {
     public static func lift(_ buf: RustBuffer) throws -> {{ type_name }} {
         var reader = createReader(data: Data(rustBuffer: buf))
@@ -193,10 +208,16 @@ public struct {{ ffi_converter_name }}__as_error: FfiConverterRustBuffer {
 We always write these public functions just in case the enum is used as
 an external type by another crate.
 #}
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 public func {{ ffi_converter_name }}_lift(_ pointer: UnsafeMutableRawPointer) throws -> {{ type_name }} {
     return try {{ ffi_converter_name }}.lift(pointer)
 }
 
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> UnsafeMutableRawPointer {
     return {{ ffi_converter_name }}.lower(value)
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/OptionalTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/OptionalTemplate.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
     typealias SwiftType = {{ type_name }}
 

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -35,6 +35,9 @@ extension {{ type_name }}: Equatable, Hashable {
 }
 {% endif %}
 
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 public struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> {{ type_name }} {
         return {%- if rec.has_fields() %}
@@ -60,10 +63,16 @@ public struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
 We always write these public functions just in case the struct is used as
 an external type by another crate.
 #}
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 public func {{ ffi_converter_name }}_lift(_ buf: RustBuffer) throws -> {{ type_name }} {
     return try {{ ffi_converter_name }}.lift(buf)
 }
 
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> RustBuffer {
     return {{ ffi_converter_name }}.lower(value)
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/RustBufferTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RustBufferTemplate.swift
@@ -157,10 +157,16 @@ fileprivate protocol FfiConverter {
 fileprivate protocol FfiConverterPrimitive: FfiConverter where FfiType == SwiftType { }
 
 extension FfiConverterPrimitive {
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     public static func lift(_ value: FfiType) throws -> SwiftType {
         return value
     }
 
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     public static func lower(_ value: SwiftType) -> FfiType {
         return value
     }
@@ -171,6 +177,9 @@ extension FfiConverterPrimitive {
 fileprivate protocol FfiConverterRustBuffer: FfiConverter where FfiType == RustBuffer {}
 
 extension FfiConverterRustBuffer {
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     public static func lift(_ buf: RustBuffer) throws -> SwiftType {
         var reader = createReader(data: Data(rustBuffer: buf))
         let value = try read(from: &reader)
@@ -181,6 +190,9 @@ extension FfiConverterRustBuffer {
         return value
     }
 
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     public static func lower(_ value: SwiftType) -> RustBuffer {
           var writer = createWriter()
           write(value, into: &writer)

--- a/uniffi_bindgen/src/bindings/swift/templates/SequenceTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/SequenceTemplate.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
     typealias SwiftType = {{ type_name }}
 

--- a/uniffi_bindgen/src/bindings/swift/templates/StringHelper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/StringHelper.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterString: FfiConverter {
     typealias SwiftType = String
     typealias FfiType = RustBuffer

--- a/uniffi_bindgen/src/bindings/swift/templates/TimestampHelper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/TimestampHelper.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterTimestamp: FfiConverterRustBuffer {
     typealias SwiftType = Date
 

--- a/uniffi_bindgen/src/bindings/swift/templates/UInt16Helper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/UInt16Helper.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterUInt16: FfiConverterPrimitive {
     typealias FfiType = UInt16
     typealias SwiftType = UInt16

--- a/uniffi_bindgen/src/bindings/swift/templates/UInt32Helper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/UInt32Helper.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterUInt32: FfiConverterPrimitive {
     typealias FfiType = UInt32
     typealias SwiftType = UInt32

--- a/uniffi_bindgen/src/bindings/swift/templates/UInt64Helper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/UInt64Helper.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterUInt64: FfiConverterPrimitive {
     typealias FfiType = UInt64
     typealias SwiftType = UInt64

--- a/uniffi_bindgen/src/bindings/swift/templates/UInt8Helper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/UInt8Helper.swift
@@ -1,3 +1,6 @@
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterUInt8: FfiConverterPrimitive {
     typealias FfiType = UInt8
     typealias SwiftType = UInt8


### PR DESCRIPTION
Some of these could be made internal, but most could not.  The reason is that UniFFI code needs to import them from other modules in order to support external types.  This change mostly adds docstrings/annotations to hide them from the generated docs.