### PR TITLE
Move old and dated authors entries from Cargo.tomls

### DIFF
--- a/examples/arithmetic-procmacro/Cargo.toml
+++ b/examples/arithmetic-procmacro/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-example-arithmetic-procmacro"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-example-arithmetic"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/examples/callbacks/Cargo.toml
+++ b/examples/callbacks/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-example-callbacks"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/examples/custom-types/Cargo.toml
+++ b/examples/custom-types/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-example-custom-types"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/examples/futures/Cargo.toml
+++ b/examples/futures/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-example-futures"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/examples/geometry/Cargo.toml
+++ b/examples/geometry/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-example-geometry"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/examples/rondpoint/Cargo.toml
+++ b/examples/rondpoint/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-example-rondpoint"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/examples/sprites/Cargo.toml
+++ b/examples/sprites/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-example-sprites"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/examples/todolist/Cargo.toml
+++ b/examples/todolist/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-example-todolist"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/examples/traits/Cargo.toml
+++ b/examples/traits/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-example-traits"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/fixtures/benchmarks/Cargo.toml
+++ b/fixtures/benchmarks/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-fixture-benchmarks"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/fixtures/callbacks/Cargo.toml
+++ b/fixtures/callbacks/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi-fixture-callbacks"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"
 publish = false

--- a/fixtures/coverall/Cargo.toml
+++ b/fixtures/coverall/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi-fixture-coverall"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"
 publish = false

--- a/fixtures/docstring-proc-macro/Cargo.toml
+++ b/fixtures/docstring-proc-macro/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi-fixture-docstring-proc-macro"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"
 publish = false

--- a/fixtures/docstring/Cargo.toml
+++ b/fixtures/docstring/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi-fixture-docstring"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"
 publish = false

--- a/fixtures/enum-types/Cargo.toml
+++ b/fixtures/enum-types/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi-fixture-enum-types"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"
 publish = false

--- a/fixtures/ext-types/custom-types/Cargo.toml
+++ b/fixtures/ext-types/custom-types/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-fixture-ext-types-custom-types"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/fixtures/ext-types/external-crate/Cargo.toml
+++ b/fixtures/ext-types/external-crate/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-fixture-ext-types-external-crate"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/fixtures/ext-types/lib/Cargo.toml
+++ b/fixtures/ext-types/lib/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-fixture-ext-types"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/fixtures/ext-types/proc-macro-lib/Cargo.toml
+++ b/fixtures/ext-types/proc-macro-lib/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-fixture-ext-types-proc-macro"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/fixtures/ext-types/sub-lib/Cargo.toml
+++ b/fixtures/ext-types/sub-lib/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-fixture-ext-types-sub-lib"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/fixtures/ext-types/uniffi-one/Cargo.toml
+++ b/fixtures/ext-types/uniffi-one/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-fixture-ext-types-lib-one"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/fixtures/futures/Cargo.toml
+++ b/fixtures/futures/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi-fixture-futures"
 version = "0.21.0"
-authors = ["Ivan Enderlin <ivan@mnt.io>"]
 edition = "2021"
 license = "MPL-2.0"
 publish = false

--- a/fixtures/keywords/kotlin/Cargo.toml
+++ b/fixtures/keywords/kotlin/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi-fixture-keywords-kotlin"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 publish = false
 

--- a/fixtures/keywords/rust/Cargo.toml
+++ b/fixtures/keywords/rust/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi-fixture-keywords-rust"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 publish = false
 

--- a/fixtures/keywords/swift/Cargo.toml
+++ b/fixtures/keywords/swift/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi-fixture-keywords-swift"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 publish = false
 

--- a/fixtures/large-enum/Cargo.toml
+++ b/fixtures/large-enum/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "large-enum"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"
 publish = false

--- a/fixtures/large-error/Cargo.toml
+++ b/fixtures/large-error/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "large-error"
 version = "0.26.1"
-authors = ["Alexander Cyon <alex.cyon@gmail.com>"]
 edition = "2021"
 license = "MPL-2.0"
 publish = false

--- a/fixtures/proc-macro-no-implicit-prelude/Cargo.toml
+++ b/fixtures/proc-macro-no-implicit-prelude/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi-fixture-proc-macro-no-implicit-prelude"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 license = "MPL-2.0"
 publish = false

--- a/fixtures/proc-macro/Cargo.toml
+++ b/fixtures/proc-macro/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi-fixture-proc-macro"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency/Cargo.toml
+++ b/fixtures/regressions/cdylib-crate-type-dependency/cdylib-dependency/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi-fixture-regression-cdylib-dependency"
 version = "0.22.0"
-authors = ["king6cong <king6cong@gmail.com>"]
 edition = "2021"
 license = "MPL-2.0"
 publish = false

--- a/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
+++ b/fixtures/regressions/cdylib-crate-type-dependency/ffi-crate/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-fixture-regression-cdylib-dependency-ffi-crate"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
+++ b/fixtures/regressions/enum-without-i32-helpers/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-fixture-regression-i356-enum-without-int-helpers"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/fixtures/regressions/fully-qualified-types/Cargo.toml
+++ b/fixtures/regressions/fully-qualified-types/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-fixture-regression-i1015-fully-qualified-types"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
+++ b/fixtures/regressions/kotlin-experimental-unsigned-types/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-fixture-regression-kotlin-experimental-unsigned-types"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/fixtures/regressions/nested-module-import/Cargo.toml
+++ b/fixtures/regressions/nested-module-import/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-fixture-regression-nested-module-import"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/fixtures/simple-fns/Cargo.toml
+++ b/fixtures/simple-fns/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi-fixture-simple-fns"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 license = "MPL-2.0"
 publish = false

--- a/fixtures/simple-iface/Cargo.toml
+++ b/fixtures/simple-iface/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi-fixture-simple-iface"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 license = "MPL-2.0"
 publish = false

--- a/fixtures/struct-default-values/Cargo.toml
+++ b/fixtures/struct-default-values/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi-fixture-struct-default-values"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"
 publish = false

--- a/fixtures/swift-omit-labels/Cargo.toml
+++ b/fixtures/swift-omit-labels/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi-fixture-swift-omit-argument-labels"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"
 publish = false

--- a/fixtures/uitests/Cargo.toml
+++ b/fixtures/uitests/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi_uitests"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"
 publish = false

--- a/fixtures/uniffi-fixture-time/Cargo.toml
+++ b/fixtures/uniffi-fixture-time/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uniffi-fixture-time"
 edition = "2021"
 version = "0.22.0"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 publish = false
 

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -8,7 +8,6 @@ repository = "https://github.com/mozilla/uniffi-rs"
 #   * See `docs/uniffi-versioning.md` for guidance on when to increment this
 #   * Make sure to also update `uniffi_bindgen::UNIFFI_CONTRACT_VERSION"
 version = "0.28.2"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 edition = "2021"
 keywords = ["ffi", "bindgen"]

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi_bindgen"
 version = "0.28.2"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (codegen and cli tooling)"
 documentation = "https://mozilla.github.io/uniffi-rs"
 homepage = "https://mozilla.github.io/uniffi-rs"

--- a/uniffi_build/Cargo.toml
+++ b/uniffi_build/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi_build"
 version = "0.28.2"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (build script helpers)"
 documentation = "https://mozilla.github.io/uniffi-rs"
 homepage = "https://mozilla.github.io/uniffi-rs"

--- a/uniffi_checksum_derive/Cargo.toml
+++ b/uniffi_checksum_derive/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi_checksum_derive"
 version = "0.28.2"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (checksum custom derive)"
 documentation = "https://mozilla.github.io/uniffi-rs"
 homepage = "https://mozilla.github.io/uniffi-rs"

--- a/uniffi_core/Cargo.toml
+++ b/uniffi_core/Cargo.toml
@@ -5,7 +5,6 @@ documentation = "https://mozilla.github.io/uniffi-rs"
 homepage = "https://mozilla.github.io/uniffi-rs"
 repository = "https://github.com/mozilla/uniffi-rs"
 version = "0.28.2"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 edition = "2021"
 keywords = ["ffi", "bindgen"]

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi_macros"
 version = "0.28.2"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (convenience macros)"
 documentation = "https://mozilla.github.io/uniffi-rs"
 homepage = "https://mozilla.github.io/uniffi-rs"

--- a/uniffi_testing/Cargo.toml
+++ b/uniffi_testing/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "uniffi_testing"
 version = "0.28.2"
-authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
 description = "a multi-language bindings generator for rust (testing helpers)"
 documentation = "https://mozilla.github.io/uniffi-rs"
 homepage = "https://mozilla.github.io/uniffi-rs"


### PR DESCRIPTION
I think the many references to "sync-team" aren't particularly relevant or even accurate today. There are many contributors not listed - let's just use git to work out who contributed what.