### PR TITLE
Remove a panic in add_type_definition and add error contexts so resul…

### DIFF
--- a/fixtures/uitests/tests/ui/trait_methods_unknown_trait.stderr
+++ b/fixtures/uitests/tests/ui/trait_methods_unknown_trait.stderr
@@ -1,4 +1,4 @@
-error: Failed to generate scaffolding from UDL file at ../../../../fixtures/uitests/src/trait_methods_unknown_trait.udl: Invalid trait name: PartialEq
+error: Failed to generate scaffolding from UDL file at ../../../../fixtures/uitests/src/trait_methods_unknown_trait.udl: parsing udl file ../../../../fixtures/uitests/src/trait_methods_unknown_trait.udl: Invalid trait name: PartialEq
  --> tests/ui/trait_methods_unknown_trait.rs:2:1
   |
 2 | uniffi_macros::generate_and_include_scaffolding!("../../../../fixtures/uitests/src/trait_methods_unknown_trait.udl");

--- a/fixtures/uitests/tests/ui/typedef_extern.stderr
+++ b/fixtures/uitests/tests/ui/typedef_extern.stderr
@@ -1,4 +1,4 @@
-error: Failed to generate scaffolding from UDL file at ../../../../fixtures/uitests/src/typedef_extern.udl: `typedef extern` is no longer supported.
+error: Failed to generate scaffolding from UDL file at ../../../../fixtures/uitests/src/typedef_extern.udl: parsing udl file ../../../../fixtures/uitests/src/typedef_extern.udl: `typedef extern` is no longer supported.
        You must replace `extern` with the type of the object:
        * "enum" for Enums.
        * "record", "dictionary" or "struct" for Records.

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -335,7 +335,8 @@ pub fn generate_component_scaffolding(
     out_dir_override: Option<&Utf8Path>,
     format_code: bool,
 ) -> Result<()> {
-    let component = parse_udl(udl_file, &crate_name_from_cargo_toml(udl_file)?)?;
+    let component = parse_udl(udl_file, &crate_name_from_cargo_toml(udl_file)?)
+        .with_context(|| format!("parsing udl file {udl_file}"))?;
     generate_component_scaffolding_inner(component, udl_file, out_dir_override, format_code)
 }
 
@@ -348,7 +349,8 @@ pub fn generate_component_scaffolding_for_crate(
     out_dir_override: Option<&Utf8Path>,
     format_code: bool,
 ) -> Result<()> {
-    let component = parse_udl(udl_file, crate_name)?;
+    let component =
+        parse_udl(udl_file, crate_name).with_context(|| format!("parsing udl file {udl_file}"))?;
     generate_component_scaffolding_inner(component, udl_file, out_dir_override, format_code)
 }
 
@@ -365,7 +367,7 @@ fn generate_component_scaffolding_inner(
     write!(f, "{}", RustScaffolding::new(&component, file_stem))
         .context("Failed to write output file")?;
     if format_code {
-        format_code_with_rustfmt(&out_path)?;
+        format_code_with_rustfmt(&out_path).context("formatting generated Rust code")?;
     }
     Ok(())
 }


### PR DESCRIPTION
…ting errors make sense.

With this patch, output from errors looks something like:
```
  Caused by:
      0: adding function Function { name: "get_maybe_url", module_path: "uniffi_ext_types_lib", is_async: false, arguments: [Argument { name: "url", type_: Optional { inner_type: Custom { module_path: "custom_types", name: "Url", builtin: None } }, by_ref: false, optional: false, default: None }], return_type: Some(Optional { inner_type: Custom { module_path: "custom_types", name: "Url", builtin: None } }), ffi_func: FfiFunction { name: "uniffi_uniffi_ext_types_lib_fn_func_get_maybe_url", is_async: false, arguments: [], return_type: None, has_rust_call_status_arg: true, is_object_free_function: false }, docstring: None, throws: None, checksum_fn_name: "uniffi_uniffi_ext_types_lib_checksum_func_get_maybe_url", checksum: None }
      1: adding type Optional { inner_type: Custom { module_path: "custom_types", name: "Url", builtin: None } }
      2: adding optional type Custom { module_path: "custom_types", name: "Url", builtin: None }
      3: Custom { module_path: "custom_types", name: "Url", builtin: None } must have a resolved builtin

```