### PR TITLE
uniffi_bindgen: Add support for specifying extra link frameworks in generated modulemap file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   it also means foreign implemented traits also must when Swift 6 conformance is enabled.
   See the Swift section of the manual for more. ([#2450](https://github.com/mozilla/uniffi-rs/pull/2450))
 
+- You can now optionally specify extra frameworks like `CoreBluetooth` or `CoreFoundation` when generating a modulemap file for an xcframework.
+
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.29.0...HEAD).
 
 ## v0.29.0 (backend crates: v0.29.0) - (_2025-02-06_)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,6 +1989,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-fixture-swift-link-frameworks"
+version = "0.1.0"
+dependencies = [
+ "uniffi",
+]
+
+[[package]]
 name = "uniffi-fixture-swift-omit-argument-labels"
 version = "0.22.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ members = [
   "fixtures/swift-omit-labels",
   "fixtures/futures",
   "fixtures/swift-bridging-header-compile",
+  "fixtures/swift-link-frameworks",
   "fixtures/type-limits",
   "fixtures/large-enum",
   "fixtures/large-error",

--- a/docs/manual/src/swift/configuration.md
+++ b/docs/manual/src/swift/configuration.md
@@ -19,6 +19,7 @@ more likely to change than other configurations.
 | `custom_types`                     |                          | A map which controls how custom types are exposed to Swift. See the [custom types section of the manual](../types/custom_types.md#custom-types-in-the-bindings-code) |
 | `omit_localized_error_conformance` | `false`                  | Whether to make generated error types conform to `LocalizedError`.                                                                                                   |
 | `omit_checksums`                   | `false`                  | Whether to omit checking the library checksums as the library is initialized. Changing this will shoot yourself in the foot if you mixup your build pipeline in any way, but might speed up initialization.
+| `link_frameworks`                  | `[]`                     | The extra frameworks to link this binary against, such as `CoreBluetooth` or `CoreAudio`. Usually only used for interacting with native platform libraries.
 
 [^1]: `namespace` is the top-level namespace from your UDL file.
 

--- a/fixtures/swift-link-frameworks/Cargo.toml
+++ b/fixtures/swift-link-frameworks/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "uniffi-fixture-swift-link-frameworks"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "uniffi_swift_link_frameworks"
+
+[dependencies]
+uniffi = { workspace = true }
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["build"] }
+
+[dev-dependencies]
+uniffi = { workspace = true, features = ["bindgen-tests"] }
+
+[features]
+ffi-trace = ["uniffi/ffi-trace"]

--- a/fixtures/swift-link-frameworks/build.rs
+++ b/fixtures/swift-link-frameworks/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::generate_scaffolding("src/swift-link-frameworks.udl").unwrap();
+}

--- a/fixtures/swift-link-frameworks/src/lib.rs
+++ b/fixtures/swift-link-frameworks/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn no_arguments() {}
+
+uniffi::include_scaffolding!("swift-link-frameworks");

--- a/fixtures/swift-link-frameworks/src/swift-link-frameworks.udl
+++ b/fixtures/swift-link-frameworks/src/swift-link-frameworks.udl
@@ -1,0 +1,3 @@
+namespace swift_link_frameworks {
+    void no_arguments();
+};

--- a/fixtures/swift-link-frameworks/uniffi.toml
+++ b/fixtures/swift-link-frameworks/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.swift]
+link_frameworks = ["CoreFoundation"]

--- a/uniffi/src/cli/swift.rs
+++ b/uniffi/src/cli/swift.rs
@@ -33,6 +33,9 @@ struct Cli {
     /// all sub-dependencies causes obscure platform specific problems.
     #[clap(long)]
     metadata_no_deps: bool,
+    /// What frameworks to link against when generating the modulemap file.
+    #[arg(long)]
+    link_frameworks: Vec<String>,
 }
 
 #[derive(Debug, Args)]
@@ -68,6 +71,7 @@ impl From<Cli> for SwiftBindingsOptions {
             module_name: cli.module_name,
             modulemap_filename: cli.modulemap_filename,
             metadata_no_deps: cli.metadata_no_deps,
+            link_frameworks: cli.link_frameworks,
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -172,6 +172,8 @@ pub struct Config {
     omit_localized_error_conformance: Option<bool>,
     #[serde(default)]
     custom_types: HashMap<String, CustomTypeConfig>,
+    #[serde(default)]
+    link_frameworks: Vec<String>,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -256,9 +258,15 @@ impl Config {
         self.generate_immutable_records.unwrap_or(false)
     }
 
-    // Whether to make generated error types conform to `LocalizedError`. Default: false.
+    /// Whether to make generated error types conform to `LocalizedError`. Default: false.
     pub fn omit_localized_error_conformance(&self) -> bool {
         self.omit_localized_error_conformance.unwrap_or(false)
+    }
+
+    /// Extra frameworks to link this Swift module against. This is populated in the modulemap file,
+    /// usually as part of an `xcframework`.
+    pub fn link_frameworks(&self) -> Vec<String> {
+        self.link_frameworks.clone()
     }
 }
 
@@ -326,11 +334,13 @@ pub fn generate_modulemap(
     module_name: String,
     header_filenames: Vec<String>,
     xcframework: bool,
+    link_frameworks: Vec<String>,
 ) -> Result<String> {
     ModuleMap {
         module_name,
         header_filenames,
         xcframework,
+        link_frameworks,
     }
     .render()
     .context("failed to render Swift library")
@@ -418,6 +428,7 @@ pub struct ModuleMap {
     module_name: String,
     header_filenames: Vec<String>,
     xcframework: bool,
+    link_frameworks: Vec<String>,
 }
 
 impl ModuleMap {
@@ -426,6 +437,7 @@ impl ModuleMap {
             module_name: config.ffi_module_name(),
             header_filenames: vec![config.header_filename()],
             xcframework: false,
+            link_frameworks: config.link_frameworks(),
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -210,8 +210,12 @@ pub fn generate_swift_bindings(options: SwiftBindingsOptions) -> Result<()> {
             .map(|Component { config, .. }| config.header_filename())
             .collect();
         header_filenames.sort();
-        let modulemap_source =
-            generate_modulemap(module_name, header_filenames, options.xcframework)?;
+        let modulemap_source = generate_modulemap(
+            module_name,
+            header_filenames,
+            options.xcframework,
+            options.link_frameworks,
+        )?;
         let modulemap_path = options.out_dir.join(modulemap_filename);
         fs::write(modulemap_path, modulemap_source)?;
     }
@@ -230,4 +234,5 @@ pub struct SwiftBindingsOptions {
     pub module_name: Option<String>,
     pub modulemap_filename: Option<String>,
     pub metadata_no_deps: bool,
+    pub link_frameworks: Vec<String>,
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/ModuleMapTemplate.modulemap
+++ b/uniffi_bindgen/src/bindings/swift/templates/ModuleMapTemplate.modulemap
@@ -3,4 +3,7 @@
     header "{{ filename }}"
     {%- endfor %}
     export *
+    {%- for link_framework in link_frameworks %}
+    link framework "{{ link_framework }}"
+    {%- endfor %}
 }


### PR DESCRIPTION
When including another static library in the form of an xcframework (C++/C), the resulting Rust library also takes a dependency on the frameworks that are linked as part of that xcframework. This change allows specifying the frameworks so that this contract is upheld.