### PR TITLE
Add `Callable::ffi_func`

### DIFF
--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -269,6 +269,9 @@ pub trait Callable {
         }
     }
 
+    // Scaffolding function
+    fn ffi_func(&self) -> &FfiFunction;
+
     // Quick way to get the rust future scaffolding function that corresponds to our return type.
 
     fn ffi_rust_future_poll(&self, ci: &ComponentInterface) -> String {
@@ -312,6 +315,10 @@ impl Callable for Function {
     fn is_async(&self) -> bool {
         self.is_async
     }
+
+    fn ffi_func(&self) -> &FfiFunction {
+        &self.ffi_func
+    }
 }
 
 // Needed because Rinja likes to add extra refs to variables
@@ -330,6 +337,10 @@ impl<T: Callable> Callable for &T {
 
     fn is_async(&self) -> bool {
         (*self).is_async()
+    }
+
+    fn ffi_func(&self) -> &FfiFunction {
+        (*self).ffi_func()
     }
 
     fn takes_self(&self) -> bool {

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -729,6 +729,10 @@ impl Callable for Constructor {
     fn is_async(&self) -> bool {
         self.is_async
     }
+
+    fn ffi_func(&self) -> &FfiFunction {
+        &self.ffi_func
+    }
 }
 
 impl Callable for Method {
@@ -750,6 +754,10 @@ impl Callable for Method {
 
     fn takes_self(&self) -> bool {
         true
+    }
+
+    fn ffi_func(&self) -> &FfiFunction {
+        &self.ffi_func
     }
 }
 


### PR DESCRIPTION
All the callable types implement this, so let's add it to the trait.  I want to use this eventually for the Gecko JS bindings.