### PR TITLE
Provide a better error with trait default methods.

### DIFF
--- a/fixtures/uitests/tests/ui/trait_default_methods.rs
+++ b/fixtures/uitests/tests/ui/trait_default_methods.rs
@@ -1,0 +1,9 @@
+#[uniffi::export]
+pub trait Trait: Send + Sync {
+    // a method with a default impl causes problems (#2597 etc)
+    fn default(&self) -> String {
+        unreachable!()
+    }
+}
+
+fn main() { /* empty main required by `trybuild` */}

--- a/fixtures/uitests/tests/ui/trait_default_methods.stderr
+++ b/fixtures/uitests/tests/ui/trait_default_methods.stderr
@@ -1,0 +1,8 @@
+error: uniffi::export'd trait methods can't have a default implementation.
+ --> tests/ui/trait_default_methods.rs:4:33
+  |
+4 |       fn default(&self) -> String {
+  |  _________________________________^
+5 | |         unreachable!()
+6 | |     }
+  | |_____^

--- a/uniffi_macros/src/export/item.rs
+++ b/uniffi_macros/src/export/item.rs
@@ -161,6 +161,12 @@ impl ExportItem {
                         ));
                     }
                 };
+                if let Some(default) = tim.default {
+                    return Err(syn::Error::new_spanned(
+                        default,
+                        "uniffi::export'd trait methods can't have a default implementation.",
+                    ));
+                }
 
                 let docstring = extract_docstring(&tim.attrs)?;
                 let attrs = ExportedImplFnAttributes::new(&tim.attrs)?;


### PR DESCRIPTION
Side-steps #2597 and gives a better error when attempted. I'll probably close #2579 too, we'll leave the crash to whoever works on this and it will no longer be reproducible.