### PR TITLE
askama 0.13->0.14. Significant as all filter function signatures change.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "askama"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a4e46abb203e00ef226442d452769233142bbfdd79c3941e84c8e61c4112543"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
 dependencies = [
  "askama_derive",
  "itoa",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54398906821fd32c728135f7b351f0c7494ab95ae421d41b6f5a020e158f28a6"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
 dependencies = [
  "askama_parser",
  "basic-toml",
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "askama_parser"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
 dependencies = [
  "memchr",
  "serde",

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -18,7 +18,7 @@ ffi-trace = ["uniffi_testing?/ffi-trace"]
 
 [dependencies]
 anyhow = "1"
-askama = { version = "0.13.0", default-features = false, features = ["config", "derive", "alloc"] }
+askama = { version = "0.14", default-features = false, features = ["config", "derive", "alloc"] }
 camino = "1.0.8"
 cargo_metadata = { version = "0.19", optional = true }
 fs-err = "2.7.0"

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -619,54 +619,80 @@ mod filters {
 
     pub(super) fn type_name(
         as_ct: &impl AsCodeType,
+        _: &dyn askama::Values,
         ci: &ComponentInterface,
     ) -> Result<String, askama::Error> {
         Ok(as_ct.as_codetype().type_label(ci))
     }
 
-    pub(super) fn canonical_name(as_ct: &impl AsCodeType) -> Result<String, askama::Error> {
+    pub(super) fn canonical_name(
+        as_ct: &impl AsCodeType,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(as_ct.as_codetype().canonical_name())
     }
 
-    pub(super) fn ffi_converter_name(as_ct: &impl AsCodeType) -> Result<String, askama::Error> {
+    pub(super) fn ffi_converter_name(
+        as_ct: &impl AsCodeType,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(as_ct.as_codetype().ffi_converter_name())
     }
 
-    pub(super) fn ffi_type(type_: &impl AsType) -> askama::Result<FfiType, askama::Error> {
+    pub(super) fn ffi_type(
+        type_: &impl AsType,
+        _: &dyn askama::Values,
+    ) -> askama::Result<FfiType, askama::Error> {
         Ok(type_.as_type().into())
     }
 
-    pub(super) fn lower_fn(as_ct: &impl AsCodeType) -> Result<String, askama::Error> {
+    pub(super) fn lower_fn(
+        as_ct: &impl AsCodeType,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(format!(
             "{}.lower",
             as_ct.as_codetype().ffi_converter_name()
         ))
     }
 
-    pub(super) fn allocation_size_fn(as_ct: &impl AsCodeType) -> Result<String, askama::Error> {
+    pub(super) fn allocation_size_fn(
+        as_ct: &impl AsCodeType,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(format!(
             "{}.allocationSize",
             as_ct.as_codetype().ffi_converter_name()
         ))
     }
 
-    pub(super) fn write_fn(as_ct: &impl AsCodeType) -> Result<String, askama::Error> {
+    pub(super) fn write_fn(
+        as_ct: &impl AsCodeType,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(format!(
             "{}.write",
             as_ct.as_codetype().ffi_converter_name()
         ))
     }
 
-    pub(super) fn lift_fn(as_ct: &impl AsCodeType) -> Result<String, askama::Error> {
+    pub(super) fn lift_fn(
+        as_ct: &impl AsCodeType,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(format!("{}.lift", as_ct.as_codetype().ffi_converter_name()))
     }
 
-    pub(super) fn read_fn(as_ct: &impl AsCodeType) -> Result<String, askama::Error> {
+    pub(super) fn read_fn(
+        as_ct: &impl AsCodeType,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(format!("{}.read", as_ct.as_codetype().ffi_converter_name()))
     }
 
     pub fn render_default(
         default: &DefaultValue,
+        _: &dyn askama::Values,
         as_ct: &impl AsType,
         ci: &ComponentInterface,
     ) -> Result<String, askama::Error> {
@@ -694,7 +720,11 @@ mod filters {
     }
 
     // Get the idiomatic Kotlin rendering of an individual enum variant's discriminant
-    pub fn variant_discr_literal(e: &Enum, index: &usize) -> Result<String, askama::Error> {
+    pub fn variant_discr_literal(
+        e: &Enum,
+        _: &dyn askama::Values,
+        index: &usize,
+    ) -> Result<String, askama::Error> {
         let literal = e.variant_discr(*index).expect("invalid index");
         match literal {
             // Kotlin doesn't convert between signed and unsigned by default
@@ -709,6 +739,7 @@ mod filters {
 
     pub fn ffi_type_name_by_value(
         type_: &FfiType,
+        _: &dyn askama::Values,
         ci: &ComponentInterface,
     ) -> Result<String, askama::Error> {
         Ok(KotlinCodeOracle.ffi_type_label_by_value(type_, ci))
@@ -716,60 +747,78 @@ mod filters {
 
     pub fn ffi_type_name_for_ffi_struct(
         type_: &FfiType,
+        _: &dyn askama::Values,
         ci: &ComponentInterface,
     ) -> Result<String, askama::Error> {
         Ok(KotlinCodeOracle.ffi_type_label_for_ffi_struct(type_, ci))
     }
 
-    pub fn ffi_default_value(type_: FfiType) -> Result<String, askama::Error> {
+    pub fn ffi_default_value(
+        type_: FfiType,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(KotlinCodeOracle.ffi_default_value(&type_))
     }
 
     /// Get the idiomatic Kotlin rendering of a function name.
     pub fn class_name<S: AsRef<str>>(
         nm: S,
+        _: &dyn askama::Values,
         ci: &ComponentInterface,
     ) -> Result<String, askama::Error> {
         Ok(KotlinCodeOracle.class_name(ci, nm.as_ref()))
     }
 
     /// Get the idiomatic Kotlin rendering of a function name.
-    pub fn fn_name<S: AsRef<str>>(nm: S) -> Result<String, askama::Error> {
+    pub fn fn_name<S: AsRef<str>>(nm: S, _: &dyn askama::Values) -> Result<String, askama::Error> {
         Ok(KotlinCodeOracle.fn_name(nm.as_ref()))
     }
 
     /// Get the idiomatic Kotlin rendering of a variable name.
-    pub fn var_name<S: AsRef<str>>(nm: S) -> Result<String, askama::Error> {
+    pub fn var_name<S: AsRef<str>>(nm: S, _: &dyn askama::Values) -> Result<String, askama::Error> {
         Ok(KotlinCodeOracle.var_name(nm.as_ref()))
     }
 
     /// Get the idiomatic Kotlin rendering of a variable name.
-    pub fn var_name_raw<S: AsRef<str>>(nm: S) -> Result<String, askama::Error> {
+    pub fn var_name_raw<S: AsRef<str>>(
+        nm: S,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(KotlinCodeOracle.var_name_raw(nm.as_ref()))
     }
 
     /// Get a String representing the name used for an individual enum variant.
-    pub fn variant_name(v: &Variant) -> Result<String, askama::Error> {
+    pub fn variant_name(v: &Variant, _: &dyn askama::Values) -> Result<String, askama::Error> {
         Ok(KotlinCodeOracle.enum_variant_name(v.name()))
     }
 
-    pub fn error_variant_name(v: &Variant) -> Result<String, askama::Error> {
+    pub fn error_variant_name(
+        v: &Variant,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         let name = v.name().to_string().to_upper_camel_case();
         Ok(KotlinCodeOracle.convert_error_suffix(&name))
     }
 
     /// Get the idiomatic Kotlin rendering of an FFI callback function name
-    pub fn ffi_callback_name<S: AsRef<str>>(nm: S) -> Result<String, askama::Error> {
+    pub fn ffi_callback_name<S: AsRef<str>>(
+        nm: S,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(KotlinCodeOracle.ffi_callback_name(nm.as_ref()))
     }
 
     /// Get the idiomatic Kotlin rendering of an FFI struct name
-    pub fn ffi_struct_name<S: AsRef<str>>(nm: S) -> Result<String, askama::Error> {
+    pub fn ffi_struct_name<S: AsRef<str>>(
+        nm: S,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(KotlinCodeOracle.ffi_struct_name(nm.as_ref()))
     }
 
     pub fn async_poll(
         callable: impl Callable,
+        _: &dyn askama::Values,
         ci: &ComponentInterface,
     ) -> Result<String, askama::Error> {
         let ffi_func = callable.ffi_rust_future_poll(ci);
@@ -780,6 +829,7 @@ mod filters {
 
     pub fn async_complete(
         callable: impl Callable,
+        _: &dyn askama::Values,
         ci: &ComponentInterface,
     ) -> Result<String, askama::Error> {
         let ffi_func = callable.ffi_rust_future_complete(ci);
@@ -803,6 +853,7 @@ mod filters {
 
     pub fn async_free(
         callable: impl Callable,
+        _: &dyn askama::Values,
         ci: &ComponentInterface,
     ) -> Result<String, askama::Error> {
         let ffi_func = callable.ffi_rust_future_free(ci);
@@ -816,12 +867,16 @@ mod filters {
     /// These are used to avoid name clashes with kotlin identifiers, but sometimes you want to
     /// render the name unquoted.  One example is the message property for errors where we want to
     /// display the name for the user.
-    pub fn unquote<S: AsRef<str>>(nm: S) -> Result<String, askama::Error> {
+    pub fn unquote<S: AsRef<str>>(nm: S, _: &dyn askama::Values) -> Result<String, askama::Error> {
         Ok(nm.as_ref().trim_matches('`').to_string())
     }
 
     /// Get the idiomatic Kotlin rendering of docstring
-    pub fn docstring<S: AsRef<str>>(docstring: S, spaces: &i32) -> Result<String, askama::Error> {
+    pub fn docstring<S: AsRef<str>>(
+        docstring: S,
+        _: &dyn askama::Values,
+        spaces: &i32,
+    ) -> Result<String, askama::Error> {
         let middle = textwrap::indent(&textwrap::dedent(docstring.as_ref()), " * ");
         let wrapped = format!("/**\n{middle}\n */");
 

--- a/uniffi_bindgen/src/bindings/python/filters.rs
+++ b/uniffi_bindgen/src/bindings/python/filters.rs
@@ -19,7 +19,11 @@ use askama::Result;
 ///
 /// This makes it so the template code can use something like
 /// `{{ item.docstring|docstring(4) -}}` to render the correct docstring in both cases.
-pub fn docstring(docstring: &Option<String>, indent: usize) -> Result<String> {
+pub fn docstring(
+    docstring: &Option<String>,
+    _: &dyn askama::Values,
+    indent: usize,
+) -> Result<String> {
     let Some(docstring) = docstring.as_deref() else {
         return Ok("".to_string());
     };

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -688,26 +688,41 @@ pub mod filters {
         &SwiftCodeOracle
     }
 
-    pub fn type_name(as_type: &impl AsType) -> Result<String, askama::Error> {
+    pub fn type_name(
+        as_type: &impl AsType,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(oracle().find(&as_type.as_type()).type_label())
     }
 
-    pub fn return_type_name(as_type: Option<&impl AsType>) -> Result<String, askama::Error> {
+    pub fn return_type_name(
+        as_type: Option<&impl AsType>,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(match as_type {
             Some(as_type) => oracle().find(&as_type.as_type()).type_label(),
             None => "()".to_owned(),
         })
     }
 
-    pub fn canonical_name(as_type: &impl AsType) -> Result<String, askama::Error> {
+    pub fn canonical_name(
+        as_type: &impl AsType,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(oracle().find(&as_type.as_type()).canonical_name())
     }
 
-    pub fn ffi_converter_name(as_type: &impl AsType) -> Result<String, askama::Error> {
+    pub fn ffi_converter_name(
+        as_type: &impl AsType,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(oracle().find(&as_type.as_type()).ffi_converter_name())
     }
 
-    pub fn ffi_error_converter_name(as_type: &impl AsType) -> Result<String, askama::Error> {
+    pub fn ffi_error_converter_name(
+        as_type: &impl AsType,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         // special handling for types used as errors.
         let mut name = oracle().find(&as_type.as_type()).ffi_converter_name();
         if matches!(&as_type.as_type(), Type::Object { .. }) {
@@ -716,14 +731,20 @@ pub mod filters {
         Ok(name)
     }
 
-    pub(super) fn ffi_type(type_: &impl AsType) -> askama::Result<FfiType, askama::Error> {
+    pub(super) fn ffi_type(
+        type_: &impl AsType,
+        _: &dyn askama::Values,
+    ) -> askama::Result<FfiType, askama::Error> {
         Ok(type_.as_type().into())
     }
 
     // To better support external types, we always call the "public" lift and lower functions for
     // "named" types, regardless of whether they are being called from a type in the same crate
     // (ie, a "local" type) or from a different crate (ie, an "external" type)
-    pub fn lower_fn(as_type: &impl AsType) -> Result<String, askama::Error> {
+    pub fn lower_fn(
+        as_type: &impl AsType,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         let ty = &as_type.as_type();
         let ffi_converter_name = oracle().find(ty).ffi_converter_name();
         Ok(match ty.name() {
@@ -732,14 +753,17 @@ pub mod filters {
         })
     }
 
-    pub fn write_fn(as_type: &impl AsType) -> Result<String, askama::Error> {
+    pub fn write_fn(
+        as_type: &impl AsType,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         let ty = &as_type.as_type();
         let ffi_converter_name = oracle().find(ty).ffi_converter_name();
         Ok(format!("{}.write", ffi_converter_name))
     }
 
     // See above re lower_fn - we always use the public version for named types.
-    pub fn lift_fn(as_type: &impl AsType) -> Result<String, askama::Error> {
+    pub fn lift_fn(as_type: &impl AsType, _: &dyn askama::Values) -> Result<String, askama::Error> {
         let ty = &as_type.as_type();
         let ffi_converter_name = oracle().find(ty).ffi_converter_name();
         Ok(match ty.name() {
@@ -748,7 +772,7 @@ pub mod filters {
         })
     }
 
-    pub fn read_fn(as_type: &impl AsType) -> Result<String, askama::Error> {
+    pub fn read_fn(as_type: &impl AsType, _: &dyn askama::Values) -> Result<String, askama::Error> {
         let ty = &as_type.as_type();
         let ffi_converter_name = oracle().find(ty).ffi_converter_name();
         Ok(format!("{}.read", ffi_converter_name))
@@ -756,6 +780,7 @@ pub mod filters {
 
     pub fn default_swift(
         default: &DefaultValue,
+        _: &dyn askama::Values,
         as_type: &impl AsType,
     ) -> Result<String, askama::Error> {
         Ok(oracle()
@@ -765,7 +790,11 @@ pub mod filters {
     }
 
     // Get the idiomatic Swift rendering of an individual enum variant's discriminant
-    pub fn variant_discr_literal(e: &Enum, index: &usize) -> Result<String, askama::Error> {
+    pub fn variant_discr_literal(
+        e: &Enum,
+        _: &dyn askama::Values,
+        index: &usize,
+    ) -> Result<String, askama::Error> {
         let literal = e.variant_discr(*index).expect("invalid index");
         match literal {
             LiteralMetadata::UInt(v, _, _) => Ok(v.to_string()),
@@ -775,17 +804,26 @@ pub mod filters {
     }
 
     /// Get the Swift type for an FFIType
-    pub fn ffi_type_name(ffi_type: &FfiType) -> Result<String, askama::Error> {
+    pub fn ffi_type_name(
+        ffi_type: &FfiType,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(oracle().ffi_type_label(ffi_type))
     }
 
-    pub fn ffi_default_value(return_type: Option<FfiType>) -> Result<String, askama::Error> {
+    pub fn ffi_default_value(
+        return_type: Option<FfiType>,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(oracle().ffi_default_value(return_type.as_ref()))
     }
 
     /// Like `ffi_type_name`, but used in `BridgingHeaderTemplate.h` which uses a slightly different
     /// names.
-    pub fn header_ffi_type_name(ffi_type: &FfiType) -> Result<String, askama::Error> {
+    pub fn header_ffi_type_name(
+        ffi_type: &FfiType,
+        values: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(match ffi_type {
             FfiType::Int8 => "int8_t".into(),
             FfiType::UInt8 => "uint8_t".into(),
@@ -806,61 +844,73 @@ pub mod filters {
             }
             FfiType::Struct(name) => SwiftCodeOracle.ffi_struct_name(name),
             FfiType::Reference(inner) => {
-                format!("const {}* _Nonnull", header_ffi_type_name(inner)?)
+                format!("const {}* _Nonnull", header_ffi_type_name(inner, values)?)
             }
-            FfiType::MutReference(inner) => format!("{}* _Nonnull", header_ffi_type_name(inner)?),
+            FfiType::MutReference(inner) => {
+                format!("{}* _Nonnull", header_ffi_type_name(inner, values)?)
+            }
             FfiType::VoidPointer => "void* _Nonnull".into(),
         })
     }
 
     /// Get the idiomatic Swift rendering of a class name (for enums, records, errors, etc).
-    pub fn class_name(nm: &str) -> Result<String, askama::Error> {
+    pub fn class_name(nm: &str, _: &dyn askama::Values) -> Result<String, askama::Error> {
         Ok(oracle().class_name(nm))
     }
 
     /// Get the idiomatic Swift rendering of a function name.
-    pub fn fn_name(nm: &str) -> Result<String, askama::Error> {
+    pub fn fn_name(nm: &str, _: &dyn askama::Values) -> Result<String, askama::Error> {
         Ok(quote_general_keyword(oracle().fn_name(nm)))
     }
 
     /// Get the idiomatic Swift rendering of a variable name.
-    pub fn var_name(nm: &str) -> Result<String, askama::Error> {
+    pub fn var_name(nm: &str, _: &dyn askama::Values) -> Result<String, askama::Error> {
         Ok(quote_general_keyword(oracle().var_name(nm)))
     }
 
     /// Get the idiomatic Swift rendering of an arguments name.
     /// This is the same as the var name but quoting is not required.
-    pub fn arg_name(nm: &str) -> Result<String, askama::Error> {
+    pub fn arg_name(nm: &str, _: &dyn askama::Values) -> Result<String, askama::Error> {
         Ok(quote_arg_keyword(oracle().var_name(nm)))
     }
 
     /// Get the idiomatic Swift rendering of an individual enum variant, quoted if it is a keyword (for use in e.g. declarations)
-    pub fn enum_variant_swift_quoted(nm: &str) -> Result<String, askama::Error> {
+    pub fn enum_variant_swift_quoted(
+        nm: &str,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(quote_general_keyword(oracle().enum_variant_name(nm)))
     }
 
     /// Like enum_variant_swift_quoted, but a class name.
-    pub fn error_variant_swift_quoted(nm: &str) -> Result<String, askama::Error> {
+    pub fn error_variant_swift_quoted(
+        nm: &str,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
         Ok(quote_general_keyword(oracle().class_name(nm)))
     }
 
     /// Get the idiomatic Swift rendering of an FFI callback function name
-    pub fn ffi_callback_name(nm: &str) -> Result<String, askama::Error> {
+    pub fn ffi_callback_name(nm: &str, _: &dyn askama::Values) -> Result<String, askama::Error> {
         Ok(oracle().ffi_callback_name(nm))
     }
 
     /// Get the idiomatic Swift rendering of an FFI struct name
-    pub fn ffi_struct_name(nm: &str) -> Result<String, askama::Error> {
+    pub fn ffi_struct_name(nm: &str, _: &dyn askama::Values) -> Result<String, askama::Error> {
         Ok(oracle().ffi_struct_name(nm))
     }
 
     /// Get the idiomatic Swift rendering of an if guard name
-    pub fn if_guard_name(nm: &str) -> Result<String, askama::Error> {
+    pub fn if_guard_name(nm: &str, _: &dyn askama::Values) -> Result<String, askama::Error> {
         Ok(oracle().if_guard_name(nm))
     }
 
     /// Get the idiomatic Swift rendering of docstring
-    pub fn docstring(docstring: &str, spaces: &i32) -> Result<String, askama::Error> {
+    pub fn docstring(
+        docstring: &str,
+        _: &dyn askama::Values,
+        spaces: &i32,
+    ) -> Result<String, askama::Error> {
         let middle = textwrap::indent(&textwrap::dedent(docstring), " * ");
         let wrapped = format!("/**\n{middle}\n */");
 
@@ -868,7 +918,10 @@ pub mod filters {
         Ok(textwrap::indent(&wrapped, &" ".repeat(spaces)))
     }
 
-    pub fn object_names(obj: &Object) -> Result<(String, String), askama::Error> {
+    pub fn object_names(
+        obj: &Object,
+        _: &dyn askama::Values,
+    ) -> Result<(String, String), askama::Error> {
         Ok(SwiftCodeOracle.object_names(obj))
     }
 }

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -23,7 +23,7 @@ impl<'a> RustScaffolding<'a> {
 mod filters {
     use super::*;
 
-    pub fn type_rs(type_: &Type) -> Result<String, askama::Error> {
+    pub fn type_rs(type_: &Type, values: &dyn askama::Values) -> Result<String, askama::Error> {
         Ok(match type_ {
             Type::Int8 => "i8".into(),
             Type::UInt8 => "u8".into(),
@@ -46,16 +46,18 @@ mod filters {
             }
             Type::CallbackInterface { name, .. } => format!("Box<dyn r#{name}>"),
             Type::Optional { inner_type } => {
-                format!("::std::option::Option<{}>", type_rs(inner_type)?)
+                format!("::std::option::Option<{}>", type_rs(inner_type, values)?)
             }
-            Type::Sequence { inner_type } => format!("std::vec::Vec<{}>", type_rs(inner_type)?),
+            Type::Sequence { inner_type } => {
+                format!("std::vec::Vec<{}>", type_rs(inner_type, values)?)
+            }
             Type::Map {
                 key_type,
                 value_type,
             } => format!(
                 "::std::collections::HashMap<{}, {}>",
-                type_rs(key_type)?,
-                type_rs(value_type)?
+                type_rs(key_type, values)?,
+                type_rs(value_type, values)?
             ),
             Type::Custom { name, .. } => format!("r#{name}"),
         })


### PR DESCRIPTION
All filter functions now take at least 2 args; the new 2nd arg is now typically `_: &dyn askama::Values`. The `askama::Values` concept seems good in general.

@badboy @bendk this is going to be a little painful, but I guess we have to take this eventually so uniffi .30 seems like it should be fine? We'll probably need to upgrade nimbis-fml at the same time.