### PR TITLE
Derive Default for SwiftBindingsOptions

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -223,7 +223,7 @@ pub fn generate_swift_bindings(options: SwiftBindingsOptions) -> Result<()> {
     Ok(())
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SwiftBindingsOptions {
     pub generate_swift_sources: bool,
     pub generate_headers: bool,


### PR DESCRIPTION
This makes it easier for consumers to construct these, when they only care about some of the fields.