### PR TITLE
render global variable as a constant

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/wrapper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/wrapper.swift
@@ -40,7 +40,7 @@ private enum InitializationResult {
 }
 // Use a global variable to perform the versioning checks. Swift ensures that
 // the code inside is only computed once.
-private var initializationResult: InitializationResult = {
+private let initializationResult: InitializationResult = {
     // Get the bindings contract version from our ComponentInterface
     let bindings_contract_version = {{ ci.uniffi_contract_version() }}
     // Get the scaffolding contract version by calling the into the dylib


### PR DESCRIPTION
more correctly handles swift6 data race concerns

fixes the specific issue in #2279, but may not be all of the changes needed or desired for swift6 compatibility 