### PR TITLE
Allow `uniffi_reexport_scaffolding!` macro to work in Rust 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [[UnreleasedUniFFIVersion]] (backend crates: [[UnreleasedBackendVersion]]) - (_[[ReleaseDate]]_)
 
+### What's fixed?
+
+- Allow `uniffi_reexport_scaffolding!` macro to work in Rust 2024 ([#2476](https://github.com/mozilla/uniffi-rs/issues/2476))
+
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.29.1...HEAD).
 
 ## v0.29.1 (backend crates: v0.29.1) - (_2025-03-18_)

--- a/uniffi_macros/src/export/callback_interface.rs
+++ b/uniffi_macros/src/export/callback_interface.rs
@@ -89,7 +89,7 @@ pub(super) fn trait_impl(
         static #vtable_cell: ::uniffi::UniffiForeignPointerCell::<#vtable_type> = ::uniffi::UniffiForeignPointerCell::<#vtable_type>::new();
 
         #[allow(missing_docs)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn #init_ident(vtable: ::std::ptr::NonNull<#vtable_type>) {
             #vtable_cell.set(vtable);
         }

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -252,7 +252,7 @@ pub(super) fn gen_ffi_function(
             ffi_buffer_scaffolding_fn(&ffi_ident, &ffi_return_ty, &param_types, true);
         quote! {
             #[doc(hidden)]
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub extern "C" fn #ffi_ident(
                 #(#param_names: #param_types,)*
                 call_status: &mut ::uniffi::RustCallStatus,
@@ -287,7 +287,7 @@ pub(super) fn gen_ffi_function(
 
         quote! {
             #[doc(hidden)]
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub extern "C" fn #ffi_ident(#(#param_names: #param_types,)*) -> ::uniffi::Handle {
                 ::uniffi::deps::trace!("calling: {}", #name);
                 let uniffi_lifted_args = (#lift_closure)();
@@ -326,7 +326,7 @@ fn ffi_buffer_scaffolding_fn(
     if has_rust_call_status {
         quote! {
             #[doc(hidden)]
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub unsafe extern "C" fn #ident(
                 arg_ptr: *mut ::uniffi::FfiBufferElement,
                 return_ptr: *mut ::uniffi::FfiBufferElement,
@@ -348,7 +348,7 @@ fn ffi_buffer_scaffolding_fn(
     } else {
         quote! {
             #[doc(hidden)]
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub unsafe extern "C" fn #ident(
                 arg_ptr: *mut ::uniffi::FfiBufferElement,
                 return_ptr: *mut ::uniffi::FfiBufferElement,

--- a/uniffi_macros/src/export/trait_interface.rs
+++ b/uniffi_macros/src/export/trait_interface.rs
@@ -45,7 +45,7 @@ pub(super) fn gen_trait_scaffolding(
 
     let helper_fn_tokens = quote! {
         #[doc(hidden)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         /// Clone a pointer to this object type
         ///
         /// Safety: Only pass pointers returned by a UniFFI call.  Do not pass pointers that were
@@ -67,7 +67,7 @@ pub(super) fn gen_trait_scaffolding(
         }
 
         #[doc(hidden)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         /// Free a pointer to this object type
         ///
         /// Safety: Only pass pointers returned by a UniFFI call.  Do not pass pointers that were

--- a/uniffi_macros/src/object.rs
+++ b/uniffi_macros/src/object.rs
@@ -62,7 +62,7 @@ pub fn expand_object(input: DeriveInput, options: DeriveOptions) -> syn::Result<
 
     Ok(quote! {
         #[doc(hidden)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn #clone_fn_ident(
             ptr: *const ::std::ffi::c_void,
             call_status: &mut ::uniffi::RustCallStatus
@@ -75,7 +75,7 @@ pub fn expand_object(input: DeriveInput, options: DeriveOptions) -> syn::Result<
         }
 
         #[doc(hidden)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn #free_fn_ident(
             ptr: *const ::std::ffi::c_void,
             call_status: &mut ::uniffi::RustCallStatus

--- a/uniffi_macros/src/setup_scaffolding.rs
+++ b/uniffi_macros/src/setup_scaffolding.rs
@@ -39,7 +39,7 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
 
         #[allow(clippy::missing_safety_doc, missing_docs)]
         #[doc(hidden)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn #ffi_contract_version_ident() -> ::std::primitive::u32 {
             #UNIFFI_CONTRACT_VERSION
         }
@@ -55,7 +55,7 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
                 .concat_str(#namespace);
 
         #[doc(hidden)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub static #namespace_static_ident: [::std::primitive::u8; #namespace_const_ident.size] =
             #namespace_const_ident.into_array();
 
@@ -65,7 +65,7 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
 
         #[allow(clippy::missing_safety_doc, missing_docs)]
         #[doc(hidden)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn #ffi_rustbuffer_alloc_ident(
             size: ::std::primitive::u64,
             call_status: &mut ::uniffi::RustCallStatus,
@@ -75,7 +75,7 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
 
         #[allow(clippy::missing_safety_doc, missing_docs)]
         #[doc(hidden)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn #ffi_rustbuffer_from_bytes_ident(
             bytes: ::uniffi::ForeignBytes,
             call_status: &mut ::uniffi::RustCallStatus,
@@ -85,7 +85,7 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
 
         #[allow(clippy::missing_safety_doc, missing_docs)]
         #[doc(hidden)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn #ffi_rustbuffer_free_ident(
             buf: ::uniffi::RustBuffer,
             call_status: &mut ::uniffi::RustCallStatus,
@@ -95,7 +95,7 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
 
         #[allow(clippy::missing_safety_doc, missing_docs)]
         #[doc(hidden)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn #ffi_rustbuffer_reserve_ident(
             buf: ::uniffi::RustBuffer,
             additional: ::std::primitive::u64,
@@ -128,7 +128,7 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
         macro_rules! uniffi_reexport_scaffolding {
             () => {
                 #[doc(hidden)]
-                #[no_mangle]
+                #[unsafe(no_mangle)]
                 pub extern "C" fn #reexport_hack_ident() {
                     $crate::uniffi_reexport_hack()
                 }
@@ -175,21 +175,21 @@ fn rust_future_scaffolding_fns(module_path: &str) -> TokenStream {
         quote! {
             #[allow(clippy::missing_safety_doc, missing_docs)]
             #[doc(hidden)]
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub unsafe extern "C" fn #ffi_rust_future_poll(handle: ::uniffi::Handle, callback: ::uniffi::RustFutureContinuationCallback, data: u64) {
                 ::uniffi::ffi::rust_future_poll::<#return_type, crate::UniFfiTag>(handle, callback, data);
             }
 
             #[allow(clippy::missing_safety_doc, missing_docs)]
             #[doc(hidden)]
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub unsafe extern "C" fn #ffi_rust_future_cancel(handle: ::uniffi::Handle) {
                 ::uniffi::ffi::rust_future_cancel::<#return_type, crate::UniFfiTag>(handle)
             }
 
             #[allow(clippy::missing_safety_doc, missing_docs)]
             #[doc(hidden)]
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub unsafe extern "C" fn #ffi_rust_future_complete(
                 handle: ::uniffi::Handle,
                 out_status: &mut ::uniffi::RustCallStatus
@@ -199,7 +199,7 @@ fn rust_future_scaffolding_fns(module_path: &str) -> TokenStream {
 
             #[allow(clippy::missing_safety_doc, missing_docs)]
             #[doc(hidden)]
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub unsafe extern "C" fn #ffi_rust_future_free(handle: ::uniffi::Handle) {
                 ::uniffi::ffi::rust_future_free::<#return_type, crate::UniFfiTag>(handle)
             }

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -115,7 +115,7 @@ pub fn create_metadata_items(
         let ident = Ident::new(&name, Span::call_site());
         quote! {
             #[doc(hidden)]
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub extern "C" fn #ident() -> u16 {
                 // Force constant evaluation to ensure:
                 // 1. The checksum is computed at compile time; and
@@ -128,7 +128,7 @@ pub fn create_metadata_items(
 
     quote! {
         const #const_ident: ::uniffi::MetadataBuffer = #metadata_expr;
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         #[doc(hidden)]
         pub static #static_ident: [u8; #const_ident.size] = #const_ident.into_array();
 


### PR DESCRIPTION
As noted in #2459 and #2475, the `uniffi_reexport_scaffolding!` macro doesn't work in Rust 2024.