### PR TITLE
Python: fix `ffi_default_value`

### DIFF
--- a/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceImpl.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceImpl.py
@@ -63,7 +63,7 @@ class {{ trait_impl }}:
                 {{ meth.foreign_future_ffi_result_struct().name()|ffi_struct_name }}(
                     {%- match meth.return_type() %}
                     {%- when Some(return_type) %}
-                    {{ meth.return_type().map(FfiType::from)|ffi_default_value }},
+                    {{ meth.return_type().map(FfiType::from)|ffi_default_value(ci) }},
                     {%- when None %}
                     {%- endmatch %}
                     _UniffiRustCallStatus(status_code, rust_buffer),


### PR DESCRIPTION
The change to `ffi_type_label` from
`https://github.com/mozilla/uniffi-rs/pull/2385` also needs to be applied here.

See https://github.com/mozilla/uniffi-rs/issues/2508 for details.

I didn't add a test case for this one since I'm planning to revive https://github.com/mozilla/uniffi-rs/pull/2348 and start a whole new set of test fixtures soon.  I can definitely add one though if you think it's needed.