### PR TITLE
Consistently use `uniffi::use_remote_type!()` and have the crate name…

### DIFF
--- a/docs/manual/src/udl/remote_ext_types.md
+++ b/docs/manual/src/udl/remote_ext_types.md
@@ -92,7 +92,7 @@ Types that are remote and external require a `use_remote_type!` macro call.
 If `crate_a` defines [IpAddr](https://doc.rust-lang.org/std/net/enum.IpAddr.html) as a remote type, then `crate_b` can use that type with the following Rust code:
 
 ```rust
-uniffi::use_remote_type!(IpAddr, crate_a);
+uniffi::use_remote_type!(crate_a, IpAddr);
 ```
 
 ## UDL

--- a/fixtures/ext-types/lib/src/lib.rs
+++ b/fixtures/ext-types/lib/src/lib.rs
@@ -12,7 +12,7 @@ use uniffi_sublib::SubLibType;
 use url::Url;
 
 // Remote types require a macro call in the Rust source
-uniffi::remote_type!(Url, custom_types);
+uniffi::use_remote_type!(custom_types, Url);
 
 pub struct CombinedType {
     pub uoe: UniffiOneEnum,

--- a/fixtures/ext-types/proc-macro-lib/src/lib.rs
+++ b/fixtures/ext-types/proc-macro-lib/src/lib.rs
@@ -6,7 +6,7 @@ use uniffi_one::{
 };
 use url::Url;
 
-uniffi::remote_type!(Url, custom_types);
+uniffi::use_remote_type!(custom_types, Url);
 
 #[derive(uniffi::Record)]
 pub struct CombinedType {

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -252,7 +252,7 @@ pub fn include_scaffolding(udl_stem: TokenStream) -> TokenStream {
 ///
 /// See `<https://mozilla.github.io/uniffi-rs/udl/remote_ext_types.html>` for details.
 #[proc_macro]
-pub fn remote_type(tokens: TokenStream) -> TokenStream {
+pub fn use_remote_type(tokens: TokenStream) -> TokenStream {
     remote::expand_remote_type(parse_macro_input!(tokens)).into()
 }
 

--- a/uniffi_macros/src/remote.rs
+++ b/uniffi_macros/src/remote.rs
@@ -10,25 +10,25 @@ use syn::{
 };
 
 pub struct RemoteTypeArgs {
-    pub ty: Type,
-    pub sep: Token![,],
     pub implementing_crate: Ident,
+    pub sep: Token![,],
+    pub ty: Type,
 }
 
 impl Parse for RemoteTypeArgs {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         Ok(Self {
-            ty: input.parse()?,
-            sep: input.parse()?,
             implementing_crate: input.parse()?,
+            sep: input.parse()?,
+            ty: input.parse()?,
         })
     }
 }
 
 pub fn expand_remote_type(args: RemoteTypeArgs) -> TokenStream {
     let RemoteTypeArgs {
-        ty,
         implementing_crate,
+        ty,
         ..
     } = args;
     let existing_tag = quote! { #implementing_crate::UniFfiTag };


### PR DESCRIPTION
… before the type name