### PR TITLE
Force const evaluation to avoid leaking metadata buffers to the binary

### DIFF
--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -117,7 +117,11 @@ pub fn create_metadata_items(
             #[doc(hidden)]
             #[no_mangle]
             pub extern "C" fn #ident() -> u16 {
-                #const_ident.checksum()
+                // Force constant evaluation to ensure:
+                // 1. The checksum is computed at compile time; and
+                // 2. The metadata buffer is not embedded into the binary.
+                const CHECKSUM: u16 = #const_ident.checksum();
+                CHECKSUM
             }
         }
     });


### PR DESCRIPTION
In our setup, we've found that uniffi's MetadataBuffer generated by the proc macros were being embedded into our output binary, adding 4KB (we currently run on v0.26) of binary size per struct/impl/method. Starting from v0.27, this [increases to 16KB](https://github.com/mozilla/uniffi-rs/blob/69ecfbd7fdf587a4ab24d1234e2d6afb8a496581/uniffi_core/src/metadata.rs#L87).

In our case, this amounts to 2.6MB of superfluous binary space, or about 666 instances of metadata buffers being preserved in the binary. In v0.27, this would increase to 10.4MB.

The MetadataBuffer is kept around because it's referenced directly in the checksum method, which is needed at runtime, and rustc does not (always?) do constant evaluation for this specific method.

This diff ensures:

1. The checksum is computed at compile time; and
2. The metadata buffer is not embedded into the binary.