### PR TITLE
wasm-unstable-single-threaded: Relax `Send` for `async_trait` for `ForeignFuture`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1992,6 +1992,7 @@ dependencies = [
 name = "uniffi-fixtures-wasm-unstable-single-threaded"
 version = "0.29.0"
 dependencies = [
+ "async-trait",
  "uniffi",
 ]
 

--- a/fixtures/wasm-unstable-single-threaded/Cargo.toml
+++ b/fixtures/wasm-unstable-single-threaded/Cargo.toml
@@ -11,6 +11,7 @@ name = "wasm_unstable_single_threaded"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
+async-trait = "0.1"
 uniffi = { workspace = true, features = ["cli", "wasm-unstable-single-threaded"] }
 
 [build-dependencies]

--- a/uniffi_macros/src/export/trait_interface.rs
+++ b/uniffi_macros/src/export/trait_interface.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     ffiops,
     object::interface_meta_static_var,
-    util::{ident_to_string, tagged_impl_header},
+    util::{ident_to_string, tagged_impl_header, wasm_single_threaded_annotation},
 };
 
 pub(super) fn gen_trait_scaffolding(
@@ -155,12 +155,14 @@ pub(crate) fn ffi_converter(
     };
     let lower_self = ffiops::lower(quote! { ::std::sync::Arc<Self> });
     let try_lift_self = ffiops::try_lift(quote! { ::std::sync::Arc<Self> });
+    let single_threaded_annotation = wasm_single_threaded_annotation();
 
     quote! {
         // All traits must be `Sync + Send`. The generated scaffolding will fail to compile
         // if they are not, but unfortunately it fails with an unactionably obscure error message.
         // By asserting the requirement explicitly, we help Rust produce a more scrutable error message
         // and thus help the user debug why the requirement isn't being met.
+        #single_threaded_annotation
         ::uniffi::deps::static_assertions::assert_impl_all!(
             dyn #trait_ident: ::core::marker::Sync, ::core::marker::Send
         );

--- a/uniffi_macros/src/object.rs
+++ b/uniffi_macros/src/object.rs
@@ -4,7 +4,10 @@ use syn::DeriveInput;
 
 use crate::{
     ffiops,
-    util::{create_metadata_items, extract_docstring, ident_to_string, mod_path},
+    util::{
+        create_metadata_items, extract_docstring, ident_to_string, mod_path,
+        wasm_single_threaded_annotation,
+    },
     DeriveOptions,
 };
 use uniffi_meta::ObjectImpl;
@@ -94,19 +97,6 @@ pub fn expand_object(input: DeriveInput, options: DeriveOptions) -> syn::Result<
         #interface_impl
         #meta_static_var
     })
-}
-
-fn wasm_single_threaded_annotation() -> TokenStream {
-    #[cfg(feature = "wasm-unstable-single-threaded")]
-    {
-        quote! {
-            #[cfg(not(target_arch = "wasm32"))]
-        }
-    }
-    #[cfg(not(feature = "wasm-unstable-single-threaded"))]
-    {
-        TokenStream::default()
-    }
 }
 
 fn interface_impl(object: &ObjectItem, options: &DeriveOptions) -> TokenStream {

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -302,3 +302,32 @@ pub(crate) fn extract_docstring(attrs: &[Attribute]) -> syn::Result<String> {
         .collect::<syn::Result<Vec<_>>>()
         .map(|lines| lines.join("\n"))
 }
+
+pub(crate) fn wasm_single_threaded_annotation() -> TokenStream {
+    #[cfg(feature = "wasm-unstable-single-threaded")]
+    {
+        quote! {
+            #[cfg(not(target_arch = "wasm32"))]
+        }
+    }
+    #[cfg(not(feature = "wasm-unstable-single-threaded"))]
+    {
+        TokenStream::default()
+    }
+}
+
+pub(crate) fn async_trait_annotation() -> TokenStream {
+    #[cfg(feature = "wasm-unstable-single-threaded")]
+    {
+        quote! {
+            #[cfg_attr(not(target_arch = "wasm32"), ::async_trait::async_trait)]
+            #[cfg_attr(target_arch = "wasm32", ::async_trait::async_trait(?Send))]
+        }
+    }
+    #[cfg(not(feature = "wasm-unstable-single-threaded"))]
+    {
+        quote! {
+            #[::async_trait::async_trait]
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2511 

This is a followup for #2418 and #2497.

It does not add anything fundamentally new, just doing the same as the other PRs but for `ForeignFuture`s.