### PR TITLE
Add missing semicolons in UDL interface declarations

### DIFF
--- a/docs/adr/0003-threadsafe-interfaces.md
+++ b/docs/adr/0003-threadsafe-interfaces.md
@@ -148,7 +148,7 @@ We would advise Nimbus SDK to update their UDL definition for `NimbusClient` lik
 [Threadsafe]
 interface NimbusClient {
   // existing method definitions remain unchanged
-}
+};
 ```
 
 The [`uniffi_bindgen::interface::Object`](https://github.com/mozilla/uniffi-rs/blob/803bb3d79daa8ea088fb2d8f05c08ada09821986/uniffi_bindgen/src/interface/mod.rs#L722) struct

--- a/docs/manual/src/types/interfaces.md
+++ b/docs/manual/src/types/interfaces.md
@@ -37,7 +37,7 @@ UniFFI will generate these proxies with an interface or protocol to help with te
 interface TodoListInterface {
     fun addItem(todo: String)
     fun getItems(): List<String>
-}
+};
 
 class TodoList : TodoListInterface {
    // implementations to call the Rust code.
@@ -141,7 +141,7 @@ For example, consider the following example:
 [Traits=(Debug)]
 interface TodoList {
     ...
-}
+};
 ```
 and the following Rust code:
 ```rust

--- a/docs/manual/src/udl/interfaces.md
+++ b/docs/manual/src/udl/interfaces.md
@@ -29,6 +29,7 @@ interface TodoList {
     [Async, Name=new_async]
     constructor(sequence<string> items);
     ...
+};
 ```
 
 For each alternate constructor, UniFFI will expose an appropriate static-method, class-method or similar


### PR DESCRIPTION
A couple of documentation snippets are missing the trailing semicolons, one of which I ended up copy-pasting, resulting in quite a bit of confusion as to why my `.udl` file suddenly kept failing to parse.