### PR TITLE
Declare `UniffiForeignFutureTask` as fileprivate

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/Async.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Async.swift
@@ -90,7 +90,7 @@ fileprivate let UNIFFI_FOREIGN_FUTURE_HANDLE_MAP = UniffiHandleMap<UniffiForeign
 //
 // Defining a protocol allows all tasks to be stored in the same handle map.  This can't be done
 // with the task object itself, since has generic parameters.
-protocol UniffiForeignFutureTask {
+fileprivate protocol UniffiForeignFutureTask {
     func cancel()
 }
 


### PR DESCRIPTION
Like many other types in the generated binding files, `UniffiForeignFutureTask` should be declared as `fileprivate` or `private`. It's currently causing conflicts when multiple libraries have public async functions.