### PR TITLE
Update KMP bindings project link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Other tools we know of which try and solve a similarly shaped problem are:
 ## Third-party foreign language bindings
 
 * [React Native bindings](https://github.com/jhugman/uniffi-bindgen-react-native). The repository contains tooling to generate bindings for [Hermes](https://github.com/facebook/hermes) and for [creating Turbo Modules](https://reactnative.dev/blog/2024/10/23/the-new-architecture-is-here#new-native-modules).
-* [Kotlin Multiplatform support](https://gitlab.com/trixnity/uniffi-kotlin-multiplatform-bindings). The repository contains Kotlin Multiplatform bindings generation for UniFFI, letting you target both JVM and Native.
+* [Kotlin Multiplatform support (Gobley)](https://github.com/gobley/gobley). The repository contains Kotlin Multiplatform bindings generation for UniFFI, letting you target both JVM and Native.
 * [Go bindings](https://github.com/NordSecurity/uniffi-bindgen-go)
 * [C# bindings](https://github.com/NordSecurity/uniffi-bindgen-cs)
 * [Dart bindings](https://github.com/NiallBunting/uniffi-rs-dart)


### PR DESCRIPTION
The original UniFFI KMP bindings project is forked to another repo.

@benkuly