### PR TITLE
Remove Python var_name and class_name filters

### DIFF
--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -150,4 +150,7 @@ assert(MixedEnum.BOTH("hello", 1)[:] == ('hello', 1))
 assert(MixedEnum.BOTH("hello", 1)[-1] == 1)
 assert(str(MixedEnum.BOTH("hello", 2)) == "MixedEnum.BOTH('hello', 2)")
 
+# In #2270 we realized confusion about whether we generated our
+# variant checker as, eg, `is_ALL()` vs `is_all()` so decided to do both.
 assert(get_mixed_enum(MixedEnum.ALL("string", 2)).is_all())
+assert(get_mixed_enum(MixedEnum.ALL("string", 2)).is_ALL())

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -446,12 +446,8 @@ impl VisitMut for PythonCodeOracle {
         ffi_argument.rename(self.class_name(ffi_argument.name()));
     }
 
-    fn visit_enum(&self, is_error: bool, enum_: &mut Enum) {
-        if is_error {
-            enum_.rename(self.class_name(enum_.name()));
-        } else {
-            enum_.rename(self.enum_variant_name(enum_.name()));
-        }
+    fn visit_enum(&self, _is_error: bool, enum_: &mut Enum) {
+        enum_.rename(self.class_name(enum_.name()));
     }
 
     fn visit_enum_key(&self, key: &mut String) -> String {
@@ -459,12 +455,6 @@ impl VisitMut for PythonCodeOracle {
     }
 
     fn visit_variant(&self, is_error: bool, variant: &mut Variant) {
-        //TODO: If we want to remove the last var_name filter
-        // in the template, this is it. We need an additional
-        // attribute for the `Variant` so we can
-        // display Python is_NAME functions
-        // variant.set_is_name(self.var_name(variant.name()));
-
         if is_error {
             variant.rename(self.class_name(variant.name()));
         } else {
@@ -566,20 +556,6 @@ pub mod filters {
 
     pub(super) fn type_name(as_ct: &impl AsCodeType) -> Result<String, askama::Error> {
         Ok(as_ct.as_codetype().type_label())
-    }
-
-    //TODO: Remove. Currently just being used by EnumTemplate.py to
-    // display is_NAME_OF_ENUM.
-    /// Get the idiomatic Python rendering of a variable name.
-    pub fn var_name(nm: &str) -> Result<String, askama::Error> {
-        Ok(PythonCodeOracle.var_name(nm))
-    }
-
-    //TODO: Remove. Currently just being used by wrapper.py to display the
-    // callback_interface function names.
-    /// Get the idiomatic Python rendering of a class name (for enums, records, errors, etc).
-    pub fn class_name(nm: &str) -> Result<String, askama::Error> {
-        Ok(PythonCodeOracle.class_name(nm))
     }
 
     pub(super) fn ffi_converter_name(as_ct: &impl AsCodeType) -> Result<String, askama::Error> {

--- a/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
@@ -41,7 +41,7 @@ class {{ type_name }}:
             return f"{{ type_name }}.{{ variant.name() }}{self._values!r}"
 
         def __eq__(self, other):
-            if not other.is_{{ variant.name()|var_name }}():
+            if not other.is_{{ variant.name() }}():
                 return False
             return self._values == other._values
 
@@ -64,7 +64,7 @@ class {{ type_name }}:
             return "{{ type_name }}.{{ variant.name() }}({% for field in variant.fields() %}{{ field.name() }}={}{% if loop.last %}{% else %}, {% endif %}{% endfor %})".format({% for field in variant.fields() %}self.{{ field.name() }}{% if loop.last %}{% else %}, {% endif %}{% endfor %})
 
         def __eq__(self, other):
-            if not other.is_{{ variant.name()|var_name }}():
+            if not other.is_{{ variant.name() }}():
                 return False
             {%- for field in variant.fields() %}
             if self.{{ field.name() }} != other.{{ field.name() }}:
@@ -74,11 +74,17 @@ class {{ type_name }}:
     {%  endif %}
     {% endfor %}
 
-    # For each variant, we have an `is_NAME` method for easily checking
+    # For each variant, we have `is_NAME` and `is_name` methods for easily checking
     # whether an instance is that variant.
     {% for variant in e.variants() -%}
-    def is_{{ variant.name()|var_name }}(self) -> bool:
+    def is_{{ variant.name() }}(self) -> bool:
         return isinstance(self, {{ type_name }}.{{ variant.name() }})
+
+    {#- We used to think we used `is_NAME` but did `is_name` instead. In #2270 we decided to do both. #}
+    {%- if variant.name() != variant.name().to_snake_case() %}
+    def is_{{ variant.name().to_snake_case() }}(self) -> bool:
+        return isinstance(self, {{ type_name }}.{{ variant.name() }})
+    {%- endif %}
     {% endfor %}
 
 # Now, a little trick - we make each nested variant class be a subclass of the main
@@ -118,7 +124,7 @@ class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
         {%- if e.is_flat() %}
         if value == {{ type_name }}.{{ variant.name() }}:
         {%- else %}
-        if value.is_{{ variant.name()|var_name }}():
+        if value.is_{{ variant.name() }}():
         {%- endif %}
             {%- for field in variant.fields() %}
             {%- if variant.has_nameless_fields() %}
@@ -139,7 +145,7 @@ class {{ ffi_converter_name }}(_UniffiConverterRustBuffer):
         if value == {{ type_name }}.{{ variant.name() }}:
             buf.write_i32({{ loop.index }})
         {%- else %}
-        if value.is_{{ variant.name()|var_name }}():
+        if value.is_{{ variant.name() }}():
             buf.write_i32({{ loop.index }})
             {%- for field in variant.fields() %}
             {%- if variant.has_nameless_fields() %}

--- a/uniffi_bindgen/src/bindings/python/templates/wrapper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/wrapper.py
@@ -61,19 +61,19 @@ _DEFAULT = object() # type: typing.Any
 __all__ = [
     "InternalError",
     {%- for e in ci.enum_definitions() %}
-    "{{ e|type_name }}",
+    "{{ e.name() }}",
     {%- endfor %}
     {%- for record in ci.record_definitions() %}
-    "{{ record|type_name }}",
+    "{{ record.name() }}",
     {%- endfor %}
     {%- for func in ci.function_definitions() %}
     "{{ func.name() }}",
     {%- endfor %}
     {%- for obj in ci.object_definitions() %}
-    "{{ obj|type_name }}",
+    "{{ obj.name() }}",
     {%- endfor %}
     {%- for c in ci.callback_interface_definitions() %}
-    "{{ c.name()|class_name }}",
+    "{{ c.name() }}",
     {%- endfor %}
 ]
 


### PR DESCRIPTION
A followup to where I accidentally used these filters. It turns out the bindings were slightly inconsistent in how variant names were used. This fixes that and as a result, enums now have 2 `is_*` methods - the `is_VARIANT()` we thought and commented that we wrote, and the `is_variant()` we actually wrote.