### PR TITLE
Remove uniffi::generate_component_scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ or use UDL with types from more than one crate.
 - Various `use_udl_*`/`use_remote_type` etc macros have been removed.
 
 [Detailed upgrade notes](https://mozilla.github.io/uniffi-rs/next/Upgrading.html)
+
+- `uniffi::generate_component_scaffolding` has been removed. It's almost certainly unused as it is
+  behind the wrong feature and undocumented. `uniffi::generate_scaffolding` does exacly the same thing and is
+  correctly behind the `build` feature.
+
 ### What's new?
 
 - Kotlin and Swift: Proc-macros exporting an `impl Trait for Struct` block now has a class inheritance

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -33,7 +33,7 @@ ffi-trace = ["uniffi_core/ffi-trace", "uniffi_bindgen?/ffi-trace"]
 # Support for features needed by the `build.rs` script. Enable this in your
 # `build-dependencies`.
 build = [ "dep:uniffi_build" ]
-# Support for `uniffi_bindgen::{generate_bindings, generate_component_scaffolding}`.
+# Support for `uniffi_bindgen::generate_bindings`.
 # Enable this feature for your `uniffi-bindgen` binaries if you don't need the full CLI.
 bindgen = ["dep:uniffi_bindgen"]
 cargo-metadata = ["dep:cargo_metadata", "uniffi_bindgen?/cargo-metadata"]

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -19,8 +19,7 @@ pub use uniffi_bindgen::{
     bindings::{
         KotlinBindingGenerator, PythonBindingGenerator, RubyBindingGenerator, SwiftBindingGenerator,
     },
-    generate_bindings, generate_component_scaffolding, generate_component_scaffolding_for_crate,
-    print_repr,
+    generate_bindings, print_repr,
 };
 #[cfg(feature = "build")]
 pub use uniffi_build::{generate_scaffolding, generate_scaffolding_for_crate};

--- a/uniffi_build/src/lib.rs
+++ b/uniffi_build/src/lib.rs
@@ -39,9 +39,6 @@ pub fn generate_scaffolding_for_crate(
     // The UNIFFI_TESTS_DISABLE_EXTENSIONS variable disables some bindings, but it is evaluated
     // at *build* time, so we need to rebuild when it changes.
     println!("cargo:rerun-if-env-changed=UNIFFI_TESTS_DISABLE_EXTENSIONS");
-    // Why don't we just depend on uniffi-bindgen and call the public functions?
-    // Calling the command line helps making sure that the generated swift/Kotlin/whatever
-    // bindings were generated with the same version of uniffi as the Rust scaffolding code.
     let out_dir = env::var("OUT_DIR").context("$OUT_DIR missing?!")?;
     uniffi_bindgen::generate_component_scaffolding_for_crate(
         udl_file,


### PR DESCRIPTION
It's a direct re-export of uniffi_bindgen::generate_component_scaffolding and behind the 'bindgen' feature. For this reason it's not actually used in build scripts - they use 'uniffi::generate_scaffolding' which is correctly behind the 'build' feature.

We can't commit the "bindgen" feature to generating scaffolding, and it's kinda confusing, so let's kill it.