### PR TITLE
Macro support for custom autogenerated Swift protocols

### DIFF
--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -205,6 +205,7 @@ mod test_metadata {
                     },
                 ],
                 docstring: None,
+                swift_protocols: vec![],
             },
         );
     }

--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -241,6 +241,7 @@ mod test_metadata {
                 ],
                 non_exhaustive: false,
                 docstring: None,
+                swift_protocols: vec![],
             },
         );
     }
@@ -290,6 +291,7 @@ mod test_metadata {
                 ],
                 non_exhaustive: false,
                 docstring: None,
+                swift_protocols: vec![],
             },
         );
     }
@@ -326,6 +328,7 @@ mod test_metadata {
                 ],
                 non_exhaustive: false,
                 docstring: None,
+                swift_protocols: vec![],
             },
         );
     }
@@ -348,6 +351,7 @@ mod test_metadata {
                 }],
                 non_exhaustive: false,
                 docstring: None,
+                swift_protocols: vec![],
             },
         );
     }
@@ -378,6 +382,7 @@ mod test_metadata {
                 ],
                 non_exhaustive: false,
                 docstring: None,
+                swift_protocols: vec![],
             },
         );
     }
@@ -427,6 +432,7 @@ mod test_metadata {
                 ],
                 non_exhaustive: false,
                 docstring: None,
+                swift_protocols: vec![],
             },
         );
     }

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -9,6 +9,7 @@ mod callback_interface;
 use callback_interface::TestCallbackInterface;
 
 #[derive(uniffi::Record)]
+#[uniffi(swift_protocols = ["Copyable", "Codable"])]
 pub struct One {
     inner: i32,
 }

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -9,7 +9,7 @@ mod callback_interface;
 use callback_interface::TestCallbackInterface;
 
 #[derive(uniffi::Record)]
-#[uniffi(swift_protocols = ["Copyable", "Codable"])]
+#[uniffi(swift_protocols = ["Encodable", "Decodable"])]
 pub struct One {
     inner: i32,
 }

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -221,10 +221,19 @@ fn make_record_with_bytes() -> RecordWithBytes {
 }
 
 #[derive(uniffi::Enum)]
+#[uniffi(swift_protocols = "CaseIterable")]
 pub enum MaybeBool {
     True,
     False,
     Uncertain,
+}
+
+#[derive(uniffi::Enum)]
+#[uniffi(swift_protocols = ["CaseIterable", "Codable"])]
+pub enum SwiftCaseIterableAndCodable {
+    A,
+    B,
+    C,
 }
 
 #[derive(uniffi::Enum)]

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.swift
@@ -145,3 +145,7 @@ switch MixedEnum.all(s: "string", i: 2) {
 }
 
 assert(getMixedEnum(v: MixedEnum.vec(["hello"])) == .vec(["hello"]))
+
+// Swift protocols
+assert(MaybeBool.allCases.map({ "\($0)" }).joined(separator: ", ") == "true, false, uncertain")
+assert(SwiftCaseIterableAndCodable.allCases.map({ "\($0)" }).joined(separator: ", ") == "a, b, c")

--- a/fixtures/uitests/tests/ui/export_attrs.stderr
+++ b/fixtures/uitests/tests/ui/export_attrs.stderr
@@ -24,7 +24,7 @@ error: attribute `with_foreign` is not supported here.
 17 | #[uniffi::export(with_foreign)]
    |                  ^^^^^^^^^^^^
 
-error: attribute arguments are not currently recognized in this position
+error: expected `swift_protocols`
   --> tests/ui/export_attrs.rs:22:10
    |
 22 | #[uniffi(flat_error)]

--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -90,3 +90,7 @@ public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> RustBuff
 {% if !contains_object_references %}
 extension {{ type_name }}: Equatable, Hashable {}
 {% endif %}
+
+{% for swift_protocol in e.swift_protocols() %}
+extension {{ type_name }}: {{ swift_protocol }} {}
+{% endfor %}

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -39,6 +39,10 @@ extension {{ type_name }}: Equatable, Hashable {
 
 {% endif %}
 
+{% for swift_protocol in rec.swift_protocols() %}
+extension {{ type_name }}: {{ swift_protocol }} {}
+{% endfor %}
+
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -181,6 +181,7 @@ pub struct Enum {
     pub(super) non_exhaustive: bool,
     #[checksum_ignore]
     pub(super) docstring: Option<String>,
+    pub(super) swift_protocols: Vec<String>,
 }
 
 impl Enum {
@@ -263,6 +264,10 @@ impl Enum {
     pub fn docstring(&self) -> Option<&str> {
         self.docstring.as_deref()
     }
+
+    pub fn swift_protocols(&self) -> &[String] {
+        &self.swift_protocols
+    }
 }
 
 impl TryFrom<uniffi_meta::EnumMetadata> for Enum {
@@ -281,7 +286,8 @@ impl TryFrom<uniffi_meta::EnumMetadata> for Enum {
                 .collect::<Result<_>>()?,
             shape: meta.shape,
             non_exhaustive: meta.non_exhaustive,
-            docstring: meta.docstring.clone(),
+            docstring: meta.docstring,
+            swift_protocols: meta.swift_protocols,
         })
     }
 }
@@ -680,6 +686,7 @@ mod test {
             shape: EnumShape::Enum,
             non_exhaustive: false,
             docstring: None,
+            swift_protocols: vec![],
         };
 
         assert!(e.variant_discr(0).is_err());

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -1263,6 +1263,7 @@ existing definition: Enum {
     shape: Enum,
     non_exhaustive: false,
     docstring: None,
+    swift_protocols: [],
 },
 new definition: Enum {
     name: \"Testing\",
@@ -1288,6 +1289,7 @@ new definition: Enum {
     },
     non_exhaustive: false,
     docstring: None,
+    swift_protocols: [],
 }",
         );
 

--- a/uniffi_bindgen/src/interface/record.rs
+++ b/uniffi_bindgen/src/interface/record.rs
@@ -63,6 +63,7 @@ pub struct Record {
     pub(super) fields: Vec<Field>,
     #[checksum_ignore]
     pub(super) docstring: Option<String>,
+    pub(super) swift_protocols: Vec<String>,
 }
 
 impl Record {
@@ -84,6 +85,10 @@ impl Record {
 
     pub fn docstring(&self) -> Option<&str> {
         self.docstring.as_deref()
+    }
+
+    pub fn swift_protocols(&self) -> &[String] {
+        &self.swift_protocols
     }
 
     pub fn iter_types(&self) -> TypeIterator<'_> {
@@ -118,6 +123,7 @@ impl TryFrom<uniffi_meta::RecordMetadata> for Record {
                 .map(TryInto::try_into)
                 .collect::<Result<_>>()?,
             docstring: meta.docstring.clone(),
+            swift_protocols: meta.swift_protocols,
         })
     }
 }

--- a/uniffi_macros/src/error.rs
+++ b/uniffi_macros/src/error.rs
@@ -4,7 +4,7 @@ use syn::{DeriveInput, Index};
 use uniffi_meta::EnumShape;
 
 use crate::{
-    enum_::{rich_error_ffi_converter_impl, variant_metadata, EnumItem},
+    enum_::{rich_error_ffi_converter_impl, string_array, variant_metadata, EnumItem},
     ffiops,
     util::{
         chain, create_metadata_items, extract_docstring, ident_to_string, mod_path,
@@ -200,6 +200,8 @@ pub(crate) fn error_meta_static_var(item: &EnumItem) -> syn::Result<TokenStream>
         .concat_bool(#non_exhaustive)
         .concat_long_str(#docstring)
     });
+    metadata_expr.extend(string_array(&[])?); // swift_protocols
+
     Ok(create_metadata_items("error", &name, metadata_expr, None))
 }
 

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -27,6 +27,7 @@ mod object;
 mod record;
 mod remote;
 mod setup_scaffolding;
+mod swift_protocols;
 mod test;
 mod util;
 
@@ -100,7 +101,7 @@ pub fn derive_record(input: TokenStream) -> TokenStream {
         .into()
 }
 
-#[proc_macro_derive(Enum)]
+#[proc_macro_derive(Enum, attributes(uniffi))]
 pub fn derive_enum(input: TokenStream) -> TokenStream {
     expand_enum(parse_macro_input!(input), DeriveOptions::default())
         .unwrap_or_else(syn::Error::into_compile_error)

--- a/uniffi_macros/src/record.rs
+++ b/uniffi_macros/src/record.rs
@@ -206,7 +206,6 @@ impl UniffiAttributeArgs for RecordAttr {
             let _: Token![=] = input.parse()?;
             Ok(Self {
                 swift_protocols: Some(input.parse()?),
-                ..Self::default()
             })
         } else {
             Err(lookahead.error())

--- a/uniffi_macros/src/swift_protocols.rs
+++ b/uniffi_macros/src/swift_protocols.rs
@@ -1,0 +1,49 @@
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{
+    bracketed,
+    parse::{Parse, ParseStream},
+    token, LitStr, Token,
+};
+
+#[derive(Clone)]
+pub enum SwiftProtocols {
+    Single(LitStr),
+    Multiple(Vec<LitStr>),
+}
+
+impl ToTokens for SwiftProtocols {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            SwiftProtocols::Single(lit) => lit.to_tokens(tokens),
+            SwiftProtocols::Multiple(items) => tokens.extend(quote! { #(#items),* }),
+        }
+    }
+}
+
+impl Parse for SwiftProtocols {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(token::Bracket) {
+            let content;
+            let _ = bracketed!(content in input);
+            Ok(Self::Multiple(
+                content
+                    .parse_terminated(|stream| stream.parse::<LitStr>(), Token![,])?
+                    .into_iter()
+                    .collect(),
+            ))
+        } else {
+            Ok(Self::Single(input.parse()?))
+        }
+    }
+}
+
+impl SwiftProtocols {
+    pub(crate) fn to_vec(&self) -> Vec<String> {
+        match self {
+            SwiftProtocols::Single(lit) => vec![lit.value()],
+            SwiftProtocols::Multiple(items) => items.iter().map(|item| item.value()).collect(),
+        }
+    }
+}

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -265,6 +265,7 @@ pub mod kw {
     syn::custom_keyword!(Display);
     syn::custom_keyword!(Eq);
     syn::custom_keyword!(Hash);
+    syn::custom_keyword!(swift_protocols);
     // Not used anymore
     syn::custom_keyword!(handle_unknown_callback_error);
 }

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -300,6 +300,7 @@ pub struct RecordMetadata {
     pub remote: bool, // only used when generating scaffolding from UDL
     pub fields: Vec<FieldMetadata>,
     pub docstring: Option<String>,
+    pub swift_protocols: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -345,6 +345,7 @@ pub struct EnumMetadata {
     pub discr_type: Option<Type>,
     pub non_exhaustive: bool,
     pub docstring: Option<String>,
+    pub swift_protocols: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/uniffi_meta/src/reader.rs
+++ b/uniffi_meta/src/reader.rs
@@ -313,6 +313,7 @@ impl<'a> MetadataReader<'a> {
             remote: false, // only used when generating scaffolding from UDL
             fields: self.read_fields()?,
             docstring: self.read_optional_long_string()?,
+            swift_protocols: self.read_string_array()?,
         })
     }
 

--- a/uniffi_udl/src/converters/enum_.rs
+++ b/uniffi_udl/src/converters/enum_.rs
@@ -41,6 +41,7 @@ impl APIConverter<EnumMetadata> for weedle::EnumDefinition<'_> {
                 .collect::<Result<Vec<_>>>()?,
             non_exhaustive: attributes.contains_non_exhaustive_attr(),
             docstring: self.docstring.as_ref().map(|v| convert_docstring(&v.0)),
+            swift_protocols: vec![],
         })
     }
 }
@@ -76,6 +77,7 @@ impl APIConverter<EnumMetadata> for weedle::InterfaceDefinition<'_> {
             discr_type: None,
             non_exhaustive: attributes.contains_non_exhaustive_attr(),
             docstring: self.docstring.as_ref().map(|v| convert_docstring(&v.0)),
+            swift_protocols: vec![],
             // Enums declared using the `[Enum] interface` syntax might have variants with fields.
             //flat: false,
         })

--- a/uniffi_udl/src/converters/mod.rs
+++ b/uniffi_udl/src/converters/mod.rs
@@ -101,6 +101,7 @@ impl APIConverter<RecordMetadata> for weedle::DictionaryDefinition<'_> {
             remote: attributes.contains_remote(),
             fields: self.members.body.convert(ci)?,
             docstring: self.docstring.as_ref().map(|v| convert_docstring(&v.0)),
+            swift_protocols: vec![],
         })
     }
 }


### PR DESCRIPTION
A draft implementation for generation of Swift declarations for protocols supporting automatic implementation like  `Codable` or `CaseIterable`

This should provide a fix for https://github.com/mozilla/uniffi-rs/issues/1905 and https://github.com/mozilla/uniffi-rs/issues/2357

I'm not sure about the naming and the whole ergonomy of the new annotation. Feel free to propose changes.

TODOs:
- [ ] decide whether we even want something like this
- [ ] decide on the annotation syntax (considering readability, ergonomy, future extensibility, ...)
- [ ] currently supported only for Enum and Record. Maybe it makes sense also for Error? For the other types I cannot think of a use-case.
- [ ] extend tests
- [ ] add docs