### PR TITLE
Build docs.rs documentation with rustdoc "jump to definition" feature enabled

### DIFF
--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -59,3 +59,6 @@ wasm-unstable-single-threaded = [
     "uniffi_core/wasm-unstable-single-threaded",
     "uniffi_macros/wasm-unstable-single-threaded",
 ]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -38,3 +38,6 @@ uniffi_udl = { path = "../uniffi_udl", version = "=0.29.1" }
 # Don't include the `unicode-linebreak` or `unicode-width` since that functionality isn't needed for
 # docstrings.
 textwrap = { version = "0.16", features=["smawk"], default-features = false }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/uniffi_build/Cargo.toml
+++ b/uniffi_build/Cargo.toml
@@ -19,3 +19,6 @@ uniffi_bindgen = { path = "../uniffi_bindgen", default-features = false, version
 default = []
 # Deprecated feature that doesn't do anything anymore, but we still allow for backwards-compatibility.
 builtin-bindgen = []
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/uniffi_core/Cargo.toml
+++ b/uniffi_core/Cargo.toml
@@ -34,3 +34,6 @@ scaffolding-ffi-buffer-fns = []
 # Support for WebAssembly targets in a single-threaded environment.
 # This feature is unstable and may change in the future.
 wasm-unstable-single-threaded = []
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/uniffi_internal_macros/Cargo.toml
+++ b/uniffi_internal_macros/Cargo.toml
@@ -23,3 +23,6 @@ syn = { version = "2.0", features = ["full", "visit-mut", "extra-traits"] }
 [features]
 default = []
 nightly = []
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -38,3 +38,6 @@ nightly = []
 # Support for WebAssembly targets in a single-threaded environment.
 # This feature is unstable and may change in the future.
 wasm-unstable-single-threaded = []
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/uniffi_meta/Cargo.toml
+++ b/uniffi_meta/Cargo.toml
@@ -14,3 +14,6 @@ anyhow = "1"
 siphasher = "0.3"
 uniffi_internal_macros = { version = "0.29.1", path = "../uniffi_internal_macros" }
 uniffi_pipeline = { version = "0.29.1", path = "../uniffi_pipeline" }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/uniffi_pipeline/Cargo.toml
+++ b/uniffi_pipeline/Cargo.toml
@@ -16,3 +16,6 @@ heck = "0.5"
 indexmap = { version = "2.2" }
 tempfile = "3"
 uniffi_internal_macros = { path = "../uniffi_internal_macros", version = "=0.29.1" }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/uniffi_testing/Cargo.toml
+++ b/uniffi_testing/Cargo.toml
@@ -18,3 +18,6 @@ once_cell = "1.12"
 
 [features]
 ffi-trace = []
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/uniffi_udl/Cargo.toml
+++ b/uniffi_udl/Cargo.toml
@@ -17,3 +17,6 @@ weedle2 = { version = "5.0.0", path = "../weedle2" }
 # docstrings.
 textwrap = { version = "0.16", features = ["smawk"], default-features = false }
 uniffi_meta = { path = "../uniffi_meta", version = "=0.29.1" }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]


### PR DESCRIPTION
I was reading source code on docs.rs and realized that the feature was not enabled, so here it is. :)

Enabling this feature makes your source code pages generate links on items so you can jump to where they're defined.

You can this feature in action in [`syn`](https://docs.rs/syn/latest/src/syn/lib.rs.html#986-1010) for example.