### PR TITLE
Update README to say uniffi-bindgen-react-native now supports WASM

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Other tools we know of which try and solve a similarly shaped problem are:
 
 ## Third-party foreign language bindings
 
-* [React Native bindings](https://github.com/jhugman/uniffi-bindgen-react-native). The repository contains tooling to generate bindings for [Hermes](https://github.com/facebook/hermes) and for [creating Turbo Modules](https://reactnative.dev/blog/2024/10/23/the-new-architecture-is-here#new-native-modules).
+* [Javascript bindings](https://github.com/jhugman/uniffi-bindgen-react-native): running in a web page, targeting WASM; and React Native targeting Android, iOS. The repository contains tooling to generate bindings for [Hermes](https://github.com/facebook/hermes), [creating Turbo Modules](https://reactnative.dev/blog/2024/10/23/the-new-architecture-is-here#new-native-modules), and for creating a [`wasm-bindgen` bindings crate](https://rustwasm.github.io/wasm-bindgen).
 * [Kotlin Multiplatform support (Gobley)](https://github.com/gobley/gobley). The repository contains Kotlin Multiplatform bindings generation for UniFFI, letting you target both JVM and Native.
 * [Go bindings](https://github.com/NordSecurity/uniffi-bindgen-go)
 * [C# bindings](https://github.com/NordSecurity/uniffi-bindgen-cs)


### PR DESCRIPTION
PR title describes the change.