### PR TITLE
Avoid emitting duplicate metadata for uniffi traits.

### DIFF
--- a/fixtures/uitests/tests/ui/trait_methods_no_trait.stderr
+++ b/fixtures/uitests/tests/ui/trait_methods_no_trait.stderr
@@ -9,16 +9,16 @@ error[E0277]: `TraitMethods` doesn't implement `std::fmt::Display`
 note: required by a bound in `TraitMethods::uniffi_trait_display::_::{closure#0}::assert_impl_all`
  --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
   |
-  | #[uniffi::export(Display)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
-  = note: this error originates in the macro `::uniffi::deps::static_assertions::assert_impl_all` which comes from the expansion of the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
+  | #[::uniffi::export_for_udl_derive(Display)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+  = note: this error originates in the macro `::uniffi::deps::static_assertions::assert_impl_all` which comes from the expansion of the attribute macro `::uniffi::export_for_udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `TraitMethods` doesn't implement `std::fmt::Display`
  --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
   |
-  | #[uniffi::export(Display)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `TraitMethods` cannot be formatted with the default formatter
+  | #[::uniffi::export_for_udl_derive(Display)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `TraitMethods` cannot be formatted with the default formatter
   |
   = help: the trait `std::fmt::Display` is not implemented for `TraitMethods`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-  = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the attribute macro `::uniffi::export_for_udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/uniffi_bindgen/src/library_mode.rs
+++ b/uniffi_bindgen/src/library_mode.rs
@@ -111,14 +111,7 @@ pub fn find_components(
     for group in metadata_groups.values_mut() {
         let crate_name = group.namespace.crate_name.clone();
         if let Some(udl_group) = load_udl_metadata(group, &crate_name, config_supplier)? {
-            let mut udl_items = udl_group
-                .items
-                .into_iter()
-                // some items are both in UDL and library metadata. For many that's fine but
-                // uniffi-traits aren't trivial to compare meaning we end up with dupes.
-                // We filter out such problematic items here.
-                .filter(|item| !matches!(item, Metadata::UniffiTrait { .. }))
-                .collect();
+            let mut udl_items = udl_group.items.into_iter().collect();
             group.items.append(&mut udl_items);
             if group.namespace_docstring.is_none() {
                 group.namespace_docstring = udl_group.namespace_docstring;

--- a/uniffi_bindgen/src/pipeline/initial/mod.rs
+++ b/uniffi_bindgen/src/pipeline/initial/mod.rs
@@ -105,12 +105,6 @@ impl Root {
         metadata_converter
             .add_metadata_item(uniffi_meta::Metadata::Namespace(metadata_group.namespace))?;
         for mut meta in metadata_group.items {
-            // some items are both in UDL and library metadata. For many that's fine but
-            // uniffi-traits aren't trivial to compare meaning we end up with dupes.
-            // We filter out such problematic items here.
-            if library_mode && matches!(meta, uniffi_meta::Metadata::UniffiTrait { .. }) {
-                continue;
-            }
             // Make sure metadata checksums are set
             match &mut meta {
                 uniffi_meta::Metadata::Func(func) => {

--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -22,19 +22,19 @@ pub trait r#{{ obj.name() }} {
 }
 {%- else %}
 {%- for tm in obj.uniffi_traits() %}
-{%      match tm %}
-{%          when UniffiTrait::Debug { fmt }%}
-#[uniffi::export(Debug)]
-{%          when UniffiTrait::Display { fmt }%}
-#[uniffi::export(Display)]
-{%          when UniffiTrait::Hash { hash }%}
-#[uniffi::export(Hash)]
-{%          when UniffiTrait::Ord { cmp }%}
-#[uniffi::export(Ord)]
-{%          when UniffiTrait::Eq { eq, ne }%}
-#[uniffi::export(Eq)]
-{%      endmatch %}
-{% endfor %}
+{%-      match tm %}
+{%-          when UniffiTrait::Debug { fmt } %}
+#[::uniffi::export_for_udl_derive(Debug)]
+{%-          when UniffiTrait::Display { fmt } %}
+#[::uniffi::export_for_udl_derive(Display)]
+{%-          when UniffiTrait::Hash { hash } %}
+#[::uniffi::export_for_udl_derive(Hash)]
+{%-          when UniffiTrait::Ord { cmp } %}
+#[::uniffi::export_for_udl_derive(Ord)]
+{%-          when UniffiTrait::Eq { eq, ne } %}
+#[::uniffi::export_for_udl_derive(Eq)]
+{%-      endmatch %}
+{%- endfor %}
 {%- if obj.remote() %}
 #[::uniffi::udl_remote(Object)]
 {%- else %}

--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -148,8 +148,8 @@ pub(crate) fn expand_export(
             uniffi_traits,
             ..
         } => {
-            assert!(!udl_mode);
-            utrait::expand_uniffi_trait_export(self_ident, uniffi_traits)
+            let include_meta = !udl_mode;
+            utrait::expand_uniffi_trait_export(self_ident, uniffi_traits, include_meta)
         }
     }
 }

--- a/uniffi_macros/src/export/utrait.rs
+++ b/uniffi_macros/src/export/utrait.rs
@@ -13,8 +13,8 @@ use uniffi_meta::{MethodReceiverKind, UniffiTraitDiscriminants};
 pub(crate) fn expand_uniffi_trait_export(
     self_ident: Ident,
     uniffi_traits: Vec<UniffiTraitDiscriminants>,
+    include_metadata: bool,
 ) -> syn::Result<TokenStream> {
-    let udl_mode = false;
     let mut impl_items = Vec::new();
     let mut global_items = Vec::new();
     for trait_id in uniffi_traits {
@@ -26,23 +26,23 @@ pub(crate) fn expand_uniffi_trait_export(
                         format!("{:?}", self)
                     }
                 };
-                let (ffi_func, method_meta) =
-                    process_uniffi_trait_method(&method, &self_ident, udl_mode)?;
+                let (ffi_func, method_meta) = process_uniffi_trait_method(&method, &self_ident)?;
                 // metadata for the trait - which includes metadata for the method.
                 let discr = UniffiTraitDiscriminants::Debug as u8;
-                let trait_meta = crate::util::create_metadata_items(
-                    "uniffi_trait",
-                    &format!("{}_Debug", self_ident.unraw()),
-                    quote! {
-                        ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::UNIFFI_TRAIT)
-                        .concat_value(#discr)
-                        .concat(#method_meta)
-                    },
-                    None,
-                );
                 impl_items.push(method);
                 global_items.push(ffi_func);
-                global_items.push(trait_meta);
+                if include_metadata {
+                    global_items.push(crate::util::create_metadata_items(
+                        "uniffi_trait",
+                        &format!("{}_Debug", self_ident.unraw()),
+                        quote! {
+                            ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::UNIFFI_TRAIT)
+                            .concat_value(#discr)
+                            .concat(#method_meta)
+                        },
+                        None,
+                    ));
+                }
             }
             UniffiTraitDiscriminants::Display => {
                 let method = quote! {
@@ -51,23 +51,23 @@ pub(crate) fn expand_uniffi_trait_export(
                         format!("{}", self)
                     }
                 };
-                let (ffi_func, method_meta) =
-                    process_uniffi_trait_method(&method, &self_ident, udl_mode)?;
+                let (ffi_func, method_meta) = process_uniffi_trait_method(&method, &self_ident)?;
                 // metadata for the trait - which includes metadata for the method.
                 let discr = UniffiTraitDiscriminants::Display as u8;
-                let trait_meta = crate::util::create_metadata_items(
-                    "uniffi_trait",
-                    &format!("{}_Display", self_ident.unraw()),
-                    quote! {
-                        ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::UNIFFI_TRAIT)
-                        .concat_value(#discr)
-                        .concat(#method_meta)
-                    },
-                    None,
-                );
                 impl_items.push(method);
                 global_items.push(ffi_func);
-                global_items.push(trait_meta);
+                if include_metadata {
+                    global_items.push(crate::util::create_metadata_items(
+                        "uniffi_trait",
+                        &format!("{}_Display", self_ident.unraw()),
+                        quote! {
+                            ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::UNIFFI_TRAIT)
+                            .concat_value(#discr)
+                            .concat(#method_meta)
+                        },
+                        None,
+                    ));
+                }
             }
             UniffiTraitDiscriminants::Hash => {
                 let method = quote! {
@@ -79,23 +79,23 @@ pub(crate) fn expand_uniffi_trait_export(
                         s.finish()
                     }
                 };
-                let (ffi_func, method_meta) =
-                    process_uniffi_trait_method(&method, &self_ident, udl_mode)?;
+                let (ffi_func, method_meta) = process_uniffi_trait_method(&method, &self_ident)?;
                 // metadata for the trait - which includes metadata for the hash method.
                 let discr = UniffiTraitDiscriminants::Hash as u8;
-                let trait_meta = crate::util::create_metadata_items(
-                    "uniffi_trait",
-                    &format!("{}_Hash", self_ident.unraw()),
-                    quote! {
-                        ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::UNIFFI_TRAIT)
-                        .concat_value(#discr)
-                        .concat(#method_meta)
-                    },
-                    None,
-                );
                 impl_items.push(method);
                 global_items.push(ffi_func);
-                global_items.push(trait_meta);
+                if include_metadata {
+                    global_items.push(crate::util::create_metadata_items(
+                        "uniffi_trait",
+                        &format!("{}_Hash", self_ident.unraw()),
+                        quote! {
+                            ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::UNIFFI_TRAIT)
+                            .concat_value(#discr)
+                            .concat(#method_meta)
+                        },
+                        None,
+                    ));
+                }
             }
             UniffiTraitDiscriminants::Eq => {
                 let method_eq = quote! {
@@ -113,27 +113,28 @@ pub(crate) fn expand_uniffi_trait_export(
                     }
                 };
                 let (ffi_func_eq, method_meta_eq) =
-                    process_uniffi_trait_method(&method_eq, &self_ident, udl_mode)?;
+                    process_uniffi_trait_method(&method_eq, &self_ident)?;
                 let (ffi_func_ne, method_meta_ne) =
-                    process_uniffi_trait_method(&method_ne, &self_ident, udl_mode)?;
+                    process_uniffi_trait_method(&method_ne, &self_ident)?;
                 // metadata for the trait itself.
                 let discr = UniffiTraitDiscriminants::Eq as u8;
-                let trait_meta = crate::util::create_metadata_items(
-                    "uniffi_trait",
-                    &format!("{}_Eq", self_ident.unraw()),
-                    quote! {
-                        ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::UNIFFI_TRAIT)
-                        .concat_value(#discr)
-                        .concat(#method_meta_eq)
-                        .concat(#method_meta_ne)
-                    },
-                    None,
-                );
                 impl_items.push(method_eq);
                 impl_items.push(method_ne);
                 global_items.push(ffi_func_eq);
                 global_items.push(ffi_func_ne);
-                global_items.push(trait_meta);
+                if include_metadata {
+                    global_items.push(crate::util::create_metadata_items(
+                        "uniffi_trait",
+                        &format!("{}_Eq", self_ident.unraw()),
+                        quote! {
+                            ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::UNIFFI_TRAIT)
+                            .concat_value(#discr)
+                            .concat(#method_meta_eq)
+                            .concat(#method_meta_ne)
+                        },
+                        None,
+                    ));
+                }
             }
             UniffiTraitDiscriminants::Ord => {
                 let method_cmp = quote! {
@@ -144,22 +145,23 @@ pub(crate) fn expand_uniffi_trait_export(
                     }
                 };
                 let (ffi_func_cmp, method_meta_cmp) =
-                    process_uniffi_trait_method(&method_cmp, &self_ident, udl_mode)?;
+                    process_uniffi_trait_method(&method_cmp, &self_ident)?;
                 // metadata for the trait itself.
                 let discr = UniffiTraitDiscriminants::Ord as u8;
-                let trait_meta = crate::util::create_metadata_items(
-                    "uniffi_trait",
-                    &format!("{}_Ord", self_ident.unraw()),
-                    quote! {
-                        ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::UNIFFI_TRAIT)
-                        .concat_value(#discr)
-                        .concat(#method_meta_cmp)
-                    },
-                    None,
-                );
                 impl_items.push(method_cmp);
                 global_items.push(ffi_func_cmp);
-                global_items.push(trait_meta);
+                if include_metadata {
+                    global_items.push(crate::util::create_metadata_items(
+                        "uniffi_trait",
+                        &format!("{}_Ord", self_ident.unraw()),
+                        quote! {
+                            ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::UNIFFI_TRAIT)
+                            .concat_value(#discr)
+                            .concat(#method_meta_cmp)
+                        },
+                        None,
+                    ));
+                }
             }
         }
     }
@@ -175,8 +177,8 @@ pub(crate) fn expand_uniffi_trait_export(
 fn process_uniffi_trait_method(
     method: &TokenStream,
     self_ident: &Ident,
-    udl_mode: bool,
 ) -> syn::Result<(TokenStream, TokenStream)> {
+    let udl_mode = false; // We don't need the hacky `Result<>` optimization UDL functions get even if we are in UDL.
     let item = syn::parse(method.clone().into())?;
 
     let syn::Item::Fn(item) = item else {


### PR DESCRIPTION
This means we don't have special handling in various places to filter out these dupes, which causes confusion and complexity.

It does mean there's a new macro used here - `export_for_udl_derive()` is similar to `export_for_udl`, but is used whenever `udl_derive()` or `udl_remote()` is going to be used on the object. This macro keeps the input tokens as they need to be seen by `udl_derive()` etc.