### PR TITLE
General pipeline updates

### DIFF
--- a/docs/manual/src/internals/bindings_ir_pipeline.md
+++ b/docs/manual/src/internals/bindings_ir_pipeline.md
@@ -65,6 +65,33 @@ pub struct Node {
 }
 ```
 
+### Field Conversion order
+
+Fields are converted in declaration order.
+This matters when a field is listed twice with one of them using `#[node(from(<name_of_the_other_field>)]`.
+In this case the first field declared will be initialized with the data from the previous pass and the second field will be initialized to the default value.
+
+You can take advantage of this to convert an optional value into a non-optional value.
+For example:
+
+```rust
+#[derive(Node)]
+pub struct SourceNode {
+    name: Option<String>
+}
+
+#[derive(Node)]
+pub struct DestNode {
+    /// This field will be set to `SourceNode::name`
+    #[node(from(name))]
+    name_from_previous_pass: Option<String>
+    /// This field will be a non-optional version of `SourceNode::name`.
+    /// It will be initialized to an empty string, then a pipeline pass will populate it using
+    /// `name_from_previous_pass` combined with logic to handle the `None` case.
+    name: String,
+}
+```
+
 ## Module structure
 
 Each IRs will typically have a module dedicated to them with the following structure:
@@ -89,7 +116,6 @@ pub fn pipeline(): Pipeline<initial::Root, Root> {
         // This will use the logic from the Node conversions section above.
         .convert_ir_pass::<Root>()
         // Add passes to populate the new fields, mutate existing fields, etc.
-        // Each pass
         .pass(foo::pass)
         .pass(bar::pass)
         .pass(baz::pass)

--- a/uniffi_bindgen/src/pipeline/general/callback_interfaces.rs
+++ b/uniffi_bindgen/src/pipeline/general/callback_interfaces.rs
@@ -5,17 +5,24 @@
 //! FFI info for callback interfaces
 
 use super::*;
+use heck::ToUpperCamelCase;
 use std::collections::HashSet;
 
 pub fn pass(module: &mut Module) -> Result<()> {
     let crate_name = module.crate_name.clone();
+    let module_name = module.name.clone();
     module.try_visit_mut(|cbi: &mut CallbackInterface| {
-        cbi.vtable = vtable(&crate_name, &cbi.name, cbi.methods.clone())?;
+        cbi.vtable = vtable(&module_name, &crate_name, &cbi.name, cbi.methods.clone())?;
         Ok(())
     })?;
     module.try_visit_mut(|int: &mut Interface| {
         if int.imp.has_callback_interface() {
-            int.vtable = Some(vtable(&crate_name, &int.name, int.methods.clone())?);
+            int.vtable = Some(vtable(
+                &module_name,
+                &crate_name,
+                &int.name,
+                int.methods.clone(),
+            )?);
         }
         Ok(())
     })?;
@@ -47,16 +54,26 @@ pub fn pass(module: &mut Module) -> Result<()> {
     Ok(())
 }
 
-fn vtable(crate_name: &str, interface_name: &str, methods: Vec<Method>) -> Result<VTable> {
+fn vtable(
+    module_name: &str,
+    crate_name: &str,
+    interface_name: &str,
+    methods: Vec<Method>,
+) -> Result<VTable> {
     Ok(VTable {
         struct_type: FfiType::Struct(FfiStructName(format!(
             "VTableCallbackInterface{}",
             interface_name
-        ))),
+        )))
+        .into(),
         interface_name: interface_name.to_string(),
         init_fn: RustFfiFunctionName(uniffi_meta::init_callback_vtable_fn_symbol_name(
             crate_name,
             interface_name,
+        )),
+        free_fn_type: FfiFunctionTypeName(format!(
+            "CallbackInterfaceFree{}_{interface_name}",
+            module_name.to_upper_camel_case(),
         )),
         methods: methods
             .into_iter()
@@ -67,7 +84,8 @@ fn vtable(crate_name: &str, interface_name: &str, methods: Vec<Method>) -> Resul
                     ffi_type: FfiType::Function(FfiFunctionTypeName(format!(
                         "CallbackInterface{}Method{i}",
                         interface_name
-                    ))),
+                    )))
+                    .into(),
                 })
             })
             .collect::<Result<Vec<_>>>()?,
@@ -119,7 +137,7 @@ fn add_vtable_ffi_definitions(module: &mut Module) -> Result<()> {
                         name: async_info.ffi_foreign_future_result.clone(),
                         fields: match ffi_return_type {
                             Some(return_ffi_type) => vec![
-                                FfiField::new("return_value", return_ffi_type),
+                                FfiField::new("return_value", return_ffi_type.ty),
                                 FfiField::new("call_status", FfiType::RustCallStatus),
                             ],
                             None => vec![
@@ -154,7 +172,8 @@ fn add_vtable_ffi_definitions(module: &mut Module) -> Result<()> {
         ffi_definitions.extend([
             FfiFunctionType {
                 name: FfiFunctionTypeName(format!(
-                    "CallbackInterfaceFree{module_name}_{interface_name}"
+                    "CallbackInterfaceFree{}_{interface_name}",
+                    module_name.to_upper_camel_case(),
                 )),
                 arguments: vec![FfiArgument::new(
                     "handle",
@@ -172,13 +191,15 @@ fn add_vtable_ffi_definitions(module: &mut Module) -> Result<()> {
                 fields: vtable
                     .methods
                     .iter()
-                    .map(|vtable_meth| {
-                        FfiField::new(&vtable_meth.callable.name, vtable_meth.ffi_type.clone())
+                    .map(|vtable_meth| FfiField {
+                        name: vtable_meth.callable.name.clone(),
+                        ty: vtable_meth.ffi_type.clone(),
                     })
                     .chain([FfiField::new(
                         "uniffi_free",
                         FfiType::Function(FfiFunctionTypeName(format!(
-                            "CallbackInterfaceFree{module_name}_{interface_name}"
+                            "CallbackInterfaceFree{}_{interface_name}",
+                            module_name.to_upper_camel_case(),
                         ))),
                     )])
                     .collect(),
@@ -191,7 +212,7 @@ fn add_vtable_ffi_definitions(module: &mut Module) -> Result<()> {
                 name: vtable.init_fn.clone(),
                 arguments: vec![FfiArgument {
                     name: "vtable".into(),
-                    ty: FfiType::Reference(Box::new(vtable.struct_type.clone())),
+                    ty: FfiType::Reference(Box::new(vtable.struct_type.ty.clone())).into(),
                 }],
                 return_type: FfiReturnType { ty: None },
                 async_data: None,
@@ -220,7 +241,8 @@ fn vtable_method(
             ty: FfiType::Handle(HandleKind::CallbackInterface {
                 module_name: module_name.to_string(),
                 interface_name: interface_name.to_string(),
-            }),
+            })
+            .into(),
         })
         .chain(callable.arguments.iter().map(|arg| FfiArgument {
             name: arg.name.clone(),
@@ -229,11 +251,11 @@ fn vtable_method(
         .chain(std::iter::once(match &callable.return_type.ty {
             Some(ty) => FfiArgument {
                 name: "uniffi_out_return".into(),
-                ty: FfiType::MutReference(Box::new(ty.ffi_type.clone())),
+                ty: FfiType::MutReference(Box::new(ty.ffi_type.ty.clone())).into(),
             },
             None => FfiArgument {
                 name: "uniffi_out_return".into(),
-                ty: FfiType::VoidPointer,
+                ty: FfiType::VoidPointer.into(),
             },
         }))
         .collect(),
@@ -257,7 +279,8 @@ fn vtable_method_async(
             ty: FfiType::Handle(HandleKind::CallbackInterface {
                 module_name: module_name.to_string(),
                 interface_name: interface_name.to_string(),
-            }),
+            })
+            .into(),
         })
         .chain(callable.arguments.iter().map(|arg| FfiArgument {
             name: arg.name.clone(),
@@ -266,17 +289,18 @@ fn vtable_method_async(
         .chain([
             FfiArgument {
                 name: "uniffi_future_callback".into(),
-                ty: FfiType::Function(async_data.ffi_foreign_future_complete.clone()),
+                ty: FfiType::Function(async_data.ffi_foreign_future_complete.clone()).into(),
             },
             FfiArgument {
                 name: "uniffi_callback_data".into(),
-                ty: FfiType::Handle(HandleKind::ForeignFutureCallbackData),
+                ty: FfiType::Handle(HandleKind::ForeignFutureCallbackData).into(),
             },
             FfiArgument {
                 name: "uniffi_out_return".into(),
                 ty: FfiType::MutReference(Box::new(FfiType::Struct(FfiStructName(
                     "ForeignFuture".to_owned(),
-                )))),
+                ))))
+                .into(),
             },
         ])
         .collect(),

--- a/uniffi_bindgen/src/pipeline/general/enums.rs
+++ b/uniffi_bindgen/src/pipeline/general/enums.rs
@@ -3,11 +3,128 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
+use std::cmp::{max, min};
 
 pub fn pass(en: &mut Enum) -> Result<()> {
     en.is_flat = match en.shape {
         EnumShape::Error { flat } => flat,
         EnumShape::Enum => en.variants.iter().all(|v| v.fields.is_empty()),
     };
+    for v in en.variants.iter_mut() {
+        v.fields_kind = if v.fields.is_empty() {
+            FieldsKind::Unit
+        } else if v.fields.iter().any(|f| f.name.is_empty()) {
+            FieldsKind::Unnamed
+        } else {
+            FieldsKind::Named
+        };
+    }
+    determine_discriminants(en)?;
+    Ok(())
+}
+
+/// Set the `Enum::discr_type` and `Variant::discr` fields
+///
+/// If we get a value from the metadata, then those will be used.  Otherwise, we will calculate the
+/// discriminants by following Rust's logic.
+pub fn determine_discriminants(en: &mut Enum) -> Result<()> {
+    let signed = match &en.meta_discr_type {
+        Some(type_node) => match &type_node.ty {
+            Type::UInt8 | Type::UInt16 | Type::UInt32 | Type::UInt64 => false,
+            Type::Int8 | Type::Int16 | Type::Int32 | Type::Int64 => true,
+            ty => bail!("Invalid enum discriminant type: {ty:?}"),
+        },
+        // If not specified, then the discriminant type is signed.  We'll calculate the width as we
+        // go through the variant discriminants
+        None => true,
+    };
+
+    // Calculate all variant discriminants.
+    // Use a placeholder value for the type, since we don't necessarily know it yet.
+    let mut max_value: u64 = 0;
+    let mut min_value: i64 = 0;
+    let mut last_variant: Option<&Variant> = None;
+
+    for variant in en.variants.iter_mut() {
+        let discr = match &variant.meta_discr {
+            None => {
+                let lit = match last_variant {
+                    None => {
+                        if signed {
+                            Literal::Int(0, Radix::Decimal, TypeNode::default())
+                        } else {
+                            Literal::UInt(0, Radix::Decimal, TypeNode::default())
+                        }
+                    }
+                    Some(variant) => match &variant.discr.lit {
+                        Literal::UInt(val, _, _) => {
+                            Literal::UInt(val + 1, Radix::Decimal, TypeNode::default())
+                        }
+                        Literal::Int(val, _, _) => {
+                            Literal::Int(val + 1, Radix::Decimal, TypeNode::default())
+                        }
+                        lit => bail!("Invalid enum discriminant literal: {lit:?}"),
+                    },
+                };
+                LiteralNode { lit }
+            }
+            Some(lit_node) => lit_node.clone(),
+        };
+        match &discr.lit {
+            Literal::UInt(val, _, _) => {
+                max_value = max(max_value, *val);
+            }
+            Literal::Int(val, _, _) => {
+                if *val >= 0 {
+                    max_value = max(max_value, *val as u64);
+                } else {
+                    min_value = min(min_value, *val);
+                }
+            }
+            _ => unreachable!(),
+        }
+        variant.discr = discr;
+        last_variant = Some(variant);
+    }
+
+    // Finally, we can figure out the discriminant type
+    en.discr_type = match &en.meta_discr_type {
+        Some(type_node) => type_node.clone(),
+        None => {
+            if min_value >= i8::MIN as i64 && max_value <= i8::MAX as u64 {
+                TypeNode {
+                    ty: Type::Int8,
+                    ..TypeNode::default()
+                }
+            } else if min_value >= i16::MIN as i64 && max_value <= i16::MAX as u64 {
+                TypeNode {
+                    ty: Type::Int16,
+                    ..TypeNode::default()
+                }
+            } else if min_value >= i32::MIN as i64 && max_value <= i32::MAX as u64 {
+                TypeNode {
+                    ty: Type::Int32,
+                    ..TypeNode::default()
+                }
+            } else if max_value <= i64::MAX as u64 {
+                // Note: no need to check `min_value` since that's always in the `i64` bounds.
+                TypeNode {
+                    ty: Type::Int64,
+                    ..TypeNode::default()
+                }
+            } else {
+                bail!("Enum repr not set and magnitude exceeds i64::MAX");
+            }
+        }
+    };
+    for variant in en.variants.iter_mut() {
+        match &mut variant.discr.lit {
+            Literal::UInt(_, _, type_node) | Literal::Int(_, _, type_node) => {
+                *type_node = en.discr_type.clone();
+            }
+            _ => unreachable!(),
+        }
+    }
+
     Ok(())
 }

--- a/uniffi_bindgen/src/pipeline/general/ffi_functions.rs
+++ b/uniffi_bindgen/src/pipeline/general/ffi_functions.rs
@@ -32,7 +32,8 @@ pub fn pass(module: &mut Module) -> Result<()> {
                 ty: FfiType::RustArcPtr {
                     module_name: module_name.clone(),
                     object_name: interface_name.clone(),
-                },
+                }
+                .into(),
             }),
             _ => None,
         };
@@ -70,7 +71,7 @@ pub fn pass(module: &mut Module) -> Result<()> {
                     .chain(base_arguments)
                     .collect(),
                 return_type: FfiReturnType {
-                    ty: Some(FfiType::Handle(HandleKind::RustFuture)),
+                    ty: Some(FfiType::Handle(HandleKind::RustFuture).into()),
                 },
                 has_rust_call_status_arg: false,
                 kind: FfiFunctionKind::Scaffolding,

--- a/uniffi_bindgen/src/pipeline/general/mod.rs
+++ b/uniffi_bindgen/src/pipeline/general/mod.rs
@@ -17,7 +17,9 @@ mod enums;
 mod ffi_async_data;
 mod ffi_functions;
 mod ffi_types;
+mod modules;
 mod objects;
+mod records;
 mod rust_buffer;
 mod rust_future;
 mod self_types;
@@ -38,15 +40,17 @@ use uniffi_pipeline::{new_pipeline, Node, Pipeline};
 pub fn pipeline() -> Pipeline<initial::Root, Root> {
     new_pipeline()
         .convert_ir_pass::<Root>()
+        .pass(modules::pass)
         .pass(callable::pass)
         .pass(rust_buffer::pass)
         .pass(rust_future::pass)
         .pass(self_types::pass)
         .pass(type_definitions_from_api::pass)
+        .pass(enums::pass)
+        .pass(records::pass)
         .pass(type_nodes::pass)
         .pass(ffi_types::pass)
         .pass(ffi_async_data::pass)
-        .pass(enums::pass)
         .pass(objects::pass)
         .pass(callback_interfaces::pass)
         .pass(ffi_functions::pass)

--- a/uniffi_bindgen/src/pipeline/general/modules.rs
+++ b/uniffi_bindgen/src/pipeline/general/modules.rs
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::*;
+
+pub fn pass(module: &mut Module) -> Result<()> {
+    module.string_type_node = TypeNode {
+        ty: Type::String,
+        ..TypeNode::default()
+    };
+    Ok(())
+}

--- a/uniffi_bindgen/src/pipeline/general/objects.rs
+++ b/uniffi_bindgen/src/pipeline/general/objects.rs
@@ -24,13 +24,17 @@ pub fn pass(module: &mut Module) -> Result<()> {
                     ty: FfiType::RustArcPtr {
                         module_name: module_name.clone(),
                         object_name: int.name.to_string(),
-                    },
+                    }
+                    .into(),
                 }],
                 return_type: FfiReturnType {
-                    ty: Some(FfiType::RustArcPtr {
-                        module_name: module_name.clone(),
-                        object_name: int.name.to_string(),
-                    }),
+                    ty: Some(
+                        FfiType::RustArcPtr {
+                            module_name: module_name.clone(),
+                            object_name: int.name.to_string(),
+                        }
+                        .into(),
+                    ),
                 },
                 has_rust_call_status_arg: true,
                 kind: FfiFunctionKind::ObjectClone,
@@ -47,7 +51,8 @@ pub fn pass(module: &mut Module) -> Result<()> {
                     ty: FfiType::RustArcPtr {
                         module_name: module_name.clone(),
                         object_name: int.name.to_string(),
-                    },
+                    }
+                    .into(),
                 }],
                 return_type: FfiReturnType { ty: None },
                 has_rust_call_status_arg: true,

--- a/uniffi_bindgen/src/pipeline/general/records.rs
+++ b/uniffi_bindgen/src/pipeline/general/records.rs
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::*;
+
+pub fn pass(rec: &mut Record) -> Result<()> {
+    rec.fields_kind = if rec.fields.is_empty() {
+        FieldsKind::Unit
+    } else if rec.fields.iter().any(|f| f.name.is_empty()) {
+        FieldsKind::Unnamed
+    } else {
+        FieldsKind::Named
+    };
+    Ok(())
+}

--- a/uniffi_bindgen/src/pipeline/general/rust_buffer.rs
+++ b/uniffi_bindgen/src/pipeline/general/rust_buffer.rs
@@ -21,10 +21,10 @@ pub fn pass(module: &mut Module) -> Result<()> {
             async_data: None,
             arguments: vec![FfiArgument {
                 name: "size".to_string(),
-                ty: FfiType::UInt64,
+                ty: FfiType::UInt64.into(),
             }],
             return_type: FfiReturnType {
-                ty: Some(FfiType::RustBuffer(None)),
+                ty: Some(FfiType::RustBuffer(None).into()),
             },
             has_rust_call_status_arg: true,
             kind: FfiFunctionKind::RustBufferAlloc,
@@ -36,10 +36,10 @@ pub fn pass(module: &mut Module) -> Result<()> {
             async_data: None,
             arguments: vec![FfiArgument {
                 name: "bytes".to_string(),
-                ty: FfiType::ForeignBytes,
+                ty: FfiType::ForeignBytes.into(),
             }],
             return_type: FfiReturnType {
-                ty: Some(FfiType::RustBuffer(None)),
+                ty: Some(FfiType::RustBuffer(None).into()),
             },
             has_rust_call_status_arg: true,
             kind: FfiFunctionKind::RustBufferFromBytes,
@@ -51,7 +51,7 @@ pub fn pass(module: &mut Module) -> Result<()> {
             async_data: None,
             arguments: vec![FfiArgument {
                 name: "buf".to_string(),
-                ty: FfiType::RustBuffer(None),
+                ty: FfiType::RustBuffer(None).into(),
             }],
             return_type: FfiReturnType { ty: None },
             has_rust_call_status_arg: true,
@@ -65,15 +65,15 @@ pub fn pass(module: &mut Module) -> Result<()> {
             arguments: vec![
                 FfiArgument {
                     name: "buf".to_string(),
-                    ty: FfiType::RustBuffer(None),
+                    ty: FfiType::RustBuffer(None).into(),
                 },
                 FfiArgument {
                     name: "additional".to_string(),
-                    ty: FfiType::UInt64,
+                    ty: FfiType::UInt64.into(),
                 },
             ],
             return_type: FfiReturnType {
-                ty: Some(FfiType::RustBuffer(None)),
+                ty: Some(FfiType::RustBuffer(None).into()),
             },
             has_rust_call_status_arg: true,
             kind: FfiFunctionKind::RustBufferReserve,

--- a/uniffi_bindgen/src/pipeline/general/rust_future.rs
+++ b/uniffi_bindgen/src/pipeline/general/rust_future.rs
@@ -91,17 +91,18 @@ fn ffi_rust_future_poll(symbol_name: String) -> FfiDefinition {
         arguments: vec![
             FfiArgument {
                 name: "handle".to_owned(),
-                ty: FfiType::Handle(HandleKind::RustFuture),
+                ty: FfiType::Handle(HandleKind::RustFuture).into(),
             },
             FfiArgument {
                 name: "callback".to_owned(),
                 ty: FfiType::Function(FfiFunctionTypeName(
                     "RustFutureContinuationCallback".to_owned(),
-                )),
+                ))
+                .into(),
             },
             FfiArgument {
                 name: "callback_data".to_owned(),
-                ty: FfiType::Handle(HandleKind::RustFuture),
+                ty: FfiType::Handle(HandleKind::RustFuture).into(),
             },
         ],
         return_type: FfiReturnType { ty: None },
@@ -118,7 +119,7 @@ fn ffi_rust_future_cancel(symbol_name: String) -> FfiDefinition {
         async_data: None,
         arguments: vec![FfiArgument {
             name: "handle".to_owned(),
-            ty: FfiType::Handle(HandleKind::RustFuture),
+            ty: FfiType::Handle(HandleKind::RustFuture).into(),
         }],
         return_type: FfiReturnType { ty: None },
         has_rust_call_status_arg: false,
@@ -134,9 +135,11 @@ fn ffi_rust_future_complete(return_type: Option<FfiType>, symbol_name: String) -
         async_data: None,
         arguments: vec![FfiArgument {
             name: "handle".to_owned(),
-            ty: FfiType::Handle(HandleKind::RustFuture),
+            ty: FfiType::Handle(HandleKind::RustFuture).into(),
         }],
-        return_type: FfiReturnType { ty: return_type },
+        return_type: FfiReturnType {
+            ty: return_type.map(FfiTypeNode::from),
+        },
         has_rust_call_status_arg: true,
         kind: FfiFunctionKind::RustFutureComplete,
         ..FfiFunction::default()
@@ -150,7 +153,7 @@ fn ffi_rust_future_free(symbol_name: String) -> FfiDefinition {
         async_data: None,
         arguments: vec![FfiArgument {
             name: "handle".to_owned(),
-            ty: FfiType::Handle(HandleKind::RustFuture),
+            ty: FfiType::Handle(HandleKind::RustFuture).into(),
         }],
         return_type: FfiReturnType { ty: None },
         has_rust_call_status_arg: false,

--- a/uniffi_bindgen/src/pipeline/general/sort.rs
+++ b/uniffi_bindgen/src/pipeline/general/sort.rs
@@ -96,21 +96,21 @@ impl DependencyLogic for FfiDefinitionDependencyLogic {
             FfiDefinition::Struct(ffi_struct) => ffi_struct
                 .fields
                 .iter()
-                .filter_map(|f| Self::type_dependency_name(&f.ty))
+                .filter_map(|f| Self::type_dependency_name(&f.ty.ty))
                 .collect(),
             FfiDefinition::RustFunction(func) => func
                 .arguments
                 .iter()
                 .map(|a| &a.ty)
                 .chain(&func.return_type.ty)
-                .filter_map(Self::type_dependency_name)
+                .filter_map(|ty| Self::type_dependency_name(&ty.ty))
                 .collect(),
             FfiDefinition::FunctionType(func_type) => func_type
                 .arguments
                 .iter()
                 .map(|a| &a.ty)
                 .chain(&func_type.return_type.ty)
-                .filter_map(Self::type_dependency_name)
+                .filter_map(|ty| Self::type_dependency_name(&ty.ty))
                 .collect(),
         }
     }

--- a/uniffi_bindgen/src/pipeline/initial/mod.rs
+++ b/uniffi_bindgen/src/pipeline/initial/mod.rs
@@ -57,7 +57,7 @@ impl Root {
             )?;
         }
         let mut root = metadata_converter.try_into_initial_ir()?;
-        root.cdylib = Some(path.to_string());
+        root.cdylib = calc_cdylib_name(path);
         Ok(root)
     }
 
@@ -136,4 +136,17 @@ impl Root {
         }
         Ok(())
     }
+}
+
+// If `library_path` is a C dynamic library, return its name
+fn calc_cdylib_name(library_path: &Utf8Path) -> Option<String> {
+    let cdylib_extensions = [".so", ".dll", ".dylib"];
+    let filename = library_path.file_name()?;
+    let filename = filename.strip_prefix("lib").unwrap_or(filename);
+    for ext in cdylib_extensions {
+        if let Some(f) = filename.strip_suffix(ext) {
+            return Some(f.to_string());
+        }
+    }
+    None
 }

--- a/uniffi_pipeline/src/node.rs
+++ b/uniffi_pipeline/src/node.rs
@@ -4,7 +4,7 @@
 
 use std::{any::Any, fmt, hash::Hash};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use indexmap::{IndexMap, IndexSet};
 
 use super::Value;
@@ -107,6 +107,32 @@ pub trait Node: fmt::Debug + Any {
         Self: Sized,
     {
         (self as &mut dyn Node).try_visit_descendents_recurse_mut(&mut visitor)
+    }
+
+    /// Does this node has any descendant where the closure returns `true`?
+    fn has_descendant<T: Node>(&self, mut matcher: impl FnMut(&T) -> bool) -> bool
+    where
+        Self: Sized,
+    {
+        self.try_visit(|node: &T| {
+            if matcher(node) {
+                // `matcher` returned true, so we want to short-circuit the `try_visit`.  To do
+                // that, return an error, then check the error after `try_visit` completes.  It's
+                // weird, but it works
+                bail!("");
+            } else {
+                Ok(())
+            }
+        })
+        .is_err()
+    }
+
+    /// Does this node have any descendant of a given type?
+    fn has_descendant_with_type<T: Node>(&self) -> bool
+    where
+        Self: Sized,
+    {
+        self.has_descendant(|_: &T| true)
     }
 
     /// Take the current value from `self` leaving behind an empty value


### PR DESCRIPTION
This were the result of me implementing the Python bindings using the new pipeline system.  There were a handful of things I realized I needed/wanted there that didn't come up when I was implementing the JS bindings.

Add `FfiTypeNode`. I didn't originally have this as part of the general pipeline, since it wasn't needed there.  However, virtually all language pipelines are going to want to add it so we may as well do it in shared code.

Determine enum discriminants for the bindings. This uses basically the same algorithm as from `ComponentInterface`. The one difference is that for enums without a specified `repr`, this calculates the smallest integer width needed to store the variants.

I used a new pipeline technique for the enum discriminents: the old/optional `discr` field gets renamed to `meta_discr` so that we can create a new/non-optional `discr` field.

Adding the `Node::has_descendant` method. I've noticed I'm implementing this code again and again, so it feels a good time to generalize.

Several other smaller changes/fixes.