### PR TITLE
Have the bindgen tool print the "debug" format of the error.

### DIFF
--- a/uniffi/src/cli/mod.rs
+++ b/uniffi/src/cli/mod.rs
@@ -7,14 +7,14 @@ mod uniffi_bindgen;
 
 pub fn uniffi_bindgen_main() {
     if let Err(e) = uniffi_bindgen::run_main() {
-        eprintln!("{e}");
+        eprintln!("{e:?}");
         std::process::exit(1);
     }
 }
 
 pub fn uniffi_bindgen_swift() {
     if let Err(e) = swift::run_main() {
-        eprintln!("{e}");
+        eprintln!("{e:?}");
         std::process::exit(1);
     }
 }

--- a/uniffi_bindgen/src/macro_metadata/extract.rs
+++ b/uniffi_bindgen/src/macro_metadata/extract.rs
@@ -215,7 +215,9 @@ impl ExtractedItems {
         // This works fine, because `MetadataReader` knows when the serialized data is terminated
         // and will just ignore the trailing data.
         let data = &file_data[offset..];
-        self.items.push(Metadata::read(data)?);
+        self.items.push(
+            Metadata::read(data).with_context(|| format!("extracting metadata for '{name}'"))?,
+        );
         self.names.insert(name.to_string());
         Ok(())
     }


### PR DESCRIPTION
Alternative would be ":#" which is more concise, but will not give us tracebacks, and is the default if you return an Err from main()

Fixes #2324