### PR TITLE
Remove unused dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,7 +2020,6 @@ dependencies = [
  "anyhow",
  "textwrap",
  "uniffi_meta",
- "uniffi_testing",
  "weedle2",
 ]
 

--- a/uniffi_udl/Cargo.toml
+++ b/uniffi_udl/Cargo.toml
@@ -15,6 +15,5 @@ anyhow = "1"
 weedle2 = { version = "5.0.0", path = "../weedle2" }
 # Don't include the `unicode-linebreak` or `unicode-width` since that functionality isn't needed for
 # docstrings.
-textwrap = { version = "0.16", features=["smawk"], default-features = false }
+textwrap = { version = "0.16", features = ["smawk"], default-features = false }
 uniffi_meta = { path = "../uniffi_meta", version = "=0.28.2" }
-uniffi_testing = { path = "../uniffi_testing", version = "=0.28.2" }


### PR DESCRIPTION
Removes the unused `uniffi-testing` dependency from `uniffi-udl`, which also prevents using UniFFI in a cargoless setup as it's looking for the `CARGO` env var at compile time. 