### PR TITLE
core: reduce monomorphization of the futures code

### DIFF
--- a/uniffi_core/src/ffi/rustfuture/mod.rs
+++ b/uniffi_core/src/ffi/rustfuture/mod.rs
@@ -109,8 +109,8 @@ where
     // Needed to allocate a handle
     dyn RustFutureFfi<T::ReturnType>: HandleAlloc<UT>,
 {
-    let handle = <dyn RustFutureFfi<T::ReturnType> as HandleAlloc<UT>>::new_handle(
-        RustFuture::new(future, tag) as Arc<dyn RustFutureFfi<T::ReturnType>>,
+    let handle = HandleAlloc::new_handle(
+        RustFuture::new(Box::pin(future), tag) as Arc<dyn RustFutureFfi<T::ReturnType>>
     );
     trace!("rust_future_new: {handle:?}");
     handle

--- a/uniffi_core/src/ffi/rustfuture/tests.rs
+++ b/uniffi_core/src/ffi/rustfuture/tests.rs
@@ -78,7 +78,7 @@ fn channel() -> (Sender, Arc<dyn RustFutureFfi<RustBuffer>>) {
         result: None,
         waker: None,
     }));
-    let rust_future = RustFuture::new(Receiver(channel.clone()), crate::UniFfiTag);
+    let rust_future = RustFuture::new(Box::pin(Receiver(channel.clone())), crate::UniFfiTag);
     (Sender(channel), rust_future)
 }
 
@@ -246,7 +246,8 @@ fn test_wake_during_poll() {
             Poll::Ready(Ok("All done".to_owned()))
         }
     });
-    let rust_future: Arc<dyn RustFutureFfi<RustBuffer>> = RustFuture::new(future, crate::UniFfiTag);
+    let rust_future: Arc<dyn RustFutureFfi<RustBuffer>> =
+        RustFuture::new(Box::pin(future), crate::UniFfiTag);
     let continuation_result = poll(&rust_future);
     // The continuation function should called immediately
     assert_eq!(continuation_result.get(), Some(&RustFuturePoll::MaybeReady));


### PR DESCRIPTION
These changes will reduce the monomorphization of the futures code, resulting in a reduction of the binary size.

In my case, the binaries for android targets have become 100/200kb smaller.