### PR TITLE
Refactor group type converter

### DIFF
--- a/uniffi_bindgen/src/library_mode.rs
+++ b/uniffi_bindgen/src/library_mode.rs
@@ -24,7 +24,7 @@ use camino::Utf8Path;
 use std::{collections::HashMap, fs};
 use toml::value::Table as TomlTable;
 use uniffi_meta::{
-    create_metadata_groups, fixup_external_type, group_metadata, Metadata, MetadataGroup,
+    convert_external_metadata_item, create_metadata_groups, group_metadata, Metadata, MetadataGroup,
 };
 
 /// Generate foreign bindings
@@ -119,7 +119,7 @@ pub fn find_components(
             metadata_group.items = metadata_group
                 .items
                 .into_iter()
-                .map(|item| fixup_external_type(item, &metadata_groups))
+                .map(|item| convert_external_metadata_item(item, &metadata_groups))
                 // some items are both in UDL and library metadata. For many that's fine but
                 // uniffi-traits aren't trivial to compare meaning we end up with dupes.
                 // We filter out such problematic items here.

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -10,7 +10,7 @@ pub use ffi_names::*;
 
 mod group;
 pub use group::{
-    convert_external_type, create_metadata_groups, fixup_external_type, group_metadata,
+    convert_external_metadata_item, convert_external_type, create_metadata_groups, group_metadata,
     MetadataGroup,
 };
 

--- a/uniffi_udl/src/finder.rs
+++ b/uniffi_udl/src/finder.rs
@@ -194,7 +194,7 @@ impl TypeFinder for weedle::TypedefDefinition<'_> {
             }
         };
         // mangle external types - Type::External must die.
-        let ty = uniffi_meta::convert_external_type(ty, &types.module_path(), &|s| s.to_string());
+        let ty = uniffi_meta::convert_external_type(ty, &types.module_path());
         types.add_type_definition(self.identifier.0, ty)
     }
 }


### PR DESCRIPTION
This is a refactor of the group.rs converter/walker - it tries to split the "walking" from the "converting". It should have no functional changes, but should make it easier to perform different kinds of walking in the future.