### PR TITLE
Relax `Send` bound for objects containing `Future`s for wasm32 targets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ commands:
       # So long as this is executed after the checkout it will use the version specified in rust-toolchain.yaml
       - run: rustup self update
       - run: rustup toolchain install
+      - run: rustup target add wasm32-unknown-unknown
   # Our minimum supported rust version is specified here.
   prepare-rust-min-version:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,13 @@ jobs:
       - run: rustup component add clippy
       - run: cargo clippy --version
       - run: cargo clippy --all --all-targets -- -D warnings
+      - run: |
+            for manifest_path in $(ls fixtures/wasm-*/Cargo.toml) ; do
+              cargo clippy \
+                --target wasm32-unknown-unknown \
+                --manifest-path "$manifest_path" \
+                -- -D warnings
+            done
   Lint Rust Docs:
     docker:
       - image: cimg/rust:1.77.1
@@ -86,6 +93,14 @@ jobs:
           command: |
             # Ensures that all examples are built and avaiable
             cargo build
+      - run:
+          name: Build WASM crates
+          command: |
+            for manifest_path in $(ls fixtures/wasm-*/Cargo.toml) ; do
+              cargo build \
+                --target wasm32-unknown-unknown \
+                --manifest-path "$manifest_path"
+            done
       - run: cargo test
       - run:
           name: mypy Python typechecks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,6 +1175,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1917,6 +1923,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-fixtures-wasm-unstable-single-threaded"
+version = "0.29.0"
+dependencies = [
+ "uniffi",
+]
+
+[[package]]
 name = "uniffi_bindgen"
 version = "0.29.1"
 dependencies = [
@@ -2062,23 +2075,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -2099,9 +2113,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2109,9 +2123,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2122,9 +2136,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ members = [
   "fixtures/large-enum",
   "fixtures/large-error",
   "fixtures/enum-types",
+  "fixtures/wasm-unstable-single-threaded",
 ]
 
 resolver = "2"

--- a/docs/manual/src/wasm/configuration.md
+++ b/docs/manual/src/wasm/configuration.md
@@ -1,0 +1,60 @@
+# WASM
+
+WASM defines a portable binary format for virtual machines running untrusted code in browsers and various other scenarios. Depending on the scenario, the host language may vary.
+
+As such, `uniffi-rs` does not come with bindings generators "for WASM". This is the job for external uniffi-bindgen generators. e.g. [Typescript][ubrn], [Kotlin][gobley].
+
+However, the generated scaffolding needs to be configured for that WASM32 target.
+
+[ubrn]: https://github.com/jhugman/uniffi-bindgen-react-native
+[gobley]: https://github.com/gobley/gobley
+
+# Configuration
+
+Configuring the Rust scaffolding ready for WASM binding generators is done by opting into features.
+
+e.g.
+
+```toml
+[dependendencies]
+uniffi = { version = "0.29.2", features = ["wasm-unstable-single-threaded"]}
+```
+
+## Features
+
+### `wasm-unstable-single-threaded`
+
+At time of writing, the state of threading in WASM and Rust support is still in flux.
+
+Much of the ecosystem is built around [gloo][gloo], [`web-sys`][websys] and [`wasm-rayon`][rayon].
+
+Enabling the `wasm-unstable-single-threaded` feature opts out of the `Send` and `Sync` checks when building for `wasm32` target architectures.
+
+This feature only affects the `wasm32` architecture.
+
+Hint: running `clippy` on client code built for `wasm32` may trigger a clippy [warning when constructing `Arc`s][clippy/arc].
+
+The lint's remedy is either to:
+- make the object to `Send` and `Sync`, or
+- change from an `Arc` to an `Rc`.
+
+As we are using this feature:
+- to allow `Send` and `Sync`, and
+- we can't use `Rc` for other targets
+
+we can disable this warning for `wasm32` *only* like so:
+
+```rust
+#[cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
+fn new() -> Arc<Self> {
+    Arc::new(Self {})
+}
+```
+
+Note: as support for WASM threads evolves, this feature is likely to change or go away completely.
+
+[gloo]: https://crates.io/crates/gloo
+[webdev/thread]: https://web.dev/articles/webassembly-threads#rust
+[rayon]: https://github.com/RReverser/wasm-bindgen-rayon
+[websys]: https://docs.rs/web-sys/latest/web_sys/
+[clippy/arc]: https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync

--- a/fixtures/wasm-unstable-single-threaded/.cargo/config.toml
+++ b/fixtures/wasm-unstable-single-threaded/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "wasm32-unknown-unknown"
+
+[target.wasm32-unknown-unknown]
+runner = "wasm-bindgen-test-runner"

--- a/fixtures/wasm-unstable-single-threaded/Cargo.toml
+++ b/fixtures/wasm-unstable-single-threaded/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "uniffi-fixtures-wasm-unstable-single-threaded"
+version = "0.29.0"
+authors = ["zzorba", "jhugman"]
+edition = "2021"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+name = "wasm_unstable_single_threaded"
+crate-type = ["lib", "cdylib"]
+
+[dependencies]
+uniffi = { workspace = true, features = ["cli"] }
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["build"] }
+
+[dev-dependencies]
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/wasm-unstable-single-threaded/Cargo.toml
+++ b/fixtures/wasm-unstable-single-threaded/Cargo.toml
@@ -11,10 +11,10 @@ name = "wasm_unstable_single_threaded"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-uniffi = { workspace = true, features = ["cli"] }
+uniffi = { workspace = true, features = ["cli", "wasm-unstable-single-threaded"] }
 
 [build-dependencies]
-uniffi = { workspace = true, features = ["build"] }
+uniffi = { workspace = true, features = ["build", "wasm-unstable-single-threaded"] }
 
 [dev-dependencies]
-uniffi = { workspace = true, features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests", "wasm-unstable-single-threaded"] }

--- a/fixtures/wasm-unstable-single-threaded/README.md
+++ b/fixtures/wasm-unstable-single-threaded/README.md
@@ -1,0 +1,6 @@
+# Testing the `wasm-unstable-single-threaded` feature.
+
+This feature changes the `Sync` + `Send` bounds on some traits, especially around `Futures` and
+objects.
+
+This test should pass by dint of compiling under both `wasm32-unknown-unknown` and any non-wasm targets.

--- a/fixtures/wasm-unstable-single-threaded/src/lib.rs
+++ b/fixtures/wasm-unstable-single-threaded/src/lib.rs
@@ -1,0 +1,75 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ */
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+
+/// This will return a Future which is Send + Sync for non-wasm targets, but
+/// not for wasm targets.
+#[uniffi::export]
+pub async fn static_future(_old: String, _new: String) {
+    // NOOP
+}
+
+// We also want to allow objects which has state which might rely on such Futures.
+#[cfg(not(target_arch = "wasm32"))]
+type EventHandlerFut = Pin<Box<dyn Future<Output = ()> + Send>>;
+#[cfg(target_arch = "wasm32")]
+type EventHandlerFut = Pin<Box<dyn Future<Output = ()>>>;
+
+#[cfg(not(target_arch = "wasm32"))]
+type EventHandlerFn = dyn Fn(String, String) -> EventHandlerFut + Send + Sync;
+#[cfg(target_arch = "wasm32")]
+type EventHandlerFn = dyn Fn(String, String) -> EventHandlerFut;
+
+// Here we have a struct which contains async functions.
+// WASM focused bindgen implementations should run this, but it should at least
+// compile here.
+#[derive(uniffi::Object)]
+pub struct SimpleObject {
+    inner: Mutex<String>,
+    callbacks: Vec<Box<EventHandlerFn>>,
+}
+
+impl SimpleObject {
+    fn new_with_callback(cb: Box<EventHandlerFn>) -> Arc<Self> {
+        Arc::new(SimpleObject {
+            inner: Mutex::new("key".to_string()),
+            callbacks: vec![cb],
+        })
+    }
+}
+
+#[uniffi::export]
+impl SimpleObject {
+    pub async fn update(self: Arc<Self>, updated: String) {
+        let old = {
+            let mut data = self.inner.lock().unwrap();
+            let old = data.clone();
+            *data = updated.clone();
+            old
+        };
+        for callback in self.callbacks.iter() {
+            callback(old.clone(), updated.clone()).await;
+        }
+    }
+}
+
+fn from_static() -> Box<EventHandlerFn> {
+    Box::new(|old, new| Box::pin(static_future(old, new)))
+}
+
+// Make an object, with a callback implemented from a static function.
+// This relies on a timer, which is implemented for wasm using gloo.
+// This is not Send, so EventHandlerFn and EventHandlerFut are different
+// for wasm.
+#[uniffi::export]
+async fn make_object() -> Arc<SimpleObject> {
+    SimpleObject::new_with_callback(from_static())
+}
+
+uniffi::setup_scaffolding!();

--- a/fixtures/wasm-unstable-single-threaded/src/lib.rs
+++ b/fixtures/wasm-unstable-single-threaded/src/lib.rs
@@ -36,6 +36,7 @@ pub struct SimpleObject {
 }
 
 impl SimpleObject {
+    #[cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
     fn new_with_callback(cb: Box<EventHandlerFn>) -> Arc<Self> {
         Arc::new(SimpleObject {
             inner: Mutex::new("key".to_string()),

--- a/fixtures/wasm-unstable-single-threaded/src/lib.rs
+++ b/fixtures/wasm-unstable-single-threaded/src/lib.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
  */
 
+use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
@@ -33,6 +34,18 @@ type EventHandlerFn = dyn Fn(String, String) -> EventHandlerFut;
 pub struct SimpleObject {
     inner: Mutex<String>,
     callbacks: Vec<Box<EventHandlerFn>>,
+}
+
+impl fmt::Debug for SimpleObject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SimpleObject")
+    }
+}
+
+impl fmt::Display for SimpleObject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 impl SimpleObject {
@@ -71,6 +84,27 @@ fn from_static() -> Box<EventHandlerFn> {
 #[uniffi::export]
 async fn make_object() -> Arc<SimpleObject> {
     SimpleObject::new_with_callback(from_static())
+}
+
+#[uniffi::export]
+async fn throw_object() -> Result<(), Arc<SimpleObject>> {
+    let obj = make_object().await;
+    Err(obj)
+}
+
+#[derive(uniffi::Object, Debug)]
+pub struct ErrorObject;
+
+impl fmt::Display for ErrorObject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ErrorObject")
+    }
+}
+
+#[uniffi::export]
+async fn throw_error_object() -> Result<(), Arc<ErrorObject>> {
+    let obj = Arc::new(ErrorObject);
+    Err(obj)
 }
 
 uniffi::setup_scaffolding!();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,9 @@ nav:
 
   - 'Python': ./python/configuration.md
 
+  - 'WASM':
+    - ./wasm/configuration.md
+
 - Internals:
   - ./internals/design_principles.md
   - ./internals/crates.md

--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -51,3 +51,10 @@ tokio = ["uniffi_core/tokio"]
 # Generate extra scaffolding functions that use FfiBuffer to pass arguments and return values
 # This is needed for the gecko-js bindings.
 scaffolding-ffi-buffer-fns = ["uniffi_core/scaffolding-ffi-buffer-fns", "uniffi_macros/scaffolding-ffi-buffer-fns"]
+
+# Support for WebAssembly targets in a single-threaded environment.
+# This feature is unstable and may change in the future.
+wasm-unstable-single-threaded = [
+    "uniffi_core/wasm-unstable-single-threaded",
+    "uniffi_macros/wasm-unstable-single-threaded",
+]

--- a/uniffi_core/Cargo.toml
+++ b/uniffi_core/Cargo.toml
@@ -30,3 +30,7 @@ tokio = ["dep:async-compat"]
 
 # Enable support for the ffi buffer scaffolding functions
 scaffolding-ffi-buffer-fns = []
+
+# Support for WebAssembly targets in a single-threaded environment.
+# This feature is unstable and may change in the future.
+wasm-unstable-single-threaded = []

--- a/uniffi_core/src/ffi/rustfuture/future.rs
+++ b/uniffi_core/src/ffi/rustfuture/future.rs
@@ -85,15 +85,18 @@ use std::{
     task::{Context, Poll, Wake},
 };
 
-use super::{RustFutureContinuationCallback, RustFuturePoll, Scheduler, UniffiCompatibleFuture};
-use crate::{rust_call_with_out_status, FfiDefault, LiftArgsError, LowerReturn, RustCallStatus};
+use super::{
+    FutureLowerReturn, RustFutureContinuationCallback, RustFuturePoll, Scheduler,
+    UniffiCompatibleFuture,
+};
+use crate::{rust_call_with_out_status, FfiDefault, LiftArgsError, RustCallStatus};
 
 type BoxedFuture<T> = Pin<Box<dyn UniffiCompatibleFuture<Result<T, LiftArgsError>>>>;
 
 /// Wraps the actual future we're polling
 struct WrappedFuture<T, UT>
 where
-    T: LowerReturn<UT> + Send + 'static,
+    T: FutureLowerReturn<UT> + 'static,
     UT: Send + 'static,
 {
     // Note: this could be a single enum, but that would make it easy to mess up the future pinning
@@ -105,7 +108,7 @@ where
 
 impl<T, UT> WrappedFuture<T, UT>
 where
-    T: LowerReturn<UT> + Send + 'static,
+    T: FutureLowerReturn<UT> + 'static,
     UT: Send + 'static,
 {
     fn new(future: BoxedFuture<T>) -> Self {
@@ -183,7 +186,7 @@ where
 // that we will treat the raw pointer properly, for example by not returning it twice.
 unsafe impl<T, UT> Send for WrappedFuture<T, UT>
 where
-    T: LowerReturn<UT> + Send + 'static,
+    T: FutureLowerReturn<UT> + 'static,
     UT: Send + 'static,
 {
 }
@@ -191,7 +194,7 @@ where
 /// Future that the foreign code is awaiting
 pub(super) struct RustFuture<T, UT>
 where
-    T: LowerReturn<UT> + Send + 'static,
+    T: FutureLowerReturn<UT> + 'static,
     UT: Send + 'static,
 {
     // This Mutex should never block if our code is working correctly, since there should not be
@@ -205,7 +208,7 @@ where
 
 impl<T, UT> RustFuture<T, UT>
 where
-    T: LowerReturn<UT> + Send + 'static,
+    T: FutureLowerReturn<UT> + 'static,
     UT: Send + 'static,
 {
     pub(super) fn new(future: BoxedFuture<T>, _tag: UT) -> Arc<Self> {
@@ -258,7 +261,7 @@ where
 
 impl<T, UT> Wake for RustFuture<T, UT>
 where
-    T: LowerReturn<UT> + Send + 'static,
+    T: FutureLowerReturn<UT> + 'static,
     UT: Send + 'static,
 {
     fn wake(self: Arc<Self>) {
@@ -291,7 +294,7 @@ pub trait RustFutureFfi<ReturnType>: Send + Sync {
 
 impl<T, UT> RustFutureFfi<T::ReturnType> for RustFuture<T, UT>
 where
-    T: LowerReturn<UT> + Send + 'static,
+    T: FutureLowerReturn<UT> + 'static,
     UT: Send + 'static,
 {
     fn ffi_poll(self: Arc<Self>, callback: RustFutureContinuationCallback, data: u64) {

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -35,3 +35,6 @@ scaffolding-ffi-buffer-fns = []
 # * Add the full module path of exported items to FFI metadata instead of just the crate name.
 #   This may be used by language backends to generate nested module structures in the future.
 nightly = []
+# Support for WebAssembly targets in a single-threaded environment.
+# This feature is unstable and may change in the future.
+wasm-unstable-single-threaded = []


### PR DESCRIPTION
This is a followup to #2417, #2418.

This PR provides a [test](https://github.com/mozilla/uniffi-rs/blob/96a3a8de28cd84f233cac5f767f0f7273d23d522/fixtures/wasm-arc-futures/src/lib.rs) which was failing to compile, and the fix.
