### PR TITLE
Fixup lifetimes in Callable/ResultType

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -581,7 +581,7 @@ fn can_render_callable(callable: &dyn Callable, ci: &ComponentInterface) -> bool
     // can't handle external errors.
     callable
         .throws_type()
-        .map(|t| !ci.is_external(&t))
+        .map(|t| !ci.is_external(t))
         .unwrap_or(true)
 }
 
@@ -749,7 +749,7 @@ mod filters {
         let call = format!("UniffiLib.INSTANCE.{ffi_func}(future, continuation)");
         // May need to convert the RustBuffer from our package to the RustBuffer of the external package
         let call = match callable.return_type() {
-            Some(return_type) if ci.is_external(&return_type) => {
+            Some(return_type) if ci.is_external(return_type) => {
                 let ffi_type = FfiType::from(return_type);
                 match ffi_type {
                     FfiType::RustBuffer(Some(ExternalFfiMetadata { name, .. })) => {

--- a/uniffi_bindgen/src/interface/callbacks.rs
+++ b/uniffi_bindgen/src/interface/callbacks.rs
@@ -40,7 +40,7 @@ use uniffi_meta::Checksum;
 
 use super::ffi::{FfiArgument, FfiCallbackFunction, FfiField, FfiFunction, FfiStruct, FfiType};
 use super::object::Method;
-use super::{AsType, Type, TypeIterator};
+use super::{AsType, Callable, Type, TypeIterator};
 
 #[derive(Debug, Clone, Checksum)]
 pub struct CallbackInterface {

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -603,7 +603,7 @@ impl ComponentInterface {
     }
 
     /// Iterate over return/throws types for async functions
-    pub fn iter_async_result_types(&self) -> impl Iterator<Item = ResultType> {
+    pub fn iter_async_result_types(&self) -> impl Iterator<Item = ResultType<'_>> {
         let unique_results = self
             .iter_callables()
             .map(|c| c.result_type())


### PR DESCRIPTION
Changing `return_type` and `throws_type` to be references is more consistent and allows the trait to implement `iter_types`.

I came across this recently and thought I'd have a poke and it turned out to be easier than I thought.
