### PR TITLE
fix: `#[no_mangle]` error in Rust 2024 Edition

### DIFF
--- a/uniffi_bindgen/src/scaffolding/templates/Checksums.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/Checksums.rs
@@ -1,5 +1,5 @@
 {%- for (name, checksum) in ci.iter_checksums() %}
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[doc(hidden)]
 pub extern "C" fn r#{{ name }}() -> u16 {
     {{ checksum }}

--- a/uniffi_bindgen/src/scaffolding/templates/ReexportUniFFIScaffolding.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ReexportUniFFIScaffolding.rs
@@ -20,7 +20,7 @@ pub const fn uniffi_reexport_hack() {}
 macro_rules! uniffi_reexport_scaffolding {
     () => {
         #[doc(hidden)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn {{ ci.namespace() }}_uniffi_reexport_hack() {
             $crate::uniffi_reexport_hack()
         }

--- a/uniffi_bindgen/src/scaffolding/templates/UdlMetadata.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/UdlMetadata.rs
@@ -9,5 +9,5 @@ const {{ const_udl_var }}: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::
     .concat_str("{{ udl_base_name }}");
 
 #[doc(hidden)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub static {{ static_udl_var }}: [u8; {{ const_udl_var }}.size] = {{ const_udl_var }}.into_array();


### PR DESCRIPTION
Hey,

I know, I know - Rust 2024 just dropped, and I’m not trying to rush anything. But after upgrading to the Rust 2024 edition, I ran into the following build error:

```rust
error: unsafe attribute used without unsafe
  --> /Users/martinmose/project/target/debug/build/project_shared-0c37e55cf0c6dc4f/out/project_shared.uniffi.rs:96:3
   |
96 | #[no_mangle]
   |   ^^^^^^^^^ usage of unsafe attribute
   |
help: wrap the attribute in `unsafe(...)`
   |
96 | #[unsafe(no_mangle)]
   |   +++++++         +
```

I found this [Unsafe Attributes](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html)

This seems like a simple fix - just wrapping `#[no_mangle]` in `#[unsafe(...)]`. But maybe there is something I’m unaware of?

It looks like it fixes my upgraded Rust project at least 😅
