### PR TITLE
Metadata for Enums and Records carries uniffi-trait info.

### DIFF
--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -87,6 +87,18 @@ mod uniffi_traits {
     #[derive(Debug, PartialEq, Eq, Ord, PartialOrd, uniffi::Object)]
     #[uniffi::export(Debug, Eq, Ord)]
     pub struct Special {}
+
+    #[derive(Debug, PartialEq, Eq, Ord, PartialOrd, uniffi::Enum)]
+    #[uniffi::export(Debug, Eq, Ord)]
+    pub enum SpecialEnum {
+        A,
+    }
+
+    #[derive(Debug, PartialEq, Eq, Ord, PartialOrd, uniffi::Record)]
+    #[uniffi::export(Debug, Eq, Ord)]
+    pub struct SpecialRecord {
+        a: u8,
+    }
 }
 
 #[uniffi::export(callback_interface)]
@@ -476,6 +488,54 @@ mod test_metadata {
             Metadata::UniffiTrait(UniffiTraitMetadata::Ord { cmp })
                 if cmp.module_path == "uniffi_fixture_metadata" &&
                    cmp.self_name == "Special"
+        ));
+    }
+
+    #[test]
+    fn test_uniffi_traits_enum() {
+        assert!(matches!(
+            uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIALENUM_DEBUG).unwrap(),
+            Metadata::UniffiTrait(UniffiTraitMetadata::Debug { fmt })
+                if fmt.module_path == "uniffi_fixture_metadata" &&
+                   fmt.self_name == "SpecialEnum"
+        ));
+        assert!(matches!(
+            uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIALENUM_EQ).unwrap(),
+            Metadata::UniffiTrait(UniffiTraitMetadata::Eq { eq, ne })
+                if eq.module_path == "uniffi_fixture_metadata" &&
+                   eq.self_name == "SpecialEnum" &&
+                   ne.module_path == "uniffi_fixture_metadata" &&
+                   ne.self_name == "SpecialEnum"
+        ));
+        assert!(matches!(
+            uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIALENUM_ORD).unwrap(),
+            Metadata::UniffiTrait(UniffiTraitMetadata::Ord { cmp })
+                if cmp.module_path == "uniffi_fixture_metadata" &&
+                   cmp.self_name == "SpecialEnum"
+        ));
+    }
+
+    #[test]
+    fn test_uniffi_traits_record() {
+        assert!(matches!(
+            uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIALRECORD_DEBUG).unwrap(),
+            Metadata::UniffiTrait(UniffiTraitMetadata::Debug { fmt })
+                if fmt.module_path == "uniffi_fixture_metadata" &&
+                   fmt.self_name == "SpecialRecord"
+        ));
+        assert!(matches!(
+            uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIALRECORD_EQ).unwrap(),
+            Metadata::UniffiTrait(UniffiTraitMetadata::Eq { eq, ne })
+                if eq.module_path == "uniffi_fixture_metadata" &&
+                   eq.self_name == "SpecialRecord" &&
+                   ne.module_path == "uniffi_fixture_metadata" &&
+                   ne.self_name == "SpecialRecord"
+        ));
+        assert!(matches!(
+            uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIALRECORD_ORD).unwrap(),
+            Metadata::UniffiTrait(UniffiTraitMetadata::Ord { cmp })
+                if cmp.module_path == "uniffi_fixture_metadata" &&
+                   cmp.self_name == "SpecialRecord"
         ));
     }
 }

--- a/fixtures/trait-methods/src/lib.rs
+++ b/fixtures/trait-methods/src/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -62,6 +63,207 @@ impl Ord for ProcTraitMethods {
 impl std::fmt::Display for ProcTraitMethods {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "ProcTraitMethods({})", self.val)
+    }
+}
+
+// Enums and Records.
+// Our bindings will often auto-generate the local equivalent of `Eq` etc, so if we
+// just `#[derive(Eq)` etc here , our tests would see the same results even if our versions weren't hoooked up.
+// So we need to implement a non-obvious implementation to test against.
+// Records
+#[derive(uniffi::Record, Debug)]
+#[uniffi::export(Debug, Eq, Ord, Hash)]
+pub struct TraitRecord {
+    s: String,
+    i: i8,
+}
+
+// only compare the string, not the int
+impl Ord for TraitRecord {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        Ord::cmp(&self.s, &other.s)
+    }
+}
+
+impl PartialOrd for TraitRecord {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for TraitRecord {
+    fn eq(&self, other: &Self) -> bool {
+        Ord::cmp(self, other) == std::cmp::Ordering::Equal
+    }
+}
+
+impl Eq for TraitRecord {}
+
+impl Hash for TraitRecord {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.s.hash(state)
+    }
+}
+
+#[derive(Debug)]
+pub struct UdlRecord {
+    s: String,
+    i: i8,
+}
+
+// only compare the string, not the int
+impl Ord for UdlRecord {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        Ord::cmp(&self.s, &other.s)
+    }
+}
+
+impl PartialOrd for UdlRecord {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for UdlRecord {
+    fn eq(&self, other: &Self) -> bool {
+        Ord::cmp(self, other) == std::cmp::Ordering::Equal
+    }
+}
+
+impl Eq for UdlRecord {}
+
+impl Hash for UdlRecord {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.s.hash(state)
+    }
+}
+
+// Enums
+#[derive(uniffi::Enum, Debug)]
+#[uniffi::export(Debug, Display, Eq, Ord, Hash)]
+pub enum TraitEnum {
+    S(String),
+    I(i8),
+}
+
+impl std::fmt::Display for TraitEnum {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::S(s) => write!(f, "TraitEnum::S({s:?})"),
+            Self::I(i) => write!(f, "TraitEnum::I({i})"),
+        }
+    }
+}
+
+// only compare the variant, not the content
+impl Ord for TraitEnum {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // no `Ord` for `std::mem::discriminant`?
+        match self {
+            TraitEnum::S { .. } => match other {
+                TraitEnum::S(_) => std::cmp::Ordering::Equal,
+                TraitEnum::I(_) => std::cmp::Ordering::Less,
+            },
+            TraitEnum::I(_) => match other {
+                TraitEnum::S(_) => std::cmp::Ordering::Greater,
+                TraitEnum::I(_) => std::cmp::Ordering::Equal,
+            },
+        }
+    }
+}
+impl PartialOrd for TraitEnum {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for TraitEnum {
+    fn eq(&self, other: &Self) -> bool {
+        Ord::cmp(self, other) == std::cmp::Ordering::Equal
+    }
+}
+
+impl Eq for TraitEnum {}
+
+impl Hash for TraitEnum {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state)
+    }
+}
+
+#[cfg(test)]
+// make sure the semantics are what we expect locally.
+#[test]
+fn test_traitenum_traits() {
+    let s1 = TraitEnum::S("s1".to_string());
+    assert_eq!(format!("{s1:?}"), "S(\"s1\")");
+    assert_eq!(format!("{s1}"), "TraitEnum::S(\"s1\")");
+
+    // ord/eq etc
+    assert_eq!(Ord::cmp(&s1, &s1), std::cmp::Ordering::Equal);
+    assert_eq!(s1, s1);
+    // compare equal with different data.
+    assert_eq!(
+        Ord::cmp(&s1, &TraitEnum::S("s2".to_string())),
+        std::cmp::Ordering::Equal
+    );
+    assert_eq!(
+        Ord::cmp(&TraitEnum::I(0), &TraitEnum::I(1)),
+        std::cmp::Ordering::Equal
+    );
+    assert_eq!(TraitEnum::I(0), TraitEnum::I(1));
+    assert_ne!(s1, TraitEnum::I(0));
+    assert!(s1 < TraitEnum::I(0));
+}
+
+#[derive(Debug)]
+pub enum UdlEnum {
+    S { s: String },
+    I { i: i8 },
+}
+
+impl std::fmt::Display for UdlEnum {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::S { s } => write!(f, "UdlEnum::S {{ s: {s:?} }}"),
+            Self::I { i } => write!(f, "UdlEnum::I {{ i: {i} }}"),
+        }
+    }
+}
+
+// only compare the variant, not the content
+impl Ord for UdlEnum {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // no `Ord` for `std::mem::discriminant`?
+        match self {
+            UdlEnum::S { .. } => match other {
+                UdlEnum::S { .. } => std::cmp::Ordering::Equal,
+                UdlEnum::I { .. } => std::cmp::Ordering::Less,
+            },
+            UdlEnum::I { .. } => match other {
+                UdlEnum::S { .. } => std::cmp::Ordering::Greater,
+                UdlEnum::I { .. } => std::cmp::Ordering::Equal,
+            },
+        }
+    }
+}
+impl PartialOrd for UdlEnum {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for UdlEnum {
+    fn eq(&self, other: &Self) -> bool {
+        Ord::cmp(self, other) == std::cmp::Ordering::Equal
+    }
+}
+
+impl Eq for UdlEnum {}
+
+impl Hash for UdlEnum {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state)
     }
 }
 

--- a/fixtures/trait-methods/src/trait_methods.udl
+++ b/fixtures/trait-methods/src/trait_methods.udl
@@ -4,3 +4,15 @@ namespace trait_methods {};
 interface TraitMethods {
     constructor(string name);
 };
+
+[Enum, Traits=(Debug, Eq, Hash, Ord)]
+interface UdlEnum {
+    S(string s);
+    I(i8 i);
+};
+
+[Traits=(Debug, Eq, Hash, Ord)]
+dictionary UdlRecord {
+    string s;
+    i8 i;
+};

--- a/fixtures/uitests/tests/ui/trait_methods_no_trait.rs
+++ b/fixtures/uitests/tests/ui/trait_methods_no_trait.rs
@@ -12,3 +12,15 @@ impl TraitMethods {
         unreachable!();
     }
 }
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum UdlEnum {
+    S { s: String },
+    I { i: i8 },
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct UdlRecord {
+    s: String,
+    i: i8,
+}

--- a/fixtures/uitests/tests/ui/trait_methods_no_trait.stderr
+++ b/fixtures/uitests/tests/ui/trait_methods_no_trait.stderr
@@ -1,3 +1,18 @@
+error[E0277]: `UdlEnum` doesn't implement `std::fmt::Display`
+ --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
+  |
+  | enum r#UdlEnum {
+  |      ^^^^^^^^^ `UdlEnum` cannot be formatted with the default formatter
+  |
+  = help: the trait `std::fmt::Display` is not implemented for `UdlEnum`
+  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `UdlEnum::uniffi_trait_display::_::{closure#0}::assert_impl_all`
+ --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
+  |
+  | #[::uniffi::export_for_udl_derive(Display)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+  = note: this error originates in the macro `::uniffi::deps::static_assertions::assert_impl_all` which comes from the expansion of the attribute macro `::uniffi::export_for_udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: `TraitMethods` doesn't implement `std::fmt::Display`
  --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
   |
@@ -12,6 +27,16 @@ note: required by a bound in `TraitMethods::uniffi_trait_display::_::{closure#0}
   | #[::uniffi::export_for_udl_derive(Display)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
   = note: this error originates in the macro `::uniffi::deps::static_assertions::assert_impl_all` which comes from the expansion of the attribute macro `::uniffi::export_for_udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `UdlEnum` doesn't implement `std::fmt::Display`
+ --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
+  |
+  | #[::uniffi::export_for_udl_derive(Display)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UdlEnum` cannot be formatted with the default formatter
+  |
+  = help: the trait `std::fmt::Display` is not implemented for `UdlEnum`
+  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+  = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the attribute macro `::uniffi::export_for_udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `TraitMethods` doesn't implement `std::fmt::Display`
  --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -63,7 +63,7 @@ pub use enum_::{Enum, Variant};
 mod function;
 pub use function::{Argument, Callable, Function, ResultType};
 mod object;
-pub use object::{Constructor, Method, Object, UniffiTrait};
+pub use object::{Constructor, Method, Object, UniffiTrait, UniffiTraitMethods};
 mod record;
 pub use record::{Field, Record};
 
@@ -775,8 +775,9 @@ impl ComponentInterface {
     ///
     /// This includes FFI functions for:
     ///   - Top-level functions
-    ///   - Object methods
+    ///   - Object, Enum and Record data methods
     ///   - Callback interfaces
+    ///   - UniffiTrait methods
     pub fn iter_user_ffi_function_definitions(&self) -> impl Iterator<Item = &FfiFunction> + '_ {
         iter::empty()
             .chain(
@@ -788,6 +789,16 @@ impl ComponentInterface {
                 self.callback_interfaces
                     .iter()
                     .map(|cb| cb.ffi_init_callback()),
+            )
+            .chain(
+                self.enums
+                    .iter()
+                    .flat_map(|enum_| enum_.iter_ffi_function_definitions()),
+            )
+            .chain(
+                self.records
+                    .iter()
+                    .flat_map(|r| r.iter_ffi_function_definitions()),
             )
             .chain(self.functions.iter().map(|f| &f.ffi_func))
     }
@@ -969,14 +980,27 @@ impl ComponentInterface {
     }
 
     pub(super) fn add_uniffitrait_meta(&mut self, meta: UniffiTraitMetadata) -> Result<()> {
-        let object = get_object(&mut self.objects, meta.self_name())
-            .ok_or_else(|| anyhow!("add_uniffitrait_meta: object not found"))?;
-        let ut = UniffiTrait::from_metadata(meta, object.as_type());
+        let self_name = meta.self_name().to_string();
+        let self_type = self
+            .get_type(&self_name)
+            .ok_or_else(|| anyhow!("add_uniffitrait_meta: object {} not found", self_name))?;
+        let ut = UniffiTrait::from_metadata(meta, self_type);
 
         self.types
             .add_known_types(ut.iter_types())
             .with_context(|| format!("adding builtin trait {ut:?}"))?;
-        object.uniffi_traits.push(ut);
+        if let Some(object) = get_object(&mut self.objects, &self_name) {
+            object.uniffi_traits.push(ut);
+        } else if let Some(enum_) = self.enums.iter_mut().find(|o| o.name == self_name) {
+            enum_.add_uniffi_trait(ut);
+        } else if let Some(record) = self.records.iter_mut().find(|o| o.name == self_name) {
+            record.add_uniffi_trait(ut);
+        } else {
+            bail!(
+                "add_uniffitrait_meta: object '{}' does not support trait methods.",
+                self_name
+            );
+        }
         Ok(())
     }
 
@@ -1096,6 +1120,12 @@ impl ComponentInterface {
         }
         for obj in self.objects.iter_mut() {
             obj.derive_ffi_funcs()?;
+        }
+        for enum_ in self.enums.iter_mut() {
+            enum_.derive_ffi_funcs()?;
+        }
+        for record in self.records.iter_mut() {
+            record.derive_ffi_funcs()?;
         }
         for callback in self.callback_interfaces.iter_mut() {
             callback.derive_ffi_funcs();
@@ -1318,6 +1348,7 @@ existing definition: Enum {
     ],
     shape: Enum,
     non_exhaustive: false,
+    uniffi_traits: [],
     docstring: None,
 },
 new definition: Enum {
@@ -1343,6 +1374,7 @@ new definition: Enum {
         flat: true,
     },
     non_exhaustive: false,
+    uniffi_traits: [],
     docstring: None,
 }",
         );

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -488,7 +488,7 @@ impl From<uniffi_meta::ConstructorMetadata> for Constructor {
 pub struct Method {
     pub(super) name: String,
     pub(super) is_async: bool,
-    pub(super) receiver: Type,
+    pub(super) self_type: Type,
     pub(super) arguments: Vec<Argument>,
     pub(super) return_type: Option<Type>,
     // We don't include the FFIFunc in the hash calculation, because:
@@ -523,7 +523,7 @@ impl Method {
     }
 
     pub fn object_name(&self) -> &str {
-        self.receiver.name().unwrap()
+        self.self_type.name().unwrap()
     }
 
     pub fn arguments(&self) -> Vec<&Argument> {
@@ -535,7 +535,7 @@ impl Method {
     pub fn full_arguments(&self) -> Vec<Argument> {
         vec![Argument {
             name: "ptr".to_string(),
-            type_: self.receiver.clone(),
+            type_: self.self_type.clone(),
             by_ref: !self.takes_self_by_arc,
             optional: false,
             default: None,
@@ -609,7 +609,7 @@ impl Method {
 
         Self {
             name: meta.name,
-            receiver,
+            self_type: receiver,
             is_async: meta.is_async,
             arguments,
             return_type: meta.return_type,
@@ -699,7 +699,7 @@ pub struct UniffiTraitMethods {
 }
 
 impl UniffiTraitMethods {
-    fn new(uniffi_traits: &[UniffiTrait]) -> Self {
+    pub fn new(uniffi_traits: &[UniffiTrait]) -> Self {
         let mut new = Self::default();
         for t in uniffi_traits {
             match t.clone() {
@@ -769,7 +769,7 @@ impl Callable for Method {
     }
 
     fn self_type(&self) -> Option<Type> {
-        Some(self.receiver.clone())
+        Some(self.self_type.clone())
     }
 }
 

--- a/uniffi_bindgen/src/pipeline/general/callable.rs
+++ b/uniffi_bindgen/src/pipeline/general/callable.rs
@@ -6,6 +6,29 @@
 
 use super::*;
 
+fn new_callable_method(meth: &Method, self_type: TypeNode) -> Callable {
+    Callable {
+        name: meth.name.clone(),
+        is_async: meth.is_async,
+        kind: CallableKind::Method { self_type },
+        arguments: meth.inputs.clone(),
+        return_type: ReturnType {
+            ty: meth.return_type.clone().map(|ty| TypeNode {
+                ty,
+                ..TypeNode::default()
+            }),
+        },
+        throws_type: ThrowsType {
+            ty: meth.throws.clone().map(|ty| TypeNode {
+                ty,
+                ..TypeNode::default()
+            }),
+        },
+        checksum: meth.checksum,
+        ..Callable::default()
+    }
+}
+
 pub fn pass(root: &mut Root) -> Result<()> {
     root.visit_mut(|func: &mut Function| {
         func.callable = Callable {
@@ -34,6 +57,7 @@ pub fn pass(root: &mut Root) -> Result<()> {
         namespace.visit_mut(|int: &mut Interface| {
             let interface_name = int.name.clone();
             let interface_imp = int.imp.clone();
+            let self_type = int.self_type.clone();
             int.visit_mut(|cons: &mut Constructor| {
                 cons.callable = Callable {
                     name: cons.name.clone(),
@@ -64,56 +88,29 @@ pub fn pass(root: &mut Root) -> Result<()> {
                 }
             });
             int.visit_mut(|meth: &mut Method| {
-                meth.callable = Callable {
-                    name: meth.name.clone(),
-                    is_async: meth.is_async,
-                    kind: CallableKind::Method {
-                        interface_name: interface_name.clone(),
-                    },
-                    arguments: meth.inputs.clone(),
-                    return_type: ReturnType {
-                        ty: meth.return_type.clone().map(|ty| TypeNode {
-                            ty,
-                            ..TypeNode::default()
-                        }),
-                    },
-                    throws_type: ThrowsType {
-                        ty: meth.throws.clone().map(|ty| TypeNode {
-                            ty,
-                            ..TypeNode::default()
-                        }),
-                    },
-                    checksum: meth.checksum,
-                    ..Callable::default()
-                }
+                meth.callable = new_callable_method(meth, self_type.clone());
             });
         });
     });
     root.visit_mut(|cbi: &mut CallbackInterface| {
-        let interface_name = cbi.name.clone();
-        cbi.visit_mut(|meth: &mut Method| {
-            meth.callable = Callable {
-                name: meth.name.clone(),
-                is_async: meth.is_async,
-                kind: CallableKind::Method {
-                    interface_name: interface_name.clone(),
-                },
-                arguments: meth.inputs.clone(),
-                return_type: ReturnType {
-                    ty: meth.return_type.clone().map(|ty| TypeNode {
-                        ty,
-                        ..TypeNode::default()
-                    }),
-                },
-                throws_type: ThrowsType {
-                    ty: meth.throws.clone().map(|ty| TypeNode {
-                        ty,
-                        ..TypeNode::default()
-                    }),
-                },
-                checksum: meth.checksum,
-                ..Callable::default()
-            }
+        let self_type = cbi.self_type.clone();
+
+        cbi.visit_mut(|m: &mut Method| {
+            m.callable = new_callable_method(m, self_type.clone());
+        })
+    });
+
+    root.visit_mut(|e: &mut Enum| {
+        let self_type = e.self_type.clone();
+        e.visit_mut(|meth: &mut Method| {
+            meth.callable = new_callable_method(meth, self_type.clone());
+        });
+    });
+
+    root.visit_mut(|r: &mut Record| {
+        let self_type = r.self_type.clone();
+        r.visit_mut(|meth: &mut Method| {
+            meth.callable = new_callable_method(meth, self_type.clone());
         });
     });
     Ok(())

--- a/uniffi_bindgen/src/pipeline/general/callback_interfaces.rs
+++ b/uniffi_bindgen/src/pipeline/general/callback_interfaces.rs
@@ -29,8 +29,8 @@ pub fn pass(namespace: &mut Namespace) -> Result<()> {
     namespace.try_visit_mut(|cbi: &mut CallbackInterface| {
         for meth in cbi.methods.iter_mut() {
             meth.callable.kind = match meth.callable.kind.take() {
-                CallableKind::Method { interface_name } => CallableKind::VTableMethod {
-                    trait_name: interface_name,
+                CallableKind::Method { self_type } => CallableKind::VTableMethod {
+                    trait_name: self_type.ty.name().unwrap().to_string(),
                 },
                 kind => bail!("Unexpected callable kind: {kind:?}"),
             };
@@ -40,8 +40,8 @@ pub fn pass(namespace: &mut Namespace) -> Result<()> {
     namespace.try_visit_mut(|vtable: &mut VTable| {
         for meth in vtable.methods.iter_mut() {
             meth.callable.kind = match meth.callable.kind.take() {
-                CallableKind::Method { interface_name } => CallableKind::VTableMethod {
-                    trait_name: interface_name,
+                CallableKind::Method { self_type } => CallableKind::VTableMethod {
+                    trait_name: self_type.ty.name().unwrap().to_string(),
                 },
                 kind => bail!("Unexpected callable kind: {kind:?}"),
             };

--- a/uniffi_bindgen/src/pipeline/general/checksums.rs
+++ b/uniffi_bindgen/src/pipeline/general/checksums.rs
@@ -42,10 +42,15 @@ pub fn pass(namespace: &mut Namespace) -> Result<()> {
             CallableKind::Function => {
                 uniffi_meta::fn_checksum_symbol_name(&namespace.crate_name, &callable.name)
             }
-            CallableKind::Method {
-                interface_name: name,
+            CallableKind::Method { self_type } => {
+                let name = self_type.ty.name().unwrap();
+                uniffi_meta::method_checksum_symbol_name(
+                    &namespace.crate_name,
+                    name,
+                    &callable.name,
+                )
             }
-            | CallableKind::VTableMethod { trait_name: name } => {
+            CallableKind::VTableMethod { trait_name: name } => {
                 uniffi_meta::method_checksum_symbol_name(
                     &namespace.crate_name,
                     name,

--- a/uniffi_bindgen/src/pipeline/general/ffi_functions.rs
+++ b/uniffi_bindgen/src/pipeline/general/ffi_functions.rs
@@ -8,15 +8,14 @@ use super::*;
 
 pub fn pass(namespace: &mut Namespace) -> Result<()> {
     let crate_name = namespace.crate_name.clone();
-    let namespace_name = namespace.name.clone();
     let mut ffi_definitions = vec![];
 
     namespace.visit_mut(|callable: &mut Callable| {
         let name = &callable.name;
         let ffi_func_name = match &callable.kind {
             CallableKind::Function => uniffi_meta::fn_symbol_name(&crate_name, name),
-            CallableKind::Method { interface_name } => {
-                uniffi_meta::method_symbol_name(&crate_name, interface_name, name)
+            CallableKind::Method { self_type } => {
+                uniffi_meta::method_symbol_name(&crate_name, self_type.ty.name().unwrap(), name)
             }
             CallableKind::Constructor { interface_name, .. } => {
                 uniffi_meta::constructor_symbol_name(&crate_name, interface_name, name)
@@ -27,13 +26,9 @@ pub fn pass(namespace: &mut Namespace) -> Result<()> {
         callable.ffi_func = RustFfiFunctionName(ffi_func_name.clone());
 
         let receiver_argument = match &callable.kind {
-            CallableKind::Method { interface_name } => Some(FfiArgument {
-                name: "uniffi_ptr".to_string(),
-                ty: FfiType::Handle(HandleKind::Interface {
-                    namespace: namespace_name.clone(),
-                    interface_name: interface_name.clone(),
-                })
-                .into(),
+            CallableKind::Method { self_type } => Some(FfiArgument {
+                name: "uniffi_self".to_string(),
+                ty: self_type.ffi_type.clone(),
             }),
             _ => None,
         };

--- a/uniffi_bindgen/src/pipeline/general/mod.rs
+++ b/uniffi_bindgen/src/pipeline/general/mod.rs
@@ -24,6 +24,7 @@ mod self_types;
 mod sort;
 mod type_definitions_from_api;
 mod type_nodes;
+mod uniffi_traits;
 
 use crate::pipeline::initial;
 use anyhow::{bail, Result};
@@ -43,6 +44,7 @@ pub fn pipeline() -> Pipeline<initial::Root, Root> {
         .pass(rust_buffer::pass)
         .pass(rust_future::pass)
         .pass(self_types::pass)
+        .pass(callable::pass)
         .pass(type_definitions_from_api::pass)
         .pass(enums::pass)
         .pass(records::pass)
@@ -55,4 +57,5 @@ pub fn pipeline() -> Pipeline<initial::Root, Root> {
         .pass(checksums::pass)
         .pass(sort::pass)
         .pass(default::pass)
+        .pass(uniffi_traits::pass)
 }

--- a/uniffi_bindgen/src/pipeline/general/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/general/nodes.rs
@@ -110,7 +110,7 @@ pub enum CallableKind {
     /// Toplevel function
     Function,
     /// Interface/Trait interface method
-    Method { interface_name: String },
+    Method { self_type: TypeNode },
     /// Interface constructor
     Constructor {
         interface_name: String,
@@ -202,6 +202,8 @@ pub struct Record {
     pub fields: Vec<Field>,
     pub docstring: Option<String>,
     pub self_type: TypeNode,
+    pub uniffi_traits: Vec<UniffiTrait>,
+    pub uniffi_trait_methods: UniffiTraitMethods,
 }
 
 #[derive(Debug, Clone, Node)]
@@ -242,6 +244,8 @@ pub struct Enum {
     pub discr_type: TypeNode,
     pub docstring: Option<String>,
     pub self_type: TypeNode,
+    pub uniffi_traits: Vec<UniffiTrait>,
+    pub uniffi_trait_methods: UniffiTraitMethods,
 }
 
 #[derive(Debug, Clone, Node)]
@@ -601,23 +605,6 @@ pub struct UniffiTraitMethods {
     pub eq_ne: Option<Method>,
     pub hash_hash: Option<Method>,
     pub ord_cmp: Option<Method>,
-}
-
-impl UniffiTraitMethods {
-    pub fn fill_from(&mut self, uniffi_traits: &[UniffiTrait]) {
-        for t in uniffi_traits {
-            match t.clone() {
-                UniffiTrait::Debug { fmt } => self.debug_fmt = Some(fmt),
-                UniffiTrait::Display { fmt } => self.display_fmt = Some(fmt),
-                UniffiTrait::Eq { eq, ne } => {
-                    self.eq_eq = Some(eq);
-                    self.eq_ne = Some(ne);
-                }
-                UniffiTrait::Hash { hash } => self.hash_hash = Some(hash),
-                UniffiTrait::Ord { cmp } => self.ord_cmp = Some(cmp),
-            }
-        }
-    }
 }
 
 impl FfiDefinition {

--- a/uniffi_bindgen/src/pipeline/general/objects.rs
+++ b/uniffi_bindgen/src/pipeline/general/objects.rs
@@ -61,7 +61,6 @@ pub fn pass(namespace: &mut Namespace) -> Result<()> {
             }
             .into(),
         );
-        UniffiTraitMethods::fill_from(&mut int.uniffi_trait_methods, &int.uniffi_traits);
     });
     namespace.ffi_definitions.extend(ffi_definitions);
     Ok(())

--- a/uniffi_bindgen/src/pipeline/general/uniffi_traits.rs
+++ b/uniffi_bindgen/src/pipeline/general/uniffi_traits.rs
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Removes uniffi_traits from nodes, moving them to uniffi_trait_methods.
+
+use super::*;
+
+pub fn pass(namespace: &mut Namespace) -> Result<()> {
+    namespace.visit_mut(|i: &mut Interface| {
+        consume_from(&mut i.uniffi_trait_methods, &mut i.uniffi_traits);
+    });
+    namespace.visit_mut(|e: &mut Enum| {
+        consume_from(&mut e.uniffi_trait_methods, &mut e.uniffi_traits);
+    });
+    namespace.visit_mut(|rec: &mut Record| {
+        consume_from(&mut rec.uniffi_trait_methods, &mut rec.uniffi_traits);
+    });
+    Ok(())
+}
+
+fn consume_from(dest: &mut UniffiTraitMethods, uniffi_traits: &mut Vec<UniffiTrait>) {
+    for t in uniffi_traits.drain(..) {
+        match t {
+            UniffiTrait::Debug { fmt } => dest.debug_fmt = Some(fmt),
+            UniffiTrait::Display { fmt } => dest.display_fmt = Some(fmt),
+            UniffiTrait::Eq { eq, ne } => {
+                dest.eq_eq = Some(eq);
+                dest.eq_ne = Some(ne);
+            }
+            UniffiTrait::Hash { hash } => dest.hash_hash = Some(hash),
+            UniffiTrait::Ord { cmp } => dest.ord_cmp = Some(cmp),
+        }
+    }
+}

--- a/uniffi_bindgen/src/pipeline/initial/from_uniffi_meta.rs
+++ b/uniffi_bindgen/src/pipeline/initial/from_uniffi_meta.rs
@@ -207,12 +207,32 @@ impl UniffiMetaConverter {
         for (module_path, list) in self.records {
             get_namespace(&self.module_path_map, &mut root, &module_path)?
                 .type_definitions
-                .extend(list.into_values().map(TypeDefinition::Record));
+                .extend(
+                    list.into_values()
+                        .map(|mut r| {
+                            let key = (module_path.clone(), r.name.clone());
+                            if let Some(uniffi_traits) = self.uniffi_traits.remove(&key) {
+                                r.uniffi_traits.extend(uniffi_traits.into_values())
+                            }
+                            Ok(TypeDefinition::Record(r))
+                        })
+                        .collect::<Result<Vec<_>>>()?,
+                )
         }
         for (module_path, list) in self.enums {
             get_namespace(&self.module_path_map, &mut root, &module_path)?
                 .type_definitions
-                .extend(list.into_values().map(TypeDefinition::Enum));
+                .extend(
+                    list.into_values()
+                        .map(|mut e| {
+                            let key = (module_path.clone(), e.name.clone());
+                            if let Some(uniffi_traits) = self.uniffi_traits.remove(&key) {
+                                e.uniffi_traits.extend(uniffi_traits.into_values())
+                            }
+                            Ok(TypeDefinition::Enum(e))
+                        })
+                        .collect::<Result<Vec<_>>>()?,
+                )
         }
         for (module_path, list) in self.custom_types {
             get_namespace(&self.module_path_map, &mut root, &module_path)?

--- a/uniffi_bindgen/src/pipeline/initial/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/initial/nodes.rs
@@ -136,6 +136,7 @@ pub enum Radix {
 pub struct Record {
     pub name: String,
     pub fields: Vec<Field>,
+    pub uniffi_traits: Vec<UniffiTrait>,
     pub docstring: Option<String>,
 }
 
@@ -161,6 +162,7 @@ pub struct Enum {
     pub shape: EnumShape,
     pub variants: Vec<Variant>,
     pub discr_type: Option<Type>,
+    pub uniffi_traits: Vec<UniffiTrait>,
     pub docstring: Option<String>,
 }
 

--- a/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/EnumTemplate.rs
@@ -2,6 +2,22 @@
 // Forward work to `uniffi_macros` This keeps macro-based and UDL-based generated code consistent.
 #}
 
+{%- let uniffi_trait_methods = e.uniffi_trait_methods() %}
+{%- if uniffi_trait_methods.debug_fmt.is_some() %}
+#[::uniffi::export_for_udl_derive(Debug)]
+{%- endif %}
+{%- if uniffi_trait_methods.debug_fmt.is_some() %}
+#[::uniffi::export_for_udl_derive(Display)]
+{%- endif %}
+{%- if uniffi_trait_methods.hash_hash.is_some() %}
+#[::uniffi::export_for_udl_derive(Hash)]
+{%- endif %}
+{%- if uniffi_trait_methods.ord_cmp.is_some() %}
+#[::uniffi::export_for_udl_derive(Ord)]
+{%- endif %}
+{%- if uniffi_trait_methods.eq_eq.is_some() %}
+#[::uniffi::export_for_udl_derive(Eq)]
+{%- endif %}
 {%- if e.remote() %}
 #[::uniffi::udl_remote(Enum)]
 {%- else %}

--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -21,20 +21,22 @@ pub trait r#{{ obj.name() }} {
     {% endfor %}
 }
 {%- else %}
-{%- for tm in obj.uniffi_traits() %}
-{%-      match tm %}
-{%-          when UniffiTrait::Debug { fmt } %}
+{%- let uniffi_trait_methods = obj.uniffi_trait_methods() %}
+{%- if uniffi_trait_methods.debug_fmt.is_some() %}
 #[::uniffi::export_for_udl_derive(Debug)]
-{%-          when UniffiTrait::Display { fmt } %}
+{%- endif %}
+{%- if uniffi_trait_methods.display_fmt.is_some() %}
 #[::uniffi::export_for_udl_derive(Display)]
-{%-          when UniffiTrait::Hash { hash } %}
+{%- endif %}
+{%- if uniffi_trait_methods.hash_hash.is_some() %}
 #[::uniffi::export_for_udl_derive(Hash)]
-{%-          when UniffiTrait::Ord { cmp } %}
+{%- endif %}
+{%- if uniffi_trait_methods.ord_cmp.is_some() %}
 #[::uniffi::export_for_udl_derive(Ord)]
-{%-          when UniffiTrait::Eq { eq, ne } %}
+{%- endif %}
+{%- if uniffi_trait_methods.eq_eq.is_some() %}
 #[::uniffi::export_for_udl_derive(Eq)]
-{%-      endmatch %}
-{%- endfor %}
+{%- endif %}
 {%- if obj.remote() %}
 #[::uniffi::udl_remote(Object)]
 {%- else %}

--- a/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/RecordTemplate.rs
@@ -2,6 +2,22 @@
 // Forward work to `uniffi_macros` This keeps macro-based and UDL-based generated code consistent.
 #}
 
+{%- let uniffi_trait_methods = rec.uniffi_trait_methods() %}
+{%- if uniffi_trait_methods.debug_fmt.is_some() %}
+#[::uniffi::export_for_udl_derive(Debug)]
+{%- endif %}
+{%- if uniffi_trait_methods.display_fmt.is_some() %}
+#[::uniffi::export_for_udl_derive(Display)]
+{%- endif %}
+{%- if uniffi_trait_methods.hash_hash.is_some() %}
+#[::uniffi::export_for_udl_derive(Hash)]
+{%- endif %}
+{%- if uniffi_trait_methods.ord_cmp.is_some() %}
+#[::uniffi::export_for_udl_derive(Ord)]
+{%- endif %}
+{%- if uniffi_trait_methods.eq_eq.is_some() %}
+#[::uniffi::export_for_udl_derive(Eq)]
+{%- endif %}
 {%- if rec.remote() %}
 #[::uniffi::udl_remote(Record)]
 {%- else %}

--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -39,6 +39,9 @@ pub(crate) fn expand_export(
     // new functions outside of the `impl`).
     rewrite_self_type(&mut item);
 
+    // trying to split `udl_mode` into "no meta" and "other"
+    let include_meta = !udl_mode;
+
     let metadata = ExportItem::new(item, all_args)?;
 
     match metadata {
@@ -154,10 +157,12 @@ pub(crate) fn expand_export(
             self_ident,
             uniffi_traits,
             ..
-        } => {
-            let include_meta = !udl_mode;
-            utrait::expand_uniffi_trait_export(self_ident, uniffi_traits, include_meta)
-        }
+        } => utrait::expand_uniffi_trait_export(self_ident, uniffi_traits, include_meta),
+        ExportItem::Enum {
+            self_ident,
+            uniffi_traits,
+            ..
+        } => utrait::expand_uniffi_trait_export(self_ident, uniffi_traits, include_meta),
     }
 }
 

--- a/uniffi_macros/src/export/item.rs
+++ b/uniffi_macros/src/export/item.rs
@@ -36,6 +36,10 @@ pub(super) enum ExportItem {
         self_ident: Ident,
         uniffi_traits: Vec<UniffiTraitDiscriminants>,
     },
+    Enum {
+        self_ident: Ident,
+        uniffi_traits: Vec<UniffiTraitDiscriminants>,
+    },
 }
 
 impl ExportItem {
@@ -50,11 +54,11 @@ impl ExportItem {
             syn::Item::Impl(item) => Self::from_impl(item, attr_args),
             syn::Item::Trait(item) => Self::from_trait(item, attr_args),
             syn::Item::Struct(item) => Self::from_struct(item, attr_args),
+            syn::Item::Enum(item) => Self::from_enum(item, attr_args),
             // FIXME: Support const / static?
             _ => Err(syn::Error::new(
                 Span::call_site(),
-                "unsupported item: only functions and impl \
-                 blocks may be annotated with this attribute",
+                "unsupported item: This block doesn't support `uniffi::export`",
             )),
         }
     }
@@ -206,6 +210,21 @@ impl ExportItem {
             ))
         } else {
             Ok(Self::Struct {
+                self_ident: item.ident,
+                uniffi_traits,
+            })
+        }
+    }
+
+    fn from_enum(item: syn::ItemEnum, attr_args: TokenStream) -> syn::Result<Self> {
+        let args: ExportStructArgs = syn::parse(attr_args)?;
+        let uniffi_traits: Vec<UniffiTraitDiscriminants> = args.traits.into_iter().collect();
+        if uniffi_traits.is_empty() {
+            Err(syn::Error::new(Span::call_site(),
+                "uniffi::export on an enum must supply a builtin trait name. Did you mean `#[derive(uniffi::Enum)]`?"
+            ))
+        } else {
+            Ok(Self::Enum {
                 self_ident: item.ident,
                 uniffi_traits,
             })

--- a/uniffi_macros/src/export/utrait.rs
+++ b/uniffi_macros/src/export/utrait.rs
@@ -178,7 +178,6 @@ fn process_uniffi_trait_method(
     method: &TokenStream,
     self_ident: &Ident,
 ) -> syn::Result<(TokenStream, TokenStream)> {
-    let udl_mode = false; // We don't need the hacky `Result<>` optimization UDL functions get even if we are in UDL.
     let item = syn::parse(method.clone().into())?;
 
     let syn::Item::Fn(item) = item else {
@@ -195,7 +194,7 @@ fn process_uniffi_trait_method(
             docstring.clone(),
         )?,
         None,
-        udl_mode,
+        false, // udl_mode - We don't need the `Result<>` magic UDL functions get even if we are in UDL.
         None,
     )?;
     // metadata for the method, which will be packed inside metadata for the trait.

--- a/uniffi_udl/src/converters/enum_.rs
+++ b/uniffi_udl/src/converters/enum_.rs
@@ -6,7 +6,7 @@ use super::APIConverter;
 use crate::{attributes::EnumAttributes, converters::convert_docstring, InterfaceCollector};
 use anyhow::{bail, Result};
 
-use uniffi_meta::{EnumMetadata, EnumShape, VariantMetadata};
+use uniffi_meta::{EnumMetadata, EnumShape, Type, VariantMetadata};
 
 // Note that we have 2 `APIConverter` impls here - one for the `enum` case
 // (including an enum with `[Error]`), and one for the `[Error] interface` cas
@@ -56,6 +56,20 @@ impl APIConverter<EnumMetadata> for weedle::InterfaceDefinition<'_> {
         } else {
             EnumShape::Enum
         };
+        let other = Type::Enum {
+            module_path: ci.module_path().to_string(),
+            name: self.identifier.0.to_string(),
+        };
+
+        for ut in super::make_uniffi_traits(
+            &ci.module_path(),
+            self.identifier.0,
+            &attributes.get_uniffi_traits(),
+            &other,
+        )? {
+            ci.items.insert(ut.into());
+        }
+
         Ok(EnumMetadata {
             module_path: ci.module_path(),
             name: self.identifier.0.to_string(),

--- a/uniffi_udl/src/converters/interface.rs
+++ b/uniffi_udl/src/converters/interface.rs
@@ -144,6 +144,7 @@ impl APIConverter<ObjectMetadata> for weedle::InterfaceDefinition<'_> {
         for ut in uniffi_traits {
             ci.items.insert(ut.into());
         }
+
         Ok(ObjectMetadata {
             module_path: ci.module_path(),
             name: object_name.to_string(),


### PR DESCRIPTION
This is towards Enums and Records exposing `Debug`, `Eq` etc. None of the bindings support it yet, but the tests show how this is setup for the scaffolding.

(I do have all the bindings supporting it in [here](https://github.com/mhammond/uniffi-rs/tree/all-uniffi-traits) though :)
