### PR TITLE
Make all extern C functions public

### DIFF
--- a/uniffi_macros/src/export/callback_interface.rs
+++ b/uniffi_macros/src/export/callback_interface.rs
@@ -52,7 +52,7 @@ pub(super) fn trait_impl(
         let lift_return_type = ffiops::lift_return_type(&sig.return_ty);
         if !sig.is_async {
             quote! {
-                #ident: extern "C" fn(
+                pub #ident: extern "C" fn(
                     uniffi_handle: u64,
                     #(#param_names: #param_types,)*
                     uniffi_out_return: &mut #lift_return_type,
@@ -61,7 +61,7 @@ pub(super) fn trait_impl(
             }
         } else {
             quote! {
-                #ident: extern "C" fn(
+                pub #ident: extern "C" fn(
                     uniffi_handle: u64,
                     #(#param_names: #param_types,)*
                     uniffi_future_callback: ::uniffi::ForeignFutureCallback<#lift_return_type>,
@@ -80,15 +80,15 @@ pub(super) fn trait_impl(
     let impl_attributes = has_async_method.then(|| quote! { #[::async_trait::async_trait] });
 
     Ok(quote! {
-        struct #vtable_type {
+        pub struct #vtable_type {
             #(#vtable_fields)*
-            uniffi_free: extern "C" fn(handle: u64),
+            pub uniffi_free: extern "C" fn(handle: u64),
         }
 
         static #vtable_cell: ::uniffi::UniffiForeignPointerCell::<#vtable_type> = ::uniffi::UniffiForeignPointerCell::<#vtable_type>::new();
 
         #[no_mangle]
-        extern "C" fn #init_ident(vtable: ::std::ptr::NonNull<#vtable_type>) {
+        pub extern "C" fn #init_ident(vtable: ::std::ptr::NonNull<#vtable_type>) {
             #vtable_cell.set(vtable);
         }
 

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -238,12 +238,6 @@ pub(super) fn gen_ffi_function(
             ScaffoldingBits::new_for_constructor(sig, self_ident, udl_mode)
         }
     };
-    // Scaffolding functions are logically `pub`, but we don't use that in UDL mode since UDL has
-    // historically not required types to be `pub`
-    let vis = match udl_mode {
-        false => quote! { pub },
-        true => quote! {},
-    };
 
     let ffi_ident = sig.scaffolding_fn_ident()?;
     let ffi_fn_name = ffi_ident.to_string();
@@ -259,7 +253,7 @@ pub(super) fn gen_ffi_function(
         quote! {
             #[doc(hidden)]
             #[no_mangle]
-            #vis extern "C" fn #ffi_ident(
+            pub extern "C" fn #ffi_ident(
                 #(#param_names: #param_types,)*
                 call_status: &mut ::uniffi::RustCallStatus,
             ) -> #ffi_return_ty {


### PR DESCRIPTION
This PR verifies that the `extern "C"` functions are all `pub`.

In the case of `FfiFunctions` defined by UDL, and callback functions, this required a change.