### PR TITLE
fix: move all dependencies to workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,9 +777,9 @@ checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,4 +73,45 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
+anyhow = "1"
+async-compat = "0.2.1"
+async-trait = "0.1"
+bincode = "1.3"
+bytes = "1.3"
+camino = "1.0.8"
+cargo_metadata = "0.15"
+chrono = { version = "0.4.23", default-features = false }
+clap = "4"
+fs-err = "2.7.0"
+futures = "0.3"
+glob = "0.3"
+goblin = "0.8"
+heck = "0.5"
+http = "1.1"
+lazy_static = "1.4"
+log = "0.4"
+nom = "7.1.0"
+once_cell = "1.12"
+paste = "1.0"
+proc-macro2 = "1.0"
+quote = "1.0"
+rinja = { version = "0.3", default-features = false }
+serde = "1"
+siphasher = "0.3"
+static_assertions = "1.1.0"
+syn = "2.0"
+textwrap = {  version = "0.16", default-features = false }
+thiserror = "1.0"
+tokio = { version = "1.24.1" }
+toml = "0.5"
 uniffi = { path = "./uniffi", version = "0.28" }
+uniffi_bindgen = { path = "./uniffi_bindgen", version = "=0.28.2", default-features = false }
+uniffi_build = { path = "./uniffi_build", version = "=0.28.2" }
+uniffi_checksum_derive = { path = "./uniffi_checksum_derive", version = "0.28.2" }
+uniffi_core = { path = "./uniffi_core", version = "=0.28.2" }
+uniffi_macros = { path = "./uniffi_macros", version = "=0.28.2" }
+uniffi_meta = { path = "./uniffi_meta", version = "=0.28.2" }
+uniffi_testing = { path = "./uniffi_testing", version = "=0.28.2" }
+uniffi_udl = { path = "./uniffi_udl", version = "=0.28.2" }
+url = "2.2"
+weedle2 = {  path = "./weedle2", version = "5.0.0" }

--- a/examples/arithmetic-procmacro/Cargo.toml
+++ b/examples/arithmetic-procmacro/Cargo.toml
@@ -11,7 +11,7 @@ name = "arithmeticpm"
 
 [dependencies]
 uniffi = { workspace = true }
-thiserror = "1.0"
+thiserror = { workspace = true }
 
 [dev-dependencies]
 uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/examples/arithmetic/Cargo.toml
+++ b/examples/arithmetic/Cargo.toml
@@ -11,7 +11,7 @@ name = "arithmetical"
 
 [dependencies]
 uniffi = { workspace = true, features=["scaffolding-ffi-buffer-fns"] }
-thiserror = "1.0"
+thiserror = { workspace = true }
 
 [build-dependencies]
 # Add the "scaffolding-ffi-buffer-fns" feature to make sure things can build correctly

--- a/examples/async-api-client/Cargo.toml
+++ b/examples/async-api-client/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = "0.1"
 uniffi = { workspace = true }
 serde = { version = "1", features=["derive"] }
 serde_json = "1"
-thiserror = "1.0"
+thiserror = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/examples/callbacks/Cargo.toml
+++ b/examples/callbacks/Cargo.toml
@@ -11,7 +11,7 @@ name = "uniffi_callbacks"
 
 [dependencies]
 uniffi = { workspace = true }
-thiserror = "1.0"
+thiserror = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/examples/futures/Cargo.toml
+++ b/examples/futures/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 async-std = "1.12.0"
-thiserror = "1.0"
+thiserror = { workspace = true }
 uniffi = { workspace = true }
 
 [build-dependencies]

--- a/examples/todolist/Cargo.toml
+++ b/examples/todolist/Cargo.toml
@@ -12,7 +12,7 @@ name = "uniffi_todolist"
 [dependencies]
 uniffi = { workspace = true }
 once_cell = "1.12"
-thiserror = "1.0"
+thiserror = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/examples/traits/Cargo.toml
+++ b/examples/traits/Cargo.toml
@@ -11,7 +11,7 @@ name = "uniffi_traits"
 
 [dependencies]
 uniffi = { workspace = true }
-thiserror = "1.0"
+thiserror = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/fixtures/benchmarks/Cargo.toml
+++ b/fixtures/benchmarks/Cargo.toml
@@ -12,14 +12,14 @@ bench = false
 
 [dependencies]
 uniffi = { workspace = true }
-clap = { version = "4", features = ["cargo", "std", "derive"] }
+clap = { workspace = true, features = ["cargo", "std", "derive"] }
 criterion = "0.5.1"
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi_bindgen = {path = "../../uniffi_bindgen", features = ["bindgen-tests"]}
+uniffi_bindgen = { workspace = true, features = ["bindgen-tests"] }
 
 [[bench]]
 name = "benchmarks"

--- a/fixtures/callbacks/Cargo.toml
+++ b/fixtures/callbacks/Cargo.toml
@@ -10,9 +10,8 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_fixture_callbacks"
 
 [dependencies]
-# Add the "scaffolding-ffi-buffer-fns" feature to make sure things can build correctly
-uniffi = { workspace = true, features=["scaffolding-ffi-buffer-fns"] }
-thiserror = "1.0"
+uniffi = { workspace = true, features = ["scaffolding-ffi-buffer-fns"] }
+thiserror = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/fixtures/coverall/Cargo.toml
+++ b/fixtures/coverall/Cargo.toml
@@ -11,16 +11,16 @@ name = "uniffi_coverall"
 
 [dependencies]
 # Add the "scaffolding-ffi-buffer-fns" feature to make sure things can build correctly
-uniffi = { workspace = true, features=["scaffolding-ffi-buffer-fns"]}
-once_cell = "1.12"
-thiserror = "1.0"
+uniffi = { workspace = true, features = ["scaffolding-ffi-buffer-fns"] }
+once_cell = { workspace = true }
+thiserror = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
 uniffi = { workspace = true, features = ["bindgen-tests"] }
-uniffi_meta = { path = "../../uniffi_meta/" }
+uniffi_meta = { workspace = true }
 
 [features]
 ffi-trace = ["uniffi/ffi-trace"]

--- a/fixtures/docstring-proc-macro/Cargo.toml
+++ b/fixtures/docstring-proc-macro/Cargo.toml
@@ -10,18 +10,18 @@ name = "uniffi_fixture_docstring_proc_macro"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-cargo_metadata = { version = "0.15" }
-thiserror = "1.0"
-uniffi = { path = "../../uniffi" }
+cargo_metadata = { workspace = true }
+thiserror = { workspace = true }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = { path = "../../uniffi", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-glob = "0.3"
-uniffi = { path = "../../uniffi", features = ["bindgen-tests"] }
-uniffi_bindgen = { path = "../../uniffi_bindgen" }
-uniffi_testing = { path = "../../uniffi_testing" }
+glob = { workspace = true }
+uniffi = { workspace = true, features = ["bindgen-tests"] }
+uniffi_bindgen = { workspace = true }
+uniffi_testing = { workspace = true }
 
 [features]
 ffi-trace = ["uniffi/ffi-trace"]

--- a/fixtures/docstring/Cargo.toml
+++ b/fixtures/docstring/Cargo.toml
@@ -10,18 +10,18 @@ name = "uniffi_fixture_docstring"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-thiserror = "1.0"
-uniffi = { path = "../../uniffi" }
+thiserror = { workspace = true }
+uniffi = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-camino = "1.0.8"
-glob = "0.3"
-uniffi = { path = "../../uniffi", features = ["bindgen-tests"] }
-uniffi_bindgen = { path = "../../uniffi_bindgen" }
-uniffi_testing = { path = "../../uniffi_testing" }
+camino = { workspace = true }
+glob = { workspace = true }
+uniffi = { workspace = true, features = ["bindgen-tests"] }
+uniffi_bindgen = { workspace = true }
+uniffi_testing = { workspace = true }
 
 [features]
 ffi-trace = ["uniffi/ffi-trace"]

--- a/fixtures/enum-types/Cargo.toml
+++ b/fixtures/enum-types/Cargo.toml
@@ -11,7 +11,7 @@ name = "enum_types"
 
 [dependencies]
 uniffi = { workspace = true }
-thiserror = "1.0"
+thiserror = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/fixtures/error-types/Cargo.toml
+++ b/fixtures/error-types/Cargo.toml
@@ -10,15 +10,15 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_error_types"
 
 [dependencies]
-uniffi = {path = "../../uniffi"}
-anyhow = "1"
-thiserror = "1.0"
+uniffi = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
 
 [build-dependencies]
-uniffi = {path = "../../uniffi", features = ["build"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-uniffi = {path = "../../uniffi", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }
 
 [features]
 ffi-trace = ["uniffi/ffi-trace"]

--- a/fixtures/ext-types/custom-types/Cargo.toml
+++ b/fixtures/ext-types/custom-types/Cargo.toml
@@ -10,9 +10,9 @@ crate-type = ["lib", "cdylib"]
 name = "ext_types_custom"
 
 [dependencies]
-anyhow = "1"
-bytes = "1.3"
-thiserror = "1.0"
+anyhow = { workspace = true }
+bytes = { workspace = true }
+thiserror = { workspace = true }
 uniffi = { workspace = true }
 
 [build-dependencies]

--- a/fixtures/ext-types/http-headermap/Cargo.toml
+++ b/fixtures/ext-types/http-headermap/Cargo.toml
@@ -10,10 +10,10 @@ crate-type = ["lib", "cdylib"]
 name = "ext_types_http_headermap"
 
 [dependencies]
-anyhow = "1"
-bytes = "1.3"
-http = "0.2.9"
-thiserror = "1.0"
+anyhow = { workspace = true }
+bytes = { workspace = true }
+http = { workspace = true }
+thiserror = { workspace = true }
 uniffi = { workspace = true }
 
 [build-dependencies]

--- a/fixtures/ext-types/lib/Cargo.toml
+++ b/fixtures/ext-types/lib/Cargo.toml
@@ -19,20 +19,17 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_ext_types_lib"
 
 [dependencies]
-anyhow = "1"
-bytes = "1.3"
+anyhow = { workspace = true }
+bytes = { workspace = true }
 # Add the "scaffolding-ffi-buffer-fns" feature to make sure things can build correctly
-uniffi = { workspace = true }
+uniffi = { workspace = true, features = ["scaffolding-ffi-buffer-fns"] }
+url = { workspace = true }
 
-uniffi-fixture-ext-types-external-crate = {path = "../external-crate"}
-uniffi-fixture-ext-types-lib-one = {path = "../uniffi-one"}
-uniffi-fixture-ext-types-custom-types = {path = "../custom-types"}
-uniffi-fixture-ext-types-sub-lib = {path = "../sub-lib"}
-
-# Reuse one of our examples.
-uniffi-example-custom-types = {path = "../../../examples/custom-types"}
-
-url = "2.2"
+uniffi-fixture-ext-types-external-crate = { path = "../external-crate" }
+uniffi-fixture-ext-types-lib-one = { path = "../uniffi-one" }
+uniffi-fixture-ext-types-custom-types = { path = "../custom-types" }
+uniffi-fixture-ext-types-sub-lib = { path = "../sub-lib" }
+uniffi-example-custom-types = { path = "../../../examples/custom-types" }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/fixtures/ext-types/proc-macro-lib/Cargo.toml
+++ b/fixtures/ext-types/proc-macro-lib/Cargo.toml
@@ -17,8 +17,8 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_ext_types_proc_macro_lib"
 
 [dependencies]
-anyhow = "1"
-bytes = "1.3"
+anyhow = { workspace = true }
+bytes = { workspace = true }
 uniffi = { workspace = true }
 
 uniffi-fixture-ext-types-lib-one = {path = "../uniffi-one"}
@@ -27,7 +27,7 @@ uniffi-fixture-ext-types-custom-types = {path = "../custom-types"}
 # Reuse one of our examples.
 uniffi-example-custom-types = {path = "../../../examples/custom-types"}
 
-url = "2.2"
+url = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/fixtures/ext-types/sub-lib/Cargo.toml
+++ b/fixtures/ext-types/sub-lib/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_sublib"
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 uniffi = { workspace = true }
 uniffi-fixture-ext-types-lib-one = {path = "../uniffi-one"}
 

--- a/fixtures/ext-types/uniffi-one/Cargo.toml
+++ b/fixtures/ext-types/uniffi-one/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_one"
 
 [dependencies]
-anyhow = "1"
-bytes = "1.3"
+anyhow = { workspace = true }
+bytes = { workspace = true }
 uniffi = { workspace = true }
 
 [build-dependencies]

--- a/fixtures/futures/Cargo.toml
+++ b/fixtures/futures/Cargo.toml
@@ -16,11 +16,11 @@ path = "src/bin.rs"
 [dependencies]
 # Add the "scaffolding-ffi-buffer-fns" feature to make sure things can build correctly
 uniffi = { workspace = true, features = ["tokio", "cli", "scaffolding-ffi-buffer-fns"] }
-async-trait = "0.1"
-futures = "0.3"
-thiserror = "1.0"
-tokio = { version = "1.24.1", features = ["time", "sync"] }
-once_cell = "1.18.0"
+async-trait = { workspace = true }
+futures = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["time", "sync"] }
+once_cell = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build", "scaffolding-ffi-buffer-fns"] }

--- a/fixtures/keywords/kotlin/Cargo.toml
+++ b/fixtures/keywords/kotlin/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_keywords_kotlin"
 
 [dependencies]
-thiserror = "1.0"
+thiserror = { workspace = true }
 uniffi = { workspace = true }
 
 [build-dependencies]

--- a/fixtures/keywords/rust/Cargo.toml
+++ b/fixtures/keywords/rust/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_keywords_rust"
 
 [dependencies]
-thiserror = "1.0"
+thiserror = { workspace = true }
 uniffi = { workspace = true }
 
 [build-dependencies]

--- a/fixtures/keywords/swift/Cargo.toml
+++ b/fixtures/keywords/swift/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_keywords_swift"
 
 [dependencies]
-thiserror = "1.0"
+thiserror = { workspace = true }
 uniffi = { workspace = true }
 
 [build-dependencies]

--- a/fixtures/large-enum/Cargo.toml
+++ b/fixtures/large-enum/Cargo.toml
@@ -11,7 +11,7 @@ name = "large_enum"
 
 [dependencies]
 uniffi = { workspace = true }
-thiserror = "1.0"
+thiserror = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/fixtures/large-error/Cargo.toml
+++ b/fixtures/large-error/Cargo.toml
@@ -11,7 +11,7 @@ name = "large_error"
 
 [dependencies]
 uniffi = { workspace = true }
-thiserror = "1.0"
+thiserror = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/fixtures/metadata/Cargo.toml
+++ b/fixtures/metadata/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 name = "uniffi_fixture_metadata"
 
 [dependencies]
-thiserror = "1.0"
+thiserror = { workspace = true }
 uniffi = { workspace = true }
-uniffi_meta = { path = "../../uniffi_meta" }
-uniffi_core = { path = "../../uniffi_core" }
+uniffi_meta = { workspace = true }
+uniffi_core = { workspace = true }
 
 [features]
 ffi-trace = ["uniffi/ffi-trace"]

--- a/fixtures/proc-macro/Cargo.toml
+++ b/fixtures/proc-macro/Cargo.toml
@@ -17,8 +17,8 @@ myfeature = []
 [dependencies]
 # Add the "scaffolding-ffi-buffer-fns" feature to make sure things can build correctly
 uniffi = { workspace = true, features = ["scaffolding-ffi-buffer-fns"] }
-thiserror = "1.0"
-lazy_static = "1.4"
+thiserror = { workspace = true }
+lazy_static = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build", "scaffolding-ffi-buffer-fns"] }

--- a/fixtures/regressions/logging-callback-interface/Cargo.toml
+++ b/fixtures/regressions/logging-callback-interface/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["lib", "cdylib"]
 name = "uniffi_regression_logging_callback_interface"
 
 [dependencies]
-log = "0.4"
+log = { workspace = true }
 uniffi = { workspace = true }
 
 [build-dependencies]

--- a/fixtures/regressions/unary-result-alias/Cargo.toml
+++ b/fixtures/regressions/unary-result-alias/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 uniffi = { workspace = true }
-thiserror = "1.0"
+thiserror = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/fixtures/simple-iface/Cargo.toml
+++ b/fixtures/simple-iface/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 uniffi = { workspace = true }
-thiserror = "1.0"
-lazy_static = "1.4"
+thiserror = { workspace = true }
+lazy_static = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/fixtures/swift-bridging-header-compile/Cargo.toml
+++ b/fixtures/swift-bridging-header-compile/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 uniffi = { workspace = true }
-camino = "1.0.8"
+camino = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/fixtures/trait-methods/Cargo.toml
+++ b/fixtures/trait-methods/Cargo.toml
@@ -11,8 +11,8 @@ name = "uniffi_trait_methods"
 
 [dependencies]
 uniffi = { workspace = true }
-once_cell = "1.12"
-thiserror = "1.0"
+once_cell = { workspace = true }
+thiserror = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/fixtures/uitests/Cargo.toml
+++ b/fixtures/uitests/Cargo.toml
@@ -10,8 +10,8 @@ name = "uniffi_uitests"
 
 [dependencies]
 uniffi = { workspace = true }
-uniffi_macros = { path = "../../uniffi_macros", features = ["trybuild"] }
-thiserror = "1.0"
+uniffi_macros = { workspace = true, features = ["trybuild"] }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 trybuild = "1.0.76"

--- a/fixtures/uniffi-fixture-time/Cargo.toml
+++ b/fixtures/uniffi-fixture-time/Cargo.toml
@@ -11,8 +11,8 @@ name = "uniffi_chronological"
 
 [dependencies]
 uniffi = { workspace = true }
-thiserror = "1.0"
-chrono = { version = "0.4.23", default-features = false, features = ["alloc", "std"] }
+thiserror = { workspace = true }
+chrono = { workspace = true, features = ["alloc", "std"] }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -14,14 +14,14 @@ keywords = ["ffi", "bindgen"]
 readme = "../README.md"
 
 [dependencies]
-uniffi_bindgen = { path = "../uniffi_bindgen", version = "=0.28.2", optional = true }
-uniffi_build = { path = "../uniffi_build", version = "=0.28.2", optional = true }
-uniffi_core = { path = "../uniffi_core", version = "=0.28.2" }
-uniffi_macros = { path = "../uniffi_macros", version = "=0.28.2" }
-anyhow = "1"
-camino = { version = "1.0.8", optional = true }
-cargo_metadata = { version = "0.15", optional = true }
-clap = { version = "4", features = ["cargo", "std", "derive"], optional = true }
+anyhow = {  workspace = true }
+camino = { workspace = true, optional = true }
+cargo_metadata = {  workspace = true, optional = true }
+clap = { workspace = true, features = ["cargo", "std", "derive"], optional = true }
+uniffi_bindgen = { workspace = true, optional = true }
+uniffi_build = { workspace = true, optional = true }
+uniffi_core = { workspace = true  }
+uniffi_macros = { workspace = true }
 
 [dev-dependencies]
 trybuild = "1"

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -17,21 +17,21 @@ bindgen-tests = ["cargo-metadata", "dep:uniffi_testing"]
 ffi-trace = ["uniffi_testing?/ffi-trace"]
 
 [dependencies]
-anyhow = "1"
-rinja = { version = "0.3", default-features = false, features = ["config"] }
-camino = "1.0.8"
-cargo_metadata = { version = "0.15", optional = true }
-fs-err = "2.7.0"
-glob = "0.3"
-goblin = "0.8"
-heck = "0.5"
-once_cell = "1.12"
-paste = "1.0"
-serde = { version = "1", features = ["derive"] }
-toml = "0.5"
-uniffi_meta = { path = "../uniffi_meta", version = "=0.28.2" }
-uniffi_testing = { path = "../uniffi_testing", version = "=0.28.2", optional = true }
-uniffi_udl = { path = "../uniffi_udl", version = "=0.28.2" }
+anyhow =  { workspace = true }
+camino = { workspace = true }
+cargo_metadata = { workspace = true, optional = true }
+fs-err = { workspace = true }
+glob = { workspace = true }
+goblin = { workspace = true }
+heck = { workspace = true }
+once_cell = { workspace = true }
+paste = { workspace = true }
+rinja = { workspace = true, features = ["config"] }
+serde = { workspace = true, features = ["derive"] }
 # Don't include the `unicode-linebreak` or `unicode-width` since that functionality isn't needed for
 # docstrings.
-textwrap = { version = "0.16", features=["smawk"], default-features = false }
+textwrap = { workspace = true, features=["smawk"] }
+toml = { workspace = true }
+uniffi_meta = { workspace = true }
+uniffi_testing = { workspace = true, optional = true }
+uniffi_udl = { workspace = true }

--- a/uniffi_build/Cargo.toml
+++ b/uniffi_build/Cargo.toml
@@ -11,9 +11,9 @@ keywords = ["ffi", "bindgen"]
 readme = "../README.md"
 
 [dependencies]
-anyhow = "1"
-camino = "1.0.8"
-uniffi_bindgen = { path = "../uniffi_bindgen", default-features = false, version = "=0.28.2" }
+anyhow = { workspace = true }
+camino = { workspace = true }
+uniffi_bindgen = { workspace = true }
 
 [features]
 default = []

--- a/uniffi_checksum_derive/Cargo.toml
+++ b/uniffi_checksum_derive/Cargo.toml
@@ -14,8 +14,8 @@ readme = "../README.md"
 proc-macro = true
 
 [dependencies]
-quote = "1.0"
-syn = { version = "2.0", features = ["derive", "parsing"] }
+quote = { workspace = true }
+syn = { workspace = true, features = ["derive", "parsing"] }
 
 [features]
 default = []

--- a/uniffi_core/Cargo.toml
+++ b/uniffi_core/Cargo.toml
@@ -12,13 +12,13 @@ readme = "../README.md"
 
 [dependencies]
 # Re-exported dependencies used in generated Rust scaffolding files.
-anyhow = "1"
-async-compat = { version = "0.2.1", optional = true }
-bytes = "1.3"
-once_cell = "1.10.0"
+anyhow = { workspace = true }
+async-compat = { workspace = true, optional = true }
+bytes = { workspace = true }
+once_cell ={ workspace = true }
 # Regular dependencies
-paste = "1.0"
-static_assertions = "1.1.0"
+paste = { workspace = true }
+static_assertions = { workspace = true }
 
 [features]
 default = []

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -14,17 +14,17 @@ readme = "../README.md"
 proc-macro = true
 
 [dependencies]
-bincode = "1.3"
-camino = "1.0.8"
-fs-err = "2.7.0"
-once_cell = "1.10.0"
-proc-macro2 = "1.0"
-quote = "1.0"
-serde = { version = "1.0.136", features = ["derive"] }
-syn = { version = "2.0", features = ["full", "visit-mut"] }
-toml = "0.5.9"
-uniffi_build = { path = "../uniffi_build", version = "=0.28.2", optional = true }
-uniffi_meta = { path = "../uniffi_meta", version = "=0.28.2" }
+bincode = { workspace = true }
+camino = { workspace = true }
+fs-err = { workspace = true }
+once_cell = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+syn = { workspace = true, features = ["full", "visit-mut"] }
+toml = { workspace = true }
+uniffi_build = { workspace = true, optional = true }
+uniffi_meta = { workspace = true }
 
 [features]
 default = []

--- a/uniffi_meta/Cargo.toml
+++ b/uniffi_meta/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["ffi", "bindgen"]
 readme = "../README.md"
 
 [dependencies]
-anyhow = "1"
-bytes = "1.3"
-siphasher = "0.3"
-uniffi_checksum_derive = { version = "0.28.2", path = "../uniffi_checksum_derive" }
+anyhow = { workspace = true }
+bytes = { workspace = true }
+siphasher = { workspace = true }
+uniffi_checksum_derive = { workspace = true }

--- a/uniffi_testing/Cargo.toml
+++ b/uniffi_testing/Cargo.toml
@@ -10,11 +10,11 @@ license = "MPL-2.0"
 readme = "../README.md"
 
 [dependencies]
-anyhow = "1"
-camino = "1.0.8"
-cargo_metadata = "0.15"
-fs-err = "2.7.0"
-once_cell = "1.12"
+anyhow = { workspace = true }
+camino = { workspace = true }
+cargo_metadata = { workspace = true }
+fs-err = { workspace = true }
+once_cell = { workspace = true }
 
 [features]
 ffi-trace = []

--- a/uniffi_udl/Cargo.toml
+++ b/uniffi_udl/Cargo.toml
@@ -11,9 +11,10 @@ keywords = ["ffi", "bindgen"]
 readme = "../README.md"
 
 [dependencies]
-anyhow = "1"
-weedle2 = { version = "5.0.0", path = "../weedle2" }
+uniffi_meta = { workspace = true }
+anyhow = { workspace = true }
+weedle2 = { workspace = true }
 # Don't include the `unicode-linebreak` or `unicode-width` since that functionality isn't needed for
 # docstrings.
-textwrap = { version = "0.16", features = ["smawk"], default-features = false }
-uniffi_meta = { path = "../uniffi_meta", version = "=0.28.2" }
+textwrap = { workspace = true, features = ["smawk"] }
+

--- a/weedle2/Cargo.toml
+++ b/weedle2/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["tests"]
 name = "weedle"
 
 [dependencies]
-nom = "7.1.0"
+nom = { workspace = true }
 
 [dev-dependencies]
 fs-err = "2.7.0"


### PR DESCRIPTION
Started with one and ended up with moving every dependency to a `workspace.dependency`. I think it's easier to manage version upgrades and get a view on which crates the whole project is relying on. 

But also, not sure what should be a workspace dependency and what shouldn't. We can argue just dependencies in > 1 workspace member should be moved to be a `workspace.dependency`. Happy to discuss, or drop it all together. 
