### PR TITLE
Python: fix using Vecs and other composite types in tuple enums.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Bindings support `lift` and `lower` for CustomTypes in uniffi.toml to match the docs ([#2438](https://github.com/mozilla/uniffi-rs/issues/2438))
 
+- Python: fix using Vecs and other composite types in tuple enums ([#2445](https://github.com/mozilla/uniffi-rs/issues/2445))
+
 ### What's changed?
 
 - The uniffi-bindgen CLI support no longer brings in the `clap/color` feature, reducing dependencies ([#2435](https://github.com/mozilla/uniffi-rs/pull/2435))

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -234,6 +234,7 @@ pub enum MixedEnum {
     Int(i64),
     Both(String, i64),
     All { s: String, i: i64 },
+    Vec(Vec<String>),
 }
 
 #[uniffi::export]

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.kts
@@ -122,3 +122,5 @@ val eb = MixedEnum.Both("hi", 2)
 val (s, i) = eb
 assert(s == "hi")
 assert(i == 2L)
+
+assert(getMixedEnum(MixedEnum.Vec(listOf("hello"))) == MixedEnum.Vec(listOf("hello")))

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -81,6 +81,8 @@ assert(record_with_defaults.vec == [])
 assert(record_with_defaults.opt_vec == None)
 assert(record_with_defaults.opt_integer == 42)
 
+assert(RecordWithDefaults(no_default_string="", vec=["oops"]) == RecordWithDefaults(no_default_string="", vec=["oops"]))
+
 assert(double_with_default() == 42)
 
 obj_with_defaults = ObjectWithDefaults()
@@ -156,3 +158,5 @@ assert(str(MixedEnum.BOTH("hello", 2)) == "MixedEnum.BOTH('hello', 2)")
 # variant checker as, eg, `is_ALL()` vs `is_all()` so decided to do both.
 assert(get_mixed_enum(MixedEnum.ALL("string", 2)).is_all())
 assert(get_mixed_enum(MixedEnum.ALL("string", 2)).is_ALL())
+
+assert(get_mixed_enum(MixedEnum.VEC(["string"])).is_VEC())

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
@@ -143,3 +143,5 @@ switch MixedEnum.all(s: "string", i: 2) {
     default:
         assert(false)
 }
+
+assert(getMixedEnum(v: MixedEnum.vec(["hello"])) == .vec(["hello"]))

--- a/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
@@ -28,10 +28,6 @@ class {{ type_name }}:
         def __init__(self, *values):
             if len(values) != {{ variant.fields().len() }}:
                 raise TypeError(f"Expected {{ variant.fields().len() }} arguments, found {len(values)}")
-        {%- for field in variant.fields() %}
-            if not isinstance(values[{{ loop.index0 }}], {{ field|type_name }}):
-                raise TypeError(f"unexpected type for tuple element {{ loop.index0 }} - expected '{{ field|type_name }}', got '{type(values[{{ loop.index0 }}])}'")
-        {%- endfor %}
             self._values = values
 
         def __getitem__(self, index):


### PR DESCRIPTION
Fixes #2445