### PR TITLE
make `mod_path()` consistent with/without nightly feature

### DIFF
--- a/uniffi_macros/src/setup_scaffolding.rs
+++ b/uniffi_macros/src/setup_scaffolding.rs
@@ -11,16 +11,20 @@ use uniffi_meta::UNIFFI_CONTRACT_VERSION;
 
 pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
     let module_path = mod_path()?;
-    let ffi_contract_version_ident = format_ident!("ffi_{module_path}_uniffi_contract_version");
+    let normalized_module_path = module_path.replace("::", "__");
+    let ffi_contract_version_ident =
+        format_ident!("ffi_{normalized_module_path}_uniffi_contract_version");
     let namespace_upper = namespace.to_ascii_uppercase();
     let namespace_const_ident = format_ident!("UNIFFI_META_CONST_NAMESPACE_{namespace_upper}");
     let namespace_static_ident = format_ident!("UNIFFI_META_NAMESPACE_{namespace_upper}");
-    let ffi_rustbuffer_alloc_ident = format_ident!("ffi_{module_path}_rustbuffer_alloc");
-    let ffi_rustbuffer_from_bytes_ident = format_ident!("ffi_{module_path}_rustbuffer_from_bytes");
-    let ffi_rustbuffer_free_ident = format_ident!("ffi_{module_path}_rustbuffer_free");
-    let ffi_rustbuffer_reserve_ident = format_ident!("ffi_{module_path}_rustbuffer_reserve");
-    let reexport_hack_ident = format_ident!("{module_path}_uniffi_reexport_hack");
-    let ffi_rust_future_scaffolding_fns = rust_future_scaffolding_fns(&module_path);
+    let ffi_rustbuffer_alloc_ident = format_ident!("ffi_{normalized_module_path}_rustbuffer_alloc");
+    let ffi_rustbuffer_from_bytes_ident =
+        format_ident!("ffi_{normalized_module_path}_rustbuffer_from_bytes");
+    let ffi_rustbuffer_free_ident = format_ident!("ffi_{normalized_module_path}_rustbuffer_free");
+    let ffi_rustbuffer_reserve_ident =
+        format_ident!("ffi_{normalized_module_path}_rustbuffer_reserve");
+    let reexport_hack_ident = format_ident!("{normalized_module_path}_uniffi_reexport_hack");
+    let ffi_rust_future_scaffolding_fns = rust_future_scaffolding_fns(&normalized_module_path);
 
     Ok(quote! {
         // Unit struct to parameterize the FfiConverter trait.

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -75,10 +75,7 @@ pub fn mod_path() -> syn::Result<String> {
         .map_err(|e| syn::Error::new(Span::call_site(), e))?;
     Ok(syn::parse::<syn::LitStr>(expanded_module_path)?
         .value()
-        .split("::")
-        .next()
-        .unwrap()
-        .to_owned())
+        .replace("::", "_"))
 }
 
 pub fn try_read_field(f: &syn::Field) -> TokenStream {

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -73,7 +73,12 @@ pub fn mod_path() -> syn::Result<String> {
     // This is a nightly feature, tracked at https://github.com/rust-lang/rust/issues/90765
     let expanded_module_path = TokenStream::expand_expr(&module_path_invoc)
         .map_err(|e| syn::Error::new(Span::call_site(), e))?;
-    Ok(syn::parse::<syn::LitStr>(expanded_module_path)?.value())
+    Ok(syn::parse::<syn::LitStr>(expanded_module_path)?
+        .value()
+        .split("::")
+        .next()
+        .unwrap()
+        .to_owned())
 }
 
 pub fn try_read_field(f: &syn::Field) -> TokenStream {

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -73,9 +73,7 @@ pub fn mod_path() -> syn::Result<String> {
     // This is a nightly feature, tracked at https://github.com/rust-lang/rust/issues/90765
     let expanded_module_path = TokenStream::expand_expr(&module_path_invoc)
         .map_err(|e| syn::Error::new(Span::call_site(), e))?;
-    Ok(syn::parse::<syn::LitStr>(expanded_module_path)?
-        .value()
-        .replace("::", "_"))
+    Ok(syn::parse::<syn::LitStr>(expanded_module_path)?.value())
 }
 
 pub fn try_read_field(f: &syn::Field) -> TokenStream {

--- a/uniffi_meta/src/ffi_names.rs
+++ b/uniffi_meta/src/ffi_names.rs
@@ -15,12 +15,14 @@
 
 /// FFI symbol name for a top-level function
 pub fn fn_symbol_name(namespace: &str, name: &str) -> String {
+    let namespace = namespace.replace("::", "__");
     let name = name.to_ascii_lowercase();
     format!("uniffi_{namespace}_fn_func_{name}")
 }
 
 /// FFI symbol name for an object constructor
 pub fn constructor_symbol_name(namespace: &str, object_name: &str, name: &str) -> String {
+    let namespace = namespace.replace("::", "__");
     let object_name = object_name.to_ascii_lowercase();
     let name = name.to_ascii_lowercase();
     format!("uniffi_{namespace}_fn_constructor_{object_name}_{name}")
@@ -28,6 +30,7 @@ pub fn constructor_symbol_name(namespace: &str, object_name: &str, name: &str) -
 
 /// FFI symbol name for an object method
 pub fn method_symbol_name(namespace: &str, object_name: &str, name: &str) -> String {
+    let namespace = namespace.replace("::", "__");
     let object_name = object_name.to_ascii_lowercase();
     let name = name.to_ascii_lowercase();
     format!("uniffi_{namespace}_fn_method_{object_name}_{name}")
@@ -35,12 +38,14 @@ pub fn method_symbol_name(namespace: &str, object_name: &str, name: &str) -> Str
 
 /// FFI symbol name for the `clone` function for an object.
 pub fn clone_fn_symbol_name(namespace: &str, object_name: &str) -> String {
+    let namespace = namespace.replace("::", "__");
     let object_name = object_name.to_ascii_lowercase();
     format!("uniffi_{namespace}_fn_clone_{object_name}")
 }
 
 /// FFI symbol name for the `free` function for an object.
 pub fn free_fn_symbol_name(namespace: &str, object_name: &str) -> String {
+    let namespace = namespace.replace("::", "__");
     let object_name = object_name.to_ascii_lowercase();
     format!("uniffi_{namespace}_fn_free_{object_name}")
 }
@@ -50,18 +55,21 @@ pub fn init_callback_vtable_fn_symbol_name(
     namespace: &str,
     callback_interface_name: &str,
 ) -> String {
+    let namespace = namespace.replace("::", "__");
     let callback_interface_name = callback_interface_name.to_ascii_lowercase();
     format!("uniffi_{namespace}_fn_init_callback_vtable_{callback_interface_name}")
 }
 
 /// FFI checksum symbol name for a top-level function
 pub fn fn_checksum_symbol_name(namespace: &str, name: &str) -> String {
+    let namespace = namespace.replace("::", "__");
     let name = name.to_ascii_lowercase();
     format!("uniffi_{namespace}_checksum_func_{name}")
 }
 
 /// FFI checksum symbol name for an object constructor
 pub fn constructor_checksum_symbol_name(namespace: &str, object_name: &str, name: &str) -> String {
+    let namespace = namespace.replace("::", "__");
     let object_name = object_name.to_ascii_lowercase();
     let name = name.to_ascii_lowercase();
     format!("uniffi_{namespace}_checksum_constructor_{object_name}_{name}")
@@ -69,6 +77,7 @@ pub fn constructor_checksum_symbol_name(namespace: &str, object_name: &str, name
 
 /// FFI checksum symbol name for an object method
 pub fn method_checksum_symbol_name(namespace: &str, object_name: &str, name: &str) -> String {
+    let namespace = namespace.replace("::", "__");
     let object_name = object_name.to_ascii_lowercase();
     let name = name.to_ascii_lowercase();
     format!("uniffi_{namespace}_checksum_method_{object_name}_{name}")


### PR DESCRIPTION
The `nightly` version of the `mod_path()` function does not do the same thing as the one reading `Cargo.toml`.

We'll only ever get the crate name from `Cargo.toml`, but the `core::module_path!()` macro will return the module path, with components separated by `::`, as the Rust convention goes.

The problem is that the crate name is the first element of `core::module_path!()` macro, and the current impl does not consider that. This might not have been visible if tested from the `lib.rs` of a crate, since the `module_path == crate_name`, but UniFFI objects in nested modules will pose issues.

If the desire is to hold on to the full module path, then we could at least replace the `::` with `_` as otherwise `syn` complains that identifiers are not valid. Let me know if that's a better approach (though I think the behavior should be consistent with the non-nightly version).