### PR TITLE
Fix Kotlin interfaces in Lists and Maps being not destroyed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Python: fix using Vecs and other composite types in tuple enums ([#2445](https://github.com/mozilla/uniffi-rs/issues/2445))
 
+- Kotlin: fix interfaces in sequences and records being not disposed ([#2479](https://github.com/mozilla/uniffi-rs/issues/2479))
+
 ### What's changed?
 
 - Rust 2024 edition is supported, msrv is 1.82.0

--- a/fixtures/coverall/src/coverall.udl
+++ b/fixtures/coverall/src/coverall.udl
@@ -63,6 +63,8 @@ dictionary SimpleDict {
     double float64;
     double? maybe_float64;
     Coveralls? coveralls;
+    sequence<Coveralls?> coveralls_list;
+    record<string, Coveralls?> coveralls_map;
     NodeTrait? test_trait;
 };
 

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -194,6 +194,8 @@ pub struct SimpleDict {
     float64: f64,
     maybe_float64: Option<f64>,
     coveralls: Option<Arc<Coveralls>>,
+    coveralls_list: Vec<Option<Arc<Coveralls>>>,
+    coveralls_map: HashMap<String, Option<Arc<Coveralls>>>,
     test_trait: Option<Arc<dyn NodeTrait>>,
 }
 
@@ -329,6 +331,24 @@ fn create_some_dict() -> SimpleDict {
         float64: 0.0,
         maybe_float64: Some(1.0),
         coveralls: Some(Arc::new(Coveralls::new("some_dict".to_string()))),
+        coveralls_list: vec![
+            Some(Arc::new(Coveralls::new("some_dict_1".to_string()))),
+            None,
+            Some(Arc::new(Coveralls::new("some_dict_2".to_string()))),
+        ],
+        coveralls_map: [
+            (
+                "some_dict_3".to_string(),
+                Some(Arc::new(Coveralls::new("some_dict_3".to_string()))),
+            ),
+            ("none".to_string(), None),
+            (
+                "some_dict_4".to_string(),
+                Some(Arc::new(Coveralls::new("some_dict_4".to_string()))),
+            ),
+        ]
+        .into_iter()
+        .collect(),
         test_trait: Some(Arc::new(traits::Node::default())),
     }
 }

--- a/fixtures/coverall/tests/bindings/test_coverall.kts
+++ b/fixtures/coverall/tests/bindings/test_coverall.kts
@@ -39,7 +39,19 @@ createSomeDict().use { d ->
     assert(d.maybeFloat64!!.almostEquals(1.0))
 
     assert(d.coveralls!!.getName() == "some_dict")
+
+    assert(d.coverallsList[0]!!.getName() == "some_dict_1")
+    assert(d.coverallsList[1] == null)
+    assert(d.coverallsList[2]!!.getName() == "some_dict_2")
+
+    assert(d.coverallsMap["some_dict_3"]!!.getName() == "some_dict_3")
+    assert(d.coverallsMap["none"] == null)
+    assert(d.coverallsMap["some_dict_4"]!!.getName() == "some_dict_4")
+
+    assert(getNumAlive() == 5UL)
 }
+
+assert(getNumAlive() == 0UL)
 
 createNoneDict().use { d ->
     assert(d.text == "text")
@@ -69,8 +81,11 @@ createNoneDict().use { d ->
     assert(d.maybeFloat64 == null)
 
     assert(d.coveralls == null)
+
+    assert(getNumAlive() == 0UL)
 }
 
+assert(getNumAlive() == 0UL)
 
 // Test arcs.
 

--- a/fixtures/coverall/tests/bindings/test_coverall.py
+++ b/fixtures/coverall/tests/bindings/test_coverall.py
@@ -41,6 +41,18 @@ class TestCoverall(unittest.TestCase):
         self.assertAlmostEqual(d.float64, 0.0)
         self.assertAlmostEqual(d.maybe_float64, 1.0)
 
+        self.assertEqual(d.coveralls_list[0].get_name(), "some_dict_1")
+        self.assertIsNone(d.coveralls_list[1])
+        self.assertEqual(d.coveralls_list[2].get_name(), "some_dict_2")
+
+        self.assertEqual(d.coveralls_map["some_dict_3"].get_name(), "some_dict_3")
+        self.assertIsNone(d.coveralls_map["none"])
+        self.assertEqual(d.coveralls_map["some_dict_4"].get_name(), "some_dict_4")
+
+        self.assertEqual(get_num_alive(), 5)
+        d = None
+        self.assertEqual(get_num_alive(), 0)
+
     def test_none_dict(self):
         d = create_none_dict()
         self.assertEqual(d.text, "text")
@@ -66,6 +78,10 @@ class TestCoverall(unittest.TestCase):
         self.assertIsNone(d.maybe_float64)
         self.assertIsNone(d.coveralls)
         self.assertIsNone(d.test_trait)
+
+        self.assertEqual(get_num_alive(), 0)
+        d = None
+        self.assertEqual(get_num_alive(), 0)
 
     def test_constructors(self):
         self.assertEqual(get_num_alive(), 0)

--- a/fixtures/coverall/tests/bindings/test_coverall.rb
+++ b/fixtures/coverall/tests/bindings/test_coverall.rb
@@ -49,6 +49,7 @@ class TestCoverall < Test::Unit::TestCase
     assert_nil(d.coveralls_map["none"])
     assert_equal(d.coveralls_map["some_dict_4"].get_name, "some_dict_4")
 
+    GC.start
     assert_equal 5, Coverall.get_num_alive
     d = nil
     GC.start
@@ -81,6 +82,7 @@ class TestCoverall < Test::Unit::TestCase
     assert_equal(d.float64, 0.0)
     assert_nil(d.maybe_float64)
 
+    GC.start
     assert_equal 0, Coverall.get_num_alive
     d = nil
     GC.start

--- a/fixtures/coverall/tests/bindings/test_coverall.rb
+++ b/fixtures/coverall/tests/bindings/test_coverall.rb
@@ -40,6 +40,19 @@ class TestCoverall < Test::Unit::TestCase
     assert_equal(d.maybe_float64, 1.0)
 
     assert_equal(d.coveralls.get_name(), "some_dict")
+
+    assert_equal(d.coveralls_list[0].get_name, "some_dict_1")
+    assert_nil(d.coveralls_list[1])
+    assert_equal(d.coveralls_list[2].get_name, "some_dict_2")
+
+    assert_equal(d.coveralls_map["some_dict_3"].get_name, "some_dict_3")
+    assert_nil(d.coveralls_map["none"])
+    assert_equal(d.coveralls_map["some_dict_4"].get_name, "some_dict_4")
+
+    assert_equal 5, Coverall.get_num_alive
+    d = nil
+    GC.start
+    assert_equal 0, Coverall.get_num_alive
   end
 
   def test_none_dict
@@ -67,6 +80,11 @@ class TestCoverall < Test::Unit::TestCase
     assert_nil(d.maybe_float32)
     assert_equal(d.float64, 0.0)
     assert_nil(d.maybe_float64)
+
+    assert_equal 0, Coverall.get_num_alive
+    d = nil
+    GC.start
+    assert_equal 0, Coverall.get_num_alive
   end
 
   def test_constructors

--- a/fixtures/coverall/tests/bindings/test_coverall.swift
+++ b/fixtures/coverall/tests/bindings/test_coverall.swift
@@ -45,7 +45,18 @@ do {
     assert(d.float64.almostEquals(0.0))
     assert(d.maybeFloat64!.almostEquals(1.0))
     assert(d.coveralls!.getName() == "some_dict")
+
+    assert(d.coverallsList[0]!.getName() == "some_dict_1")
+    assert(d.coverallsList[1] == nil)
+    assert(d.coverallsList[2]!.getName() == "some_dict_2")
+
+    assert(d.coverallsMap["some_dict_3"]!!.getName() == "some_dict_3")
+    assert(d.coverallsMap["none"]! == nil)
+    assert(d.coverallsMap["some_dict_4"]!!.getName() == "some_dict_4")
+
+    assert(getNumAlive() == 5)
 }
+assert(getNumAlive() == 0)
 
 // Test none_dict().
 do {
@@ -71,7 +82,10 @@ do {
     assert(d.float64.almostEquals(0.0))
     assert(d.maybeFloat64 == nil)
     assert(d.coveralls == nil)
+
+    assert(getNumAlive() == 0)
 }
+assert(getNumAlive() == 0)
 
 // Test arcs.
 do {

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Types.kt
@@ -12,8 +12,33 @@ interface Disposable {
     fun destroy()
     companion object {
         fun destroy(vararg args: Any?) {
-            args.filterIsInstance<Disposable>()
-                .forEach(Disposable::destroy)
+            for (arg in args) {
+                when (arg) {
+                    is Disposable -> arg.destroy()
+                    is ArrayList<*> -> {
+                        for (idx in arg.indices) {
+                            val element = arg[idx]
+                            if (element is Disposable) {
+                                element.destroy()
+                            }
+                        }
+                    }
+                    is Map<*, *> -> {
+                        for (element in arg.values) {
+                            if (element is Disposable) {
+                                element.destroy()
+                            }
+                        }
+                    }
+                    is Iterable<*> -> {
+                        for (element in arg) {
+                            if (element is Disposable) {
+                                element.destroy()
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -151,9 +151,11 @@ v{{- field_num -}}
 
  // Macro for destroying fields
 {%- macro destroy_fields(member) %}
+    Disposable.destroy(
     {%- for field in member.fields() %}
-        Disposable.destroy(this.{%- call field_name(field, loop.index) -%})
-    {% endfor -%}
+        this.{%- call field_name(field, loop.index) -%}{% if loop.last %}{% else %},{% endif -%}
+    {%- endfor %}
+    )
 {%- endmacro -%}
 
 {%- macro docstring_value(maybe_docstring, indent_spaces) %}


### PR DESCRIPTION
Fixes #2467.

## Changes

- Made `Disposable.destroy` handle list or maps of interfaces.
- Replaced `.filterIsInstance` in `Disposable.destroy` with a plain for loop, as `.filterIsInstance` allocates an ArrayList.
- Made macro `destroy_fields` call `Disposable.destroy` only once.
- Modified `SimpleDict` in fixture `coverall` to test list/map interface deallocation.