### PR TITLE
Explicitly catch kotlin.Exception in async traits

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/Async.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Async.kt
@@ -54,7 +54,7 @@ internal inline fun<T> uniffiTraitInterfaceCallAsync(
     val job = GlobalScope.launch {
         try {
             handleSuccess(makeCall())
-        } catch(e: Exception) {
+        } catch(e: kotlin.Exception) {
             handleError(
                 UniffiRustCallStatus.create(
                     UNIFFI_CALL_UNEXPECTED_ERROR,
@@ -78,7 +78,7 @@ internal inline fun<T, reified E: Throwable> uniffiTraitInterfaceCallAsyncWithEr
     val job = GlobalScope.launch {
         try {
             handleSuccess(makeCall())
-        } catch(e: Exception) {
+        } catch(e: kotlin.Exception) {
             if (e is E) {
                 handleError(
                     UniffiRustCallStatus.create(


### PR DESCRIPTION
We had a crash in our Android apps because someone added an `Error` in uniffi that got translated to `Exception` in Kotlin.

This type then overshadowed the `kotlin.Exception` (like in https://github.com/mozilla/uniffi-rs/issues/1020) and our async traits started crashing the app because the exception was not handled in the binding.

The sync version of this method specifies the exception `kotlin.Exception` so I see no reason for async version not to specify it.

I couldn't find any tests that cover this. I could try and write failing tests, but this would take me much longer.

In general, I'd prefer if it was made impossible to export `Error` errors since this has the potential to cause huge confusions. 