### PR TITLE
Update template pattern matching to leverage rinja.

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceImpl.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceImpl.kt
@@ -14,10 +14,9 @@ internal object {{ trait_impl }} {
             uniffiCallStatus: UniffiRustCallStatus,
             {%- endif -%}
         )
-        {%- match ffi_callback.return_type() %}
-        {%- when Some(return_type) %}: {{ return_type|ffi_type_name_by_value }},
-        {%- when None %}
-        {%- endmatch %} {
+        {%- if let Some(return_type) = ffi_callback.return_type() %}
+            : {{ return_type|ffi_type_name_by_value }},
+        {%- endif %} {
             val uniffiObj = {{ ffi_converter_name }}.handleMap.get(uniffiHandle)
             val makeCall = {% if meth.is_async() %}suspend {% endif %}{ ->
                 uniffiObj.{{ meth.name()|fn_name() }}(
@@ -50,11 +49,9 @@ internal object {{ trait_impl }} {
             {%- else %}
             val uniffiHandleSuccess = { {% if meth.return_type().is_some() %}returnValue{% else %}_{% endif %}: {% match meth.return_type() %}{%- when Some(return_type) %}{{ return_type|type_name(ci) }}{%- when None %}Unit{% endmatch %} ->
                 val uniffiResult = {{ meth.foreign_future_ffi_result_struct().name()|ffi_struct_name }}.UniffiByValue(
-                    {%- match meth.return_type() %}
-                    {%- when Some(return_type) %}
+                    {%- if let Some(return_type) = meth.return_type() %}
                     {{ return_type|lower_fn }}(returnValue),
-                    {%- when None %}
-                    {%- endmatch %}
+                    {%- endif %}
                     UniffiRustCallStatus.ByValue()
                 )
                 uniffiResult.write()
@@ -64,11 +61,9 @@ internal object {{ trait_impl }} {
                 uniffiFutureCallback.callback(
                     uniffiCallbackData,
                     {{ meth.foreign_future_ffi_result_struct().name()|ffi_struct_name }}.UniffiByValue(
-                        {%- match meth.return_type() %}
-                        {%- when Some(return_type) %}
+                        {%- if let Some(return_type) = meth.return_type() %}
                         {{ return_type.into()|ffi_default_value }},
-                        {%- when None %}
-                        {%- endmatch %}
+                        {%- endif %}
                         callStatus,
                     ),
                 )

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CustomTypeTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CustomTypeTemplate.kt
@@ -9,7 +9,7 @@
 public typealias {{ type_name }} = {{ builtin|type_name(ci) }}
 public typealias {{ ffi_converter_name }} = {{ builtin|ffi_converter_name }}
 
-{%- when Some with (config) %}
+{%- when Some(config) %}
 
 {%- let ffi_type_name=builtin|ffi_type|ref|ffi_type_name_by_value %}
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
@@ -17,7 +17,7 @@ enum class {{ type_name }} {
     {%- endfor %}
     companion object
 }
-{% when Some with (variant_discr_type) %}
+{% when Some(variant_discr_type) %}
 enum class {{ type_name }}(val value: {{ variant_discr_type|type_name(ci) }}) {
     {% for variant in e.variants() -%}
     {%- call kt::docstring(variant, 4) %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Interface.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Interface.kt
@@ -5,7 +5,7 @@ public interface {{ interface_name }} {
     {% if meth.is_async() -%}suspend {% endif -%}
     fun {{ meth.name()|fn_name }}({% call kt::arg_list(meth, true) %})
     {%- match meth.return_type() -%}
-    {%- when Some with (return_type) %}: {{ return_type|type_name(ci) -}}
+    {%- when Some(return_type) %}: {{ return_type|type_name(ci) -}}
     {%- else -%}
     {%- endmatch %}
     {% endfor %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
@@ -26,10 +26,9 @@ internal interface {{ callback.name()|ffi_callback_name }} : com.sun.jna.Callbac
         uniffiCallStatus: UniffiRustCallStatus,
         {%- endif -%}
     )
-    {%- match callback.return_type() %}
-    {%- when Some(return_type) %}: {{ return_type|ffi_type_name_by_value }}
-    {%- when None %}
-    {%- endmatch %}
+    {%- if let Some(return_type) = callback.return_type() %}
+    : {{ return_type|ffi_type_name_by_value }}
+    {%- endif %}
 }
 {%- when FfiDefinition::Struct(ffi_struct) %}
 @Structure.FieldOrder({% for field in ffi_struct.fields() %}"{{ field.name()|var_name_raw }}"{% if !loop.last %}, {% endif %}{% endfor %})

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
@@ -7,7 +7,7 @@ data class {{ type_name }} (
     {%- call kt::docstring(field, 4) %}
     {% if config.generate_immutable_records() %}val{% else %}var{% endif %} {{ field.name()|var_name }}: {{ field|type_name(ci) -}}
     {%- match field.default_value() %}
-        {%- when Some with(literal) %} = {{ literal|render_literal(field, ci) }}
+        {%- when Some(literal) %} = {{ literal|render_literal(field, ci) }}
         {%- else %}
     {%- endmatch -%}
     {% if !loop.last %}, {% endif %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
@@ -104,7 +104,7 @@ object NoPointer
 {% include "ErrorTemplate.kt" %}
 {%- endif -%}
 
-{%- when Type::Object { module_path, name, imp } %}
+{%- when Type::Object { module_path, name, .. } %}
 {% include "ObjectTemplate.kt" %}
 
 {%- when Type::Record { name, module_path } %}
@@ -131,7 +131,7 @@ object NoPointer
 {%- when Type::Custom { module_path, name, builtin } %}
 {% include "CustomTypeTemplate.kt" %}
 
-{%- when Type::External { module_path, name, namespace, kind, tagged } %}
+{%- when Type::External { module_path, name, namespace, .. } %}
 {% include "ExternalTypeTemplate.kt" %}
 
 {%- else %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -16,7 +16,7 @@
 
 {%- macro to_raw_ffi_call(func) -%}
     {%- match func.throws_type() %}
-    {%- when Some with (e) %}
+    {%- when Some(e) %}
     uniffiRustCallWithError({{ e|type_name(ci) }})
     {%- else %}
     uniffiRustCall()
@@ -39,14 +39,14 @@
     @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
     {{ func_decl }} suspend fun {{ callable.name()|fn_name }}(
         {%- call arg_list(callable, !callable.takes_self()) -%}
-    ){% match callable.return_type() %}{% when Some with (return_type) %} : {{ return_type|type_name(ci) }}{% when None %}{%- endmatch %} {
+    ){% match callable.return_type() %}{% when Some(return_type) %} : {{ return_type|type_name(ci) }}{% when None %}{%- endmatch %} {
         return {% call call_async(callable) %}
     }
     {%- else -%}
     {{ func_decl }} fun {{ callable.name()|fn_name }}(
         {%- call arg_list(callable, !callable.takes_self()) -%}
     ){%- match callable.return_type() -%}
-    {%-         when Some with (return_type) -%}
+    {%-         when Some(return_type) -%}
         : {{ return_type|type_name(ci) }} {
             return {{ return_type|lift_fn }}({% call to_ffi_call(callable) %})
     }
@@ -105,7 +105,7 @@
         {{ arg.name()|var_name }}: {{ arg|type_name(ci) }}
 {%-     if is_decl %}
 {%-         match arg.default_value() %}
-{%-             when Some with(literal) %} = {{ literal|render_literal(arg, ci) }}
+{%-             when Some(literal) %} = {{ literal|render_literal(arg, ci) }}
 {%-             else %}
 {%-         endmatch %}
 {%-     endif %}

--- a/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceImpl.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceImpl.py
@@ -51,11 +51,9 @@ class {{ trait_impl }}:
             uniffi_future_callback(
                 uniffi_callback_data,
                 {{ meth.foreign_future_ffi_result_struct().name()|ffi_struct_name }}(
-                    {%- match meth.return_type() %}
-                    {%- when Some(return_type) %}
+                    {%- if let Some(return_type) = meth.return_type() %}
                     {{ return_type|lower_fn }}(return_value),
-                    {%- when None %}
-                    {%- endmatch %}
+                    {%- endif %}
                     _UniffiRustCallStatus.default()
                 )
             )

--- a/uniffi_bindgen/src/bindings/python/templates/CustomType.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CustomType.py
@@ -24,13 +24,11 @@ class _UniffiConverterType{{ name }}:
 
 {%- when Some(config) %}
 
-{%- match config.imports %}
-{%- when Some(imports) %}
+{%- if let Some(imports) = config.imports %}
 {%- for import_name in imports %}
 {{ self.add_import(import_name) }}
 {%- endfor %}
-{%- else %}
-{%- endmatch %}
+{%- endif %}
 
 {#- Custom type config supplied, use it to convert the builtin type #}
 class _UniffiConverterType{{ name }}:

--- a/uniffi_bindgen/src/bindings/python/templates/NamespaceLibraryTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/NamespaceLibraryTemplate.py
@@ -83,7 +83,7 @@ class {{ ffi_struct.name()|ffi_struct_name }}(ctypes.Structure):
 _UniffiLib.{{ func.name() }}.argtypes = (
     {%- call py::arg_list_ffi_decl(func) -%}
 )
-_UniffiLib.{{ func.name() }}.restype = {% match func.return_type() %}{% when Some with (type_) %}{{ type_|ffi_type_name }}{% when None %}None{% endmatch %}
+_UniffiLib.{{ func.name() }}.restype = {% match func.return_type() %}{% when Some(type_) %}{{ type_|ffi_type_name }}{% when None %}None{% endmatch %}
 {%- endmatch %}
 {%- endfor %}
 

--- a/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ObjectTemplate.py
@@ -31,7 +31,7 @@ class {{ impl_name }}({% for t in obj.trait_impls() %}{{ t.trait_name }},{% endf
     _pointer: ctypes.c_void_p
 
 {%- match obj.primary_constructor() %}
-{%-     when Some with (cons) %}
+{%-     when Some(cons) %}
 {%-         if cons.is_async() %}
     def __init__(self, *args, **kw):
         raise ValueError("async constructors not supported.")

--- a/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
@@ -17,7 +17,7 @@ class {{ type_name }}:
         {%- match field.default_value() %}
         {%- when None %}
         self.{{ field_name }} = {{ field_name }}
-        {%- when Some with(literal) %}
+        {%- when Some(literal) %}
         if {{ field_name }} is _DEFAULT:
             self.{{ field_name }} = {{ literal|literal_py(field) }}
         else:

--- a/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
@@ -1,7 +1,7 @@
 {%- if func.is_async() %}
 
 {%- match func.return_type() -%}
-{%- when Some with (return_type) %}
+{%- when Some(return_type) %}
 async def {{ func.name() }}({%- call py::arg_list_decl(func) -%}) -> "{{ return_type|type_name }}":
 {% when None %}
 async def {{ func.name() }}({%- call py::arg_list_decl(func) -%}) -> None:
@@ -26,7 +26,7 @@ async def {{ func.name() }}({%- call py::arg_list_decl(func) -%}) -> None:
 
 {%- else %}
 {%- match func.return_type() -%}
-{%- when Some with (return_type) %}
+{%- when Some(return_type) %}
 
 def {{ func.name() }}({%- call py::arg_list_decl(func) -%}) -> "{{ return_type|type_name }}":
     {%- call py::docstring(func, 4) %}

--- a/uniffi_bindgen/src/bindings/python/templates/Types.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Types.py
@@ -88,7 +88,7 @@
 {%- when Type::Custom { name, module_path, builtin } %}
 {%- include "CustomType.py" %}
 
-{%- when Type::External { name, module_path, namespace, kind, tagged } %}
+{%- when Type::External { name, module_path, namespace, .. } %}
 {%- include "ExternalTemplate.py" %}
 
 {%- else %}
@@ -98,7 +98,7 @@
 # objects.
 {%- for type_ in self.iter_sorted_object_types() %}
 {%- match type_ %}
-{%- when Type::Object { name, module_path, imp } %}
+{%- when Type::Object { name, .. } %}
 {%-     let type_name = type_|type_name %}
 {%-     let ffi_converter_name = type_|ffi_converter_name %}
 {%-     let canonical_type_name = type_|canonical_name %}

--- a/uniffi_bindgen/src/bindings/python/templates/macros.py
+++ b/uniffi_bindgen/src/bindings/python/templates/macros.py
@@ -16,9 +16,9 @@
 {%- match func.throws_type() -%}
 {%-     when Some with (e) -%}
 {%-         match e -%}
-{%-             when Type::Enum { name, module_path } -%}
+{%-             when Type::Enum { .. } -%}
 _uniffi_rust_call_with_error({{ e|ffi_converter_name }},
-{%-             when Type::Object { name, module_path, imp } -%}
+{%-             when Type::Object { .. } -%}
 _uniffi_rust_call_with_error({{ e|ffi_converter_name }}__as_error,
 {%-             else %}
 # unsupported error type!
@@ -40,12 +40,10 @@ _uniffi_rust_call(
 {%- endmacro -%}
 
 {%- macro docstring_value(maybe_docstring, indent_spaces) %}
-{%- match maybe_docstring %}
-{%- when Some(docstring) %}
+{%- if let Some(docstring) = maybe_docstring %}
 {{ docstring|docstring(indent_spaces) }}
 {{ "" }}
-{%- else %}
-{%- endmatch %}
+{%- endif %}
 {%- endmacro %}
 
 {%- macro docstring(defn, indent_spaces) %}
@@ -85,12 +83,10 @@ _uniffi_rust_call(
  #}
 {%- macro setup_args(func) %}
     {%- for arg in func.arguments() %}
-    {%- match arg.default_value() %}
-    {%- when None %}
-    {%- when Some with(literal) %}
+    {%- if let Some(literal) = arg.default_value() %}
     if {{ arg.name() }} is _DEFAULT:
         {{ arg.name() }} = {{ literal|literal_py(arg.as_type().borrow()) }}
-    {%- endmatch %}
+    {%- endif %}
     {{ arg|check_lower_fn }}({{ arg.name() }})
     {% endfor -%}
 {%- endmacro -%}
@@ -101,12 +97,10 @@ _uniffi_rust_call(
  #}
 {%- macro setup_args_extra_indent(func) %}
         {%- for arg in func.arguments() %}
-        {%- match arg.default_value() %}
-        {%- when None %}
-        {%- when Some with(literal) %}
+        {%- if let Some(literal) = arg.default_value() %}
         if {{ arg.name() }} is _DEFAULT:
             {{ arg.name() }} = {{ literal|literal_py(arg.as_type().borrow()) }}
-        {%- endmatch %}
+        {%- endif %}
         {{ arg|check_lower_fn }}({{ arg.name() }})
         {% endfor -%}
 {%- endmacro -%}
@@ -118,7 +112,7 @@ _uniffi_rust_call(
 {%  if meth.is_async() %}
 
 {%-     match meth.return_type() %}
-{%-         when Some with (return_type) %}
+{%-         when Some(return_type) %}
     async def {{ py_method_name }}(self, {% call arg_list_decl(meth) %}) -> "{{ return_type|type_name }}":
 {%-         when None %}
     async def {{ py_method_name }}(self, {% call arg_list_decl(meth) %}) -> None:
@@ -146,7 +140,7 @@ _uniffi_rust_call(
 {%- else -%}
 {%-     match meth.return_type() %}
 
-{%-         when Some with (return_type) %}
+{%-         when Some(return_type) %}
 
     def {{ py_method_name }}(self, {% call arg_list_decl(meth) %}) -> "{{ return_type|type_name }}":
         {%- call docstring(meth, 8) %}
@@ -171,9 +165,9 @@ _uniffi_rust_call(
 {%  match func.throws_type() %}
 {%-     when Some(e) %}
 {%-         match e -%}
-{%-             when Type::Enum { name, module_path } -%}
+{%-             when Type::Enum { .. } -%}
     {{ e|ffi_converter_name }},
-{%-             when Type::Object { name, module_path, imp } -%}
+{%-             when Type::Object { .. } -%}
     {{ e|ffi_converter_name }}__as_error,
 {%-             else %}
     # unsupported error type!

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -159,7 +159,7 @@ class RustBufferBuilder
     pack_into 4, 'L>', nanoseconds
   end
 
-  {% when Type::Object with { name: object_name, module_path, imp } -%}
+  {% when Type::Object with { name: object_name, .. } -%}
   # The Object type {{ object_name }}.
 
   def write_{{ canonical_type_name }}(obj)
@@ -167,7 +167,7 @@ class RustBufferBuilder
     pack_into(8, 'Q>', pointer.address)
   end
 
-  {% when Type::Enum { name: enum_name, module_path } -%}
+  {% when Type::Enum { name: enum_name, .. } -%}
   {% if !ci.is_name_used_as_error(enum_name) %}
   {%- let e = ci|get_enum_definition(enum_name) -%}
   # The Enum type {{ enum_name }}.
@@ -188,7 +188,7 @@ class RustBufferBuilder
  end
    {% endif %}
 
-  {% when Type::Record { name: record_name, module_path } -%}
+  {% when Type::Record { name: record_name, .. } -%}
   {%- let rec = ci|get_record_definition(record_name) -%}
   # The Record type {{ record_name }}.
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
@@ -150,7 +150,7 @@ class RustBufferStream
     Time.at(seconds, nanoseconds, :nanosecond, in: '+00:00').utc
   end
 
-  {% when Type::Object with { name: object_name, module_path, imp } -%}
+  {% when Type::Object with { name: object_name, .. } -%}
   # The Object type {{ object_name }}.
 
   def read{{ canonical_type_name }}
@@ -158,7 +158,7 @@ class RustBufferStream
     return {{ object_name|class_name_rb }}.uniffi_allocate(pointer)
   end
 
-  {% when Type::Enum { name, module_path } -%}
+  {% when Type::Enum { name, .. } -%}
   {%- let e = ci|get_enum_definition(name) -%}
   {% if !ci.is_name_used_as_error(name) %}
   {% let enum_name = name %}
@@ -230,7 +230,7 @@ class RustBufferStream
   end
   {% endif %}
 
-  {% when Type::Record { name: record_name, module_path } -%}
+  {% when Type::Record { name: record_name, .. } -%}
   {%- let rec = ci|get_record_definition(record_name) -%}
   # The Record type {{ record_name }}.
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
@@ -124,7 +124,7 @@ class RustBuffer < FFI::Struct
     end
   end
 
-  {% when Type::Record { name: record_name, module_path } -%}
+  {% when Type::Record { name: record_name, .. } -%}
   {%- let rec = ci|get_record_definition(record_name) -%}
   # The Record type {{ record_name }}.
 
@@ -147,7 +147,7 @@ class RustBuffer < FFI::Struct
     end
   end
 
-  {% when Type::Enum { name: enum_name, module_path }  -%}
+  {% when Type::Enum { name: enum_name, .. }  -%}
   {% if !ci.is_name_used_as_error(enum_name) %}
   {%- let e = ci|get_enum_definition(enum_name) -%}
   # The Enum type {{ enum_name }}.

--- a/uniffi_bindgen/src/bindings/swift/templates/BridgingHeaderTemplate.h
+++ b/uniffi_bindgen/src/bindings/swift/templates/BridgingHeaderTemplate.h
@@ -68,7 +68,7 @@ typedef struct {{ struct.name()|ffi_struct_name }} {
     {%- endfor %}
 } {{ struct.name()|ffi_struct_name }};
 {% when FfiDefinition::Function(func) %}
-{% match func.return_type() -%}{%- when Some with (type_) %}{{ type_|header_ffi_type_name }}{% when None %}void{% endmatch %} {{ func.name() }}(
+{% match func.return_type() -%}{%- when Some(type_) %}{{ type_|header_ffi_type_name }}{% when None %}void{% endmatch %} {{ func.name() }}(
     {%- if func.arguments().len() > 0 %}
         {%- for arg in func.arguments() %}
             {{- arg.type_().borrow()|header_ffi_type_name }} {{ arg.name() -}}{% if !loop.last || func.has_rust_call_status_arg() %}, {% endif %}

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceImpl.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceImpl.swift
@@ -57,11 +57,9 @@ fileprivate struct {{ trait_impl }} {
                 uniffiFutureCallback(
                     uniffiCallbackData,
                     {{ meth.foreign_future_ffi_result_struct().name()|ffi_struct_name }}(
-                        {%- match meth.return_type() %}
-                        {%- when Some(return_type) %}
+                        {%- if let Some(return_type) = meth.return_type() %}
                         returnValue: {{ return_type|lower_fn }}(returnValue),
-                        {%- when None %}
-                        {%- endmatch %}
+                        {%- endif %}
                         callStatus: RustCallStatus()
                     )
                 )
@@ -70,11 +68,9 @@ fileprivate struct {{ trait_impl }} {
                 uniffiFutureCallback(
                     uniffiCallbackData,
                     {{ meth.foreign_future_ffi_result_struct().name()|ffi_struct_name }}(
-                        {%- match meth.return_type() %}
-                        {%- when Some(return_type) %}
+                        {%- if let Some(return_type) = meth.return_type() %}
                         returnValue: {{ meth.return_type().map(FfiType::from)|ffi_default_value }},
-                        {%- when None %}
-                        {%- endmatch %}
+                        {%- endif %}
                         callStatus: RustCallStatus(code: statusCode, errorBuf: errorBuf)
                     )
                 )

--- a/uniffi_bindgen/src/bindings/swift/templates/CustomType.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CustomType.swift
@@ -29,26 +29,22 @@ public struct FfiConverterType{{ name }}: FfiConverter {
     }
 }
 
-{%- when Some with (config) %}
+{%- when Some(config) %}
 
 {# When the config specifies a different type name, create a typealias for it #}
-{%- match config.type_name %}
-{%- when Some with (concrete_type_name) %}
+{%- if let Some(concrete_type_name) = config.type_name %}
 /**
  * Typealias from the type name used in the UDL file to the custom type.  This
  * is needed because the UDL type name is used in function/method signatures.
  */
 public typealias {{ type_name }} = {{ concrete_type_name }}
-{%- else %}
-{%- endmatch %}
+{%- endif %}
 
-{%- match config.imports %}
-{%- when Some(imports) %}
+{%- if let Some(imports) = config.imports %}
 {%- for import_name in imports %}
 {{ self.add_import(import_name) }}
 {%- endfor %}
-{%- else %}
-{%- endmatch %}
+{%- endif %}
 
 #if swift(>=5.8)
 @_documentation(visibility: private)

--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -11,7 +11,7 @@ public enum {{ type_name }} {
     ){% endif -%}
     {% endfor %}
 }
-{% when Some with (variant_discr_type) %}
+{% when Some(variant_discr_type) %}
 public enum {{ type_name }} : {{ variant_discr_type|type_name }} {
     {% for variant in e.variants() %}
     {%- call swift::docstring(variant, 4) %}

--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -63,7 +63,7 @@ open class {{ impl_class_name }}:
     }
 
     {%- match obj.primary_constructor() %}
-    {%- when Some with (cons) %}
+    {%- when Some(cons) %}
     {%- call swift::ctor_decl(cons, 4) %}
     {%- when None %}
     // No primary constructor declared for this class.

--- a/uniffi_bindgen/src/bindings/swift/templates/Types.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Types.swift
@@ -75,7 +75,7 @@
 {%- include "EnumTemplate.swift" %}
 {% endif %}
 
-{%- when Type::Object{ name, module_path, imp } %}
+{%- when Type::Object{ name, module_path, .. } %}
 {%- include "ObjectTemplate.swift" %}
 
 {%- when Type::Record { name, module_path } %}


### PR DESCRIPTION
Mostly using `{ .. }`, `if let`, and `when Some with (x)` -> `when Some(x)`

I did this really just to play with some of the features and pattern matching always made me grumpy.

On the way I made some errors in the templates, and the error messages from rinja are *vastly improved* over askama - not only having very precise details about the error but often suggestions for how to fix (eg, with mismatched tags) - so thanks @GuillaumeGomez!