### PR TITLE
Fix rust-analyzer by removing dependency on `futures`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,28 +646,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
 
 [[package]]
-name = "futures"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -675,17 +659,6 @@ name = "futures-core"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -706,47 +679,6 @@ dependencies = [
  "parking",
  "pin-project-lite",
  "waker-fn",
-]
-
-[[package]]
-name = "futures-macro"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
-
-[[package]]
-name = "futures-task"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
-
-[[package]]
-name = "futures-util"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -1787,7 +1719,6 @@ name = "uniffi-fixture-futures"
 version = "0.21.0"
 dependencies = [
  "async-trait",
- "futures",
  "once_cell",
  "thiserror 1.0.47",
  "tokio",

--- a/fixtures/futures/Cargo.toml
+++ b/fixtures/futures/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/bin.rs"
 # Add the "scaffolding-ffi-buffer-fns" feature to make sure things can build correctly
 uniffi = { workspace = true, features = ["tokio", "cli", "scaffolding-ffi-buffer-fns"] }
 async-trait = "0.1"
-futures = "0.3"
 thiserror = "1.0"
 tokio = { version = "1.38.2", features = ["time", "sync"] }
 once_cell = "1.18.0"

--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -11,8 +11,6 @@ use std::{
     time::Duration,
 };
 
-use futures::future::{AbortHandle, Abortable, Aborted};
-
 /// Non-blocking timer future.
 pub struct TimerFuture {
     shared_state: Arc<Mutex<SharedState>>,
@@ -484,18 +482,6 @@ async fn try_delay_using_trait(
     delay_ms: String,
 ) -> Result<(), ParserError> {
     obj.try_delay(delay_ms).await
-}
-
-#[uniffi::export]
-async fn cancel_delay_using_trait(obj: Arc<dyn AsyncParser>, delay_ms: i32) {
-    let (abort_handle, abort_registration) = AbortHandle::new_pair();
-    thread::spawn(move || {
-        // Simulate a different thread aborting the process
-        thread::sleep(Duration::from_millis(1));
-        abort_handle.abort();
-    });
-    let future = Abortable::new(obj.delay(delay_ms), abort_registration);
-    assert_eq!(future.await, Err(Aborted));
 }
 
 uniffi::include_scaffolding!("futures");

--- a/fixtures/futures/tests/bindings/test_futures.kts
+++ b/fixtures/futures/tests/bindings/test_futures.kts
@@ -206,13 +206,6 @@ runBlocking {
     } catch(e: ParserException.NotAnInt) {
         // Expected
     }
-    val completedDelaysBefore = traitObj.completedDelays
-    cancelDelayUsingTrait(traitObj, 10)
-    // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
-    delay(100)
-    // If the task was cancelled, then completedDelays won't have increased
-    assert(traitObj.completedDelays == completedDelaysBefore)
-
     // Test that all handles were cleaned up
     assert(uniffiForeignFutureHandleCount() == 0)
 }

--- a/fixtures/futures/tests/bindings/test_futures.py
+++ b/fixtures/futures/tests/bindings/test_futures.py
@@ -166,14 +166,6 @@ class TestFutures(unittest.TestCase):
             with self.assertRaises(ParserError.NotAnInt):
                 await try_delay_using_trait(trait_obj, "one")
 
-            completed_delays_before = trait_obj.completed_delays
-            await cancel_delay_using_trait(trait_obj, 10)
-            # sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
-            await asyncio.sleep(0.1)
-            # If the task was cancelled, then completed_delays won't have increased
-            self.assertEqual(trait_obj.completed_delays, completed_delays_before)
-
-
         asyncio.run(test())
         # check that all foreign future handles were released
         self.assertEqual(len(futures._UNIFFI_FOREIGN_FUTURE_HANDLE_MAP), 0)

--- a/fixtures/futures/tests/bindings/test_futures.swift
+++ b/fixtures/futures/tests/bindings/test_futures.swift
@@ -242,13 +242,6 @@ Task {
         // Expected
     }
 
-    let completedDelaysBefore = traitObj.completedDelays
-    await cancelDelayUsingTrait(obj: traitObj, delayMs: 10)
-    // sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
-    try! await Task.sleep(nanoseconds: 100_000_000)
-    // If the task was cancelled, then completedDelays won't have increased
-    assert(traitObj.completedDelays == completedDelaysBefore)
-
     // Test that all handles here cleaned up
     assert(uniffiForeignFutureHandleCountFutures() == 0)
 


### PR DESCRIPTION
This was causing rust-analyzer to crash because of https://github.com/rust-lang/rust-analyzer/issues/20038

This dependency was only needed for one test and I don't think that test was really needed.  The simplest solution is to just drop the dependency and test together.