### PR TITLE
Legacy test filename test_guid.py renamed to test_custom_types.py

### DIFF
--- a/fixtures/ext-types/custom-types/tests/bindings/test_custom_types.py
+++ b/fixtures/ext-types/custom-types/tests/bindings/test_custom_types.py
@@ -10,7 +10,7 @@ class TestCallback(GuidCallback):
         self.saw_guid = guid
         return guid
 
-class TestGuid(unittest.TestCase):
+class TestCustomTypes(unittest.TestCase):
     def test_get_guid(self):
         self.assertEqual(get_guid(None), "NewGuid")
         self.assertEqual(get_guid("SomeGuid"), "SomeGuid")

--- a/fixtures/ext-types/custom-types/tests/test_generated_bindings.rs
+++ b/fixtures/ext-types/custom-types/tests/test_generated_bindings.rs
@@ -1,1 +1,1 @@
-uniffi::build_foreign_language_testcases!("tests/bindings/test_guid.py",);
+uniffi::build_foreign_language_testcases!("tests/bindings/test_custom_types.py",);


### PR DESCRIPTION
The name mismatch has tricked me more than once...