### PR TITLE
How to handle async-traits with external types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,6 +1807,7 @@ name = "uniffi-fixture-ext-types-lib-one"
 version = "0.22.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bytes",
  "thiserror",
  "uniffi",
@@ -1817,6 +1818,7 @@ name = "uniffi-fixture-ext-types-proc-macro"
 version = "0.22.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bytes",
  "uniffi",
  "uniffi-example-custom-types",

--- a/fixtures/ext-types/proc-macro-lib/Cargo.toml
+++ b/fixtures/ext-types/proc-macro-lib/Cargo.toml
@@ -18,6 +18,7 @@ name = "uniffi_ext_types_proc_macro_lib"
 
 [dependencies]
 anyhow = "1"
+async-trait = "0.1"
 bytes = "1.3"
 uniffi = { workspace = true }
 

--- a/fixtures/ext-types/proc-macro-lib/src/lib.rs
+++ b/fixtures/ext-types/proc-macro-lib/src/lib.rs
@@ -2,7 +2,8 @@ use custom_types::Handle;
 use ext_types_custom::{Guid, Ouid2};
 use std::sync::Arc;
 use uniffi_one::{
-    UniffiOneEnum, UniffiOneInterface, UniffiOneProcMacroType, UniffiOneTrait, UniffiOneType,
+    UniffiOneAsyncTrait, UniffiOneEnum, UniffiOneInterface, UniffiOneProcMacroType, UniffiOneTrait,
+    UniffiOneTraitError, UniffiOneType,
 };
 use url::Url;
 
@@ -155,6 +156,31 @@ fn get_uniffi_one_interface() -> Arc<UniffiOneInterface> {
 #[uniffi::export]
 fn get_uniffi_one_trait(t: Option<Arc<dyn UniffiOneTrait>>) -> Option<Arc<dyn UniffiOneTrait>> {
     t
+}
+
+#[derive(uniffi::Object)]
+pub struct UniffiOneTraitImpl;
+
+#[uniffi::export]
+impl UniffiOneTrait for UniffiOneTraitImpl {
+    fn hello(&self) -> String {
+        "uniffi-one-trait-impl".to_string()
+    }
+}
+
+#[derive(uniffi::Object)]
+pub struct UniffiOneAsyncTraitImpl;
+
+#[uniffi::export]
+#[async_trait::async_trait]
+impl UniffiOneAsyncTrait for UniffiOneAsyncTraitImpl {
+    async fn hello(&self) -> String {
+        "uniffi-one-trait-impl".to_string()
+    }
+
+    async fn try_hello(&self) -> Result<String, UniffiOneTraitError> {
+        Ok("uniffi-one-trait-impl".to_string())
+    }
 }
 
 // Some custom types via macros.

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.py
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.py
@@ -49,6 +49,11 @@ class TestIt(unittest.TestCase):
             self.assertEqual(await get_uniffi_one_async(), UniffiOneEnum.ONE)
             # This async function comes from the `proc-macro-lib` crate
             self.assertEqual(t1, await get_uniffi_one_type_async(t1))
+
+            t2 = UniffiOneTraitImpl()
+            self.assertEqual(await t2.hello(), "uniffi-one-trait-impl")
+            self.assertEqual(await t2.try_hello(), "uniffi-one-trait-impl")
+
         asyncio.run(test())
 
     def test_get_uniffi_one_proc_macro_type(self):

--- a/fixtures/ext-types/uniffi-one/Cargo.toml
+++ b/fixtures/ext-types/uniffi-one/Cargo.toml
@@ -12,6 +12,7 @@ name = "uniffi_one"
 
 [dependencies]
 anyhow = "1"
+async-trait = "0.1"
 bytes = "1.3"
 thiserror = "1"
 uniffi = { workspace = true }

--- a/fixtures/ext-types/uniffi-one/src/lib.rs
+++ b/fixtures/ext-types/uniffi-one/src/lib.rs
@@ -44,6 +44,19 @@ pub trait UniffiOneTrait: Send + Sync {
     fn hello(&self) -> String;
 }
 
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum UniffiOneTraitError {
+    #[error("Callback failed")]
+    Error,
+}
+
+#[uniffi::export(with_foreign)]
+#[async_trait::async_trait]
+pub trait UniffiOneAsyncTrait: Send + Sync {
+    async fn hello(&self) -> String;
+    async fn try_hello(&self) -> Result<String, UniffiOneTraitError>;
+}
+
 // A couple of errors used as external types.
 #[derive(thiserror::Error, uniffi::Error, Debug)]
 pub enum UniffiOneError {


### PR DESCRIPTION
I have been trying to get external types, combined with async trait implementations to work, and created this failing test to show I far have come. I don't know if this is missing something fundamental, or if I am setting it up wrong. I would appreciate any pointers.

This fails with 

```
cargo test -p uniffi-fixture-ext-types-proc-macro

running 3 tests
    Finished test [unoptimized + debuginfo] target(s) in 0.03s
test uniffi_foreign_language_testcase_test_imported_types_kts ... FAILED
test uniffi_foreign_language_testcase_test_imported_types_swift ... FAILED
Traceback (most recent call last):
  File "/Users/dignified/opensource/uniffi-rs/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.py", line 9, in <module>
    from imported_types_lib import *
  File "/Users/dignified/.rust_target/tmp/uniffi_ext_types_proc_macro_lib-1cb60e4ace85aa40/imported_types_lib.py", line 1909, in <module>
    class UniffiOneAsyncTraitImpl(UniffiOneAsyncTrait,):
                                  ^^^^^^^^^^^^^^^^^^^
NameError: name 'UniffiOneAsyncTrait' is not defined. Did you mean: 'UniffiOneTrait'?
test uniffi_foreign_language_testcase_test_imported_types_py ... FAILED

failures:

---- uniffi_foreign_language_testcase_test_imported_types_kts stdout ----
Creating testing out_dir: /Users/dignified/.rust_target/tmp/uniffi_ext_types_proc_macro_lib-d2ca99a8849fc342
Error: failed to create a binding generator

Caused by:
    0: no interface UniffiOneAsyncTrait
    1: no interface UniffiOneAsyncTrait

---- uniffi_foreign_language_testcase_test_imported_types_swift stdout ----
Creating testing out_dir: /Users/dignified/.rust_target/tmp/uniffi_ext_types_proc_macro_lib-d3c7181a63ab8a7a
thread 'uniffi_foreign_language_testcase_test_imported_types_swift' panicked at uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs:429:55:
called `Result::unwrap()` on an `Err` value: Custom(no interface UniffiOneAsyncTrait)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- uniffi_foreign_language_testcase_test_imported_types_py stdout ----
Creating testing out_dir: /Users/dignified/.rust_target/tmp/uniffi_ext_types_proc_macro_lib-1cb60e4ace85aa40
Error: running `python3` failed


failures:
    uniffi_foreign_language_testcase_test_imported_types_kts
    uniffi_foreign_language_testcase_test_imported_types_py
    uniffi_foreign_language_testcase_test_imported_types_swift

test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.44s

error: test failed, to rerun pass `-p uniffi-fixture-ext-types-proc-macro --test test_generated_bindings`
```