### PR TITLE
Remove clap color feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Bindings support `lift` and `lower` for CustomTypes in uniffi.toml to match the docs ([#2438](https://github.com/mozilla/uniffi-rs/issues/2438))
 
+### What's changed?
+
+- The uniffi-bindgen CLI support no longer brings in the `clap/color` feature, reducing dependencies ([#2435](https://github.com/mozilla/uniffi-rs/pull/2435))
+
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.29.0...HEAD).
 
 ## v0.29.0 (backend crates: v0.29.0) - (_2025-02-06_)

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -21,7 +21,8 @@ uniffi_macros = { path = "../uniffi_macros", version = "=0.29.0" }
 anyhow = "1"
 camino = { version = "1.0.8", optional = true }
 cargo_metadata = { version = "0.15", optional = true }
-clap = { version = "4", features = ["cargo", "std", "derive"], optional = true }
+# avoid 'clap/color' due to dependency hell.
+clap = { version = "4", default-features = false, features = [ "cargo", "derive", "error-context", "help", "suggestions", "std", "usage" ], optional = true }
 
 [dev-dependencies]
 trybuild = "1"


### PR DESCRIPTION
This is a WIP, but I expect something like this might be necessary to use uniffi-bindgen in m-c to avoid the many deps required by the clap `color` feature. An alternative would be to duplicate the cli parsing in m-c and avoid that dependency there.

@badboy @bendk, thoughts?