### PR TITLE
Error types in the swift binding conforms to the Error protocol

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
@@ -1,5 +1,5 @@
 {%- call swift::docstring(e, 0) %}
-public enum {{ type_name }} {
+public enum {{ type_name }}: Swift.Error {
 
     {% if e.is_flat() %}
     {% for variant in e.variants() %}

--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -201,8 +201,6 @@ public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> UnsafeMu
 {# Objects as error #}
 {%- if is_error %}
 
-extension {{ type_name }}: Swift.Error {}
-
 {% if !config.omit_localized_error_conformance() %}
 extension {{ type_name }}: Foundation.LocalizedError {
     public var errorDescription: String? {

--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -201,6 +201,8 @@ public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> UnsafeMu
 {# Objects as error #}
 {%- if is_error %}
 
+extension {{ type_name }}: Swift.Error {}
+
 {% if !config.omit_localized_error_conformance() %}
 extension {{ type_name }}: Foundation.LocalizedError {
     public var errorDescription: String? {


### PR DESCRIPTION
When the `omit_localized_error_conformance` configuration (added in https://github.com/mozilla/uniffi-rs/pull/2319) is turned on, the `Error` conformance was also removed because it was previously implied by the `LocalizedError`.

This PR makes sure error types in Swift bindings always conform to `Swift.Error`, regardless of whether they conform to `LocalizedError`.