### PR TITLE
Add a configuration to allow removing `LocalizedError` conformation

### DIFF
--- a/docs/manual/src/swift/configuration.md
+++ b/docs/manual/src/swift/configuration.md
@@ -13,11 +13,12 @@ more likely to change than other configurations.
 | `module_name`                       | `{namespace}`[^1]        | The name of the Swift module containing the high-level foreign-language bindings.                                                                                  |
 | `ffi_module_name`                   | `{module_name}FFI`       | The name of the lower-level C module containing the FFI declarations.                                                                                              |
 | `ffi_module_filename`               | `{ffi_module_name}`      | The filename stem for the lower-level C module containing the FFI declarations.                                                                                    |
-| `generate_module_map`               | `true`                   | Whether to generate a `.modulemap` file for the lower-level C module with FFI declarations. (ignored by `uniffi-bindgen-swift`)                            | 
+| `generate_module_map`               | `true`                   | Whether to generate a `.modulemap` file for the lower-level C module with FFI declarations. (ignored by `uniffi-bindgen-swift`)                            |
 | `omit_argument_labels`              | `false`                  | Whether to omit argument labels in Swift function definitions.                                                                                                     |
 | `generate_immutable_records`        | `false`                  | Whether to generate records with immutable fields (`let` instead of `var`).                                                                                        |
 | `experimental_sendable_value_types` | `false`                  | Whether to mark value types as `Sendable'.                                                                                                                         |
 | `custom_types`                      |                          | A map which controls how custom types are exposed to Swift. See the [custom types section of the manual](../udl/custom_types.md#custom-types-in-the-bindings-code) |
+| `omit_localized_error_conformance`  | `false`                  | Whether to make generated error types conform to `LocalizedError`. |
 
 [^1]: `namespace` is the top-level namespace from your UDL file.
 

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -197,6 +197,7 @@ pub struct Config {
     omit_argument_labels: Option<bool>,
     generate_immutable_records: Option<bool>,
     experimental_sendable_value_types: Option<bool>,
+    error_types_conform_to_localized_error: Option<bool>,
     #[serde(default)]
     custom_types: HashMap<String, CustomTypeConfig>,
 }
@@ -263,6 +264,11 @@ impl Config {
     /// Whether to mark value types as 'Sendable'
     pub fn experimental_sendable_value_types(&self) -> bool {
         self.experimental_sendable_value_types.unwrap_or(false)
+    }
+
+    // Whether to make generated error types conform to `LocalizedError`. Default: true.
+    pub fn error_types_conform_to_localized_error(&self) -> bool {
+        self.error_types_conform_to_localized_error.unwrap_or(true)
     }
 }
 

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -197,7 +197,7 @@ pub struct Config {
     omit_argument_labels: Option<bool>,
     generate_immutable_records: Option<bool>,
     experimental_sendable_value_types: Option<bool>,
-    error_types_conform_to_localized_error: Option<bool>,
+    omit_localized_error_conformance: Option<bool>,
     #[serde(default)]
     custom_types: HashMap<String, CustomTypeConfig>,
 }
@@ -266,9 +266,9 @@ impl Config {
         self.experimental_sendable_value_types.unwrap_or(false)
     }
 
-    // Whether to make generated error types conform to `LocalizedError`. Default: true.
-    pub fn error_types_conform_to_localized_error(&self) -> bool {
-        self.error_types_conform_to_localized_error.unwrap_or(true)
+    // Whether to make generated error types conform to `LocalizedError`. Default: false.
+    pub fn omit_localized_error_conformance(&self) -> bool {
+        self.omit_localized_error_conformance.unwrap_or(false)
     }
 }
 

--- a/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
@@ -90,8 +90,11 @@ public struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
 {% if !contains_object_references %}
 extension {{ type_name }}: Equatable, Hashable {}
 {% endif %}
+
+{% if config.error_types_conform_to_localized_error() %}
 extension {{ type_name }}: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+{% endif %}

--- a/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
@@ -91,7 +91,7 @@ public struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
 extension {{ type_name }}: Equatable, Hashable {}
 {% endif %}
 
-{% if config.error_types_conform_to_localized_error() %}
+{% if !config.omit_localized_error_conformance() %}
 extension {{ type_name }}: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)

--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -174,11 +174,13 @@ public struct {{ ffi_converter_name }}: FfiConverter {
 {# Objects as error #}
 {%- if is_error %}
 
+{% if config.error_types_conform_to_localized_error() %}
 extension {{ type_name }}: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)
     }
 }
+{% endif %}
 
 {# Due to some mismatches in the ffi converter mechanisms, errors are a RustBuffer holding a pointer #}
 #if swift(>=5.8)

--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -174,7 +174,7 @@ public struct {{ ffi_converter_name }}: FfiConverter {
 {# Objects as error #}
 {%- if is_error %}
 
-{% if config.error_types_conform_to_localized_error() %}
+{% if !config.omit_localized_error_conformance() %}
 extension {{ type_name }}: Foundation.LocalizedError {
     public var errorDescription: String? {
         String(reflecting: self)


### PR DESCRIPTION
In Swift, all generated error types conform to `LocalizedError`. The implementation uses a compiler generated string, which is not an appropriate `LocalizedError` implementation.

This PR adds a new config to "uniffi.toml": `error_types_conform_to_localized_error`. When not set, its config value is `true`, which means existing code is not affected by this change.

I looked into adding unit tests, but couldn't find how. Happy to add some though, if anyone can point me to the right direction.