### PR TITLE
Fix Circle CI rustup update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,8 @@ commands:
   prepare-rust-target-version:
     steps:
       # So long as this is executed after the checkout it will use the version specified in rust-toolchain.yaml
-      - run: rustup update
+      - run: rustup self update
+      - run: rustup toolchain install
   # Our minimum supported rust version is specified here.
   prepare-rust-min-version:
     steps:


### PR DESCRIPTION
`rustup update` will download the latest version, however we want to get the version specified in `rust-toolchain.toml`.  We're currently running into an issue with this -- my guess is that somehow the worker downloaded Rust 1.84.1 or 1.85.0 so `rustup update` isn't going to download 1.84.0.