### PR TITLE
Fix compiling issue in Swift bindings for async throw functions

### DIFF
--- a/fixtures/ext-types/lib/src/lib.rs
+++ b/fixtures/ext-types/lib/src/lib.rs
@@ -200,6 +200,11 @@ fn throw_uniffi_one_error() -> Result<(), UniffiOneError> {
     Err(UniffiOneError::Oops("oh no".to_string()))
 }
 
+#[uniffi::export]
+async fn throw_uniffi_one_error_async() -> Result<(), UniffiOneError> {
+    Err(UniffiOneError::Oops("oh no - async".to_string()))
+}
+
 // external interface errors don't quite work.
 #[uniffi::export]
 fn throw_uniffi_one_error_interface() -> Result<(), UniffiOneErrorInterface> {

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.swift
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.swift
@@ -73,6 +73,17 @@ do {
 }
 
 do {
+    try await throwUniffiOneErrorAsync()
+    fatalError("Should have thrown")
+} catch let e as UniffiOneError {
+    if case let .Oops(reason) = e {
+        assert(reason == "oh no - async")
+    } else {
+        fatalError("wrong error variant: \(e)")
+    }
+}
+
+do {
     try throwUniffiOneErrorInterface()
     fatalError("Should have thrown")
 } catch let e as UniffiOneErrorInterface {

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.swift
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.swift
@@ -72,16 +72,21 @@ do {
     }
 }
 
-do {
-    try await throwUniffiOneErrorAsync()
-    fatalError("Should have thrown")
-} catch let e as UniffiOneError {
-    if case let .Oops(reason) = e {
-        assert(reason == "oh no - async")
-    } else {
-        fatalError("wrong error variant: \(e)")
+var counter = DispatchGroup()
+counter.enter()
+Task {
+    do {
+        try await throwUniffiOneErrorAsync()
+        fatalError("Should have thrown")
+    } catch let e as UniffiOneError {
+        if case let .Oops(reason) = e {
+            assert(reason == "oh no - async")
+        } else {
+            fatalError("wrong error variant: \(e)")
+        }
     }
 }
+counter.wait()
 
 do {
     try throwUniffiOneErrorInterface()

--- a/uniffi_bindgen/src/bindings/swift/templates/macros.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/macros.swift
@@ -88,7 +88,7 @@ public convenience init(
             {%- endmatch %}
             {%- match callable.throws_type() %}
             {%- when Some with (e) %}
-            errorHandler: {{ e|ffi_error_converter_name }}.lift
+            errorHandler: {{ e|ffi_error_converter_name }}_lift
             {%- else %}
             errorHandler: nil
             {% endmatch %}


### PR DESCRIPTION
`<ErrorType>.lift` Swift functions are private API and are referenced in `errorHandler: {{ e|ffi_error_converter_name }}.lift`. That would cause compiling issues in Swift bindings of a crate that uses external error types in async functions.

The first commit reproduces the issue, and the second commit fixes the problem.