### PR TITLE
Try different commands to run `swift-format`

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -107,28 +107,28 @@ impl BindingGenerator for SwiftBindingGenerator {
             }
 
             if settings.try_format_code {
-                let mut swift_format_via_xcrun = Command::new("xcrun");
-                swift_format_via_xcrun.args(["--find", "swift-format"]);
-                let official_swift_format = Command::new("swift-format");
-                let mut swift_short_hand = Command::new("swift");
-                swift_short_hand.arg("format");
-                let swiftformat = Command::new("swiftformat");
-
-                let mut commands_to_try = [
-                    swift_format_via_xcrun,
-                    official_swift_format,
-                    swift_short_hand,
-                    swiftformat,
+                let commands_to_try = [
+                    // Available in Xcode 16.
+                    vec!["xcrun", "--find", "swift-format"],
+                    // The official swift-format command name.
+                    vec!["swift-format"],
+                    // Shortcut for the swift-format command.
+                    vec!["swift", "format"],
+                    vec!["swiftformat"],
                 ];
-                for command in &mut commands_to_try {
-                    match command.arg(source_file.as_str()).output() {
-                        Ok(_) => break,
-                        Err(e) => println!(
-                            "Warning: Unable to auto-format {} using {:?}: {e:?}",
-                            source_file.file_name().unwrap(),
-                            command.get_program().to_str(),
-                        ),
-                    }
+
+                let successful_output = commands_to_try.into_iter().find_map(|command| {
+                    Command::new(&command[0])
+                        .args(&command[1..])
+                        .arg(source_file.as_str())
+                        .output()
+                        .ok()
+                });
+                if successful_output.is_none() {
+                    println!(
+                        "Warning: Unable to auto-format {} using swift-format. Please make sure it is installed.",
+                        source_file.as_str()
+                    );
                 }
             }
         }

--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -109,7 +109,7 @@ impl BindingGenerator for SwiftBindingGenerator {
             if settings.try_format_code {
                 let commands_to_try = [
                     // Available in Xcode 16.
-                    vec!["xcrun", "--find", "swift-format"],
+                    vec!["xcrun", "swift-format"],
                     // The official swift-format command name.
                     vec!["swift-format"],
                     // Shortcut for the swift-format command.

--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -107,14 +107,28 @@ impl BindingGenerator for SwiftBindingGenerator {
             }
 
             if settings.try_format_code {
-                if let Err(e) = Command::new("swiftformat")
-                    .arg(source_file.as_str())
-                    .output()
-                {
-                    println!(
-                        "Warning: Unable to auto-format {} using swiftformat: {e:?}",
-                        source_file.file_name().unwrap(),
-                    );
+                let mut swift_format_via_xcrun = Command::new("xcrun");
+                swift_format_via_xcrun.args(["--find", "swift-format"]);
+                let official_swift_format = Command::new("swift-format");
+                let mut swift_short_hand = Command::new("swift");
+                swift_short_hand.arg("format");
+                let swiftformat = Command::new("swiftformat");
+
+                let mut commands_to_try = [
+                    swift_format_via_xcrun,
+                    official_swift_format,
+                    swift_short_hand,
+                    swiftformat,
+                ];
+                for command in &mut commands_to_try {
+                    match command.arg(source_file.as_str()).output() {
+                        Ok(_) => break,
+                        Err(e) => println!(
+                            "Warning: Unable to auto-format {} using {:?}: {e:?}",
+                            source_file.file_name().unwrap(),
+                            command.get_program().to_str(),
+                        ),
+                    }
                 }
             }
         }


### PR DESCRIPTION
Currently `swiftformat` is called to format generated Swift code. This PR adds a few more `swift-format` command candidates. Here are the new commands:
* `xcrun --find swift-format`. This command is available in Xcode 16. I expect it to be available in all future Xcode releases.
* `swift-format`. This command is the official command name. See [the README](https://github.com/swiftlang/swift-format?tab=readme-ov-file#command-line-usage).
* `swift format`. This command is a shorthand for `swift-format` (similar to how `git subcommand` is the same as `git-subcommand`)