### PR TITLE
Async naming updates and doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.29.1...HEAD).
 
+### ⚠️ Breaking Changes for external bindings authors ⚠️
+
+* Some async-related names have changed.  Bindings authors may need to update their code to reflect
+  the new names.  This is a name-change only -- the FFI and semantics are still the same.
+
+  * `UniffiForeignFutureFree` is now `UniffiForeignFutureDroppedCallback`
+  * `UniffiForeignFuture` is `UniffiForeignFutureDroppedCallbackStruct`.
+  * `RustFuturePoll::MaybeReady` is now `RustFuturePoll::Wake`.
+
 ## v0.29.1 (backend crates: v0.29.1) - (_2025-03-18_)
 
 ### What's fixed?

--- a/docs/manual/src/internals/async.md
+++ b/docs/manual/src/internals/async.md
@@ -48,8 +48,8 @@ The UniFFI generated code for an async function performs these steps:
 
 1. Call the Rust scaffolding function, receiving a `RustFuture` handle
 1. Call the `rust_future_poll` function for the future until the future is ready.
-   * The `rust_future_poll` function inputs a callback function and an opaque pointer (AKA a `void *`) to call the callback with.
-   * If the future is pending, then the generated code registers a waker that will call the callback function with `RUST_FUTURE_MAYBE_READY`.
+   * The `rust_future_poll` function inputs a callback function and a `u64` callback data value to pass to the callback.
+   * If the future is pending, then the generated code registers a waker that will call the callback function with `RUST_FUTURE_WAKE`.
      When the generated foreign code sees this, it calls poll again, starting the loop over.
    * If the future is ready, then the callback function is immediately called with `RUST_FUTURE_READY` and we move to the next step.
 1. Call `rust_future_complete`, receiving the return value of the future

--- a/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceImpl.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceImpl.kt
@@ -69,23 +69,23 @@ internal object {{ trait_impl }} {
                 )
             }
 
-            uniffiOutReturn.uniffiSetValue(
-                {%- match meth.throws_type() %}
-                {%- when None %}
-                uniffiTraitInterfaceCallAsync(
-                    makeCall,
-                    uniffiHandleSuccess,
-                    uniffiHandleError
-                )
-                {%- when Some(error_type) %}
-                uniffiTraitInterfaceCallAsyncWithError(
-                    makeCall,
-                    uniffiHandleSuccess,
-                    uniffiHandleError,
-                    { e: {{error_type|type_name(ci) }} -> {{ error_type|lower_fn }}(e) }
-                )
-                {%- endmatch %}
+            {%- match meth.throws_type() %}
+            {%- when None %}
+            uniffiTraitInterfaceCallAsync(
+                makeCall,
+                uniffiHandleSuccess,
+                uniffiHandleError,
+                uniffiOutDroppedCallback
             )
+            {%- when Some(error_type) %}
+            uniffiTraitInterfaceCallAsyncWithError(
+                makeCall,
+                uniffiHandleSuccess,
+                uniffiHandleError,
+                { e: {{error_type|type_name(ci) }} -> {{ error_type|lower_fn }}(e) },
+                uniffiOutDroppedCallback
+            )
+            {%- endmatch %}
             {%- endif %}
         }
     }

--- a/uniffi_bindgen/src/bindings/python/templates/Async.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Async.py
@@ -1,6 +1,6 @@
 # RustFuturePoll values
 _UNIFFI_RUST_FUTURE_POLL_READY = 0
-_UNIFFI_RUST_FUTURE_POLL_MAYBE_READY = 1
+_UNIFFI_RUST_FUTURE_POLL_WAKE = 1
 
 # Stores futures for _uniffi_continuation_callback
 _UniffiContinuationHandleMap = _UniffiHandleMap()
@@ -63,7 +63,7 @@ async def _uniffi_rust_call_async(rust_future, ffi_poll, ffi_complete, ffi_free,
         ffi_free(rust_future)
 
 {%- if ci.has_async_callback_interface_definition() %}
-def _uniffi_trait_interface_call_async(make_call, handle_success, handle_error):
+def _uniffi_trait_interface_call_async(make_call, uniffi_out_dropped_callback, handle_success, handle_error):
     async def make_call_and_call_callback():
         try:
             handle_success(await make_call())
@@ -77,9 +77,9 @@ def _uniffi_trait_interface_call_async(make_call, handle_success, handle_error):
     eventloop = _uniffi_get_event_loop()
     task = asyncio.run_coroutine_threadsafe(make_call_and_call_callback(), eventloop)
     handle = _UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.insert((eventloop, task))
-    return _UniffiForeignFuture(handle, _uniffi_foreign_future_free)
+    uniffi_out_dropped_callback[0] = _UniffiForeignFutureDroppedCallbackStruct(handle, _uniffi_future_dropped_callback)
 
-def _uniffi_trait_interface_call_async_with_error(make_call, handle_success, handle_error, error_type, lower_error):
+def _uniffi_trait_interface_call_async_with_error(make_call, uniffi_out_dropped_callback, handle_success, handle_error, error_type, lower_error):
     async def make_call_and_call_callback():
         try:
             try:
@@ -99,16 +99,16 @@ def _uniffi_trait_interface_call_async_with_error(make_call, handle_success, han
     eventloop = _uniffi_get_event_loop()
     task = asyncio.run_coroutine_threadsafe(make_call_and_call_callback(), eventloop)
     handle = _UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.insert((eventloop, task))
-    return _UniffiForeignFuture(handle, _uniffi_foreign_future_free)
+    uniffi_out_dropped_callback[0] = _UniffiForeignFutureDroppedCallbackStruct(handle, _uniffi_future_dropped_callback)
 
 _UNIFFI_FOREIGN_FUTURE_HANDLE_MAP = _UniffiHandleMap()
 
-@_UNIFFI_FOREIGN_FUTURE_FREE
-def _uniffi_foreign_future_free(handle):
+@_UNIFFI_FOREIGN_FUTURE_DROPPED_CALLBACK
+def _uniffi_future_dropped_callback(handle):
     (eventloop, task) = _UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.remove(handle)
-    eventloop.call_soon(_uniffi_foreign_future_do_free, task)
+    eventloop.call_soon(_uniffi_cancel_task, task)
 
-def _uniffi_foreign_future_do_free(task):
+def _uniffi_cancel_task(task):
     if not task.done():
         task.cancel()
 {%- endif %}

--- a/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceImpl.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceImpl.py
@@ -73,9 +73,9 @@ class {{ trait_impl }}:
 
         {%- match meth.throws_type() %}
         {%- when None %}
-        uniffi_out_return[0] = _uniffi_trait_interface_call_async(make_call, handle_success, handle_error)
+        _uniffi_trait_interface_call_async(make_call, uniffi_out_dropped_callback, handle_success, handle_error)
         {%- when Some(error) %}
-        uniffi_out_return[0] = _uniffi_trait_interface_call_async_with_error(make_call, handle_success, handle_error, {{ error|type_name }}, {{ error|lower_fn }})
+        _uniffi_trait_interface_call_async_with_error(make_call, uniffi_out_dropped_callback, handle_success, handle_error, {{ error|type_name }}, {{ error|lower_fn }})
         {%- endmatch %}
         {%- endif %}
     {%- endfor %}

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceImpl.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceImpl.swift
@@ -81,20 +81,21 @@ fileprivate struct {{ trait_impl }} {
 
             {%- match meth.throws_type() %}
             {%- when None %}
-            let uniffiForeignFuture = uniffiTraitInterfaceCallAsync(
-                makeCall: makeCall,
-                handleSuccess: uniffiHandleSuccess,
-                handleError: uniffiHandleError
-            )
-            {%- when Some(error_type) %}
-            let uniffiForeignFuture = uniffiTraitInterfaceCallAsyncWithError(
+            uniffiTraitInterfaceCallAsync(
                 makeCall: makeCall,
                 handleSuccess: uniffiHandleSuccess,
                 handleError: uniffiHandleError,
-                lowerError: {{ error_type|lower_fn }}
+                droppedCallback: uniffiOutDroppedCallback
+            )
+            {%- when Some(error_type) %}
+            uniffiTraitInterfaceCallAsyncWithError(
+                makeCall: makeCall,
+                handleSuccess: uniffiHandleSuccess,
+                handleError: uniffiHandleError,
+                lowerError: {{ error_type|lower_fn }},
+                droppedCallback: uniffiOutDroppedCallback
             )
             {%- endmatch %}
-            uniffiOutReturn.pointee = uniffiForeignFuture
             {%- endif %}
         },
         {%- endfor %}

--- a/uniffi_bindgen/src/interface/callbacks.rs
+++ b/uniffi_bindgen/src/interface/callbacks.rs
@@ -180,8 +180,9 @@ pub fn method_ffi_callback(trait_name: &str, method: &Method, index: usize) -> F
                     ),
                     FfiArgument::new("uniffi_callback_data", FfiType::UInt64),
                     FfiArgument::new(
-                        "uniffi_out_return",
-                        FfiType::Struct("ForeignFuture".to_owned()).mut_reference(),
+                        "uniffi_out_dropped_callback",
+                        FfiType::Struct("ForeignFutureDroppedCallbackStruct".to_owned())
+                            .mut_reference(),
                     ),
                 ])
                 .collect(),
@@ -196,7 +197,7 @@ pub fn foreign_future_ffi_result_struct(return_ffi_type: Option<FfiType>) -> Ffi
     let return_type_name =
         FfiType::return_type_name(return_ffi_type.as_ref()).to_upper_camel_case();
     FfiStruct {
-        name: format!("ForeignFutureStruct{return_type_name}"),
+        name: format!("ForeignFutureResult{return_type_name}"),
         fields: match return_ffi_type {
             Some(return_ffi_type) => vec![
                 FfiField::new("return_value", return_ffi_type),
@@ -222,7 +223,7 @@ pub fn ffi_foreign_future_complete(return_ffi_type: Option<FfiType>) -> FfiCallb
             FfiArgument::new("callback_data", FfiType::UInt64),
             FfiArgument::new(
                 "result",
-                FfiType::Struct(format!("ForeignFutureStruct{return_type_name}")),
+                FfiType::Struct(format!("ForeignFutureResult{return_type_name}")),
             ),
         ],
         return_type: None,

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -645,7 +645,7 @@ impl ComponentInterface {
             }
             .into(),
             FfiCallbackFunction {
-                name: "ForeignFutureFree".to_owned(),
+                name: "ForeignFutureDroppedCallback".to_owned(),
                 arguments: vec![FfiArgument::new("handle", FfiType::UInt64)],
                 return_type: None,
                 has_rust_call_status_arg: false,
@@ -659,10 +659,13 @@ impl ComponentInterface {
             }
             .into(),
             FfiStruct {
-                name: "ForeignFuture".to_owned(),
+                name: "ForeignFutureDroppedCallbackStruct".to_owned(),
                 fields: vec![
                     FfiField::new("handle", FfiType::UInt64),
-                    FfiField::new("free", FfiType::Callback("ForeignFutureFree".to_owned())),
+                    FfiField::new(
+                        "free",
+                        FfiType::Callback("ForeignFutureDroppedCallback".to_owned()),
+                    ),
                 ],
             }
             .into(),

--- a/uniffi_core/src/ffi/ffidefault.rs
+++ b/uniffi_core/src/ffi/ffidefault.rs
@@ -53,13 +53,6 @@ impl FfiDefault for crate::RustBuffer {
     }
 }
 
-impl FfiDefault for crate::ForeignFuture {
-    fn ffi_default() -> Self {
-        extern "C" fn free(_handle: u64) {}
-        crate::ForeignFuture { handle: 0, free }
-    }
-}
-
 impl<T> FfiDefault for Option<T> {
     fn ffi_default() -> Self {
         None

--- a/uniffi_core/src/ffi/rustfuture/mod.rs
+++ b/uniffi_core/src/ffi/rustfuture/mod.rs
@@ -21,7 +21,7 @@ pub enum RustFuturePoll {
     /// The future is ready and is waiting for [rust_future_complete] to be called
     Ready = 0,
     /// The future might be ready and [rust_future_poll] should be called again
-    MaybeReady = 1,
+    Wake = 1,
 }
 
 /// Foreign callback that's passed to [rust_future_poll]

--- a/uniffi_core/src/ffi/rustfuture/scheduler.rs
+++ b/uniffi_core/src/ffi/rustfuture/scheduler.rs
@@ -24,7 +24,7 @@ pub(super) enum Scheduler {
     /// No continuations set, neither wake() nor cancel() called.
     Empty,
     /// `wake()` was called when there was no continuation set.  The next time `store` is called,
-    /// the continuation should be immediately invoked with `RustFuturePoll::MaybeReady`
+    /// the continuation should be immediately invoked with `RustFuturePoll::Wake`
     Waked,
     /// The future has been cancelled, any future `store` calls should immediately result in the
     /// continuation being called with `RustFuturePoll::Ready`.
@@ -52,7 +52,7 @@ impl Scheduler {
             }
             Self::Waked => {
                 *self = Self::Empty;
-                callback(data, RustFuturePoll::MaybeReady);
+                callback(data, RustFuturePoll::Wake);
             }
             Self::Cancelled => {
                 callback(data, RustFuturePoll::Ready);
@@ -67,7 +67,7 @@ impl Scheduler {
                 let old_data = *old_data;
                 let callback = *callback;
                 *self = Self::Empty;
-                callback(old_data, RustFuturePoll::MaybeReady);
+                callback(old_data, RustFuturePoll::Wake);
             }
             // If we were in the `Empty` state, then transition to `Waked`.  The next time `store`
             // is called, we will immediately call the continuation.

--- a/uniffi_core/src/ffi/rustfuture/tests.rs
+++ b/uniffi_core/src/ffi/rustfuture/tests.rs
@@ -109,13 +109,13 @@ fn test_success() {
     let continuation_result = poll(&rust_future);
     assert_eq!(continuation_result.get(), None);
     sender.wake();
-    assert_eq!(continuation_result.get(), Some(&RustFuturePoll::MaybeReady));
+    assert_eq!(continuation_result.get(), Some(&RustFuturePoll::Wake));
 
     // Test polling the rust future when it's ready
     let continuation_result = poll(&rust_future);
     assert_eq!(continuation_result.get(), None);
     sender.send(Ok("All done".into()));
-    assert_eq!(continuation_result.get(), Some(&RustFuturePoll::MaybeReady));
+    assert_eq!(continuation_result.get(), Some(&RustFuturePoll::Wake));
 
     // Future polls should immediately return ready
     let continuation_result = poll(&rust_future);
@@ -137,7 +137,7 @@ fn test_error() {
     let continuation_result = poll(&rust_future);
     assert_eq!(continuation_result.get(), None);
     sender.send(Err("Something went wrong".into()));
-    assert_eq!(continuation_result.get(), Some(&RustFuturePoll::MaybeReady));
+    assert_eq!(continuation_result.get(), Some(&RustFuturePoll::Wake));
 
     let continuation_result = poll(&rust_future);
     assert_eq!(continuation_result.get(), Some(&RustFuturePoll::Ready));
@@ -160,7 +160,7 @@ fn test_lift_args_error() {
     let continuation_result = poll(&rust_future);
     assert_eq!(continuation_result.get(), None);
     sender.send_lift_args_error("arg0", anyhow::anyhow!("Invalid handle"));
-    assert_eq!(continuation_result.get(), Some(&RustFuturePoll::MaybeReady));
+    assert_eq!(continuation_result.get(), Some(&RustFuturePoll::Wake));
 
     let continuation_result = poll(&rust_future);
     assert_eq!(continuation_result.get(), Some(&RustFuturePoll::Ready));
@@ -250,7 +250,7 @@ fn test_wake_during_poll() {
         RustFuture::new(Box::pin(future), crate::UniFfiTag);
     let continuation_result = poll(&rust_future);
     // The continuation function should called immediately
-    assert_eq!(continuation_result.get(), Some(&RustFuturePoll::MaybeReady));
+    assert_eq!(continuation_result.get(), Some(&RustFuturePoll::Wake));
     // A second poll should finish the future
     let continuation_result = poll(&rust_future);
     assert_eq!(continuation_result.get(), Some(&RustFuturePoll::Ready));

--- a/uniffi_macros/src/export/callback_interface.rs
+++ b/uniffi_macros/src/export/callback_interface.rs
@@ -64,9 +64,9 @@ pub(super) fn trait_impl(
                 pub #ident: extern "C" fn(
                     uniffi_handle: u64,
                     #(#param_names: #param_types,)*
-                    uniffi_future_callback: ::uniffi::ForeignFutureCallback<#lift_return_type>,
+                    uniffi_callback: ::uniffi::ForeignFutureCallback<#lift_return_type>,
                     uniffi_callback_data: u64,
-                    uniffi_out_return: &mut ::uniffi::ForeignFuture,
+                    uniffi_out_dropped_callback: &mut ::uniffi::ForeignFutureDroppedCallbackStruct,
                 ),
             }
         }
@@ -235,10 +235,15 @@ fn gen_method_impl(sig: &FnSignature, vtable_cell: &Ident) -> syn::Result<TokenS
         Ok(quote! {
             async fn #ident(#self_param, #(#params),*) -> #return_ty {
                 let vtable = #vtable_cell.get();
-                ::uniffi::foreign_async_call::<_, #return_ty, crate::UniFfiTag>(move |uniffi_future_callback, uniffi_future_callback_data| {
-                    let mut uniffi_foreign_future: ::uniffi::ForeignFuture = ::uniffi::FfiDefault::ffi_default();
-                    (vtable.#ident)(self.handle, #(#lower_exprs,)* uniffi_future_callback, uniffi_future_callback_data, &mut uniffi_foreign_future);
-                    uniffi_foreign_future
+                ::uniffi::foreign_async_call::<_, #return_ty, crate::UniFfiTag>(
+                    move |uniffi_future_callback, uniffi_future_callback_data, uniffi_foreign_future_dropped_callback| {
+                        (vtable.#ident)(
+                            self.handle,
+                            #(#lower_exprs,)*
+                            uniffi_future_callback,
+                            uniffi_future_callback_data,
+                            uniffi_foreign_future_dropped_callback
+                        );
                 }).await
             }
         })


### PR DESCRIPTION
After implementing foreign futures these in JS, I wanted to make some updates.  The FFI is staying the same, but some names have been changed.

`UniffiForeignFutureFree` is now named `UniffiForeignFutureDroppedCallback` and `UniffiForeignFuture` is now `UniffiForeignFutureDroppedCallbackStruct`. This reflects the fact that we don't really need to use these to manage the future, the real reason they're here nowadays is to support cancellation. For languages like JS, where we can't implement cancellation, we can just ignore the param.

Updated some of the code that deals with this to treat it like the out parameter it is, rather than a return value.  I think that was leftover from previous implementations.

There's also one change for RustFuture: `RustFuturePoll::MaybeReady` is now `RustFuturePoll::Wake`.  "MaybeReady" was always a confusing/ambiguous name.  "Wake" seems reasonable, since it's what the foreign bindings should do and reflects how the Rust futures code works.

Updated some outdated docstrings.