### PR TITLE
Use IndexSet for FFI definitions

### DIFF
--- a/uniffi_bindgen/src/bindings/python/pipeline/nodes.rs
+++ b/uniffi_bindgen/src/bindings/python/pipeline/nodes.rs
@@ -4,7 +4,7 @@
 
 use askama::Template;
 use heck::ToSnakeCase;
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use serde::Deserialize;
 
 use crate::bindings::python::filters;
@@ -28,7 +28,7 @@ pub struct Module {
     pub docstring: Option<String>,
     pub functions: Vec<Function>,
     pub type_definitions: Vec<TypeDefinition>,
-    pub ffi_definitions: Vec<FfiDefinition>,
+    pub ffi_definitions: IndexSet<FfiDefinition>,
     pub checksums: Vec<Checksum>,
     pub ffi_rustbuffer_alloc: RustFfiFunctionName,
     pub ffi_rustbuffer_from_bytes: RustFfiFunctionName,
@@ -145,7 +145,7 @@ pub struct ThrowsType {
     pub ty: Option<TypeNode>,
 }
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub struct AsyncData {
     // FFI types for async Rust functions
     pub ffi_rust_future_poll: RustFfiFunctionName,
@@ -469,7 +469,7 @@ pub enum ObjectImpl {
     CallbackTrait,
 }
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub enum FfiDefinition {
     /// FFI Function exported in the Rust library
     RustFunction(FfiFunction),
@@ -491,7 +491,7 @@ pub struct FfiStructName(pub String);
 #[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub struct FfiFunctionTypeName(pub String);
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub struct FfiFunction {
     pub name: RustFfiFunctionName,
     pub is_async: bool,
@@ -502,7 +502,7 @@ pub struct FfiFunction {
     pub kind: FfiFunctionKind,
 }
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub enum FfiFunctionKind {
     Scaffolding,
     ObjectClone,
@@ -520,7 +520,7 @@ pub enum FfiFunctionKind {
     Checksum,
 }
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub struct FfiFunctionType {
     pub name: FfiFunctionTypeName,
     pub arguments: Vec<FfiArgument>,
@@ -528,24 +528,24 @@ pub struct FfiFunctionType {
     pub has_rust_call_status_arg: bool,
 }
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub struct FfiReturnType {
     pub ty: Option<FfiTypeNode>,
 }
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub struct FfiStruct {
     pub name: FfiStructName,
     pub fields: Vec<FfiField>,
 }
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub struct FfiField {
     pub name: String,
     pub ty: FfiTypeNode,
 }
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub struct FfiArgument {
     pub name: String,
     pub ty: FfiTypeNode,

--- a/uniffi_bindgen/src/pipeline/general/checksums.rs
+++ b/uniffi_bindgen/src/pipeline/general/checksums.rs
@@ -12,7 +12,7 @@ pub fn pass(module: &mut Module) -> Result<()> {
         "ffi_{}_uniffi_contract_version",
         &module.crate_name
     ));
-    module.ffi_definitions.push(
+    module.ffi_definitions.insert(
         FfiFunction {
             name: RustFfiFunctionName(format!(
                 "ffi_{}_uniffi_contract_version",
@@ -93,7 +93,7 @@ pub fn pass(module: &mut Module) -> Result<()> {
         });
         module
             .ffi_definitions
-            .push(FfiDefinition::RustFunction(ffi_func));
+            .insert(FfiDefinition::RustFunction(ffi_func));
     }
     module.correct_contract_version = uniffi_meta::UNIFFI_CONTRACT_VERSION.to_string();
     Ok(())

--- a/uniffi_bindgen/src/pipeline/general/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/general/nodes.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use uniffi_pipeline::Node;
 
 /// Initial IR, this stores the metadata and other data
@@ -22,7 +22,7 @@ pub struct Module {
     pub docstring: Option<String>,
     pub functions: Vec<Function>,
     pub type_definitions: Vec<TypeDefinition>,
-    pub ffi_definitions: Vec<FfiDefinition>,
+    pub ffi_definitions: IndexSet<FfiDefinition>,
     /// Checksum functions
     pub checksums: Vec<Checksum>,
     // FFI functions names for this module
@@ -132,7 +132,7 @@ pub struct ThrowsType {
     pub ty: Option<TypeNode>,
 }
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub struct AsyncData {
     // FFI types for async Rust functions
     pub ffi_rust_future_poll: RustFfiFunctionName,
@@ -442,7 +442,7 @@ pub enum ObjectImpl {
     CallbackTrait,
 }
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub enum FfiDefinition {
     /// FFI Function exported in the Rust library
     RustFunction(FfiFunction),
@@ -464,7 +464,7 @@ pub struct FfiStructName(pub String);
 #[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub struct FfiFunctionTypeName(pub String);
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub struct FfiFunction {
     pub name: RustFfiFunctionName,
     pub is_async: bool,
@@ -475,7 +475,7 @@ pub struct FfiFunction {
     pub kind: FfiFunctionKind,
 }
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub enum FfiFunctionKind {
     Scaffolding,
     ObjectClone,
@@ -493,7 +493,7 @@ pub enum FfiFunctionKind {
     Checksum,
 }
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub struct FfiFunctionType {
     pub name: FfiFunctionTypeName,
     pub arguments: Vec<FfiArgument>,
@@ -501,24 +501,24 @@ pub struct FfiFunctionType {
     pub has_rust_call_status_arg: bool,
 }
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub struct FfiReturnType {
     pub ty: Option<FfiTypeNode>,
 }
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub struct FfiStruct {
     pub name: FfiStructName,
     pub fields: Vec<FfiField>,
 }
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub struct FfiField {
     pub name: String,
     pub ty: FfiTypeNode,
 }
 
-#[derive(Debug, Clone, Node)]
+#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
 pub struct FfiArgument {
     pub name: String,
     pub ty: FfiTypeNode,

--- a/uniffi_bindgen/src/pipeline/general/rust_future.rs
+++ b/uniffi_bindgen/src/pipeline/general/rust_future.rs
@@ -68,20 +68,24 @@ pub fn pass(module: &mut Module) -> Result<()> {
     ];
     for (return_type, return_type_name) in all_async_return_types {
         let poll_name = format!("ffi_{namespace}_rust_future_poll_{return_type_name}");
-        module.ffi_definitions.push(ffi_rust_future_poll(poll_name));
+        module
+            .ffi_definitions
+            .insert(ffi_rust_future_poll(poll_name));
 
         let cancel_name = format!("ffi_{namespace}_rust_future_cancel_{return_type_name}");
         module
             .ffi_definitions
-            .push(ffi_rust_future_cancel(cancel_name));
+            .insert(ffi_rust_future_cancel(cancel_name));
 
         let complete_name = format!("ffi_{namespace}_rust_future_complete_{return_type_name}");
         module
             .ffi_definitions
-            .push(ffi_rust_future_complete(return_type.clone(), complete_name));
+            .insert(ffi_rust_future_complete(return_type.clone(), complete_name));
 
         let free_name = format!("ffi_{namespace}_rust_future_free_{return_type_name}");
-        module.ffi_definitions.push(ffi_rust_future_free(free_name));
+        module
+            .ffi_definitions
+            .insert(ffi_rust_future_free(free_name));
     }
     Ok(())
 }

--- a/uniffi_bindgen/src/pipeline/general/sort.rs
+++ b/uniffi_bindgen/src/pipeline/general/sort.rs
@@ -14,7 +14,7 @@ pub fn pass(module: &mut Module) -> Result<()> {
         module.ffi_definitions.drain(..),
         FfiDefinitionDependencyLogic,
     );
-    module.ffi_definitions = ffi_dep_sorter.sort();
+    module.ffi_definitions.extend(ffi_dep_sorter.sort());
 
     let type_sorter = DependencySorter::new(
         module.type_definitions.drain(..),


### PR DESCRIPTION
This simplifies the dupe removal and I think it'll make future work easier.  For example, this would make  it easier to factor out common FFI definitions into a shared module.