### PR TITLE
Kill `uniffi_meta::MethodReceiver` etc so `self_type` becomes a bindi…

### DIFF
--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -457,24 +457,25 @@ mod test_metadata {
 
     #[test]
     fn test_uniffi_traits_object() {
-        let expected_receiver = MethodReceiver::Object {
-            module_path: "uniffi_fixture_metadata".to_string(),
-            name: "Special".to_string(),
-        };
         assert!(matches!(
             uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIAL_DEBUG).unwrap(),
             Metadata::UniffiTrait(UniffiTraitMetadata::Debug { fmt })
-                if fmt.receiver == expected_receiver
+                if fmt.module_path == "uniffi_fixture_metadata" &&
+                   fmt.self_name == "Special"
         ));
         assert!(matches!(
             uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIAL_EQ).unwrap(),
             Metadata::UniffiTrait(UniffiTraitMetadata::Eq { eq, ne })
-                if eq.receiver == expected_receiver && ne.receiver == expected_receiver
+                if eq.module_path == "uniffi_fixture_metadata" &&
+                   eq.self_name == "Special" &&
+                   ne.module_path == "uniffi_fixture_metadata" &&
+                   ne.self_name == "Special"
         ));
         assert!(matches!(
             uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIAL_ORD).unwrap(),
             Metadata::UniffiTrait(UniffiTraitMetadata::Ord { cmp })
-                if cmp.receiver == expected_receiver
+                if cmp.module_path == "uniffi_fixture_metadata" &&
+                   cmp.self_name == "Special"
         ));
     }
 }
@@ -651,10 +652,8 @@ mod test_function_metadata {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATOR_ADD,
             MethodMetadata {
-                receiver: MethodReceiver::Object {
-                    module_path: "uniffi_fixture_metadata".into(),
-                    name: "Calculator".into(),
-                },
+                module_path: "uniffi_fixture_metadata".into(),
+                self_name: "Calculator".into(),
                 name: "add".into(),
                 is_async: false,
                 inputs: vec![
@@ -737,10 +736,8 @@ mod test_function_metadata {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATOR_ASYNC_SUB,
             MethodMetadata {
-                receiver: MethodReceiver::Object {
-                    module_path: "uniffi_fixture_metadata".into(),
-                    name: "Calculator".into(),
-                },
+                module_path: "uniffi_fixture_metadata".into(),
+                self_name: "Calculator".into(),
                 name: "async_sub".into(),
                 is_async: true,
                 inputs: vec![
@@ -798,10 +795,8 @@ mod test_function_metadata {
                     name: "CalculatorDisplay".into(),
                     imp: ObjectImpl::Trait,
                 }),
-                receiver: MethodReceiver::Object {
-                    module_path: "uniffi_fixture_metadata".into(),
-                    name: "Calculator".into(),
-                },
+                module_path: "uniffi_fixture_metadata".into(),
+                self_name: "Calculator".into(),
                 name: "get_display".into(),
                 is_async: false,
                 inputs: vec![],

--- a/uniffi_bindgen/src/pipeline/initial/from_uniffi_meta.rs
+++ b/uniffi_bindgen/src/pipeline/initial/from_uniffi_meta.rs
@@ -117,10 +117,7 @@ impl UniffiMetaConverter {
             }
             uniffi_meta::Metadata::Method(meth) => {
                 self.methods
-                    .entry((
-                        meth.receiver.module_path().to_string(),
-                        meth.receiver.name().to_string(),
-                    ))
+                    .entry((meth.module_path.to_string(), meth.self_name.to_string()))
                     .or_default()
                     .insert(meth.name.clone(), Method::try_from_node(meth)?);
             }
@@ -140,10 +137,7 @@ impl UniffiMetaConverter {
                 };
 
                 self.uniffi_traits
-                    .entry((
-                        meth.receiver.module_path().to_string(),
-                        meth.receiver.name().to_string(),
-                    ))
+                    .entry((meth.module_path.to_string(), meth.self_name.to_string()))
                     .or_default()
                     .insert(ut.name().to_string(), UniffiTrait::try_from_node(ut)?);
             }

--- a/uniffi_bindgen/src/pipeline/initial/mod.rs
+++ b/uniffi_bindgen/src/pipeline/initial/mod.rs
@@ -113,9 +113,11 @@ impl Root {
                     )));
                 }
                 uniffi_meta::Metadata::Method(meth) => {
-                    meth.checksum = Some(uniffi_meta::checksum(&interface::Method::from(
-                        meth.clone(),
-                    )));
+                    // making a method is mildly tricky as we need a type for self.
+                    // for the purposes of a checksum we ignore self info from udl.
+                    let method_object =
+                        interface::Method::from_metadata(meth.clone(), uniffi_meta::Type::UInt8);
+                    meth.checksum = Some(uniffi_meta::checksum(&method_object));
                 }
                 uniffi_meta::Metadata::Constructor(cons) => {
                     cons.checksum = Some(uniffi_meta::checksum(&interface::Constructor::from(

--- a/uniffi_macros/src/export/item.rs
+++ b/uniffi_macros/src/export/item.rs
@@ -10,7 +10,6 @@ use quote::ToTokens;
 use super::attributes::{
     ExportFnArgs, ExportImplArgs, ExportStructArgs, ExportTraitArgs, ExportedImplFnAttributes,
 };
-use crate::fnsig::MethodReceiverKind;
 use crate::util::extract_docstring;
 use uniffi_meta::UniffiTraitDiscriminants;
 
@@ -114,7 +113,6 @@ impl ExportItem {
                 } else {
                     ImplItem::Method(FnSignature::new_method(
                         self_ident.clone(),
-                        MethodReceiverKind::Object,
                         impl_fn.sig,
                         attrs.args,
                         docstring,

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -9,7 +9,7 @@ use std::iter;
 use super::attributes::AsyncRuntime;
 use crate::{
     ffiops,
-    fnsig::{FnKind, FnSignature, MethodReceiverKind},
+    fnsig::{FnKind, FnSignature},
 };
 
 pub(super) fn gen_fn_scaffolding(
@@ -127,26 +127,19 @@ impl ScaffoldingBits {
     fn new_for_method(
         sig: &FnSignature,
         self_ident: &Ident,
-        receiver_kind: &MethodReceiverKind,
         is_trait: bool,
         udl_mode: bool,
     ) -> Self {
         let ident = &sig.ident;
-        let self_type = match receiver_kind {
-            MethodReceiverKind::Object => {
-                if is_trait {
-                    quote! { ::std::sync::Arc<dyn #self_ident> }
-                } else {
-                    quote! { ::std::sync::Arc<#self_ident> }
-                }
-            }
-            MethodReceiverKind::Enum | MethodReceiverKind::Record => {
-                assert!(!is_trait);
-                quote! { #self_ident }
-            }
+        let self_type = if is_trait {
+            quote! { dyn #self_ident }
+        } else {
+            quote! { #self_ident }
         };
-        let lift_type = ffiops::lift_type(&self_type);
-        let try_lift = ffiops::try_lift(&self_type);
+
+        let ref_type = ffiops::lift_ref_type(&self_type);
+        let lift_type = ffiops::lift_type(&ref_type);
+        let try_lift = ffiops::try_lift(&ref_type);
 
         let lift_closure = sig.lift_closure(Some(quote! {
             match #try_lift(uniffi_self_lowered) {
@@ -219,17 +212,12 @@ pub(super) fn gen_ffi_function(
         convert_result,
     } = match &sig.kind {
         FnKind::Function => ScaffoldingBits::new_for_function(sig, udl_mode),
-        FnKind::Method {
-            self_ident,
-            receiver_kind,
-        } => ScaffoldingBits::new_for_method(sig, self_ident, receiver_kind, false, udl_mode),
-        FnKind::TraitMethod { self_ident, .. } => ScaffoldingBits::new_for_method(
-            sig,
-            self_ident,
-            &MethodReceiverKind::Object,
-            true,
-            udl_mode,
-        ),
+        FnKind::Method { self_ident } => {
+            ScaffoldingBits::new_for_method(sig, self_ident, false, udl_mode)
+        }
+        FnKind::TraitMethod { self_ident, .. } => {
+            ScaffoldingBits::new_for_method(sig, self_ident, true, udl_mode)
+        }
         FnKind::Constructor { self_ident } => {
             ScaffoldingBits::new_for_constructor(sig, self_ident, udl_mode)
         }

--- a/uniffi_macros/src/export/utrait.rs
+++ b/uniffi_macros/src/export/utrait.rs
@@ -8,7 +8,7 @@ use syn::ext::IdentExt;
 
 use super::{gen_ffi_function, ExportFnArgs};
 use crate::{fnsig::FnSignature, util::extract_docstring};
-use uniffi_meta::{MethodReceiverKind, UniffiTraitDiscriminants};
+use uniffi_meta::UniffiTraitDiscriminants;
 
 pub(crate) fn expand_uniffi_trait_export(
     self_ident: Ident,
@@ -190,7 +190,6 @@ fn process_uniffi_trait_method(
     let ffi_func = gen_ffi_function(
         &FnSignature::new_method(
             self_ident.clone(),
-            MethodReceiverKind::Object,
             item.sig.clone(),
             ExportFnArgs::default(),
             docstring.clone(),
@@ -201,7 +200,6 @@ fn process_uniffi_trait_method(
     // metadata for the method, which will be packed inside metadata for the trait.
     let method_meta = FnSignature::new_method(
         self_ident.clone(),
-        MethodReceiverKind::Object,
         item.sig,
         ExportFnArgs::default(),
         docstring,

--- a/uniffi_meta/src/reader.rs
+++ b/uniffi_meta/src/reader.rs
@@ -280,17 +280,16 @@ impl<'a> MetadataReader<'a> {
     }
 
     fn read_method(&mut self) -> Result<MethodMetadata> {
-        let module_path = self.read_string()?;
+        let self_module_path = self.read_string()?;
         let self_name = self.read_string()?;
-        let receiver_discr = MethodReceiverKind::from(self.read_u8()?)?;
-        let receiver = receiver_discr.to_receiver(module_path, self_name);
         let name = self.read_string()?;
         let is_async = self.read_bool()?;
         let inputs = self.read_inputs()?;
         let (return_type, throws) = self.read_return_type()?;
         let docstring = self.read_optional_long_string()?;
         Ok(MethodMetadata {
-            receiver,
+            module_path: self_module_path,
+            self_name,
             name,
             is_async,
             inputs,

--- a/uniffi_udl/src/converters/callables.rs
+++ b/uniffi_udl/src/converters/callables.rs
@@ -12,7 +12,7 @@ use anyhow::{bail, Result};
 
 use uniffi_meta::{
     ConstructorMetadata, DefaultValueMetadata, FieldMetadata, FnMetadata, FnParamMetadata,
-    MethodMetadata, MethodReceiver, TraitMethodMetadata,
+    MethodMetadata, TraitMethodMetadata,
 };
 
 impl APIConverter<FieldMetadata> for weedle::argument::Argument<'_> {
@@ -155,11 +155,9 @@ impl APIConverter<MethodMetadata> for weedle::interface::OperationInterfaceMembe
 
         let takes_self_by_arc = attributes.get_self_by_arc();
         Ok(MethodMetadata {
-            receiver: MethodReceiver::Object {
-                module_path: ci.module_path(),
-                // We don't know the name of the containing `Object` at this point, fill it in later.
-                name: Default::default(),
-            },
+            module_path: ci.module_path(),
+            // We don't know the name of the containing `Object` at this point, fill it in later.
+            self_name: Default::default(),
             name: match self.identifier {
                 None => bail!("anonymous methods are not supported {:?}", self),
                 Some(id) => {

--- a/uniffi_udl/src/converters/interface.rs
+++ b/uniffi_udl/src/converters/interface.rs
@@ -8,8 +8,8 @@ use crate::{converters::convert_docstring, InterfaceCollector};
 use anyhow::{bail, Result};
 use std::collections::HashSet;
 use uniffi_meta::{
-    ConstructorMetadata, FnParamMetadata, MethodMetadata, MethodReceiver, ObjectImpl,
-    ObjectMetadata, Type, UniffiTraitMetadata,
+    ConstructorMetadata, FnParamMetadata, MethodMetadata, ObjectImpl, ObjectMetadata, Type,
+    UniffiTraitMetadata,
 };
 
 impl APIConverter<ObjectMetadata> for weedle::InterfaceDefinition<'_> {
@@ -48,13 +48,8 @@ impl APIConverter<ObjectMetadata> for weedle::InterfaceDefinition<'_> {
                     if !member_names.insert(method.name.clone()) {
                         bail!("Duplicate interface member name: \"{}\"", method.name)
                     }
-                    // a little smelly that we need to fixup the receiver here, but it is what it is...
-                    let new_name = object_name.to_string();
-                    match method.receiver {
-                        MethodReceiver::Enum { ref mut name, .. } => *name = new_name,
-                        MethodReceiver::Record { ref mut name, .. } => *name = new_name,
-                        MethodReceiver::Object { ref mut name, .. } => *name = new_name,
-                    }
+                    // a little smelly that we need to fixup `self_name` here, but it is what it is...
+                    method.self_name = object_name.to_string();
                     ci.items.insert(method.into());
                 }
                 _ => bail!("no support for interface member type {:?} yet", member),
@@ -66,10 +61,8 @@ impl APIConverter<ObjectMetadata> for weedle::InterfaceDefinition<'_> {
                                  return_type: Option<Type>|
          -> Result<MethodMetadata> {
             Ok(MethodMetadata {
-                receiver: MethodReceiver::Object {
-                    module_path: ci.module_path(),
-                    name: object_name.to_string(),
-                },
+                module_path: ci.module_path(),
+                self_name: object_name.to_string(),
                 name: name.to_string(),
                 is_async: false,
                 inputs,


### PR DESCRIPTION
…ngs-only problem.

This came out of the discussion in #2596, where Ben showed how we can avoid the metadata knowing anything about the self type.

The CI gets a little uglier - you can no longer directly `From<>` a `MethodMetadata` into a `Method`, as you need to supply a type, but it successfully decouples methods from objects.
