### PR TITLE
Add test cases to reproduce issue #2343

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,6 +1816,7 @@ name = "uniffi-fixture-ext-types-lib-one"
 version = "0.22.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bytes",
  "uniffi",
 ]
@@ -1838,6 +1839,7 @@ name = "uniffi-fixture-ext-types-sub-lib"
 version = "0.22.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "uniffi",
  "uniffi-fixture-ext-types-lib-one",
 ]

--- a/fixtures/ext-types/sub-lib/Cargo.toml
+++ b/fixtures/ext-types/sub-lib/Cargo.toml
@@ -16,6 +16,7 @@ name = "uniffi_sublib"
 
 [dependencies]
 anyhow = "1"
+async-trait = "0.1"
 uniffi = { workspace = true }
 uniffi-fixture-ext-types-lib-one = {path = "../uniffi-one"}
 

--- a/fixtures/ext-types/sub-lib/src/lib.rs
+++ b/fixtures/ext-types/sub-lib/src/lib.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use uniffi_one::{UniffiOneEnum, UniffiOneInterface, UniffiOneTrait};
+use uniffi_one::{UniffiOneAsyncTrait, UniffiOneEnum, UniffiOneInterface, UniffiOneTrait};
 
 #[derive(Default, uniffi::Record)]
 pub struct SubLibType {
@@ -21,9 +21,55 @@ impl UniffiOneTrait for OneImpl {
     }
 }
 
+#[async_trait::async_trait]
+impl UniffiOneAsyncTrait for OneImpl {
+    async fn hello_async(&self) -> String {
+        "sub-lib async trait impl says hello".to_string()
+    }
+}
+
 #[uniffi::export]
 fn get_trait_impl() -> Arc<dyn UniffiOneTrait> {
     Arc::new(OneImpl {})
+}
+
+#[uniffi::export]
+fn get_async_trait_impl() -> Arc<dyn UniffiOneAsyncTrait> {
+    Arc::new(OneImpl {})
+}
+
+#[derive(uniffi::Object)]
+struct UniffiOneTraitWrapper {
+    inner: Arc<dyn UniffiOneTrait>,
+}
+
+#[uniffi::export]
+impl UniffiOneTraitWrapper {
+    #[uniffi::constructor]
+    fn new(inner: Arc<dyn UniffiOneTrait>) -> Self {
+        Self { inner }
+    }
+
+    fn hello(&self) -> String {
+        self.inner.hello()
+    }
+}
+
+#[derive(uniffi::Object)]
+struct UniffiOneAsyncTraitWrapper {
+    inner: Arc<dyn UniffiOneAsyncTrait>,
+}
+
+#[uniffi::export]
+impl UniffiOneAsyncTraitWrapper {
+    #[uniffi::constructor]
+    fn new(inner: Arc<dyn UniffiOneAsyncTrait>) -> Self {
+        Self { inner }
+    }
+
+    async fn hello_async(&self) -> String {
+        self.inner.hello_async().await
+    }
 }
 
 uniffi::setup_scaffolding!("imported_types_sublib");

--- a/fixtures/ext-types/sub-lib/tests/bindings/test_use_external_crate.swift
+++ b/fixtures/ext-types/sub-lib/tests/bindings/test_use_external_crate.swift
@@ -1,0 +1,22 @@
+import imported_types_sublib
+import Foundation
+
+var counter = DispatchGroup()
+
+counter.enter()
+Task {
+    let impl = getTraitImpl()
+    let result = impl.hello()
+    assert(result == "sub-lib trait impl says hello")
+    counter.leave()
+}
+
+counter.enter()
+Task {
+    let impl = getAsyncTraitImpl()
+    let result = await impl.helloAsync()
+    assert(result == "sub-lib async trait impl says hello")
+    counter.leave()
+}
+
+counter.wait()

--- a/fixtures/ext-types/sub-lib/tests/bindings/test_use_trait_native_impl.swift
+++ b/fixtures/ext-types/sub-lib/tests/bindings/test_use_trait_native_impl.swift
@@ -1,0 +1,56 @@
+import imported_types_sublib
+import Foundation
+
+final class SwiftImpl: UniffiOneAsyncTrait, UniffiOneTrait {
+    func hello() -> String {
+        "Hello from Swift"
+    }
+
+    func helloAsync() async -> String {
+        "Hello async from Swift"
+    }
+}
+
+var counter = DispatchGroup()
+
+// Add 'ISSUE_2343' env var to `cargo test` command to reproduce the crash.
+// https://github.com/mozilla/uniffi-rs/issues/2343
+if ProcessInfo.processInfo.environment["ISSUE_2343"] == nil {
+    counter.enter()
+    Task {
+        let impl = getTraitImpl()
+        let result = impl.hello()
+        assert(result == "sub-lib trait impl says hello")
+        counter.leave()
+    }
+
+    counter.enter()
+    Task {
+        let impl = getAsyncTraitImpl()
+        let result = await impl.helloAsync()
+        assert(result == "sub-lib async trait impl says hello")
+        counter.leave()
+    }
+
+    counter.wait()
+}
+
+counter.enter()
+Task {
+    let impl = SwiftImpl()
+    let rust = UniffiOneTraitWrapper(inner: impl)
+    let result = rust.hello()
+    assert(result == "Hello from Swift")
+    counter.leave()
+}
+
+counter.enter()
+Task {
+    let impl = SwiftImpl()
+    let rust = UniffiOneAsyncTraitWrapper(inner: impl)
+    let result = await rust.helloAsync()
+    assert(result == "Hello async from Swift")
+    counter.leave()
+}
+
+counter.wait()

--- a/fixtures/ext-types/sub-lib/tests/bindings/test_use_trait_rust_impl.swift
+++ b/fixtures/ext-types/sub-lib/tests/bindings/test_use_trait_rust_impl.swift
@@ -1,0 +1,46 @@
+import imported_types_sublib
+import Foundation
+
+var counter = DispatchGroup()
+
+// Add 'ISSUE_2343' env var to `cargo test` command to reproduce the crash.
+// https://github.com/mozilla/uniffi-rs/issues/2343
+if ProcessInfo.processInfo.environment["ISSUE_2343"] == nil {
+    counter.enter()
+    Task {
+        let impl = getTraitImpl()
+        let result = impl.hello()
+        assert(result == "sub-lib trait impl says hello")
+        counter.leave()
+    }
+
+    counter.enter()
+    Task {
+        let impl = getAsyncTraitImpl()
+        let result = await impl.helloAsync()
+        assert(result == "sub-lib async trait impl says hello")
+        counter.leave()
+    }
+
+    counter.wait()
+}
+
+counter.enter()
+Task {
+    let impl = getTraitImpl()
+    let rust = UniffiOneTraitWrapper(inner: impl)
+    let result = rust.hello()
+    assert(result == "sub-lib trait impl says hello")
+    counter.leave()
+}
+
+counter.enter()
+Task {
+    let impl = getAsyncTraitImpl()
+    let rust = UniffiOneAsyncTraitWrapper(inner: impl)
+    let result = await rust.helloAsync()
+    assert(result == "sub-lib async trait impl says hello")
+    counter.leave()
+}
+
+counter.wait()

--- a/fixtures/ext-types/sub-lib/tests/test_generated_bindings.rs
+++ b/fixtures/ext-types/sub-lib/tests/test_generated_bindings.rs
@@ -1,0 +1,5 @@
+uniffi::build_foreign_language_testcases!(
+    "tests/bindings/test_use_external_crate.swift",
+    "tests/bindings/test_use_trait_native_impl.swift",
+    "tests/bindings/test_use_trait_rust_impl.swift"
+);

--- a/fixtures/ext-types/uniffi-one/Cargo.toml
+++ b/fixtures/ext-types/uniffi-one/Cargo.toml
@@ -12,6 +12,7 @@ name = "uniffi_one"
 
 [dependencies]
 anyhow = "1"
+async-trait = "0.1"
 bytes = "1.3"
 uniffi = { workspace = true }
 

--- a/fixtures/ext-types/uniffi-one/src/lib.rs
+++ b/fixtures/ext-types/uniffi-one/src/lib.rs
@@ -49,4 +49,10 @@ pub trait UniffiOneUDLTrait: Send + Sync {
     fn hello(&self) -> String;
 }
 
+#[uniffi::export(with_foreign)]
+#[async_trait::async_trait]
+pub trait UniffiOneAsyncTrait: Send + Sync {
+    async fn hello_async(&self) -> String;
+}
+
 uniffi::include_scaffolding!("uniffi-one");


### PR DESCRIPTION
I don't want to add failing test cases to the repo. To avoid blocking development and/or CI, the new test cases passes when running `cargo test`, but fails when adding a specific env: `ISSUE_2342=1 cargo test`.

Here is an example to verify the tests locally:

```
// Pass
cargo test --package uniffi-fixture-ext-types-sub-lib

// Panic
ISSUE_2343=1 cargo test --package uniffi-fixture-ext-types-sub-lib
```

From the crash log:

```
thread 'thread '<unnamed><unnamed>' panicked at .../uniffi_core/src/ffi/foreigncallbacks.rs:32:18' panicked at :
.../uniffi_core/src/ffi/foreigncallbacks.rs:Foreign pointer not set.  This is likely a uniffi bug.32
```