### PR TITLE
Swift always calls the public versions of lift and lower for named types

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/gen_swift/external.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/external.rs
@@ -23,14 +23,4 @@ impl CodeType for ExternalCodeType {
     fn canonical_name(&self) -> String {
         format!("Type{}", self.name)
     }
-
-    // lower and lift need to call public function which were generated for
-    // the original types.
-    fn lower(&self) -> String {
-        format!("{}_lower", self.ffi_converter_name())
-    }
-
-    fn lift(&self) -> String {
-        format!("{}_lift", self.ffi_converter_name())
-    }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -55,27 +55,6 @@ trait CodeType: Debug {
         format!("FfiConverter{}", self.canonical_name())
     }
 
-    // XXX - the below should be removed and replace with the ffi_converter_name reference in the template.
-    /// An expression for lowering a value into something we can pass over the FFI.
-    fn lower(&self) -> String {
-        format!("{}.lower", self.ffi_converter_name())
-    }
-
-    /// An expression for writing a value into a byte buffer.
-    fn write(&self) -> String {
-        format!("{}.write", self.ffi_converter_name())
-    }
-
-    /// An expression for lifting a value from something we received over the FFI.
-    fn lift(&self) -> String {
-        format!("{}.lift", self.ffi_converter_name())
-    }
-
-    /// An expression for reading a value from a byte buffer.
-    fn read(&self) -> String {
-        format!("{}.read", self.ffi_converter_name())
-    }
-
     /// A list of imports that are needed if this type is in use.
     /// Classes are imported exactly once.
     fn imports(&self) -> Option<Vec<String>> {
@@ -700,20 +679,38 @@ pub mod filters {
         Ok(name)
     }
 
+    // To better support external types, we always call the "public" lift and lower functions for
+    // "named" types, regardless of whether they are being called from a type in the same crate
+    // (ie, a "local" type) or from a different crate (ie, an "external" type)
     pub fn lower_fn(as_type: &impl AsType) -> Result<String, rinja::Error> {
-        Ok(oracle().find(&as_type.as_type()).lower())
+        let ty = &as_type.as_type();
+        let ffi_converter_name = oracle().find(ty).ffi_converter_name();
+        Ok(match ty.name() {
+            Some(_) => format!("{}_lower", ffi_converter_name),
+            None => format!("{}.lower", ffi_converter_name),
+        })
     }
 
     pub fn write_fn(as_type: &impl AsType) -> Result<String, rinja::Error> {
-        Ok(oracle().find(&as_type.as_type()).write())
+        let ty = &as_type.as_type();
+        let ffi_converter_name = oracle().find(ty).ffi_converter_name();
+        Ok(format!("{}.write", ffi_converter_name))
     }
 
+    // See above re lower_fn - we always use the public version for named types.
     pub fn lift_fn(as_type: &impl AsType) -> Result<String, rinja::Error> {
-        Ok(oracle().find(&as_type.as_type()).lift())
+        let ty = &as_type.as_type();
+        let ffi_converter_name = oracle().find(ty).ffi_converter_name();
+        Ok(match ty.name() {
+            Some(_) => format!("{}_lift", ffi_converter_name),
+            None => format!("{}.lift", ffi_converter_name),
+        })
     }
 
     pub fn read_fn(as_type: &impl AsType) -> Result<String, rinja::Error> {
-        Ok(oracle().find(&as_type.as_type()).read())
+        let ty = &as_type.as_type();
+        let ffi_converter_name = oracle().find(ty).ffi_converter_name();
+        Ok(format!("{}.read", ffi_converter_name))
     }
 
     pub fn literal_swift(literal: &Literal, as_type: &impl AsType) -> Result<String, rinja::Error> {

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
@@ -55,3 +55,21 @@ extension {{ ffi_converter_name }} : FfiConverter {
         writeInt(&buf, lower(v))
     }
 }
+
+{#
+We always write these public functions just in case the callback is used as
+an external type by another crate.
+#}
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func {{ ffi_converter_name }}_lift(_ handle: UInt64) throws -> {{ type_name }} {
+    return try {{ ffi_converter_name }}.lift(handle)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func {{ ffi_converter_name }}_lower(_ v: {{ type_name }}) -> UInt64 {
+    return {{ ffi_converter_name }}.lower(v)
+}

--- a/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
@@ -87,6 +87,24 @@ public struct {{ ffi_converter_name }}: FfiConverterRustBuffer {
     }
 }
 
+{#
+We always write these public functions just in case the error is used as
+an external type by another crate.
+#}
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func {{ ffi_converter_name }}_lift(_ buf: RustBuffer) throws -> {{ type_name }} {
+    return try {{ ffi_converter_name }}.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> RustBuffer {
+    return {{ ffi_converter_name }}.lower(value)
+}
+
 {% if !contains_object_references %}
 extension {{ type_name }}: Equatable, Hashable {}
 {% endif %}

--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -211,7 +211,7 @@ public struct {{ ffi_converter_name }}__as_error: FfiConverterRustBuffer {
 {%- endif %}
 
 {#
-We always write these public functions just in case the enum is used as
+We always write these public functions just in case the object is used as
 an external type by another crate.
 #}
 #if swift(>=5.8)


### PR DESCRIPTION
This means the calls are identical for internal and external types. Also writes the public functions for error types, which was the only named type without this support.