### PR TITLE
Update docs-related Python dependencies (follow up to #2509)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ commands:
   install-mkdocs:
     steps:
       - run:
-          name: Install mdBook
+          name: Install Material for MkDocs
           command: |
             sudo apt-get update -qq
             sudo apt-get install -qy --no-install-recommends python3-pip

--- a/tools/requirements_docs.txt
+++ b/tools/requirements_docs.txt
@@ -1,6 +1,6 @@
-mike==2.1.1
-mkdocs==1.6.0
-mkdocs-material==9.5.22
+mike==2.1.3
+mkdocs==1.6.1
+mkdocs-material==9.6.12
 mkdocs-no-sitemap-plugin==0.0.1
 pygments==2.18.0
 pymdown-extensions==10.8.1


### PR DESCRIPTION
This PR bumps 3 Material for MkDocs-related dependencies, in the hope to enable the search bar as envisioned by #2509.

I also took the liberty of fixing a typo in naming of a step the CI workflow.

I built the site locally using both the following commands:

```shell
mkdocs serve
mike deploy next
```

And both render the search bar well.