### PR TITLE
Stop carrying the namespace around in ExternalFfiMetadata and Type.

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -295,7 +295,7 @@ impl<'a> KotlinWrapper<'a> {
         })
     }
 
-    pub fn initialization_fns(&self) -> Vec<String> {
+    pub fn initialization_fns(&self, ci: &ComponentInterface) -> Vec<String> {
         let init_fns = self
             .ci
             .iter_types()
@@ -314,11 +314,7 @@ impl<'a> KotlinWrapper<'a> {
                 if module_path == self.ci.crate_name() {
                     return None;
                 }
-                let namespace = if let Type::External { namespace, .. } = ty {
-                    Some(namespace.as_str())
-                } else {
-                    None
-                };
+                let namespace = Some(ci.namespace_for_module_path(module_path).unwrap());
                 Some((module_path, namespace))
             })
             .map(|(module_path, namespace)| {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ExternalTypeTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ExternalTypeTemplate.kt
@@ -1,3 +1,4 @@
+{%- let namespace = ci.namespace_for_module_path(module_path)? %}
 {%- let package_name=self.external_type_package_name(module_path, namespace) %}
 {%- let fully_qualified_type_name = "{}.{}"|format(package_name, name|class_name(ci)) %}
 {%- let fully_qualified_ffi_converter_name = "{}.FfiConverterType{}"|format(package_name, name) %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
@@ -117,7 +117,7 @@ internal interface UniffiLib : Library {
             val lib = loadIndirect<UniffiLib>(componentName)
             // No need to check the contract version and checksums, since 
             // we already did that with `IntegrityCheckingUniffiLib` above.
-            {% for fn in self.initialization_fns() -%}
+            {% for fn in self.initialization_fns(ci) -%}
             {{ fn }}
             {% endfor -%}
             // Loading of library with integrity check done.

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
@@ -131,7 +131,7 @@ object NoPointer
 {%- when Type::Custom { module_path, name, builtin } %}
 {% include "CustomTypeTemplate.kt" %}
 
-{%- when Type::External { module_path, name, namespace, .. } %}
+{%- when Type::External { module_path, name, .. } %}
 {% include "ExternalTypeTemplate.kt" %}
 
 {%- else %}

--- a/uniffi_bindgen/src/bindings/python/templates/ExternalTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ExternalTemplate.py
@@ -1,6 +1,7 @@
+{%- let namespace = ci.namespace_for_type(type_)? %}
 {%- let module = python_config.module_for_namespace(namespace) -%}
 
-# External type {{name}} is in namespace "{{namespace}}", crate {{module_path}}
+# External type {{ name }}: `from {{ module }} import {{ name }}`
 {%- let ffi_converter_name = "_UniffiConverterType{}"|format(name) %}
 {{ self.add_import_of(module, ffi_converter_name) }}
 {{ self.add_import_of(module, name) }} {#- import the type alias itself -#}

--- a/uniffi_bindgen/src/bindings/python/templates/Types.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Types.py
@@ -88,7 +88,7 @@
 {%- when Type::Custom { name, module_path, builtin } %}
 {%- include "CustomType.py" %}
 
-{%- when Type::External { name, module_path, namespace, .. } %}
+{%- when Type::External { name, .. } %}
 {%- include "ExternalTemplate.py" %}
 
 {%- else %}

--- a/uniffi_bindgen/src/interface/ffi.rs
+++ b/uniffi_bindgen/src/interface/ffi.rs
@@ -151,12 +151,10 @@ impl From<&Type> for FfiType {
                 name,
                 kind: ExternalKind::DataClass,
                 module_path,
-                namespace,
                 ..
             } => FfiType::RustBuffer(Some(ExternalFfiMetadata {
                 name: name.clone(),
                 module_path: module_path.clone(),
-                namespace: namespace.clone(),
             })),
             Type::Custom { builtin, .. } => FfiType::from(builtin.as_ref()),
         }
@@ -167,7 +165,6 @@ impl From<&Type> for FfiType {
 pub struct ExternalFfiMetadata {
     pub name: String,
     pub module_path: String,
-    pub namespace: String,
 }
 
 // Needed for rust scaffolding rinja template

--- a/uniffi_meta/src/types.rs
+++ b/uniffi_meta/src/types.rs
@@ -116,8 +116,6 @@ pub enum Type {
     External {
         module_path: String,
         name: String,
-        #[checksum_ignore] // The namespace is not known generating scaffolding.
-        namespace: String,
         kind: ExternalKind,
     },
     // Custom type on the scaffolding side


### PR DESCRIPTION
This is needed only by bindings and can be determined as they are generated. This makes truly external types easier to support.