### PR TITLE
Cast object pointers to the correct type in `clone`/`free`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [[UnreleasedUniFFIVersion]] (backend crates: [[UnreleasedBackendVersion]]) - (_[[ReleaseDate]]_)
 
+- Fixed a bug where objects could be freed to early (https://github.com/mozilla/uniffi-rs/issues/2600)
+
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.29.3...HEAD).
 
 ## v0.29.3 (backend crates: v0.29.3) - (_2025-06-06_)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1794,6 +1794,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-fixture-gh-2600"
+version = "0.22.0"
+dependencies = [
+ "uniffi",
+]
+
+[[package]]
 name = "uniffi-fixture-keywords-kotlin"
 version = "0.22.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
 
   "fixtures/docstring",
   "fixtures/docstring-proc-macro",
+  "fixtures/gh-2600",
   "fixtures/keywords/kotlin",
   "fixtures/keywords/rust",
   "fixtures/keywords/swift",

--- a/fixtures/gh-2600/Cargo.toml
+++ b/fixtures/gh-2600/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "uniffi-fixture-gh-2600"
+version = "0.22.0"
+edition = "2018"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+name = "uniffi_fixture_gh_2600"
+crate-type = ["lib", "cdylib"]
+
+[features]
+ffi-trace = ["uniffi/ffi-trace"]
+
+[dependencies]
+uniffi = { workspace = true }
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["build" ] }
+
+[dev-dependencies]
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/gh-2600/README.txt
+++ b/fixtures/gh-2600/README.txt
@@ -1,0 +1,2 @@
+Tests github.com/mozilla/uniffi-rs/issues/2600, where objects are freed too early.
+For unknown reasons, the only known type this happens with is `__m256i`.

--- a/fixtures/gh-2600/src/lib.rs
+++ b/fixtures/gh-2600/src/lib.rs
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+uniffi::setup_scaffolding!("gh_2600");
+
+use std::arch::x86_64::{__m256i, _mm256_set1_epi8};
+
+static DROP_COUNT: AtomicU32 = AtomicU32::new(0);
+
+#[uniffi::export]
+fn drop_count() -> u32 {
+    DROP_COUNT.load(Ordering::Relaxed)
+}
+
+#[derive(uniffi::Object)]
+#[allow(unused)]
+pub struct MyStruct256(__m256i);
+
+/// This is the problematic struct:
+/// it gets dropped before its end of life...
+#[uniffi::export]
+impl MyStruct256 {
+    pub fn method(&self) {}
+
+    #[uniffi::constructor]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+// Implement `Default` so clippy doesn't complain
+impl Default for MyStruct256 {
+    fn default() -> Self {
+        Self(unsafe { _mm256_set1_epi8(0) })
+    }
+}
+
+impl Drop for MyStruct256 {
+    fn drop(&mut self) {
+        DROP_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+}

--- a/fixtures/gh-2600/tests/bindings/test_gh_2600.kts
+++ b/fixtures/gh-2600/tests/bindings/test_gh_2600.kts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import uniffi.fixture.gh_2600.*;
+
+var obj = MyStruct256()
+assert(dropCount() == 0.toUInt())
+obj.method()
+assert(dropCount() == 0.toUInt())

--- a/fixtures/gh-2600/tests/bindings/test_gh_2600.py
+++ b/fixtures/gh-2600/tests/bindings/test_gh_2600.py
@@ -1,0 +1,10 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gh_2600 import *
+
+obj = MyStruct256()
+assert(drop_count() == 0)
+obj.method()
+assert(drop_count() == 0)

--- a/fixtures/gh-2600/tests/bindings/test_gh_2600.swift
+++ b/fixtures/gh-2600/tests/bindings/test_gh_2600.swift
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import gh_2600
+
+let obj = MyStruct256()
+assert(dropCount() == 0)
+obj.method()
+assert(dropCount() == 0)

--- a/fixtures/gh-2600/tests/test_generated_bindings.rs
+++ b/fixtures/gh-2600/tests/test_generated_bindings.rs
@@ -1,0 +1,5 @@
+uniffi::build_foreign_language_testcases!(
+    "tests/bindings/test_gh_2600.kts",
+    "tests/bindings/test_gh_2600.swift",
+    "tests/bindings/test_gh_2600.py",
+);

--- a/fixtures/gh-2600/uniffi.toml
+++ b/fixtures/gh-2600/uniffi.toml
@@ -1,0 +1,3 @@
+[bindings.kotlin]
+package_name = "uniffi.fixture.gh_2600"
+

--- a/uniffi_macros/src/object.rs
+++ b/uniffi_macros/src/object.rs
@@ -72,7 +72,7 @@ pub fn expand_object(input: DeriveInput, options: DeriveOptions) -> syn::Result<
         ) -> *const ::std::ffi::c_void {
             ::uniffi::deps::trace!("clone: {} ({:?})", #name, ptr);
             ::uniffi::rust_call(call_status, || {
-                unsafe { ::std::sync::Arc::increment_strong_count(ptr) };
+                unsafe { ::std::sync::Arc::increment_strong_count(ptr as *const #ident) };
                 ::std::result::Result::Ok(ptr)
             })
         }
@@ -88,7 +88,7 @@ pub fn expand_object(input: DeriveInput, options: DeriveOptions) -> syn::Result<
                 assert!(!ptr.is_null());
                 let ptr = ptr.cast::<#ident>();
                 unsafe {
-                    ::std::sync::Arc::decrement_strong_count(ptr);
+                    ::std::sync::Arc::decrement_strong_count(ptr as *const #ident);
                 }
                 ::std::result::Result::Ok(())
             });


### PR DESCRIPTION
Before we were calling `Arc::increment_strong_count` with a `*const ::std::ffi::c_void`, rather than the correct type.  I'm not sure why but this sometimes causes objects to be dropped early (#2600).