### PR TITLE
Add builtin headers to modulemap

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/ModuleMapTemplate.modulemap
+++ b/uniffi_bindgen/src/bindings/swift/templates/ModuleMapTemplate.modulemap
@@ -3,6 +3,9 @@
     header "{{ filename }}"
     {%- endfor %}
     export *
+    use "Darwin"
+    use "_Builtin_stdbool"
+    use "_Builtin_stdint"
     {%- for link_framework in link_frameworks %}
     link framework "{{ link_framework }}"
     {%- endfor %}


### PR DESCRIPTION
The generated Swift header file uses stdbool, stddef and stdint. In certain build environments, the Swift module is unable to be generated due to these headers being missing from the modulemap dependencies.