### PR TITLE
Fix a documantation output filename conflict

### DIFF
--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -67,3 +67,4 @@ rustdoc-args = ["--generate-link-to-definition"]
 name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 required-features = ["cli"]
+doc = false


### PR DESCRIPTION
I accidentally introduced a filename collision with my previous change. It turns out, `cargo doc` doesn't like having two binaries in one project with the same name, which caused it to raise an error when I tried to generate the documentation, conflicting `uniffi/uniffi-bindgen.rs` with `examples/app/uniffi-bindgen-cli/uniffi-bindgen.rs`. To fix it, I have marked the binary with `doc = false`.