### PR TITLE
Porting fixture/gh-2600 to main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,6 +1795,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-fixture-gh-2600"
+version = "0.22.0"
+dependencies = [
+ "uniffi",
+]
+
+[[package]]
 name = "uniffi-fixture-keywords-kotlin"
 version = "0.22.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
 
   "fixtures/docstring",
   "fixtures/docstring-proc-macro",
+  "fixtures/gh-2600/",
   "fixtures/keywords/kotlin",
   "fixtures/keywords/rust",
   "fixtures/keywords/swift",

--- a/fixtures/gh-2600/Cargo.toml
+++ b/fixtures/gh-2600/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "uniffi-fixture-gh-2600"
+version = "0.22.0"
+edition = "2018"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+name = "uniffi_fixture_gh_2600"
+crate-type = ["lib", "cdylib"]
+
+[features]
+ffi-trace = ["uniffi/ffi-trace"]
+
+[dependencies]
+uniffi = { workspace = true }
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["build" ] }
+
+[dev-dependencies]
+uniffi = { workspace = true, features = ["bindgen-tests"] }

--- a/fixtures/gh-2600/README.txt
+++ b/fixtures/gh-2600/README.txt
@@ -1,0 +1,5 @@
+Tests github.com/mozilla/uniffi-rs/issues/2600, where objects are freed too early.
+This happens when the alignment is 32 (256 bits).
+Lower alignments don't trigger the bug, higher alignments probably do.
+`align(64)` also triggered the bug when tested.
+Large alignments likely change the layout of `Arc<T>` so the `usize` refcount is in a different place compared to `Arc<std::ffi::void>`.

--- a/fixtures/gh-2600/src/lib.rs
+++ b/fixtures/gh-2600/src/lib.rs
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+uniffi::setup_scaffolding!("gh_2600");
+
+static DROP_COUNT: AtomicU32 = AtomicU32::new(0);
+
+#[uniffi::export]
+fn drop_count() -> u32 {
+    DROP_COUNT.load(Ordering::Relaxed)
+}
+
+#[derive(Default, uniffi::Object)]
+#[allow(unused)]
+#[repr(align(32))]
+pub struct MyStruct256(u8);
+
+/// This is the problematic struct:
+/// it gets dropped before its end of life...
+#[uniffi::export]
+impl MyStruct256 {
+    pub fn method(&self) {}
+
+    #[uniffi::constructor]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Drop for MyStruct256 {
+    fn drop(&mut self) {
+        DROP_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+}

--- a/fixtures/gh-2600/tests/bindings/test_gh_2600.kts
+++ b/fixtures/gh-2600/tests/bindings/test_gh_2600.kts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import uniffi.fixture.gh_2600.*;
+
+var obj = MyStruct256()
+assert(dropCount() == 0.toUInt())
+obj.method()
+assert(dropCount() == 0.toUInt())

--- a/fixtures/gh-2600/tests/bindings/test_gh_2600.py
+++ b/fixtures/gh-2600/tests/bindings/test_gh_2600.py
@@ -1,0 +1,10 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from gh_2600 import *
+
+obj = MyStruct256()
+assert(drop_count() == 0)
+obj.method()
+assert(drop_count() == 0)

--- a/fixtures/gh-2600/tests/bindings/test_gh_2600.swift
+++ b/fixtures/gh-2600/tests/bindings/test_gh_2600.swift
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import gh_2600
+
+let obj = MyStruct256()
+assert(dropCount() == 0)
+obj.method()
+assert(dropCount() == 0)

--- a/fixtures/gh-2600/tests/test_generated_bindings.rs
+++ b/fixtures/gh-2600/tests/test_generated_bindings.rs
@@ -1,0 +1,5 @@
+uniffi::build_foreign_language_testcases!(
+    "tests/bindings/test_gh_2600.kts",
+    "tests/bindings/test_gh_2600.swift",
+    "tests/bindings/test_gh_2600.py",
+);

--- a/fixtures/gh-2600/uniffi.toml
+++ b/fixtures/gh-2600/uniffi.toml
@@ -1,0 +1,3 @@
+[bindings.kotlin]
+package_name = "uniffi.fixture.gh_2600"
+


### PR DESCRIPTION
Copied this test from the release-v0.29.x branch. I also generalized it a bit after figuring out a little more about the bug. The bug triggers on any type that's aligned to 32 bytes (probably more as well, but I didn't test).  Now the test uses that rather than the x86-specific 256 bit int type.