### PR TITLE
Fix test_imported_types.swift

### DIFF
--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.swift
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.swift
@@ -85,6 +85,7 @@ Task {
             fatalError("wrong error variant: \(e)")
         }
     }
+    counter.leave()
 }
 counter.wait()
 


### PR DESCRIPTION
@crazytonyli merged a change from me, but CircleCI wasn't running in his PR so we didn't catch that this line got left out.