### PR TITLE
Allow disabling java.lang.ref.Cleaner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ or use UDL with types from more than one crate.
 
 - External errors work for Swift and Python. Kotlin does not work - see #2392.
 
+- Added `disable_java_cleaner` option for kotlin to allow for Java 8 compatible code
+
 ### What's changed?
 
 - Switching jinja template engine from askama to rinja.

--- a/docs/manual/src/kotlin/configuration.md
+++ b/docs/manual/src/kotlin/configuration.md
@@ -14,7 +14,7 @@ The generated Kotlin modules can be configured using a `uniffi.toml` configurati
 | `android`                    | `false`                  | Used to toggle on Android specific optimizations
 | `android_cleaner`            | `android`                | Use the [`android.system.SystemCleaner`](https://developer.android.com/reference/android/system/SystemCleaner) instead of [`java.lang.ref.Cleaner`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/ref/Cleaner.html). Fallback in both instances is the one shipped with JNA.
 | `kotlin_target_version`      | `"x.y.z"`                | When provided, it will enable features in the bindings supported for this version. The build process will fail if an invalid format is used.
-| `disable_java_cleaner`       | `false`                  | Will disable use of `java.lange.ref.Cleaner` so generated code can be compatible with Java 8.
+| `disable_java_cleaner`       | `false`                  | Will disable use of `java.lang.ref.Cleaner` so generated code can be compatible with Java 8.
 | `omit_checksums`             | `false`                  | Whether to omit checking the library checksums as the library is initialized. Changing this will shoot yourself in the foot if you mixup your build pipeline in any way, but might speed up initialization.
 
 ## Example

--- a/docs/manual/src/kotlin/configuration.md
+++ b/docs/manual/src/kotlin/configuration.md
@@ -14,6 +14,7 @@ The generated Kotlin modules can be configured using a `uniffi.toml` configurati
 | `android`                    | `false`                  | Used to toggle on Android specific optimizations
 | `android_cleaner`            | `android`                | Use the [`android.system.SystemCleaner`](https://developer.android.com/reference/android/system/SystemCleaner) instead of [`java.lang.ref.Cleaner`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/ref/Cleaner.html). Fallback in both instances is the one shipped with JNA.
 | `kotlin_target_version`      | `"x.y.z"`                | When provided, it will enable features in the bindings supported for this version. The build process will fail if an invalid format is used.
+| `disable_java_cleaner`       | `false`                  | Will disable use of `java.lange.ref.Cleaner` so generated code can be compatible with Java 8.
 
 ## Example
 

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -82,6 +82,8 @@ pub struct Config {
     android_cleaner: Option<bool>,
     #[serde(default)]
     kotlin_target_version: Option<String>,
+    #[serde(default)]
+    disable_java_cleaner: bool,
 }
 
 impl Config {
@@ -175,6 +177,10 @@ impl Config {
     /// Whether to generate immutable records (`val` instead of `var`)
     pub fn generate_immutable_records(&self) -> bool {
         self.generate_immutable_records.unwrap_or(false)
+    }
+
+    pub fn disable_java_cleaner(&self) -> bool {
+        self.disable_java_cleaner
     }
 }
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectCleanerHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectCleanerHelper.kt
@@ -33,6 +33,9 @@ private class UniffiJnaCleanable(
     override fun clean() = cleanable.clean()
 }
 
+{% if config.disable_java_cleaner() %}
+private fun UniffiCleaner.Companion.create(): UniffiCleaner = UniffiJnaCleaner()
+{% else %}
 // We decide at uniffi binding generation time whether we were
 // using Android or not.
 // There are further runtime checks to chose the correct implementation
@@ -41,4 +44,5 @@ private class UniffiJnaCleanable(
 {%-   include "ObjectCleanerHelperAndroid.kt" %}
 {%- else %}
 {%-   include "ObjectCleanerHelperJvm.kt" %}
+{%- endif %}
 {%- endif %}


### PR DESCRIPTION
Add option to kotlin configuration which allows disabling use of java.lang.ref.Cleaner class. This will keep the generated code compatible with Java 8