### PR TITLE
Bump the Rust version to 1.84.0, but MSR remains the same.

### DIFF
--- a/fixtures/callbacks/src/lib.rs
+++ b/fixtures/callbacks/src/lib.rs
@@ -103,6 +103,7 @@ impl Default for RustGetters {
 #[allow(clippy::wrong_self_convention)]
 trait StoredForeignStringifier: Send + Sync + std::fmt::Debug {
     fn from_simple_type(&self, value: i32) -> String;
+    #[allow(dead_code)]
     fn from_complex_type(&self, values: Option<Vec<Option<f64>>>) -> String;
 }
 

--- a/fixtures/keywords/kotlin/src/lib.rs
+++ b/fixtures/keywords/kotlin/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(dead_code)]
+
 use std::{collections::HashMap, sync::Arc};
 
 pub fn r#if(_object: u8) {}

--- a/fixtures/uitests/src/lib.rs
+++ b/fixtures/uitests/src/lib.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/// This crate only exists for its tests.
+//! This crate only exists for its tests.
 
 #[cfg(test)]
 mod test {

--- a/fixtures/uitests/tests/ui/fieldless_errors_used_in_callbacks_cant_have_fields.stderr
+++ b/fixtures/uitests/tests/ui/fieldless_errors_used_in_callbacks_cant_have_fields.stderr
@@ -1,7 +1,11 @@
 error[E0533]: expected value, found struct variant `Self::DivisionByZero`
- --> $OUT_DIR[uniffi_uitests]/errors.uniffi.rs
-  |
-  | #[::uniffi::udl_derive(Error)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a value
-  |
-  = note: this error originates in the attribute macro `::uniffi::udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $OUT_DIR[uniffi_uitests]/errors.uniffi.rs
+   |
+   | #[::uniffi::udl_derive(Error)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a value
+   |
+   = note: this error originates in the attribute macro `::uniffi::udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might have meant to create a new value of the struct
+   |
+29 | #[::uniffi::udl_derive(Error)] { numerator: /* value */ }
+   |                                ++++++++++++++++++++++++++

--- a/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
+++ b/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
@@ -4,7 +4,7 @@ error[E0277]: `Cell<u32>` cannot be shared between threads safely
   | struct r#Counter { }
   |        ^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
   |
-  = help: within `Counter`, the trait `Sync` is not implemented for `Cell<u32>`, which is required by `Counter: Sync`
+  = help: within `Counter`, the trait `Sync` is not implemented for `Cell<u32>`
   = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicU32` instead
 note: required because it appears within the type `Counter`
  --> tests/ui/interface_not_sync_and_send.rs:9:12
@@ -24,7 +24,7 @@ error[E0277]: `Cell<u32>` cannot be shared between threads safely
   | struct r#Counter { }
   |        ^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
   |
-  = help: within `Counter`, the trait `Sync` is not implemented for `Cell<u32>`, which is required by `Counter: Sync`
+  = help: within `Counter`, the trait `Sync` is not implemented for `Cell<u32>`
   = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicU32` instead
 note: required because it appears within the type `Counter`
  --> tests/ui/interface_not_sync_and_send.rs:9:12
@@ -43,7 +43,7 @@ error[E0277]: `Cell<u32>` cannot be shared between threads safely
 27 | pub struct ProcMacroCounter {
    |            ^^^^^^^^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
    |
-   = help: within `ProcMacroCounter`, the trait `Sync` is not implemented for `Cell<u32>`, which is required by `ProcMacroCounter: Sync`
+   = help: within `ProcMacroCounter`, the trait `Sync` is not implemented for `Cell<u32>`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicU32` instead
 note: required because it appears within the type `ProcMacroCounter`
   --> tests/ui/interface_not_sync_and_send.rs:27:12
@@ -63,7 +63,7 @@ error[E0277]: `Cell<u32>` cannot be shared between threads safely
 27 | pub struct ProcMacroCounter {
    |            ^^^^^^^^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
    |
-   = help: within `ProcMacroCounter`, the trait `Sync` is not implemented for `Cell<u32>`, which is required by `ProcMacroCounter: Sync`
+   = help: within `ProcMacroCounter`, the trait `Sync` is not implemented for `Cell<u32>`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicU32` instead
 note: required because it appears within the type `ProcMacroCounter`
   --> tests/ui/interface_not_sync_and_send.rs:27:12
@@ -75,3 +75,47 @@ note: required by a bound in `FfiConverterArc`
    |
    | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
    |                                              ^^^^ required by this bound in `FfiConverterArc`
+
+error[E0277]: `Cell<u32>` cannot be shared between threads safely
+ --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
+  |
+  | #[::uniffi::udl_derive(Object)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
+  |
+  = help: within `Counter`, the trait `Sync` is not implemented for `Cell<u32>`
+  = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicU32` instead
+note: required because it appears within the type `Counter`
+ --> tests/ui/interface_not_sync_and_send.rs:9:12
+  |
+9 | pub struct Counter {
+  |            ^^^^^^^
+note: required by a bound in `uniffi::FfiConverterArc::FfiType`
+ --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
+  |
+  | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
+  |                                              ^^^^ required by this bound in `FfiConverterArc::FfiType`
+  |     type FfiType: FfiDefault;
+  |          ------- required by a bound in this associated type
+  = note: this error originates in the attribute macro `::uniffi::udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `Cell<u32>` cannot be shared between threads safely
+  --> tests/ui/interface_not_sync_and_send.rs:26:10
+   |
+26 | #[derive(uniffi::Object)]
+   |          ^^^^^^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
+   |
+   = help: within `ProcMacroCounter`, the trait `Sync` is not implemented for `Cell<u32>`
+   = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicU32` instead
+note: required because it appears within the type `ProcMacroCounter`
+  --> tests/ui/interface_not_sync_and_send.rs:27:12
+   |
+27 | pub struct ProcMacroCounter {
+   |            ^^^^^^^^^^^^^^^^
+note: required by a bound in `uniffi::FfiConverterArc::FfiType`
+  --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
+   |
+   | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
+   |                                              ^^^^ required by this bound in `FfiConverterArc::FfiType`
+   |     type FfiType: FfiDefault;
+   |          ------- required by a bound in this associated type
+   = note: this error originates in the derive macro `uniffi::Object` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/fixtures/uitests/tests/ui/interface_trait_not_sync_and_send.stderr
+++ b/fixtures/uitests/tests/ui/interface_trait_not_sync_and_send.stderr
@@ -109,3 +109,67 @@ note: required by a bound in `FfiConverterArc`
    | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
    |                                       ^^^^ required by this bound in `FfiConverterArc`
    = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `(dyn Trait + 'static)` cannot be sent between threads safely
+ --> $OUT_DIR[uniffi_uitests]/trait.uniffi.rs
+  |
+  | #[::uniffi::export_for_udl]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Trait + 'static)` cannot be sent between threads safely
+  |
+  = help: the trait `Send` is not implemented for `(dyn Trait + 'static)`
+note: required by a bound in `uniffi::FfiConverterArc::FfiType`
+ --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
+  |
+  | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
+  |                                       ^^^^ required by this bound in `FfiConverterArc::FfiType`
+  |     type FfiType: FfiDefault;
+  |          ------- required by a bound in this associated type
+  = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `(dyn Trait + 'static)` cannot be shared between threads safely
+ --> $OUT_DIR[uniffi_uitests]/trait.uniffi.rs
+  |
+  | #[::uniffi::export_for_udl]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Trait + 'static)` cannot be shared between threads safely
+  |
+  = help: the trait `Sync` is not implemented for `(dyn Trait + 'static)`
+note: required by a bound in `uniffi::FfiConverterArc::FfiType`
+ --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
+  |
+  | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
+  |                                              ^^^^ required by this bound in `FfiConverterArc::FfiType`
+  |     type FfiType: FfiDefault;
+  |          ------- required by a bound in this associated type
+  = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `(dyn ProcMacroTrait + 'static)` cannot be sent between threads safely
+  --> tests/ui/interface_trait_not_sync_and_send.rs:11:1
+   |
+11 | #[uniffi::export]
+   | ^^^^^^^^^^^^^^^^^ `(dyn ProcMacroTrait + 'static)` cannot be sent between threads safely
+   |
+   = help: the trait `Send` is not implemented for `(dyn ProcMacroTrait + 'static)`
+note: required by a bound in `uniffi::FfiConverterArc::FfiType`
+  --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
+   |
+   | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
+   |                                       ^^^^ required by this bound in `FfiConverterArc::FfiType`
+   |     type FfiType: FfiDefault;
+   |          ------- required by a bound in this associated type
+   = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `(dyn ProcMacroTrait + 'static)` cannot be shared between threads safely
+  --> tests/ui/interface_trait_not_sync_and_send.rs:11:1
+   |
+11 | #[uniffi::export]
+   | ^^^^^^^^^^^^^^^^^ `(dyn ProcMacroTrait + 'static)` cannot be shared between threads safely
+   |
+   = help: the trait `Sync` is not implemented for `(dyn ProcMacroTrait + 'static)`
+note: required by a bound in `uniffi::FfiConverterArc::FfiType`
+  --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
+   |
+   | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
+   |                                              ^^^^ required by this bound in `FfiConverterArc::FfiType`
+   |     type FfiType: FfiDefault;
+   |          ------- required by a bound in this associated type
+   = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/fixtures/uitests/tests/ui/invalid_types_in_signatures.stderr
+++ b/fixtures/uitests/tests/ui/invalid_types_in_signatures.stderr
@@ -5,14 +5,14 @@ error[E0277]: the trait bound `Result<(), ErrorType>: Lift<UniFfiTag>` is not sa
    | ^^^^^^^^^^^^^^^^^ the trait `Lift<UniFfiTag>` is not implemented for `Result<(), ErrorType>`
    |
    = help: the following other types implement trait `Lift<UT>`:
-             bool
-             i8
-             i16
-             i32
-             i64
-             u8
-             u16
-             u32
+             Arc<T>
+             Duration
+             ErrorType
+             HashMap<K, V>
+             Option<T>
+             String
+             SystemTime
+             Vec<T>
            and $N others
    = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -20,18 +20,71 @@ error[E0277]: the trait bound `Result<(), ErrorType>: Lower<UniFfiTag>` is not s
   --> tests/ui/invalid_types_in_signatures.rs:20:1
    |
 20 | #[uniffi::export]
-   | ^^^^^^^^^^^^^^^^^ the trait `Lower<UniFfiTag>` is not implemented for `Result<(), ErrorType>`, which is required by `Option<Result<(), ErrorType>>: LowerReturn<UniFfiTag>`
+   | ^^^^^^^^^^^^^^^^^ the trait `Lower<UniFfiTag>` is not implemented for `Result<(), ErrorType>`
    |
    = help: the following other types implement trait `Lower<UT>`:
-             bool
-             i8
-             i16
-             i32
-             i64
-             u8
-             u16
-             u32
+             Arc<T>
+             Duration
+             ErrorType
+             HashMap<K, V>
+             Option<T>
+             String
+             SystemTime
+             Vec<T>
            and $N others
    = note: required for `Option<Result<(), ErrorType>>` to implement `Lower<UniFfiTag>`
    = note: required for `Option<Result<(), ErrorType>>` to implement `LowerReturn<UniFfiTag>`
+   = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Result<(), ErrorType>: Lift<UniFfiTag>` is not satisfied
+  --> tests/ui/invalid_types_in_signatures.rs:18:25
+   |
+18 | pub fn input_result(_r: Result<(), ErrorType>) { }
+   |                         ^^^^^^^^^^^^^^^^^^^^^ the trait `Lift<UniFfiTag>` is not implemented for `Result<(), ErrorType>`
+   |
+   = help: the following other types implement trait `Lift<UT>`:
+             Arc<T>
+             Duration
+             ErrorType
+             HashMap<K, V>
+             Option<T>
+             String
+             SystemTime
+             Vec<T>
+           and $N others
+
+error[E0277]: the trait bound `Result<(), ErrorType>: Lift<UniFfiTag>` is not satisfied
+  --> tests/ui/invalid_types_in_signatures.rs:18:21
+   |
+18 | pub fn input_result(_r: Result<(), ErrorType>) { }
+   |                     ^^ the trait `Lift<UniFfiTag>` is not implemented for `Result<(), ErrorType>`
+   |
+   = help: the following other types implement trait `Lift<UT>`:
+             Arc<T>
+             Duration
+             ErrorType
+             HashMap<K, V>
+             Option<T>
+             String
+             SystemTime
+             Vec<T>
+           and $N others
+
+error[E0277]: the trait bound `Result<(), ErrorType>: Lower<UniFfiTag>` is not satisfied
+  --> tests/ui/invalid_types_in_signatures.rs:20:1
+   |
+20 | #[uniffi::export]
+   | ^^^^^^^^^^^^^^^^^ the trait `Lower<UniFfiTag>` is not implemented for `Result<(), ErrorType>`
+   |
+   = help: the following other types implement trait `Lower<UT>`:
+             Arc<T>
+             Duration
+             ErrorType
+             HashMap<K, V>
+             Option<T>
+             String
+             SystemTime
+             Vec<T>
+           and $N others
+   = note: required for `Option<Result<(), ErrorType>>` to implement `Lower<UniFfiTag>`
    = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
+++ b/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
@@ -5,14 +5,14 @@ error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
   |                                                   ^^^ the trait `std::cmp::Eq` is not implemented for `f32`
   |
   = help: the following other types implement trait `std::cmp::Eq`:
-            isize
-            i8
+            i128
             i16
             i32
             i64
-            i128
-            usize
-            u8
+            i8
+            isize
+            u128
+            u16
           and $N others
 note: required by a bound in `assert_impl_all`
  --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
@@ -28,14 +28,14 @@ error[E0277]: the trait bound `f32: Hash` is not satisfied
   |                                                   ^^^ the trait `Hash` is not implemented for `f32`
   |
   = help: the following other types implement trait `Hash`:
-            isize
-            i8
+            i128
             i16
             i32
             i64
-            i128
-            usize
-            u8
+            i8
+            isize
+            u128
+            u16
           and $N others
 note: required by a bound in `assert_impl_all`
  --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
@@ -48,17 +48,17 @@ error[E0277]: the trait bound `f32: Hash` is not satisfied
  --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
   |
   | #[::uniffi::export_for_udl]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Hash` is not implemented for `f32`, which is required by `HashMap<f32, u64>: LowerReturn<UniFfiTag>`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Hash` is not implemented for `f32`
   |
   = help: the following other types implement trait `Hash`:
-            isize
-            i8
+            i128
             i16
             i32
             i64
-            i128
-            usize
-            u8
+            i8
+            isize
+            u128
+            u16
           and $N others
   = note: required for `HashMap<f32, u64>` to implement `Lower<UniFfiTag>`
   = note: required for `HashMap<f32, u64>` to implement `LowerReturn<UniFfiTag>`
@@ -68,20 +68,58 @@ error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
  --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
   |
   | #[::uniffi::export_for_udl]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `f32`, which is required by `HashMap<f32, u64>: LowerReturn<UniFfiTag>`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `f32`
   |
   = help: the following other types implement trait `std::cmp::Eq`:
-            isize
-            i8
+            i128
             i16
             i32
             i64
-            i128
-            usize
-            u8
+            i8
+            isize
+            u128
+            u16
           and $N others
   = note: required for `HashMap<f32, u64>` to implement `Lower<UniFfiTag>`
   = note: required for `HashMap<f32, u64>` to implement `LowerReturn<UniFfiTag>`
+  = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `f32: Hash` is not satisfied
+ --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
+  |
+  | #[::uniffi::export_for_udl]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Hash` is not implemented for `f32`
+  |
+  = help: the following other types implement trait `Hash`:
+            i128
+            i16
+            i32
+            i64
+            i8
+            isize
+            u128
+            u16
+          and $N others
+  = note: required for `HashMap<f32, u64>` to implement `Lower<UniFfiTag>`
+  = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
+ --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
+  |
+  | #[::uniffi::export_for_udl]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `f32`
+  |
+  = help: the following other types implement trait `std::cmp::Eq`:
+            i128
+            i16
+            i32
+            i64
+            i8
+            isize
+            u128
+            u16
+          and $N others
+  = note: required for `HashMap<f32, u64>` to implement `Lower<UniFfiTag>`
   = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find function `get_dict` in this scope

--- a/fixtures/uitests/tests/ui/trait_methods_no_trait.rs
+++ b/fixtures/uitests/tests/ui/trait_methods_no_trait.rs
@@ -8,7 +8,7 @@ fn main() { /* empty main required by `trybuild` */}
 pub struct TraitMethods {}
 
 impl TraitMethods {
-    fn new(name: String) -> Self {
+    fn new(_name: String) -> Self {
         unreachable!();
     }
 }

--- a/fixtures/uitests/tests/ui/trait_methods_no_trait.stderr
+++ b/fixtures/uitests/tests/ui/trait_methods_no_trait.stderr
@@ -19,6 +19,6 @@ error[E0277]: `TraitMethods` doesn't implement `std::fmt::Display`
   | #[uniffi::export(Display)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `TraitMethods` cannot be formatted with the default formatter
   |
-  = help: the trait `std::fmt::Display` is not implemented for `TraitMethods`, which is required by `&TraitMethods: std::fmt::Display`
+  = help: the trait `std::fmt::Display` is not implemented for `TraitMethods`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
   = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # * ./.circleci/config.yml which also specifies the rust versions used in CI.
 
 [toolchain]
-channel = "1.77.1"
+channel = "1.84.0"
 targets = [
     "aarch64-linux-android",
     "armv7-linux-androideabi",

--- a/uniffi/tests/ui/proc_macro_arc.stderr
+++ b/uniffi/tests/ui/proc_macro_arc.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Foo: FfiConverterArc<UniFfiTag>` is not satisfied
   --> tests/ui/proc_macro_arc.rs:10:1
    |
 10 | #[uniffi::export]
-   | ^^^^^^^^^^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `Foo`, which is required by `Arc<Foo>: LowerReturn<UniFfiTag>`
+   | ^^^^^^^^^^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `Foo`
    |
    = help: the trait `LowerReturn<UT>` is implemented for `Arc<T>`
    = note: required for `Arc<Foo>` to implement `FfiConverter<UniFfiTag>`
@@ -14,7 +14,7 @@ error[E0277]: the trait bound `Foo: FfiConverterArc<UniFfiTag>` is not satisfied
   --> tests/ui/proc_macro_arc.rs:11:18
    |
 11 | fn make_foo() -> Arc<Foo> {
-   |                  ^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `Foo`, which is required by `Arc<Foo>: uniffi::TypeId<UniFfiTag>`
+   |                  ^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `Foo`
    |
    = help: the trait `uniffi::TypeId<UT>` is implemented for `Arc<T>`
    = note: required for `Arc<Foo>` to implement `FfiConverter<UniFfiTag>`
@@ -24,7 +24,7 @@ error[E0277]: the trait bound `child::Foo: FfiConverterArc<UniFfiTag>` is not sa
   --> tests/ui/proc_macro_arc.rs:20:5
    |
 20 |     #[uniffi::export]
-   |     ^^^^^^^^^^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `child::Foo`, which is required by `Arc<child::Foo>: Lift<UniFfiTag>`
+   |     ^^^^^^^^^^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `child::Foo`
    |
    = help: the trait `Lift<UT>` is implemented for `Arc<T>`
    = note: required for `Arc<child::Foo>` to implement `FfiConverter<UniFfiTag>`
@@ -35,8 +35,48 @@ error[E0277]: the trait bound `child::Foo: FfiConverterArc<UniFfiTag>` is not sa
   --> tests/ui/proc_macro_arc.rs:21:22
    |
 21 |     fn take_foo(foo: Arc<Foo>) {
-   |                      ^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `child::Foo`, which is required by `Arc<child::Foo>: uniffi::TypeId<UniFfiTag>`
+   |                      ^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `child::Foo`
    |
    = help: the trait `uniffi::TypeId<UT>` is implemented for `Arc<T>`
    = note: required for `Arc<child::Foo>` to implement `FfiConverter<UniFfiTag>`
    = note: required for `Arc<child::Foo>` to implement `uniffi::TypeId<UniFfiTag>`
+
+error[E0277]: the trait bound `Foo: FfiConverterArc<UniFfiTag>` is not satisfied
+  --> tests/ui/proc_macro_arc.rs:10:1
+   |
+10 | #[uniffi::export]
+   | ^^^^^^^^^^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `Foo`
+   |
+   = help: the trait `FfiConverter<UT>` is implemented for `Arc<T>`
+   = note: required for `Arc<Foo>` to implement `FfiConverter<UniFfiTag>`
+   = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `child::Foo: FfiConverterArc<UniFfiTag>` is not satisfied
+  --> tests/ui/proc_macro_arc.rs:20:5
+   |
+20 |     #[uniffi::export]
+   |     ^^^^^^^^^^^^^^^^^ the trait `FfiConverterArc<UniFfiTag>` is not implemented for `child::Foo`
+   |
+   = help: the trait `FfiConverter<UT>` is implemented for `Arc<T>`
+   = note: required for `Arc<child::Foo>` to implement `FfiConverter<UniFfiTag>`
+   = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0004]: non-exhaustive patterns: type `&child::Foo` is non-empty
+  --> tests/ui/proc_macro_arc.rs:22:15
+   |
+22 |         match &*foo {}
+   |               ^^^^^
+   |
+note: `child::Foo` defined here
+  --> tests/ui/proc_macro_arc.rs:18:10
+   |
+18 |     enum Foo {}
+   |          ^^^
+   = note: the matched value is of type `&child::Foo`
+   = note: references are always considered inhabited
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown
+   |
+22 ~         match &*foo {
+23 +             _ => todo!(),
+24 +         }
+   |

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -54,12 +54,6 @@ trait CodeType: Debug {
         format!("FfiConverter{}", self.canonical_name())
     }
 
-    /// A list of imports that are needed if this type is in use.
-    /// Classes are imported exactly once.
-    fn imports(&self) -> Option<Vec<String>> {
-        None
-    }
-
     /// Function to run at startup
     fn initialization_fn(&self) -> Option<String> {
         None

--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -52,17 +52,6 @@ trait CodeType: Debug {
     fn ffi_converter_name(&self) -> String {
         format!("FfiConverter{}", self.canonical_name())
     }
-
-    /// A list of imports that are needed if this type is in use.
-    /// Classes are imported exactly once.
-    fn imports(&self) -> Option<Vec<String>> {
-        None
-    }
-
-    /// Function to run at startup
-    fn initialization_fn(&self) -> Option<String> {
-        None
-    }
 }
 
 // Taken from Python's `keyword.py` module.

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -54,12 +54,6 @@ trait CodeType: Debug {
         format!("FfiConverter{}", self.canonical_name())
     }
 
-    /// A list of imports that are needed if this type is in use.
-    /// Classes are imported exactly once.
-    fn imports(&self) -> Option<Vec<String>> {
-        None
-    }
-
     /// Function to run at startup
     fn initialization_fn(&self) -> Option<String> {
         None

--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -12,10 +12,10 @@
 //! we generate:
 //!
 //!   * A C header file `exampleFFI.h` declaring the low-level structs and functions for calling
-//!    into Rust, along with a corresponding `exampleFFI.modulemap` to expose them to Swift.
+//!     into Rust, along with a corresponding `exampleFFI.modulemap` to expose them to Swift.
 //!
 //!   * A Swift source file `example.swift` that imports the `exampleFFI` module and wraps it
-//!    to provide the higher-level Swift API.
+//!     to provide the higher-level Swift API.
 //!
 //! Most of the concepts in a [`crate::ComponentInterface`] have an obvious counterpart in Swift,
 //! with the details documented in inline comments where appropriate.

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -234,7 +234,7 @@ pub struct ResultType<'a> {
     pub throws_type: Option<&'a Type>,
 }
 
-impl<'a> ResultType<'a> {
+impl ResultType<'_> {
     /// Get the `T` parameters for the `FutureCallback<T>` for this ResultType
     pub fn future_callback_param(&self) -> FfiType {
         match self.return_type {

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -32,8 +32,9 @@
 //!
 //!   * It should prevent user error and the possibility of generating bad code by doing (at least)
 //!     the following checks:
-//!       * No duplicate names (types, methods, args, etc)
-//!       * No shadowing of builtin names, or names we use in code generation
+//!     * No duplicate names (types, methods, args, etc)
+//!     * No shadowing of builtin names, or names we use in code generation
+//!
 //!     We expect that if the user actually does one of these things, then they *should* get a compile
 //!     error when trying to build the component, because the codegen will be invalid. But we can't
 //!     guarantee that there's not some edge-case where it produces valid-but-incorrect code.
@@ -150,7 +151,7 @@ impl ComponentInterface {
         }
 
         // Unconditionally add the String type, which is used by the panic handling
-        self.types.add_known_type(&uniffi_meta::Type::String)?;
+        self.types.add_known_type(&Type::String)?;
         crate::macro_metadata::add_group_to_ci(self, group)?;
         Ok(())
     }

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -262,7 +262,7 @@ impl BindgenCrateConfigSupplier for EmptyCrateConfigSupplier {}
 /// A convenience function for the CLI to help avoid using static libs
 /// in places cdylibs are required.
 pub fn is_cdylib(library_file: impl AsRef<Utf8Path>) -> bool {
-    crate::library_mode::calc_cdylib_name(library_file.as_ref()).is_some()
+    library_mode::calc_cdylib_name(library_file.as_ref()).is_some()
 }
 
 /// Generate bindings for an external binding generator
@@ -311,7 +311,7 @@ pub fn generate_external_bindings<T: BindingGenerator>(
     let settings = GenerationSettings {
         cdylib: match library_file {
             Some(ref library_file) => {
-                crate::library_mode::calc_cdylib_name(library_file.as_ref()).map(ToOwned::to_owned)
+                library_mode::calc_cdylib_name(library_file.as_ref()).map(ToOwned::to_owned)
             }
             None => None,
         },

--- a/uniffi_bindgen/src/library_mode.rs
+++ b/uniffi_bindgen/src/library_mode.rs
@@ -34,7 +34,7 @@ use uniffi_meta::{
 /// interface and allows for more flexibility in how the external bindings are generated.
 ///
 /// Returns the list of sources used to generate the bindings, in no particular order.
-pub fn generate_bindings<T: BindingGenerator + ?Sized>(
+pub fn generate_bindings<T: BindingGenerator>(
     library_path: &Utf8Path,
     crate_name: Option<String>,
     binding_generator: &T,
@@ -155,7 +155,7 @@ fn load_udl_metadata(
         .items
         .iter()
         .filter_map(|i| match i {
-            uniffi_meta::Metadata::UdlFile(meta) => Some(meta),
+            Metadata::UdlFile(meta) => Some(meta),
             _ => None,
         })
         .collect::<Vec<_>>();

--- a/uniffi_bindgen/src/macro_metadata/extract.rs
+++ b/uniffi_bindgen/src/macro_metadata/extract.rs
@@ -137,7 +137,7 @@ pub fn extract_from_macho(macho: MachO<'_>, file_data: &[u8]) -> anyhow::Result<
         if nlist.is_global()
             && nlist.get_type() == symbols::N_SECT
             && is_metadata_symbol(name)
-            && nlist.n_sect != goblin::mach::symbols::NO_SECT as usize
+            && nlist.n_sect != symbols::NO_SECT as usize
         {
             let section = &sections[nlist.n_sect - 1];
 

--- a/uniffi_core/src/ffi/callbackinterface.rs
+++ b/uniffi_core/src/ffi/callbackinterface.rs
@@ -191,6 +191,7 @@ macro_rules! convert_unexpected_error {
         // Trait for specialized conversion, implemented for all T that implements
         // `Into<ErrorType>`.  I.e. it's implemented for UnexpectedUniFFICallbackError when
         // ErrorType implements From<UnexpectedUniFFICallbackError>.
+        #[allow(dead_code)]
         pub trait GetConverterSpecialized {
             fn get_converter(&self) -> $crate::UnexpectedUniFFICallbackErrorConverterSpecialized;
         }

--- a/uniffi_core/src/ffi/ffiserialize.rs
+++ b/uniffi_core/src/ffi/ffiserialize.rs
@@ -210,7 +210,7 @@ impl FfiSerialize for RustBuffer {
     fn get(buf: &[FfiBufferElement]) -> Self {
         // Safety: the foreign bindings are responsible for sending us the correct data.
         let (capacity, len, data) = unsafe { (buf[0].u64, buf[1].u64, buf[2].ptr as *mut u8) };
-        unsafe { crate::RustBuffer::from_raw_parts(data, len, capacity) }
+        unsafe { RustBuffer::from_raw_parts(data, len, capacity) }
     }
 
     fn put(buf: &mut [FfiBufferElement], value: Self) {

--- a/uniffi_core/src/ffi/foreigncallbacks.rs
+++ b/uniffi_core/src/ffi/foreigncallbacks.rs
@@ -35,5 +35,11 @@ impl<T> UniffiForeignPointerCell<T> {
     }
 }
 
+impl<T> Default for UniffiForeignPointerCell<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 unsafe impl<T> Send for UniffiForeignPointerCell<T> {}
 unsafe impl<T> Sync for UniffiForeignPointerCell<T> {}

--- a/uniffi_core/src/ffi/foreignfuture.rs
+++ b/uniffi_core/src/ffi/foreignfuture.rs
@@ -40,9 +40,7 @@ pub struct ForeignFutureResult<T> {
     call_status: RustCallStatus,
 }
 
-/// Perform a call to a foreign async method
-
-/// C struct that represents the foreign future.
+/// C struct that represents a foreign future, used to perform a call to a foreign async method.
 ///
 /// This is what's returned by the async scaffolding functions.
 #[repr(C)]

--- a/uniffi_core/src/ffi/rustfuture/future.rs
+++ b/uniffi_core/src/ffi/rustfuture/future.rs
@@ -13,16 +13,16 @@
 //! 0. At startup, register a [RustFutureContinuationCallback] by calling
 //!    rust_future_continuation_callback_set.
 //! 1. Call the scaffolding function to get a [Handle]
-//! 2a. In a loop:
+//! 2. In a loop:
 //!   - Call [rust_future_poll]
 //!   - Suspend the function until the [rust_future_poll] continuation function is called
 //!   - If the continuation was function was called with [RustFuturePoll::Ready], then break
 //!     otherwise continue.
-//! 2b. If the async function is cancelled, then call [rust_future_cancel].  This causes the
-//!     continuation function to be called with [RustFuturePoll::Ready] and the [RustFuture] to
-//!     enter a cancelled state.
-//! 3. Call [rust_future_complete] to get the result of the future.
-//! 4. Call [rust_future_free] to free the future, ideally in a finally block.  This:
+//! 3. If the async function is cancelled, then call [rust_future_cancel].  This causes the
+//!    continuation function to be called with [RustFuturePoll::Ready] and the [RustFuture] to
+//!    enter a cancelled state.
+//! 4. Call [rust_future_complete] to get the result of the future.
+//! 5. Call [rust_future_free] to free the future, ideally in a finally block.  This:
 //!    - Releases any resources held by the future
 //!    - Calls any continuation callbacks that have not been called yet
 //!

--- a/uniffi_core/src/metadata.rs
+++ b/uniffi_core/src/metadata.rs
@@ -241,6 +241,12 @@ impl MetadataBuffer {
     }
 }
 
+impl Default for MetadataBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AsRef<[u8]> for MetadataBuffer {
     fn as_ref(&self) -> &[u8] {
         &self.bytes[..self.size]

--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -189,7 +189,7 @@ pub fn rewrite_self_type(item: &mut Item) {
 
     struct RewriteSelfVisitor<'a>(&'a Type);
 
-    impl<'a> VisitMut for RewriteSelfVisitor<'a> {
+    impl VisitMut for RewriteSelfVisitor<'_> {
         fn visit_type_mut(&mut self, i: &mut Type) {
             match i {
                 Type::Path(p) if p.qself.is_none() && p.path.is_ident("Self") => {

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -3,6 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 #![cfg_attr(feature = "nightly", feature(proc_macro_expand))]
 #![warn(rust_2018_idioms, unused_qualifications)]
+// somewhere between 1.77 and 1.84 we got a lot of new `dead_code` warnings because
+// we use structs to aid in parsing but don't actually use the items otherwise.
+#![allow(dead_code)]
 
 //! Macros for `uniffi`.
 

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -287,7 +287,7 @@ impl Parse for ExternalTypeItem {
 }
 
 pub(crate) fn extract_docstring(attrs: &[Attribute]) -> syn::Result<String> {
-    return attrs
+    attrs
         .iter()
         .filter(|attr| attr.path().is_ident("doc"))
         .map(|attr| {
@@ -300,5 +300,5 @@ pub(crate) fn extract_docstring(attrs: &[Attribute]) -> syn::Result<String> {
             Err(syn::Error::new_spanned(attr, "Cannot parse doc attribute"))
         })
         .collect::<syn::Result<Vec<_>>>()
-        .map(|lines| lines.join("\n"));
+        .map(|lines| lines.join("\n"))
 }

--- a/uniffi_testing/src/lib.rs
+++ b/uniffi_testing/src/lib.rs
@@ -177,9 +177,11 @@ fn get_cargo_build_messages() -> Vec<Message> {
         .spawn()
         .expect("Error running cargo build");
     let output = std::io::BufReader::new(child.stdout.take().unwrap());
-    Message::parse_stream(output)
+    let result = Message::parse_stream(output)
         .map(|m| m.expect("Error parsing cargo build messages"))
-        .collect()
+        .collect();
+    child.wait().expect("failed to wait for child");
+    result
 }
 
 fn hash_path(path: &Utf8Path) -> String {

--- a/weedle2/src/whitespace.rs
+++ b/weedle2/src/whitespace.rs
@@ -27,7 +27,7 @@ pub(crate) fn sp(input: &str) -> IResult<&str, &str> {
 }
 
 /// ws also ignores line & block comments
-pub(crate) fn ws<'a, F>(inner: F) -> impl FnMut(&'a str) -> IResult<&str, &str>
+pub(crate) fn ws<'a, F>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, &'a str>
 where
     F: Parser<&'a str, &'a str, nom::error::Error<&'a str>>,
 {


### PR DESCRIPTION
In line with our Rust version policy, this matches a current mozilla-central.