### PR TITLE
Initialize VTables for external types (#2343)

### DIFF
--- a/fixtures/ext-types/lib/src/lib.rs
+++ b/fixtures/ext-types/lib/src/lib.rs
@@ -181,6 +181,11 @@ fn get_uniffi_one_trait(t: Option<Arc<dyn UniffiOneTrait>>) -> Option<Arc<dyn Un
     t
 }
 
+#[uniffi::export]
+fn invoke_uniffi_one_trait(t: Arc<dyn UniffiOneTrait>) -> String {
+    t.hello()
+}
+
 fn get_uniffi_one_proc_macro_type(t: UniffiOneProcMacroType) -> UniffiOneProcMacroType {
     t
 }

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.kts
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.kts
@@ -7,6 +7,16 @@ import uniffi.imported_types_sublib.*
 import uniffi.uniffi_one_ns.*
 import uniffi.ext_types_custom.*
 
+// First step: implement a trait from an external crate in Kotlin and pass it to a function from this
+// crate.  This tests #2343 -- the codegen for this module needs to initialize the vtable from
+// uniffi_one.
+class KtUniffiOneImpl: UniffiOneTrait {
+    override fun hello(): String {
+        return "Hello from Kotlin"
+    }
+}
+assert(invokeUniffiOneTrait(KtUniffiOneImpl()) == "Hello from Kotlin")
+
 val ct = getCombinedType(null)
 assert(ct.uot.sval == "hello")
 assert(ct.guid ==  "a-guid")

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.py
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.py
@@ -9,6 +9,21 @@ from imported_types_sublib import *
 from uniffi_one_ns import *
 from ext_types_custom import *
 
+def test_external_callback_interface_impl():
+    """
+    Implement a trait from an external crate in Python and pass it to a function from this
+    crate.  This tests #2343 -- the codegen for this module needs to initialize the vtable from
+    uniffi_one.
+
+    This is written as a plain function rather than a unittest, because it
+    needs to run first before there's any chance of a `uniffi_one` funciton
+    being called.
+    """
+    class PyUniffiOneImpl(UniffiOneTrait):
+        def hello(self):
+            return "Hello from Python"
+    assert(invoke_uniffi_one_trait(PyUniffiOneImpl()) == "Hello from Python")
+
 class TestIt(unittest.TestCase):
     def test_it(self):
         ct = get_combined_type(None)
@@ -83,4 +98,5 @@ class TestIt(unittest.TestCase):
         self.assertEqual(get_nested_external_ouid(None), "nested-external-ouid")
 
 if __name__=='__main__':
+    test_external_callback_interface_impl()
     unittest.main()

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.swift
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.swift
@@ -5,6 +5,16 @@
 import imported_types_lib
 import Foundation
 
+// First step: implement a trait from an external crate in Swift and pass it to a function from this
+// crate.  This tests #2343 -- the codegen for this module needs to initialize the vtable from
+// uniffi_one.
+final class SwiftUniffiOneImpl: UniffiOneTrait {
+    func hello() -> String {
+        "Hello from Swift"
+    }
+}
+assert(invokeUniffiOneTrait(t: SwiftUniffiOneImpl()) == "Hello from Swift")
+
 let ct = getCombinedType(value: nil)
 assert(ct.uot.sval == "hello")
 assert(ct.guid ==  "a-guid")

--- a/uniffi_bindgen/src/bindings/swift/templates/Async.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Async.swift
@@ -11,9 +11,9 @@ fileprivate func uniffiRustCallAsync<F, T>(
     liftFunc: (F) throws -> T,
     errorHandler: ((RustBuffer) throws -> Swift.Error)?
 ) async throws -> T {
-    // Make sure to call uniffiEnsureInitialized() since future creation doesn't have a
+    // Make sure to call the ensure init function since future creation doesn't have a
     // RustCallStatus param, so doesn't use makeRustCall()
-    uniffiEnsureInitialized()
+    {{ ensure_init_fn_name }}()
     let rustFuture = rustFutureFunc()
     defer {
         freeFunc(rustFuture)

--- a/uniffi_bindgen/src/bindings/swift/templates/Helpers.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Helpers.swift
@@ -67,7 +67,7 @@ private func makeRustCall<T, E: Swift.Error>(
     _ callback: (UnsafeMutablePointer<RustCallStatus>) -> T,
     errorHandler: ((RustBuffer) throws -> E)?
 ) throws -> T {
-    uniffiEnsureInitialized()
+    {{ ensure_init_fn_name }}()
     var callStatus = RustCallStatus.init()
     let returnedVal = callback(&callStatus)
     try uniffiCheckCallStatus(callStatus: callStatus, errorHandler: errorHandler)

--- a/uniffi_bindgen/src/bindings/swift/templates/wrapper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/wrapper.swift
@@ -62,7 +62,9 @@ private let initializationResult: InitializationResult = {
     return InitializationResult.ok
 }()
 
-private func uniffiEnsureInitialized() {
+// Make the ensure init function public so that other modules which have external type references to
+// our types can call it.
+public func {{ ensure_init_fn_name }}() {
     switch initializationResult {
     case .ok:
         break

--- a/uniffi_bindgen/src/interface/callbacks.rs
+++ b/uniffi_bindgen/src/interface/callbacks.rs
@@ -64,6 +64,10 @@ impl CallbackInterface {
         &self.name
     }
 
+    pub fn module_path(&self) -> &str {
+        &self.module_path
+    }
+
     pub fn methods(&self) -> Vec<&Method> {
         self.methods.iter().collect()
     }


### PR DESCRIPTION
Fixed a tricky case from Swift:  Because of it's C lineage, it doesn't have a way to run initialization code when the module is imported so instead it runs a one-time initialization function the first time a FFI call is run.  This system failed when external types were used before the external module ever made an FFI call.  I believe this is Swift only, but it might affect other C-like external bindings as well.

@crazytonyli thanks for the great test case for this, I shrunk it down to a mimimal test and added it to the existing fixture.  When I rebase your test suite on top of this and run it with `ISSUE_2343=1 cargo test --package uniffi-fixture-ext-types-sub-lib` it passes.   I don't think we need the all of the tests, but tell me if you think the other ones are still worth adding.