### PR TITLE
Fix false positive for missing_docs for trait impl

### DIFF
--- a/uniffi_macros/src/export/callback_interface.rs
+++ b/uniffi_macros/src/export/callback_interface.rs
@@ -80,6 +80,7 @@ pub(super) fn trait_impl(
     let impl_attributes = has_async_method.then(|| quote! { #[::async_trait::async_trait] });
 
     Ok(quote! {
+        #[allow(missing_docs)]
         pub struct #vtable_type {
             #(#vtable_fields)*
             pub uniffi_free: extern "C" fn(handle: u64),
@@ -87,6 +88,7 @@ pub(super) fn trait_impl(
 
         static #vtable_cell: ::uniffi::UniffiForeignPointerCell::<#vtable_type> = ::uniffi::UniffiForeignPointerCell::<#vtable_type>::new();
 
+        #[allow(missing_docs)]
         #[no_mangle]
         pub extern "C" fn #init_ident(vtable: ::std::ptr::NonNull<#vtable_type>) {
             #vtable_cell.set(vtable);


### PR DESCRIPTION
Without these changes, there are new false positives for `missing_docs` when running `cargo clippy`.

I have not added tests for the changes, as I saw no other example for testing on this functionality.

I have not added an entry to the changelog as it is really a minor fix.

Any feedback/suggestions are very welcome!

---

Example code:

```rust
//! Crate documentation
#![warn(missing_docs)]

uniffi::setup_scaffolding!();

/// Documentation is here
#[uniffi::export(with_foreign)]
pub trait MyTrait: Send + Sync {}
```



Observed behavior:

```
cargo clippy --all-targets --all-features 
    Checking missing_uniffi_docs v0.1.0 (/home/theo/tmp/missing_uniffi_docs)
warning: missing documentation for a struct
 --> src/lib.rs:6:1
  |
6 | #[uniffi::export(with_foreign)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
note: the lint level is defined here
 --> src/lib.rs:2:9
  |
2 | #![warn(missing_docs)]
  |         ^^^^^^^^^^^^
  = note: this warning originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: missing documentation for a struct field
 --> src/lib.rs:6:1
  |
6 | #[uniffi::export(with_foreign)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: this warning originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: missing documentation for a function
 --> src/lib.rs:6:1
  |
6 | #[uniffi::export(with_foreign)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: this warning originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: `missing_uniffi_docs` (lib test) generated 3 warnings (3 duplicates)
warning: `missing_uniffi_docs` (lib) generated 3 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.15s

cargo-clippy finished at Thu Mar 13 10:50:30
```
