### PR TITLE
Remove log crate dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### What's new?
 
+- Removed the `log` dependency and logging statements about FFI calls.  These were not really useful
+  to consumers and could have high overhead when lots of FFI calls are made. Instead, the
+  `ffi-trace` feature can be used to get tracing-style printouts about the FFI.
+
 - Added the `uniffi-bindgen-swift` binary.  It works like `uniffi-bindgen` but with additional
   Swift-specific features. See
   https://mozilla.github.io/uniffi-rs/latest/swift/uniffi-bindgen-swift.html for details.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,7 +1969,6 @@ dependencies = [
  "anyhow",
  "async-compat",
  "bytes",
- "log",
  "once_cell",
  "paste",
  "static_assertions",

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -37,6 +37,7 @@ build = [ "dep:uniffi_build" ]
 # Enable this feature for your `uniffi-bindgen` binaries if you don't need the full CLI.
 bindgen = ["dep:uniffi_bindgen"]
 cargo-metadata = ["dep:cargo_metadata", "uniffi_bindgen?/cargo-metadata"]
+
 # Support for `uniffi_bindgen_main()`. Enable this feature for your
 # `uniffi-bindgen` binaries.
 cli = [ "bindgen", "dep:clap", "dep:camino" ]

--- a/uniffi_core/Cargo.toml
+++ b/uniffi_core/Cargo.toml
@@ -15,7 +15,6 @@ readme = "../README.md"
 anyhow = "1"
 async-compat = { version = "0.2.1", optional = true }
 bytes = "1.3"
-log = "0.4"
 once_cell = "1.10.0"
 # Regular dependencies
 paste = "1.0"

--- a/uniffi_core/src/ffi/rustcalls.rs
+++ b/uniffi_core/src/ffi/rustcalls.rs
@@ -204,7 +204,7 @@ where
                 } else {
                     "Unknown panic!".to_string()
                 };
-                log::error!("Caught a panic calling rust code: {:?}", message);
+                trace!("Caught a panic calling rust code: {:?}", message);
                 <String as Lower<UniFfiTag>>::lower(message)
             }));
             if let Ok(buf) = message_result {

--- a/uniffi_core/src/ffi/rustfuture/future.rs
+++ b/uniffi_core/src/ffi/rustfuture/future.rs
@@ -157,7 +157,7 @@ where
                 }
             }
         } else {
-            log::error!("poll with neither future nor result set");
+            trace!("poll with neither future nor result set");
             true
         }
     }

--- a/uniffi_core/src/ffi/rustfuture/scheduler.rs
+++ b/uniffi_core/src/ffi/rustfuture/scheduler.rs
@@ -44,7 +44,7 @@ impl Scheduler {
         match self {
             Self::Empty => *self = Self::Set(callback, data),
             Self::Set(old_callback, old_data) => {
-                log::error!(
+                trace!(
                     "store: observed `Self::Set` state.  Is poll() being called from multiple threads at once?"
                 );
                 old_callback(*old_data, RustFuturePoll::Ready);

--- a/uniffi_core/src/lib.rs
+++ b/uniffi_core/src/lib.rs
@@ -34,6 +34,7 @@
 
 /// Print out tracing information for FFI calls if the `ffi-trace` feature is enabled
 #[cfg(feature = "ffi-trace")]
+#[macro_export]
 macro_rules! trace {
     ($($tt:tt)*) => {
         println!($($tt)*);
@@ -41,6 +42,7 @@ macro_rules! trace {
 }
 
 #[cfg(not(feature = "ffi-trace"))]
+#[macro_export]
 macro_rules! trace {
     ($($tt:tt)*) => {};
 }
@@ -69,11 +71,11 @@ pub use metadata::*;
 // Re-export the libs that we use in the generated code,
 // so the consumer doesn't have to depend on them directly.
 pub mod deps {
+    pub use crate::trace;
     pub use anyhow;
     #[cfg(feature = "tokio")]
     pub use async_compat;
     pub use bytes;
-    pub use log;
     pub use static_assertions;
 }
 

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -262,7 +262,7 @@ pub(super) fn gen_ffi_function(
                 #(#param_names: #param_types,)*
                 call_status: &mut ::uniffi::RustCallStatus,
             ) -> #ffi_return_ty {
-                ::uniffi::deps::log::debug!(#name);
+                ::uniffi::deps::trace!(#name);
                 let uniffi_lift_args = #lift_closure;
                 ::uniffi::rust_call(call_status, || {
                     match uniffi_lift_args() {
@@ -291,7 +291,7 @@ pub(super) fn gen_ffi_function(
             #[doc(hidden)]
             #[no_mangle]
             pub extern "C" fn #ffi_ident(#(#param_names: #param_types,)*) -> ::uniffi::Handle {
-                ::uniffi::deps::log::debug!(#name);
+                ::uniffi::deps::trace!(#name);
                 let uniffi_lifted_args = (#lift_closure)();
                 ::uniffi::rust_future_new::<_, #return_ty, _>(
                     async move {


### PR DESCRIPTION
@timboudreau hasn't gotten around to making a changelog entry for #2227 and I just merged #2210, so I went ahead and reworked his PR to use the new `ffi-trace` feature.  This totally removes the `log` dependency.

Instead we can use the `trace!` macro to log details about FFI calls. By default, it's compiled out but the `ffi-trace` feature can be used to enable it. These tracing printouts are only really useful for debugging failures when writing scaffolding/bindings code.

Addresses #2224 - even disabled logging can have overhead depending with some backends, and in very high frequency calls, generates unacceptable overhead and log-spam.