### PR TITLE
Simplify RustFuture to only have 1 generic param

### DIFF
--- a/uniffi_core/src/ffi/handle.rs
+++ b/uniffi_core/src/ffi/handle.rs
@@ -63,6 +63,23 @@ impl Handle {
         Arc::from_raw(self.as_pointer())
     }
 
+    /// Re-create an Arc from a borrowed handle
+    ///
+    /// "borrowed" means a handle sent from the other side of the FFI without cloning it first.
+    /// Be very careful with using this, since it's easy to introduce races.
+    /// The one scenario this is currently used for is futures, since we can guarantee that the
+    /// foreign side will not drop the future while in the middle of polling/cancelling it.
+    ///
+    /// # Safety
+    ///
+    /// * The handle must have been created from `Handle::from_arc`.
+    /// * There must be no possibility for the handle to be dropped before the function the
+    ///   borrowed handle is passed to returns.
+    pub unsafe fn into_arc_borrowed<T>(self) -> Arc<T> {
+        self.clone_arc_handle::<T>();
+        Arc::from_raw(self.as_pointer())
+    }
+
     /// Clone a handle for an Arc
     ///
     /// # Safety

--- a/uniffi_core/src/ffi/rustfuture/future.rs
+++ b/uniffi_core/src/ffi/rustfuture/future.rs
@@ -75,44 +75,67 @@
 //! [`Waker`]: https://doc.rust-lang.org/std/task/struct.Waker.html
 //! [`RawWaker`]: https://doc.rust-lang.org/std/task/struct.RawWaker.html
 
-use std::{
-    future::Future,
-    marker::PhantomData,
-    panic,
-    pin::Pin,
-    sync::{Arc, Mutex},
-    task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
-};
-
 use super::{
     FutureLowerReturn, RustFutureContinuationCallback, RustFuturePoll, Scheduler,
     UniffiCompatibleFuture,
 };
-use crate::{rust_call_with_out_status, FfiDefault, LiftArgsError, RustCallStatus};
-
-type BoxedFuture<T> = Pin<Box<dyn UniffiCompatibleFuture<Result<T, LiftArgsError>>>>;
+use crate::{try_rust_call, FfiDefault, LiftArgsError, RustCallResult, RustCallStatus};
+use std::{
+    future, panic,
+    pin::{pin, Pin},
+    sync::{Arc, Mutex},
+    task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+};
 
 /// Wraps the actual future we're polling
-struct WrappedFuture<T, UT>
-where
-    T: FutureLowerReturn<UT> + 'static,
-    UT: Send + 'static,
-{
-    // Note: this could be a single enum, but that would make it easy to mess up the future pinning
-    // guarantee.   For example you might want to call `std::mem::take()` to try to get the result,
-    // but if the future happened to be stored that would move and break all internal references.
-    future: Option<BoxedFuture<T>>,
-    result: Option<Result<T::ReturnType, RustCallStatus>>,
+///
+/// * Lowers the future result into an FFI type
+/// * Splits `Future::poll` into 2 parts.  WrappedFuture::poll(), which returns true if the future
+///   is ready and `WrappedFuture::complete` which extracts the result.  This matches how our FFI
+///   functions work.
+/// * Polls the future inside of `rust_call_with_out_status` so that panics can be caught.
+struct WrappedFuture<FfiType> {
+    // Create an option for the future and result.
+    // This could be a single enum, but makes future pinning harder.
+    // For example if you call `std::mem::take()` while a future was stored in the enum, it would break the pinning guarantee.
+    //
+    // The output is `Result<FfiType, RustCallStatus>`.
+    // Both the `Ok` and `Err` side are easy to pass back across the FFI.
+    future: Option<Pin<Box<dyn UniffiCompatibleFuture<RustCallResult<FfiType>>>>>,
+    result: Option<Result<FfiType, RustCallStatus>>,
 }
 
-impl<T, UT> WrappedFuture<T, UT>
-where
-    T: FutureLowerReturn<UT> + 'static,
-    UT: Send + 'static,
-{
-    fn new(future: BoxedFuture<T>) -> Self {
+impl<FfiType> WrappedFuture<FfiType> {
+    fn new<F, T, UT>(future: F) -> Self
+    where
+        F: UniffiCompatibleFuture<Result<T, LiftArgsError>> + 'static,
+        T: FutureLowerReturn<UT, ReturnType = FfiType>,
+    {
+        let wrapped_future = async {
+            let mut future = pin!(future);
+            future::poll_fn(move |cx| {
+                let call_result = try_rust_call(
+                    // This closure uses a `&mut F` value, which means it's not UnwindSafe by
+                    // default.  If the future panics, it may be in an invalid state.
+                    //
+                    // However, we can safely use `AssertUnwindSafe` since a panic will lead the
+                    // `Err` case below and we will never poll the future again.
+                    panic::AssertUnwindSafe(|| match future.as_mut().poll(cx) {
+                        Poll::Pending => Ok(Poll::Pending),
+                        Poll::Ready(Ok(v)) => T::lower_return(v).map(Poll::Ready),
+                        Poll::Ready(Err(e)) => T::handle_failed_lift(e).map(Poll::Ready),
+                    }),
+                );
+                match call_result {
+                    Ok(Poll::Pending) => Poll::Pending,
+                    Ok(Poll::Ready(v)) => Poll::Ready(Ok(v)),
+                    Err(call_status) => Poll::Ready(Err(call_status)),
+                }
+            })
+            .await
+        };
         Self {
-            future: Some(future),
+            future: Some(Box::pin(wrapped_future)),
             result: None,
         }
     }
@@ -122,37 +145,11 @@ where
         if self.result.is_some() {
             true
         } else if let Some(future) = &mut self.future {
-            // SAFETY: We can call Pin::new_unchecked because:
-            //    - This is the only time we get a &mut to `self.future`
-            //    - We never poll the future after it's moved (for example by using take())
-            //    - We never move RustFuture, which contains us.
-            //    - RustFuture is private to this module so no other code can move it.
-            let pinned = unsafe { Pin::new_unchecked(future) };
-            // Run the poll and lift the result if it's ready
-            let mut out_status = RustCallStatus::default();
-            let result: Option<Poll<T::ReturnType>> = rust_call_with_out_status(
-                &mut out_status,
-                // This closure uses a `&mut F` value, which means it's not UnwindSafe by
-                // default.  If the future panics, it may be in an invalid state.
-                //
-                // However, we can safely use `AssertUnwindSafe` since a panic will lead the `None`
-                // case below and we will never poll the future again.
-                panic::AssertUnwindSafe(|| match pinned.poll(context) {
-                    Poll::Pending => Ok(Poll::Pending),
-                    Poll::Ready(Ok(v)) => T::lower_return(v).map(Poll::Ready),
-                    Poll::Ready(Err(e)) => T::handle_failed_lift(e).map(Poll::Ready),
-                }),
-            );
-            match result {
-                Some(Poll::Pending) => false,
-                Some(Poll::Ready(v)) => {
+            match future.as_mut().poll(context) {
+                Poll::Pending => false,
+                Poll::Ready(result) => {
                     self.future = None;
-                    self.result = Some(Ok(v));
-                    true
-                }
-                None => {
-                    self.future = None;
-                    self.result = Some(Err(out_status));
+                    self.result = Some(result);
                     true
                 }
             }
@@ -162,8 +159,11 @@ where
         }
     }
 
-    fn complete(&mut self, out_status: &mut RustCallStatus) -> T::ReturnType {
-        let mut return_value = T::ReturnType::ffi_default();
+    fn complete(&mut self, out_status: &mut RustCallStatus) -> FfiType
+    where
+        FfiType: FfiDefault,
+    {
+        let mut return_value = FfiType::ffi_default();
         match self.result.take() {
             Some(Ok(v)) => return_value = v,
             Some(Err(call_status)) => *out_status = call_status,
@@ -179,49 +179,24 @@ where
     }
 }
 
-// Implement `Send` on WrappedFuture under the correct conditions.
-//
-// FIXME: This is required to make the futures code compile, although it's not entirely correct.
-// If the `wasm-unstable-single-threaded` feature is enabled, then the wrapped future may not be `Send`, and thus `WrappedFuture` is not Send either.
-// This seems okay for now, since if `wasm-unstable-single-threaded` then futures should stay on one thread.
-// However, we should probably fix this in the long-term.
-//
-// In addition, `WrappedFuture::result` can be a raw pointer which is `!Send`.
-// This `!Send` bound is because Rust can't uphold safety guarantees for raw pointers.
-// However, this code does in fact treat the pointers correctly, for example we only return them across the FFI once.
-unsafe impl<T, UT> Send for WrappedFuture<T, UT>
-where
-    T: FutureLowerReturn<UT> + 'static,
-    UT: Send + 'static,
-{
-}
-
 /// Future that the foreign code is awaiting
-pub(super) struct RustFuture<T, UT>
-where
-    T: FutureLowerReturn<UT> + 'static,
-    UT: Send + 'static,
-{
+pub(super) struct RustFuture<FfiType> {
     // This Mutex should never block if our code is working correctly, since there should not be
     // multiple threads calling [Self::poll] and/or [Self::complete] at the same time.
-    future: Mutex<WrappedFuture<T, UT>>,
+    future: Mutex<WrappedFuture<FfiType>>,
     scheduler: Mutex<Scheduler>,
-    // UT is used as the generic parameter for [LowerReturn].
-    // Let's model this with PhantomData as a function that inputs a UT value.
-    _phantom: PhantomData<fn(UT) -> ()>,
 }
 
-impl<T, UT> RustFuture<T, UT>
-where
-    T: FutureLowerReturn<UT> + 'static,
-    UT: Send + 'static,
-{
-    pub(super) fn new(future: BoxedFuture<T>, _tag: UT) -> Arc<Self> {
-        Arc::new(Self {
+impl<FfiType> RustFuture<FfiType> {
+    pub(super) fn new<F, T, UT>(future: F, _tag: UT) -> Self
+    where
+        F: UniffiCompatibleFuture<Result<T, LiftArgsError>> + 'static,
+        T: FutureLowerReturn<UT, ReturnType = FfiType>,
+    {
+        Self {
             future: Mutex::new(WrappedFuture::new(future)),
             scheduler: Mutex::new(Scheduler::new()),
-            _phantom: PhantomData,
-        })
+        }
     }
 
     pub(super) fn poll(self: Arc<Self>, callback: RustFutureContinuationCallback, data: u64) {
@@ -247,7 +222,10 @@ where
         self.scheduler.lock().unwrap().cancel();
     }
 
-    pub(super) fn complete(&self, call_status: &mut RustCallStatus) -> T::ReturnType {
+    pub(super) fn complete(&self, call_status: &mut RustCallStatus) -> FfiType
+    where
+        FfiType: FfiDefault,
+    {
         self.future.lock().unwrap().complete(call_status)
     }
 
@@ -260,10 +238,8 @@ where
 }
 
 // `RawWaker` implementation for RustFuture
-impl<T, UT> RustFuture<T, UT>
+impl<FfiType> RustFuture<FfiType>
 where
-    T: FutureLowerReturn<UT> + 'static,
-    UT: Send + 'static,
     Scheduler: Send + Sync,
 {
     unsafe fn waker_clone(ptr: *const ()) -> RawWaker {
@@ -326,46 +302,5 @@ where
         //   has a `Send` + `Sync` bound.
         // * We manage the raw arc pointers correctly
         unsafe { Waker::from_raw(raw_waker) }
-    }
-}
-
-/// RustFuture FFI trait.  This allows `Arc<RustFuture<F, T, UT>>` to be cast to
-/// `Arc<dyn RustFutureFfi<T::ReturnType>>`, which is needed to implement the public FFI API.  In particular, this
-/// allows you to use RustFuture functionality without knowing the concrete Future type, which is
-/// unnamable.
-///
-/// This is parametrized on the ReturnType rather than the `T` directly, to reduce the number of
-/// scaffolding functions we need to generate.  If it was parametrized on `T`, then we would need
-/// to create a poll, cancel, complete, and free scaffolding function for each exported async
-/// function.  That would add ~1kb binary size per exported function based on a quick estimate on a
-/// x86-64 machine . By parametrizing on `T::ReturnType` we can instead monomorphize by hand and
-/// only create those functions for each of the 13 possible FFI return types.
-#[doc(hidden)]
-pub trait RustFutureFfi<ReturnType>: Send + Sync {
-    fn ffi_poll(self: Arc<Self>, callback: RustFutureContinuationCallback, data: u64);
-    fn ffi_cancel(&self);
-    fn ffi_complete(&self, call_status: &mut RustCallStatus) -> ReturnType;
-    fn ffi_free(self: Arc<Self>);
-}
-
-impl<T, UT> RustFutureFfi<T::ReturnType> for RustFuture<T, UT>
-where
-    T: FutureLowerReturn<UT> + 'static,
-    UT: Send + 'static,
-{
-    fn ffi_poll(self: Arc<Self>, callback: RustFutureContinuationCallback, data: u64) {
-        self.poll(callback, data)
-    }
-
-    fn ffi_cancel(&self) {
-        self.cancel()
-    }
-
-    fn ffi_complete(&self, call_status: &mut RustCallStatus) -> T::ReturnType {
-        self.complete(call_status)
-    }
-
-    fn ffi_free(self: Arc<Self>) {
-        self.free();
     }
 }

--- a/uniffi_macros/src/setup_scaffolding.rs
+++ b/uniffi_macros/src/setup_scaffolding.rs
@@ -176,14 +176,14 @@ fn rust_future_scaffolding_fns(module_path: &str) -> TokenStream {
             #[doc(hidden)]
             #[unsafe(no_mangle)]
             pub unsafe extern "C" fn #ffi_rust_future_poll(handle: ::uniffi::Handle, callback: ::uniffi::RustFutureContinuationCallback, data: u64) {
-                ::uniffi::ffi::rust_future_poll::<#return_type, crate::UniFfiTag>(handle, callback, data);
+                ::uniffi::ffi::rust_future_poll::<#return_type>(handle, callback, data);
             }
 
             #[allow(clippy::missing_safety_doc, missing_docs)]
             #[doc(hidden)]
             #[unsafe(no_mangle)]
             pub unsafe extern "C" fn #ffi_rust_future_cancel(handle: ::uniffi::Handle) {
-                ::uniffi::ffi::rust_future_cancel::<#return_type, crate::UniFfiTag>(handle)
+                ::uniffi::ffi::rust_future_cancel::<#return_type>(handle)
             }
 
             #[allow(clippy::missing_safety_doc, missing_docs)]
@@ -193,14 +193,14 @@ fn rust_future_scaffolding_fns(module_path: &str) -> TokenStream {
                 handle: ::uniffi::Handle,
                 out_status: &mut ::uniffi::RustCallStatus
             ) -> #return_type {
-                ::uniffi::ffi::rust_future_complete::<#return_type, crate::UniFfiTag>(handle, out_status)
+                ::uniffi::ffi::rust_future_complete::<#return_type>(handle, out_status)
             }
 
             #[allow(clippy::missing_safety_doc, missing_docs)]
             #[doc(hidden)]
             #[unsafe(no_mangle)]
             pub unsafe extern "C" fn #ffi_rust_future_free(handle: ::uniffi::Handle) {
-                ::uniffi::ffi::rust_future_free::<#return_type, crate::UniFfiTag>(handle)
+                ::uniffi::ffi::rust_future_free::<#return_type>(handle)
             }
         }
     })


### PR DESCRIPTION
(This is based on top of https://github.com/mozilla/uniffi-rs/pull/2574.  Let's merge that one first.  This PR is just for the second commit).

#2406 made `RustFuture` is store a `Box<dyn Future>` rather than a concrete type.  That change was focused on binary size, but this also gives us an opportunity to simplify some other code:

* `RustFuture` and `WrappedFuture` only need 1 generic parameter: the FFI return type.
* We can drop the entire `RustFutureFfi` trait and just use `RustFuture` directly.
* The Arcs we pass across the FFI now store `RustFuture` directly, which is `Sized`.  No more need for an double-arc wrapping.
* We don't need to implement `Send` for `WrappedFuture`, which didn't seem correct to me.  This makes it more likely that Rust can catch errors in the future as we update this code.
* We can drop the `PhantomData` field.

Other changes:

* Switched using `future::poll_fn`, which simplifies the `WrappedFuture` code a bit.
* Borrowed the `Handle` code from #2569 and use that for Arc/Handle conversions. I think we may also be able to get rid of the `HandleAlloc` trait in the near future. Losing a layer of indirection seems good to me.
* Dropped the docstrings in `rust_future_new`. The `UniffiCompatibleFuture` docstrings are a better place for this info.
