### PR TITLE
Enum and Record no longer derive `Eq`

### DIFF
--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -170,7 +170,7 @@ use super::{AsType, Literal, Type, TypeIterator};
 ///
 /// Enums are passed across the FFI by serializing to a bytebuffer, with a
 /// i32 indicating the variant followed by the serialization of each field.
-#[derive(Debug, Clone, PartialEq, Eq, Checksum)]
+#[derive(Debug, Clone, Checksum)]
 pub struct Enum {
     pub(super) name: String,
     pub(super) module_path: String,
@@ -372,7 +372,7 @@ mod test {
             enum Testing { "one", "two", "one" };
         "#;
         let ci = ComponentInterface::from_webidl(UDL, "crate_name").unwrap();
-        assert_eq!(ci.enum_definitions().count(), 1);
+        assert_eq!(ci.enum_definitions().len(), 1);
         assert_eq!(
             ci.get_enum_definition("Testing").unwrap().variants().len(),
             3
@@ -405,7 +405,7 @@ mod test {
             };
         "#;
         let ci = ComponentInterface::from_webidl(UDL, "crate_name").unwrap();
-        assert_eq!(ci.enum_definitions().count(), 3);
+        assert_eq!(ci.enum_definitions().len(), 3);
         assert_eq!(ci.function_definitions().len(), 4);
 
         // The "flat" enum with no associated data.
@@ -537,7 +537,7 @@ mod test {
             enum Testing { "one", "two", "three" };
         "#;
         let ci = ComponentInterface::from_webidl(UDL, "crate_name").unwrap();
-        assert_eq!(ci.enum_definitions().count(), 1);
+        assert_eq!(ci.enum_definitions().len(), 1);
         let error = ci.get_enum_definition("Testing").unwrap();
         assert_eq!(
             error
@@ -561,7 +561,7 @@ mod test {
             enum Testing { "one", "two", "one" };
         "#;
         let ci = ComponentInterface::from_webidl(UDL, "crate_name").unwrap();
-        assert_eq!(ci.enum_definitions().count(), 1);
+        assert_eq!(ci.enum_definitions().len(), 1);
         assert_eq!(
             ci.get_enum_definition("Testing").unwrap().variants().len(),
             3
@@ -583,7 +583,7 @@ mod test {
             };
         "#;
         let ci = ComponentInterface::from_webidl(UDL, "crate_name").unwrap();
-        assert_eq!(ci.enum_definitions().count(), 1);
+        assert_eq!(ci.enum_definitions().len(), 1);
         let error: &Enum = ci.get_enum_definition("Testing").unwrap();
         assert_eq!(
             error
@@ -609,7 +609,7 @@ mod test {
             };
         "#;
         let ci = ComponentInterface::from_webidl(UDL, "crate_name").unwrap();
-        assert_eq!(ci.enum_definitions().count(), 1);
+        assert_eq!(ci.enum_definitions().len(), 1);
         let testing: &Enum = ci.get_enum_definition("Testing").unwrap();
         assert_eq!(
             testing.variants()[0]

--- a/uniffi_bindgen/src/interface/record.rs
+++ b/uniffi_bindgen/src/interface/record.rs
@@ -55,7 +55,7 @@ use super::{AsType, Type, TypeIterator};
 /// In the FFI these are represented as a byte buffer, which one side explicitly
 /// serializes the data into and the other serializes it out of. So I guess they're
 /// kind of like "pass by clone" values.
-#[derive(Debug, Clone, PartialEq, Eq, Checksum)]
+#[derive(Debug, Clone, Checksum)]
 pub struct Record {
     pub(super) name: String,
     pub(super) module_path: String,
@@ -197,7 +197,7 @@ mod test {
             };
         "#;
         let ci = ComponentInterface::from_webidl(UDL, "crate_name").unwrap();
-        assert_eq!(ci.record_definitions().count(), 3);
+        assert_eq!(ci.record_definitions().len(), 3);
 
         let record = ci.get_record_definition("Empty").unwrap();
         assert_eq!(record.name(), "Empty");
@@ -246,7 +246,7 @@ mod test {
             };
         "#;
         let ci = ComponentInterface::from_webidl(UDL, "crate_name").unwrap();
-        assert_eq!(ci.record_definitions().count(), 1);
+        assert_eq!(ci.record_definitions().len(), 1);
         let record = ci.get_record_definition("Testing").unwrap();
         assert_eq!(record.fields().len(), 2);
         assert_eq!(record.fields()[0].name(), "maybe_name");

--- a/uniffi_bindgen/src/interface/visit_mut.rs
+++ b/uniffi_bindgen/src/interface/visit_mut.rs
@@ -1,6 +1,10 @@
-use crate::interface::{Enum, FfiDefinition, Record};
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::interface::FfiDefinition;
 use crate::{ComponentInterface, VisitMut};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use uniffi_meta::Type;
 
 impl ComponentInterface {
@@ -26,10 +30,8 @@ impl ComponentInterface {
 
         self.types.all_known_types = all_known_types_altered;
 
-        let mut updated_enums: BTreeMap<String, Enum> = BTreeMap::new();
         let errors_clone = self.errors.clone();
-        for (enum_name, enum_item) in self.enums.iter_mut() {
-            let updated_key = visitor.visit_enum_key(&mut enum_name.clone());
+        for enum_item in self.enums.iter_mut() {
             let is_error = errors_clone.contains(enum_item.name());
 
             visitor.visit_enum(is_error, enum_item);
@@ -42,11 +44,9 @@ impl ComponentInterface {
                     visitor.visit_type(&mut field.type_);
                 }
             }
-            updated_enums.insert(updated_key, enum_item.clone());
         }
-        self.enums = updated_enums;
 
-        for record_item in self.records.values_mut() {
+        for record_item in self.records.iter_mut() {
             visitor.visit_record(record_item);
 
             for field in &mut record_item.fields {
@@ -54,7 +54,6 @@ impl ComponentInterface {
                 visitor.visit_type(&mut field.type_);
             }
         }
-        self.fix_record_keys_after_rename();
 
         for function in self.functions.iter_mut() {
             visitor.visit_function(function);
@@ -140,15 +139,5 @@ impl ComponentInterface {
                 name
             })
             .collect()
-    }
-
-    fn fix_record_keys_after_rename(&mut self) {
-        let mut new_records: BTreeMap<String, Record> = BTreeMap::new();
-
-        for record in self.records.values() {
-            new_records.insert(record.name().to_string(), record.clone());
-        }
-
-        self.records = new_records;
     }
 }

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -197,11 +197,6 @@ pub trait VisitMut {
     /// adjust it to language specific naming conventions.
     fn visit_enum(&self, is_error: bool, enum_: &mut Enum);
 
-    /// Change the naming of the key in the [`ComponentInterface`]
-    /// `BTreeMap` where all `Enum`s are stored to reflect the changed
-    /// name of an `Enum`.
-    fn visit_enum_key(&self, key: &mut String) -> String;
-
     /// Go through each `Variant` of an `Enum` and
     /// adjust it to language specific naming conventions.
     fn visit_variant(&self, is_error: bool, variant: &mut Variant);


### PR DESCRIPTION
This is so they can hold `uniffi_trait` objects, which cannot reasonably implement it. We now store `Enum` and `Record` objects in a `Vec<>` like we already do for `Object`s.