### PR TITLE
Adding BindgenCrateConfigSupplier::get_toml_path

### DIFF
--- a/uniffi_bindgen/src/cargo_metadata.rs
+++ b/uniffi_bindgen/src/cargo_metadata.rs
@@ -19,8 +19,11 @@ pub struct CrateConfigSupplier {
 
 impl BindgenCrateConfigSupplier for CrateConfigSupplier {
     fn get_toml(&self, crate_name: &str) -> anyhow::Result<Option<toml::value::Table>> {
-        let toml = self.paths.get(crate_name).map(|p| p.join("uniffi.toml"));
-        crate::load_toml_file(toml.as_deref())
+        crate::load_toml_file(self.get_toml_path(crate_name).as_deref())
+    }
+
+    fn get_toml_path(&self, crate_name: &str) -> Option<Utf8PathBuf> {
+        self.paths.get(crate_name).map(|p| p.join("uniffi.toml"))
     }
 
     fn get_udl(&self, crate_name: &str, udl_name: &str) -> anyhow::Result<String> {

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -246,10 +246,18 @@ pub struct Component<Config> {
 /// In most cases `cargo_metadata` can be used, but this should be able to work in
 /// more environments.
 pub trait BindgenCrateConfigSupplier {
-    /// Get the toml for the crate. Probably came from uniffi.toml in the root of the crate source.
+    /// Get a `toml::value::Table` instance for the crate.
     fn get_toml(&self, _crate_name: &str) -> Result<Option<toml::value::Table>> {
         Ok(None)
     }
+
+    /// Get the path to the TOML file for a crate.
+    ///
+    /// This is usually the `uniffi.toml` path in the root of the crate source.
+    fn get_toml_path(&self, _crate_name: &str) -> Option<Utf8PathBuf> {
+        None
+    }
+
     /// Obtains the contents of the named UDL file which was referenced by the type metadata.
     fn get_udl(&self, crate_name: &str, udl_name: &str) -> Result<String> {
         bail!("Crate {crate_name} has no UDL {udl_name}")


### PR DESCRIPTION
This is a way to get just the path to the TOML file, without trying to parse it.  I want to use this in some of my bindings IR experiment.