### PR TITLE
Hide `init(unsafeFromRawPointer)` from docs

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -22,6 +22,9 @@ open class {{ impl_class_name }}: {{ protocol_name }}, @unchecked Sendable {
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
     required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }


### PR DESCRIPTION
This method’s comments indicates it shouldn’t be public API, so let’s exclude it from documentation generation.