### PR TITLE
Remove redundant and/or incorrect swift compiler version checks

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -22,9 +22,7 @@ public enum {{ type_name }} : {{ variant_discr_type|type_name }} {
 }
 {% endmatch %}
 
-#if compiler(>=6)
 extension {{ type_name }}: Sendable {}
-#endif
 
 #if swift(>=5.8)
 @_documentation(visibility: private)

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -15,9 +15,7 @@ public struct {{ type_name }} {
     }
 }
 
-#if compiler(>=6)
 extension {{ type_name }}: Sendable {}
-#endif
 
 {% if !contains_object_references %}
 extension {{ type_name }}: Equatable, Hashable {


### PR DESCRIPTION
In https://github.com/mozilla/uniffi-rs/pull/2450#issuecomment-2675889831

> Regarding Swift 5 support, Sendable was officially added in [Swift 5.7](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0302-concurrent-value-and-concurrent-closures.md), so this shouldn’t break compatibility.

Which got me thinking about the checks in this PR - if anything, it seems like they should be `swift(>=5.7)` checks - but we're [already unconditionally using `Sendable`](https://github.com/mozilla/uniffi-rs/blob/c82945bdf04f947215f44609d70d1ec346c662b1/uniffi_bindgen/src/bindings/swift/templates/HandleMap.swift#L1)

We have.a few `swift(>=5.8)` checks - which I guess means we implicitly support a min swift version of 5.7?

I think they were added by @crazytonyli, cc @martinmose