### PR TITLE
Update docs-related Python dependencies on 0.29 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ commands:
   install-mkdocs:
     steps:
       - run:
-          name: Install mdBook
+          name: Install Material for MkDocs
           command: |
             sudo apt-get update -qq
             sudo apt-get install -qy --no-install-recommends python3-pip

--- a/tools/requirements_docs.txt
+++ b/tools/requirements_docs.txt
@@ -1,6 +1,6 @@
-mike==2.1.1
-mkdocs==1.6.0
-mkdocs-material==9.5.22
+mike==2.1.3
+mkdocs==1.6.1
+mkdocs-material==9.6.12
 mkdocs-no-sitemap-plugin==0.0.1
 pygments==2.18.0
 pymdown-extensions==10.8.1


### PR DESCRIPTION
This is a cherry-pick of dabce8053ce08b5e778071cd0a7e4490102c45f5 (#2513) on the 0.29 branch. I think after landing this I'll need to manually re-deploy 0.29 docs so they get the search love.