### PR TITLE
Take external types into account when checking if a type contains an …

### DIFF
--- a/fixtures/ext-types/proc-macro-lib/src/lib.rs
+++ b/fixtures/ext-types/proc-macro-lib/src/lib.rs
@@ -2,7 +2,8 @@ use custom_types::Handle;
 use ext_types_custom::{Guid, Ouid2};
 use std::sync::Arc;
 use uniffi_one::{
-    UniffiOneEnum, UniffiOneInterface, UniffiOneProcMacroType, UniffiOneTrait, UniffiOneType,
+    UniffiOneEnum, UniffiOneInterface, UniffiOneProcMacroType, UniffiOneRecordContainingInterface,
+    UniffiOneTrait, UniffiOneType,
 };
 use url::Url;
 
@@ -209,6 +210,14 @@ fn get_guid_procmacro(g: Option<Guid>) -> Guid {
 #[uniffi::export]
 fn get_ouid2() -> Ouid2 {
     Ouid2("hello".to_string())
+}
+
+// record with external record with an interface,
+// making sure we walk into types in external crates, #2441
+#[derive(uniffi::Record, Default)]
+pub struct RecordContainingInterface {
+    #[uniffi(default)]
+    pub inner: UniffiOneRecordContainingInterface,
 }
 
 uniffi::setup_scaffolding!("imported_types_lib");

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.kts
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.kts
@@ -52,3 +52,5 @@ assert(getMaybeUniffiOneEnums(listOf(uoe, null)) == listOf(uoe, null))
 
 val g = getGuidProcmacro(null)
 assert(g == getGuidProcmacro(g))
+
+RecordContainingInterface().destroy()

--- a/fixtures/ext-types/uniffi-one/src/lib.rs
+++ b/fixtures/ext-types/uniffi-one/src/lib.rs
@@ -1,4 +1,7 @@
-use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::{
+    atomic::{AtomicI32, Ordering},
+    Arc,
+};
 
 pub struct UniffiOneType {
     pub sval: String,
@@ -84,6 +87,12 @@ fn _just_to_get_error_support() -> Result<(), UniffiOneErrorInterface> {
 #[uniffi::trait_interface]
 pub trait UniffiOneUDLTrait: Send + Sync {
     fn hello(&self) -> String;
+}
+
+#[derive(uniffi::Record, Default)]
+pub struct UniffiOneRecordContainingInterface {
+    #[uniffi(default)]
+    pub inner: Arc<UniffiOneInterface>,
 }
 
 uniffi::include_scaffolding!("uniffi-one");

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -101,6 +101,8 @@ pub struct ComponentInterface {
     callback_interface_throws_types: BTreeSet<Type>,
     // A mapping from an external module path to the external namespace.
     crate_to_namespace: BTreeMap<String, NamespaceMetadata>,
+    // A clone of every other CI we know about to help get external type info for bindings.
+    all_component_interfaces: Vec<ComponentInterface>,
 }
 
 impl ComponentInterface {
@@ -425,6 +427,10 @@ impl ComponentInterface {
         self.types
             .iter_local_types()
             .any(|t| matches!(t, Type::Object { .. }))
+    }
+
+    pub fn set_all_component_interfaces(&mut self, all: Vec<ComponentInterface>) {
+        self.all_component_interfaces = all;
     }
 
     // The namespace to use in crate-level FFI function definitions. Not used as the ffi
@@ -1118,7 +1124,7 @@ struct RecursiveTypeIterator<'a> {
     /// The currently-active iterator from which we're yielding.
     current: TypeIterator<'a>,
     /// A set of names of user-defined types that we have already seen.
-    seen: HashSet<&'a str>,
+    seen: HashSet<(&'a str, &'a str)>,
     /// A queue of user-defined types that we need to recurse into.
     pending: Vec<&'a Type>,
 }
@@ -1138,17 +1144,34 @@ impl<'a> RecursiveTypeIterator<'a> {
     /// Add a new type to the queue of pending types, if not previously seen.
     fn add_pending_type(&mut self, type_: &'a Type) {
         match type_ {
-            Type::Record { name, .. }
-            | Type::Enum { name, .. }
-            | Type::Object { name, .. }
-            | Type::CallbackInterface { name, .. } => {
-                if !self.seen.contains(name.as_str()) {
+            Type::Record {
+                module_path, name, ..
+            }
+            | Type::Enum {
+                module_path, name, ..
+            }
+            | Type::Object {
+                module_path, name, ..
+            }
+            | Type::CallbackInterface {
+                module_path, name, ..
+            } => {
+                if !self.seen.contains(&(module_path.as_str(), name.as_str())) {
                     self.pending.push(type_);
-                    self.seen.insert(name.as_str());
+                    self.seen.insert((module_path.as_str(), name.as_str()));
                 }
             }
             _ => (),
         }
+    }
+
+    /// Find the component interface with the type definitions for the given module.
+    fn find_ci_for(&self, module_path: &str) -> &'a ComponentInterface {
+        self.ci
+            .all_component_interfaces
+            .iter()
+            .find(|ci| ci.crate_name() == module_path)
+            .unwrap_or(self.ci)
     }
 
     /// Advance the iterator to recurse into the next pending type, if any.
@@ -1162,16 +1185,30 @@ impl<'a> RecursiveTypeIterator<'a> {
             // In the unlikely event that one of them returns `None` then, rather than trying to advance
             // to a non-existent type, we just leave the existing iterator in place and allow the recursive
             // call to `next()` to try again with the next pending type.
+            // (This is fragile - not finding a type for a name will cause difficult to diagnose bugs!)
             let next_iter = match next_type {
-                Type::Record { name, .. } => {
-                    self.ci.get_record_definition(name).map(Record::iter_types)
-                }
-                Type::Enum { name, .. } => self.ci.get_enum_definition(name).map(Enum::iter_types),
-                Type::Object { name, .. } => {
-                    self.ci.get_object_definition(name).map(Object::iter_types)
-                }
-                Type::CallbackInterface { name, .. } => self
-                    .ci
+                Type::Record {
+                    module_path, name, ..
+                } => self
+                    .find_ci_for(module_path)
+                    .get_record_definition(name)
+                    .map(Record::iter_types),
+                Type::Enum {
+                    module_path, name, ..
+                } => self
+                    .find_ci_for(module_path)
+                    .get_enum_definition(name)
+                    .map(Enum::iter_types),
+                Type::Object {
+                    module_path, name, ..
+                } => self
+                    .find_ci_for(module_path)
+                    .get_object_definition(name)
+                    .map(Object::iter_types),
+                Type::CallbackInterface {
+                    module_path, name, ..
+                } => self
+                    .find_ci_for(module_path)
                     .get_callback_interface_definition(name)
                     .map(CallbackInterface::iter_types),
                 _ => None,

--- a/uniffi_bindgen/src/library_mode.rs
+++ b/uniffi_bindgen/src/library_mode.rs
@@ -62,6 +62,13 @@ pub fn generate_bindings<T: BindingGenerator>(
     };
     binding_generator.update_component_configs(&settings, &mut components)?;
 
+    // give every CI a cloned copy of every CI - including itself for simplicity.
+    // we end up taking n^2 copies of all ci's, but it works.
+    let all_cis = components.iter().map(|c| c.ci.clone()).collect::<Vec<_>>();
+    components
+        .iter_mut()
+        .for_each(|c| c.ci.set_all_component_interfaces(all_cis.clone()));
+
     fs::create_dir_all(out_dir)?;
     if let Some(crate_name) = &crate_name {
         let old_elements = components.drain(..);


### PR DESCRIPTION
…object. Fixes #2441

This is not very memory efficient, but is quite simple and effective. I doubt the memory impact actually matters in practice as it's only during the bindgen and the interfaces we work on aren't *that* large.