### PR TITLE
CustomTypes are no longer turned into ExternalTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ or use UDL with types from more than one crate.
 
 - Added the `FfiType::MutReference` variant.
 
+- `Type::Custom` is no longer turned in to a `Type::External` for the bindings. Binding authors
+  must check the type is local themselves before deciding to treat it as a local or external type.
+  We expect `Type::External` will be removed soon and all types will be treated in this way.
+
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.28.3...HEAD).
 
 ## v0.28.3 (backend crates: v0.28.3) - (_2024-11-08_)

--- a/fixtures/ext-types/custom-types/src/lib.rs
+++ b/fixtures/ext-types/custom-types/src/lib.rs
@@ -61,6 +61,15 @@ pub fn get_ouid(ouid: Option<Ouid>) -> Ouid {
     ouid.unwrap_or_else(|| Ouid("Ouid".to_string()))
 }
 
+// A custom-type wrapping a simple ffitype which is also consumed as an external type (#2025)
+pub struct HandleU8(pub u8);
+uniffi::custom_newtype!(HandleU8, u8);
+
+#[uniffi::export]
+pub fn get_handle_u8(h: Option<HandleU8>) -> HandleU8 {
+    h.unwrap_or(HandleU8(2))
+}
+
 pub struct GuidHelper {
     pub guid: Guid,
     pub guids: Vec<Guid>,

--- a/fixtures/ext-types/custom-types/tests/bindings/test_guid.py
+++ b/fixtures/ext-types/custom-types/tests/bindings/test_guid.py
@@ -56,6 +56,7 @@ class TestGuid(unittest.TestCase):
         self.assertEqual(test_callback.saw_guid, "callback-test-payload")
 
     def test_custom(self):
+        self.assertEqual(get_handle_u8(None), 2)
         get_nested_object(InnerObject())
 
 if __name__=='__main__':

--- a/fixtures/ext-types/lib/src/lib.rs
+++ b/fixtures/ext-types/lib/src/lib.rs
@@ -1,5 +1,5 @@
 use custom_types::Handle;
-use ext_types_custom::{ANestedGuid, Guid, Ouid};
+use ext_types_custom::{ANestedGuid, Guid, HandleU8, Ouid};
 use ext_types_external_crate::{
     ExternalCrateDictionary, ExternalCrateInterface, ExternalCrateNonExhaustiveEnum,
 };
@@ -108,6 +108,11 @@ fn get_imported_guid(guid: Guid) -> Guid {
 #[uniffi::export]
 fn get_imported_ouid(ouid: Ouid) -> Ouid {
     ouid
+}
+
+#[uniffi::export]
+fn get_imported_handle_u8(h: Option<HandleU8>) -> HandleU8 {
+    h.unwrap_or(HandleU8(3))
 }
 
 // external custom types wrapping external custom types.

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.kts
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.kts
@@ -43,6 +43,7 @@ assert(getGuid("guid") == "guid")
 assert(getOuid("ouid") == "ouid")
 //assert(getImportedGuid("guid") == "guid")
 assert(getImportedOuid("ouid") == "ouid")
+assert(getImportedHandleU8(null) == 3u.toUByte())
 
 val uot = UniffiOneType("hello")
 assert(getUniffiOneType(uot) == uot)

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.py
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.py
@@ -61,6 +61,7 @@ class TestIt(unittest.TestCase):
         self.assertEqual(get_ouid("ouid"), "ouid")
         self.assertEqual(get_ouid("uuid"), "uuid")
         self.assertEqual(get_nested_guid("uuid"), "uuid")
+        self.assertEqual(get_imported_handle_u8(None), 3)
 
     def test_get_uniffi_one_type(self):
         t1 = UniffiOneType(sval="hello")

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.swift
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.swift
@@ -46,6 +46,7 @@ assert(getImportedOuid(ouid: "ouid") ==  "ouid")
 assert(getNestedOuid(nouid: "ouid") ==  "ouid")
 assert(getImportedNestedGuid(guid: nil) == "nested")
 assert(getNestedExternalOuid(ouid: nil) == "nested-external-ouid")
+assert(getImportedHandleU8(h: nil) == 3)
 
 assert(getUniffiOneType(t: UniffiOneType(sval: "hello")).sval == "hello")
 assert(getMaybeUniffiOneType(t: UniffiOneType(sval: "hello"))!.sval == "hello")

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceImpl.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceImpl.kt
@@ -8,14 +8,14 @@ internal object {{ trait_impl }} {
     internal object {{ meth.name()|var_name }}: {{ ffi_callback.name()|ffi_callback_name }} {
         override fun callback(
             {%- for arg in ffi_callback.arguments() -%}
-            {{ arg.name().borrow()|var_name }}: {{ arg.type_().borrow()|ffi_type_name_by_value }},
+            {{ arg.name().borrow()|var_name }}: {{ arg.type_().borrow()|ffi_type_name_by_value(ci) }},
             {%- endfor -%}
             {%- if ffi_callback.has_rust_call_status_arg() -%}
             uniffiCallStatus: UniffiRustCallStatus,
             {%- endif -%}
         )
         {%- if let Some(return_type) = ffi_callback.return_type() %}
-            : {{ return_type|ffi_type_name_by_value }},
+            : {{ return_type|ffi_type_name_by_value(ci) }},
         {%- endif %} {
             val uniffiObj = {{ ffi_converter_name }}.handleMap.get(uniffiHandle)
             val makeCall = {% if meth.is_async() %}suspend {% endif %}{ ->
@@ -97,7 +97,7 @@ internal object {{ trait_impl }} {
         }
     }
 
-    internal var vtable = {{ vtable|ffi_type_name_by_value }}(
+    internal var vtable = {{ vtable|ffi_type_name_by_value(ci) }}(
         {%- for (ffi_callback, meth) in vtable_methods.iter() %}
         {{ meth.name()|var_name() }},
         {%- endfor %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CustomTypeTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CustomTypeTemplate.kt
@@ -11,7 +11,7 @@ public typealias {{ ffi_converter_name }} = {{ builtin|ffi_converter_name }}
 
 {%- when Some(config) %}
 
-{%- let ffi_type_name=builtin|ffi_type|ref|ffi_type_name_by_value %}
+{%- let ffi_type_name=builtin|ffi_type|ref|ffi_type_name_by_value(ci) %}
 
 {# When the config specifies a different type name, create a typealias for it #}
 {%- match config.type_name %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
@@ -20,26 +20,26 @@ private inline fun <reified Lib : Library> loadIndirect(
 internal interface {{ callback.name()|ffi_callback_name }} : com.sun.jna.Callback {
     fun callback(
         {%- for arg in callback.arguments() -%}
-        {{ arg.name().borrow()|var_name }}: {{ arg.type_().borrow()|ffi_type_name_by_value }},
+        {{ arg.name().borrow()|var_name }}: {{ arg.type_().borrow()|ffi_type_name_by_value(ci) }},
         {%- endfor -%}
         {%- if callback.has_rust_call_status_arg() -%}
         uniffiCallStatus: UniffiRustCallStatus,
         {%- endif -%}
     )
     {%- if let Some(return_type) = callback.return_type() %}
-    : {{ return_type|ffi_type_name_by_value }}
+    : {{ return_type|ffi_type_name_by_value(ci) }}
     {%- endif %}
 }
 {%- when FfiDefinition::Struct(ffi_struct) %}
 @Structure.FieldOrder({% for field in ffi_struct.fields() %}"{{ field.name()|var_name_raw }}"{% if !loop.last %}, {% endif %}{% endfor %})
 internal open class {{ ffi_struct.name()|ffi_struct_name }}(
     {%- for field in ffi_struct.fields() %}
-    @JvmField internal var {{ field.name()|var_name }}: {{ field.type_().borrow()|ffi_type_name_for_ffi_struct }} = {{ field.type_()|ffi_default_value }},
+    @JvmField internal var {{ field.name()|var_name }}: {{ field.type_().borrow()|ffi_type_name_for_ffi_struct(ci) }} = {{ field.type_()|ffi_default_value }},
     {%- endfor %}
 ) : Structure() {
     class UniffiByValue(
         {%- for field in ffi_struct.fields() %}
-        {{ field.name()|var_name }}: {{ field.type_().borrow()|ffi_type_name_for_ffi_struct }} = {{ field.type_()|ffi_default_value }},
+        {{ field.name()|var_name }}: {{ field.type_().borrow()|ffi_type_name_for_ffi_struct(ci) }} = {{ field.type_()|ffi_default_value }},
         {%- endfor %}
     ): {{ ffi_struct.name()|ffi_struct_name }}({%- for field in ffi_struct.fields() %}{{ field.name()|var_name }}, {%- endfor %}), Structure.ByValue
 
@@ -60,7 +60,7 @@ internal open class {{ ffi_struct.name()|ffi_struct_name }}(
 {% for func in func_list -%}
 fun {{ func.name() }}(
     {%- call kt::arg_list_ffi_decl(func) %}
-): {% match func.return_type() %}{% when Some with (return_type) %}{{ return_type.borrow()|ffi_type_name_by_value }}{% when None %}Unit{% endmatch %}
+): {% match func.return_type() %}{% when Some with (return_type) %}{{ return_type.borrow()|ffi_type_name_by_value(ci) }}{% when None %}Unit{% endmatch %}
 {% endfor %}
 {%- endmacro %}
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
@@ -129,7 +129,11 @@ object NoPointer
 {% include "DurationHelper.kt" %}
 
 {%- when Type::Custom { module_path, name, builtin } %}
+{%- if ci.is_external(type_) %}
+{% include "ExternalTypeTemplate.kt" %}
+{%- else %}
 {% include "CustomTypeTemplate.kt" %}
+{%- endif %}
 
 {%- when Type::External { module_path, name, .. } %}
 {% include "ExternalTypeTemplate.kt" %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -119,7 +119,7 @@
 -#}
 {%- macro arg_list_ffi_decl(func) %}
     {%- for arg in func.arguments() %}
-        {{- arg.name()|var_name }}: {{ arg.type_().borrow()|ffi_type_name_by_value -}},
+        {{- arg.name()|var_name }}: {{ arg.type_().borrow()|ffi_type_name_by_value(ci) -}},
     {%- endfor %}
     {%- if func.has_rust_call_status_arg() %}uniffi_out_err: UniffiRustCallStatus, {% endif %}
 {%- endmacro -%}

--- a/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceImpl.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceImpl.py
@@ -85,7 +85,7 @@ class {{ trait_impl }}:
         {{ ffi_converter_name }}._handle_map.remove(uniffi_handle)
 
     # Generate the FFI VTable.  This has a field for each callback interface method.
-    _uniffi_vtable = {{ vtable|ffi_type_name }}(
+    _uniffi_vtable = {{ vtable|ffi_type_name(ci) }}(
         {%- for (_, meth) in vtable_methods.iter() %}
         {{ meth.name() }},
         {%- endfor %}

--- a/uniffi_bindgen/src/bindings/python/templates/NamespaceLibraryTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/NamespaceLibraryTemplate.py
@@ -62,11 +62,11 @@ _UniffiLib = _uniffi_load_indirect()
 {%- when FfiDefinition::CallbackFunction(callback) %}
 {{ callback.name()|ffi_callback_name }} = ctypes.CFUNCTYPE(
     {%- match callback.return_type() %}
-    {%- when Some(return_type) %}{{ return_type|ffi_type_name }},
+    {%- when Some(return_type) %}{{ return_type|ffi_type_name(ci) }},
     {%- when None %}None,
     {%- endmatch %}
     {%- for arg in callback.arguments() -%}
-    {{ arg.type_().borrow()|ffi_type_name }},
+    {{ arg.type_().borrow()|ffi_type_name(ci) }},
     {%- endfor -%}
     {%- if callback.has_rust_call_status_arg() %}
     ctypes.POINTER(_UniffiRustCallStatus),
@@ -76,14 +76,14 @@ _UniffiLib = _uniffi_load_indirect()
 class {{ ffi_struct.name()|ffi_struct_name }}(ctypes.Structure):
     _fields_ = [
         {%- for field in ffi_struct.fields() %}
-        ("{{ field.name() }}", {{ field.type_().borrow()|ffi_type_name }}),
+        ("{{ field.name() }}", {{ field.type_().borrow()|ffi_type_name(ci) }}),
         {%- endfor %}
     ]
 {%- when FfiDefinition::Function(func) %}
 _UniffiLib.{{ func.name() }}.argtypes = (
     {%- call py::arg_list_ffi_decl(func) -%}
 )
-_UniffiLib.{{ func.name() }}.restype = {% match func.return_type() %}{% when Some(type_) %}{{ type_|ffi_type_name }}{% when None %}None{% endmatch %}
+_UniffiLib.{{ func.name() }}.restype = {% match func.return_type() %}{% when Some(type_) %}{{ type_|ffi_type_name(ci) }}{% when None %}None{% endmatch %}
 {%- endmatch %}
 {%- endfor %}
 

--- a/uniffi_bindgen/src/bindings/python/templates/Types.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Types.py
@@ -86,7 +86,11 @@
 {%- include "CallbackInterfaceTemplate.py" %}
 
 {%- when Type::Custom { name, module_path, builtin } %}
+{%- if ci.is_external(type_) %}
+{%- include "ExternalTemplate.py" %}
+{%- else %}
 {%- include "CustomType.py" %}
+{%- endif %}
 
 {%- when Type::External { name, .. } %}
 {%- include "ExternalTemplate.py" %}

--- a/uniffi_bindgen/src/bindings/python/templates/macros.py
+++ b/uniffi_bindgen/src/bindings/python/templates/macros.py
@@ -72,7 +72,7 @@ _uniffi_rust_call(
 -#}
 {%- macro arg_list_ffi_decl(func) %}
     {%- for arg in func.arguments() %}
-    {{ arg.type_().borrow()|ffi_type_name }},
+    {{ arg.type_().borrow()|ffi_type_name(ci) }},
     {%- endfor %}
     {%- if func.has_rust_call_status_arg() %}
     ctypes.POINTER(_UniffiRustCallStatus),{% endif %}

--- a/uniffi_bindgen/src/bindings/swift/templates/Types.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Types.swift
@@ -65,7 +65,9 @@
 {%- include "CallbackInterfaceTemplate.swift" %}
 
 {%- when Type::Custom { name, module_path, builtin } %}
+{%- if !ci.is_external(type_) %}
 {%- include "CustomType.swift" %}
+{%- endif %}
 
 {%- when Type::Enum { name, module_path } %}
 {%- let e = ci.get_enum_definition(name).unwrap() %}

--- a/uniffi_bindgen/src/interface/ffi.rs
+++ b/uniffi_bindgen/src/interface/ffi.rs
@@ -156,7 +156,24 @@ impl From<&Type> for FfiType {
                 name: name.clone(),
                 module_path: module_path.clone(),
             })),
-            Type::Custom { builtin, .. } => FfiType::from(builtin.as_ref()),
+            Type::Custom {
+                builtin,
+                name,
+                module_path,
+                ..
+            } => {
+                // We need ffitype of the builtin.
+                match FfiType::from(builtin.as_ref()) {
+                    // and if that builtin was a "local" RustBuffer, we need to
+                    // let emit enough metadata so the bindings can call the rustbuffer impl
+                    // if necessary.
+                    FfiType::RustBuffer(None) => FfiType::RustBuffer(Some(ExternalFfiMetadata {
+                        name: name.clone(),
+                        module_path: module_path.clone(),
+                    })),
+                    t => t,
+                }
+            }
         }
     }
 }

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -330,6 +330,10 @@ impl ComponentInterface {
         self.types.iter_known_types()
     }
 
+    pub fn is_external(&self, t: &Type) -> bool {
+        self.types.is_external(t)
+    }
+
     /// Get a specific type
     pub fn get_type(&self, name: &str) -> Option<Type> {
         self.types.get_type_definition(name)

--- a/uniffi_bindgen/src/interface/universe.rs
+++ b/uniffi_bindgen/src/interface/universe.rs
@@ -91,6 +91,12 @@ impl TypeUniverse {
         Ok(())
     }
 
+    pub fn is_external(&self, t: &Type) -> bool {
+        t.module_path()
+            .map(|p| p != self.namespace.crate_name)
+            .unwrap_or(false)
+    }
+
     #[cfg(test)]
     /// Check if a [Type] is present
     pub fn contains(&self, type_: &Type) -> bool {

--- a/uniffi_meta/src/group.rs
+++ b/uniffi_meta/src/group.rs
@@ -96,15 +96,15 @@ fn do_external_type_conversion(ty: Type, owner_module_path: &str) -> Type {
 
     match ty {
         // Convert `ty` if it's external
-        Type::Enum { module_path, name }
-        | Type::Record { module_path, name }
-        | Type::Custom {
-            module_path, name, ..
-        } if is_external(&module_path) => Type::External {
-            module_path,
-            name,
-            kind: ExternalKind::DataClass,
-        },
+        Type::Enum { module_path, name } | Type::Record { module_path, name }
+            if is_external(&module_path) =>
+        {
+            Type::External {
+                module_path,
+                name,
+                kind: ExternalKind::DataClass,
+            }
+        }
         Type::Object {
             module_path,
             name,


### PR DESCRIPTION
The bindings all work when the Type::Custom has a different module_path and external bindings will need to do the same.

Fixes #2025

(There's no urgency at all with this, just wanted to get it up as I was happy to see how close things are getting to killing `Type::External`!)