### PR TITLE
Python: fix `ffi_default_value` (#2512) backport for release

### DIFF
--- a/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/gen_python/mod.rs
@@ -424,7 +424,7 @@ impl PythonCodeOracle {
     /// Default values for FFI types
     ///
     /// Used to set a default return value when returning an error
-    fn ffi_default_value(&self, return_type: Option<&FfiType>) -> String {
+    fn ffi_default_value(&self, return_type: Option<&FfiType>, ci: &ComponentInterface) -> String {
         match return_type {
             Some(t) => match t {
                 FfiType::UInt8
@@ -438,10 +438,10 @@ impl PythonCodeOracle {
                 FfiType::Float32 | FfiType::Float64 => "0.0".to_owned(),
                 FfiType::RustArcPtr(_) => "ctypes.c_void_p()".to_owned(),
                 FfiType::RustBuffer(maybe_external) => match maybe_external {
-                    Some(external_meta) => {
+                    Some(external_meta) if external_meta.module_path != ci.crate_name() => {
                         format!("_UniffiRustBuffer{}.default()", external_meta.name)
                     }
-                    None => "_UniffiRustBuffer.default()".to_owned(),
+                    _ => "_UniffiRustBuffer.default()".to_owned(),
                 },
                 _ => unimplemented!("FFI return type: {t:?}"),
             },
@@ -642,8 +642,11 @@ pub mod filters {
         Ok(PythonCodeOracle.ffi_type_label(type_, ci))
     }
 
-    pub fn ffi_default_value(return_type: Option<FfiType>) -> Result<String, rinja::Error> {
-        Ok(PythonCodeOracle.ffi_default_value(return_type.as_ref()))
+    pub fn ffi_default_value(
+        return_type: Option<FfiType>,
+        ci: &ComponentInterface,
+    ) -> Result<String, rinja::Error> {
+        Ok(PythonCodeOracle.ffi_default_value(return_type.as_ref(), ci))
     }
 
     /// Get the idiomatic Python rendering of an FFI callback function name

--- a/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceImpl.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceImpl.py
@@ -64,7 +64,7 @@ class {{ trait_impl }}:
                 {{ meth.foreign_future_ffi_result_struct().name()|ffi_struct_name }}(
                     {%- match meth.return_type() %}
                     {%- when Some(return_type) %}
-                    {{ meth.return_type().map(FfiType::from)|ffi_default_value }},
+                    {{ meth.return_type().map(FfiType::from)|ffi_default_value(ci) }},
                     {%- when None %}
                     {%- endmatch %}
                     _UniffiRustCallStatus(status_code, rust_buffer),


### PR DESCRIPTION
The change to `ffi_type_label` from
`https://github.com/mozilla/uniffi-rs/pull/2385` also needs to be applied here.

See https://github.com/mozilla/uniffi-rs/issues/2508 for details.