### PR TITLE
Add config option to omit the checking of library checksums.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ or use UDL with types from more than one crate.
 
 - Proc-macros now allow Enums to hold objects (#1372)
 
+- Swift and Kotlin make it possible to opt-out of the runtime checksum integrity tests done as the library is initialized.
+  Opting out will shoot yourself in the foot if you mixup your build pipeline in any way, but might speed the initialization.
+  (Python apparently hasn't made these checks for some time, so no changes there!)
+
 ### What's changed?
 
 - Switching jinja template engine from askama to rinja.

--- a/docs/manual/src/kotlin/configuration.md
+++ b/docs/manual/src/kotlin/configuration.md
@@ -14,6 +14,7 @@ The generated Kotlin modules can be configured using a `uniffi.toml` configurati
 | `android`                    | `false`                  | Used to toggle on Android specific optimizations
 | `android_cleaner`            | `android`                | Use the [`android.system.SystemCleaner`](https://developer.android.com/reference/android/system/SystemCleaner) instead of [`java.lang.ref.Cleaner`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/ref/Cleaner.html). Fallback in both instances is the one shipped with JNA.
 | `kotlin_target_version`      | `"x.y.z"`                | When provided, it will enable features in the bindings supported for this version. The build process will fail if an invalid format is used.
+| `omit_checksums`             | `false`                  | Whether to omit checking the library checksums as the library is initialized. Changing this will shoot yourself in the foot if you mixup your build pipeline in any way, but might speed up initialization.
 
 ## Example
 

--- a/docs/manual/src/swift/configuration.md
+++ b/docs/manual/src/swift/configuration.md
@@ -18,6 +18,7 @@ more likely to change than other configurations.
 | `generate_immutable_records`       | `false`                  | Whether to generate records with immutable fields (`let` instead of `var`).                                                                                          |
 | `custom_types`                     |                          | A map which controls how custom types are exposed to Swift. See the [custom types section of the manual](../types/custom_types.md#custom-types-in-the-bindings-code) |
 | `omit_localized_error_conformance` | `false`                  | Whether to make generated error types conform to `LocalizedError`.                                                                                                   |
+| `omit_checksums`                   | `false`                  | Whether to omit checking the library checksums as the library is initialized. Changing this will shoot yourself in the foot if you mixup your build pipeline in any way, but might speed up initialization.
 
 [^1]: `namespace` is the top-level namespace from your UDL file.
 

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -73,6 +73,8 @@ pub struct Config {
     pub(super) cdylib_name: Option<String>,
     generate_immutable_records: Option<bool>,
     #[serde(default)]
+    omit_checksums: bool,
+    #[serde(default)]
     custom_types: HashMap<String, CustomTypeConfig>,
     #[serde(default)]
     pub(super) external_packages: HashMap<String, String>,

--- a/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
@@ -102,11 +102,13 @@ internal interface UniffiLib : Library {
             // we allow for ~2x as many methods in the UniffiLib interface.
             // 
             // Thus we first load the library with `loadIndirect` as `IntegrityCheckingUniffiLib`
-            // so that we can call `uniffiCheckApiChecksums`...
+            // so that we can (optionally!) call `uniffiCheckApiChecksums`...
             loadIndirect<IntegrityCheckingUniffiLib>(componentName)
                 .also { lib: IntegrityCheckingUniffiLib ->
                     uniffiCheckContractApiVersion(lib)
+{%- if !config.omit_checksums %}
                     uniffiCheckApiChecksums(lib)
+{%- endif %}
                 }
             // ... and then we load the library as `UniffiLib`
             // N.B. we cannot use `loadIndirect` once and then try to cast it to `UniffiLib`
@@ -147,6 +149,7 @@ private fun uniffiCheckContractApiVersion(lib: IntegrityCheckingUniffiLib) {
     }
 }
 
+{%- if !config.omit_checksums %}
 @Suppress("UNUSED_PARAMETER")
 private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     {%- for (name, expected_checksum) in ci.iter_checksums() %}
@@ -155,6 +158,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     }
     {%- endfor %}
 }
+{%- endif %}
 
 /**
  * @suppress

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -172,6 +172,8 @@ pub struct Config {
     ffi_module_name: Option<String>,
     ffi_module_filename: Option<String>,
     generate_module_map: Option<bool>,
+    #[serde(default)]
+    omit_checksums: bool,
     omit_argument_labels: Option<bool>,
     generate_immutable_records: Option<bool>,
     omit_localized_error_conformance: Option<bool>,

--- a/uniffi_bindgen/src/bindings/swift/templates/wrapper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/wrapper.swift
@@ -49,11 +49,13 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.contractVersionMismatch
     }
 
+{%- if !config.omit_checksums %}
     {%- for (name, expected_checksum) in ci.iter_checksums() %}
     if ({{ name }}() != {{ expected_checksum }}) {
         return InitializationResult.apiChecksumMismatch
     }
     {%- endfor %}
+{%- endif %}
 
     {% for fn in self.initialization_fns() -%}
     {{ fn }}()


### PR DESCRIPTION
This code started showing up in profiles, so my motivation to get this in our next release went up.

Kinda hate "omit" (it seems a somewhat obscure word?) so open to all bikesheds. Started with "skip_checksums", but then saw "omit" in swift so reluctantly went for consistency there.

Doesn't always avoid generating the checksum functions, but does avoid calling them.

Fixes #2255

