### PR TITLE
Bindgen refactors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,14 +2067,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi_checksum_derive"
-version = "0.28.3"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "uniffi_core"
 version = "0.28.3"
 dependencies = [
@@ -2084,6 +2076,14 @@ dependencies = [
  "once_cell",
  "paste",
  "static_assertions",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.28.3"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2110,7 +2110,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "siphasher",
- "uniffi_checksum_derive",
+ "uniffi_internal_macros",
 ]
 
 [[package]]

--- a/tools/publish-release.sh
+++ b/tools/publish-release.sh
@@ -23,7 +23,7 @@ done
 set -ex
 
 # Note: make sure these are ordered so that dependencies come before the crates that depend on them
-cargo publish -p uniffi_checksum_derive
+cargo publish -p uniffi_internal_macros
 cargo publish -p uniffi_meta
 cargo publish -p uniffi_core
 cargo publish -p uniffi_testing

--- a/uniffi_internal_macros/Cargo.toml
+++ b/uniffi_internal_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "uniffi_checksum_derive"
+name = "uniffi_internal_macros"
 version = "0.28.3"
-description = "a multi-language bindings generator for rust (checksum custom derive)"
+description = "a multi-language bindings generator for rust (interal macro crate)"
 documentation = "https://mozilla.github.io/uniffi-rs"
 homepage = "https://mozilla.github.io/uniffi-rs"
 repository = "https://github.com/mozilla/uniffi-rs"

--- a/uniffi_internal_macros/src/lib.rs
+++ b/uniffi_internal_macros/src/lib.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-//! Custom derive for uniffi_meta::Checksum
-
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
@@ -23,6 +21,7 @@ fn has_ignore_attribute(attrs: &[Attribute]) -> bool {
     })
 }
 
+/// Custom derive for uniffi_meta::Checksum
 #[proc_macro_derive(Checksum, attributes(checksum_ignore))]
 pub fn checksum_derive(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input);

--- a/uniffi_meta/Cargo.toml
+++ b/uniffi_meta/Cargo.toml
@@ -13,4 +13,4 @@ readme = "../README.md"
 anyhow = "1"
 bytes = "1.3"
 siphasher = "0.3"
-uniffi_checksum_derive = { version = "0.28.3", path = "../uniffi_checksum_derive" }
+uniffi_internal_macros = { version = "0.28.3", path = "../uniffi_internal_macros" }

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::{collections::BTreeMap, hash::Hasher};
-pub use uniffi_checksum_derive::Checksum;
+pub use uniffi_internal_macros::Checksum;
 
 mod ffi_names;
 pub use ffi_names::*;


### PR DESCRIPTION
Added `Enum::variant_discr_iter` and use that to implement `variant_discr`. This provides a simple and efficient way for other code to get a Vec of discriminants.

Renamed `uniffi_checksum_derive` -> `uniffi_internal_macros`.  This way we can use the same crate for future internal macros.

This is prep work for the bindings IR patch I'm hoping to land.