### PR TITLE
Allow UDL to define Enums with objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ or use UDL with types from more than one crate.
 
 - External errors work for Swift and Python. Kotlin does not work - see #2392.
 
+- Proc-macros now allow Enums to hold objects (#1372)
+
 ### What's changed?
 
 - Switching jinja template engine from askama to rinja.

--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -93,6 +93,12 @@ interface MaybeSimpleDict {
     Nah();
 };
 
+[Enum]
+interface MaybeObject {
+    Obj(Patch p);
+    Nah();
+};
+
 // Note that UDL *can not* express flat enums (ie, those with variants that carry data which
 // should be ignored for the ffi), only flat errors?
 //enum SimpleFlatEnum {

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -265,6 +265,23 @@ fn get_maybe_simple_dict(index: i8) -> MaybeSimpleDict {
     }
 }
 
+#[derive(Debug)]
+enum MaybeObject {
+    Obj { p: Arc<Patch> },
+    Nah,
+}
+
+#[uniffi::export]
+fn get_maybe_object(index: i8) -> MaybeObject {
+    match index {
+        0 => MaybeObject::Obj {
+            p: Arc::new(Patch { color: Color::Red }),
+        },
+        1 => MaybeObject::Nah,
+        _ => unreachable!("invalid index: {index}"),
+    }
+}
+
 // UDL can not describe this as a "flat" enum, but we'll keep it here to help demonstrate that!
 #[derive(Debug, Clone)]
 pub enum SimpleFlatEnum {

--- a/fixtures/coverall/tests/bindings/test_coverall.py
+++ b/fixtures/coverall/tests/bindings/test_coverall.py
@@ -195,6 +195,14 @@ class TestCoverall(unittest.TestCase):
         e = get_simple_flat_macro_enum(0)
         self.assertTrue(isinstance(e, SimpleFlatMacroEnum.FIRST))
 
+        self.assertTrue(get_maybe_simple_dict(0).is_YEAH())
+        self.assertEqual(get_maybe_simple_dict(0).d.text, "")
+        self.assertTrue(get_maybe_simple_dict(1).is_NAH())
+
+        self.assertTrue(get_maybe_object(0).is_OBJ())
+        self.assertEqual(get_maybe_object(0).p.get_color(), Color.RED)
+        self.assertTrue(get_maybe_object(1).is_NAH())
+
     def test_self_by_arc(self):
         coveralls = Coveralls("test_self_by_arc")
         # One reference is held by the handlemap, and one by the `Arc<Self>` method receiver.

--- a/fixtures/enum-types/tests/bindings/test_enum_types.kts
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.kts
@@ -14,10 +14,19 @@ assert(AnimalLargeUInt.CAT.value == 4294967299.toULong())
 // could check `value == (-3).toByte()` but that's ugly :)
 assert(AnimalSignedInt.DOG.value + 3 == 0)
 
+// destroy function semantics
 // Assert that no destroy() function is created for simple Enum
 val simpleCat: Animal = Animal.CAT
 assert(simpleCat::class.functions.find { it.name == "destroy" } == null)
 
-// Assert that destroy() function is created for Enum with variants containing fields
-val cat: AnimalAssociatedType = AnimalAssociatedType.Cat
-assert(cat::class.functions.find { it.name == "destroy" } != null)
+// Assert that destroy() function is created for Enum with variants containing an object
+// Even though we are creating a non-object variant we still get it.
+val n: AnimalEnum = AnimalEnum.None
+assert(n::class.functions.find { it.name == "destroy" } != null)
+
+getAnimalEnum(Animal.DOG).let { a ->
+    assert(a is AnimalEnum.Dog)
+    assert(a == getAnimalEnum(Animal.DOG))
+    // markh can't work out how to make this work!?
+    // assert(a.v1.getRecord().name == "dog")
+}

--- a/fixtures/enum-types/tests/bindings/test_enum_types.py
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.py
@@ -28,5 +28,13 @@ class TestErrorTypes(unittest.TestCase):
         self.assertEqual(AnimalSignedInt.WALLABY.value, 0)
         self.assertEqual(AnimalSignedInt.WOMBAT.value, 1)
 
+    def test_containers(self):
+        self.assertTrue(get_animal_enum(Animal.DOG).is_DOG())
+        self.assertEqual(get_animal_enum(Animal.DOG)[0].get_record().name, "dog")
+        self.assertEqual(get_animal_enum(Animal.DOG), get_animal_enum(Animal.DOG))
+        self.assertEqual(get_animal_enum(Animal.CAT)[0].name, "cat")
+        self.assertEqual(get_animal_enum(Animal.CAT), get_animal_enum(Animal.CAT))
+        self.assertNotEqual(get_animal_enum(Animal.DOG), get_animal_enum(Animal.CAT))
+
 if __name__=='__main__':
     unittest.main()

--- a/fixtures/enum-types/tests/bindings/test_enum_types.swift
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.swift
@@ -12,3 +12,23 @@ assert(AnimalLargeUInt.dog.rawValue == 4294967298)
 assert(AnimalLargeUInt.cat.rawValue == 4294967299)
 
 assert(AnimalSignedInt.dog.rawValue == -3)
+
+do {
+    let ae = getAnimalEnum(animal: Animal.dog)
+    // Can't compare these enums for equality - #2409.
+    // assert(ae == ae)
+
+    switch ae {
+        case .dog(let o):
+            assert(o.getRecord().name == "dog")
+        default:
+            assert(false)
+    }
+
+    switch getAnimalEnum(animal: Animal.cat) {
+        case .cat(let r):
+            assert(r.name == "cat")
+        default:
+            assert(false)
+    }
+}

--- a/uniffi_udl/src/converters/callables.rs
+++ b/uniffi_udl/src/converters/callables.rs
@@ -12,7 +12,7 @@ use anyhow::{bail, Result};
 
 use uniffi_meta::{
     ConstructorMetadata, FieldMetadata, FnMetadata, FnParamMetadata, MethodMetadata,
-    TraitMethodMetadata, Type,
+    TraitMethodMetadata,
 };
 
 impl APIConverter<FieldMetadata> for weedle::argument::Argument<'_> {
@@ -27,17 +27,12 @@ impl APIConverter<FieldMetadata> for weedle::argument::Argument<'_> {
 impl APIConverter<FieldMetadata> for weedle::argument::SingleArgument<'_> {
     fn convert(&self, ci: &mut InterfaceCollector) -> Result<FieldMetadata> {
         let type_ = ci.resolve_type_expression(&self.type_)?;
-        if let Type::Object { .. } = type_ {
-            bail!("Objects cannot currently be used in enum variant data");
-        }
         if self.default.is_some() {
             bail!("enum interface variant fields must not have default values");
         }
         if self.attributes.is_some() {
             bail!("enum interface variant fields must not have attributes");
         }
-        // TODO: maybe we should use our own `Field` type here with just name and type,
-        // rather than appropriating record::Field..?
         Ok(FieldMetadata {
             name: self.identifier.0.to_string(),
             ty: type_,


### PR DESCRIPTION
proc-macros already support this, as verified by new tests.

Fixes #1372