### PR TITLE
Handle fixes

### DIFF
--- a/uniffi_bindgen/src/bindings/python/templates/CallableBody.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CallableBody.py
@@ -8,7 +8,7 @@ if {{ arg.name }} is _DEFAULT:
 
  _uniffi_lowered_args = (
     {%- if callable.is_method() %}
-    self._uniffi_clone_pointer(),
+    self._uniffi_clone_handle(),
     {%- endif %}
     {%- for arg in callable.arguments %}
     {{ arg.ty.ffi_converter_name }}.lower({{ arg.name }}),
@@ -46,7 +46,7 @@ _uniffi_ffi_result = _uniffi_rust_call_with_error(
 )
 {%- match callable.kind %}
 {%- when CallableKind::Constructor { primary: true, .. } %}
-self._pointer = _uniffi_ffi_result
+self._handle = _uniffi_ffi_result
 {%- when CallableKind::Constructor { primary: false, .. } %}
 return cls._uniffi_make_instance(_uniffi_ffi_result)
 {%- else %}

--- a/uniffi_core/src/ffi/rustfuture/future.rs
+++ b/uniffi_core/src/ffi/rustfuture/future.rs
@@ -243,7 +243,7 @@ where
     Scheduler: Send + Sync,
 {
     unsafe fn waker_clone(ptr: *const ()) -> RawWaker {
-        trace!("RustFuture::waker_clone called ({ptr:?)");
+        trace!("RustFuture::waker_clone called ({ptr:?})");
         Arc::<Self>::increment_strong_count(ptr.cast::<Self>());
         RawWaker::new(
             ptr,
@@ -257,12 +257,12 @@ where
     }
 
     unsafe fn waker_wake(ptr: *const ()) {
-        trace!("RustFuture::waker_wake called ({ptr:?)");
+        trace!("RustFuture::waker_wake called ({ptr:?})");
         Self::recreate_arc(ptr).scheduler.lock().unwrap().wake();
     }
 
     unsafe fn waker_wake_by_ref(ptr: *const ()) {
-        trace!("RustFuture::waker_wake_by_ref called ({ptr:?)");
+        trace!("RustFuture::waker_wake_by_ref called ({ptr:?})");
         // For wake_by_ref, we can use the pointer directly, without consuming it to re-create the
         // arc.
         let ptr = ptr.cast::<Self>();
@@ -270,7 +270,7 @@ where
     }
 
     unsafe fn waker_drop(ptr: *const ()) {
-        trace!("RustFuture::waker_drop called ({ptr:?)");
+        trace!("RustFuture::waker_drop called ({ptr:?})");
         drop(Self::recreate_arc(ptr));
     }
 
@@ -285,7 +285,7 @@ where
     }
 
     fn into_waker(self: Arc<Self>) -> Waker {
-        trace!("RustFuture::creating waker ({:?)", self.as_pointer());
+        trace!("RustFuture::creating waker ({:?})", Arc::as_ptr(&self));
         let raw_waker = RawWaker::new(
             Arc::into_raw(self).cast::<()>(),
             &RawWakerVTable::new(


### PR DESCRIPTION
These should have been done in #2569, but I missed them.

* Python:
    * Rename variables to use "handle" instead of "pointer"
    * Switch the interface code to store a `c_uint64` instead of a `c_void_p` I think the old code would fail on 32-bit machines.
* Fixed `trace!` call arguments