### PR TITLE
Python: methods now have typing annotations for return values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   ([#2543](https://github.com/mozilla/uniffi-rs/pull/2543)).
   Custom types too ([#2603](https://github.com/mozilla/uniffi-rs/pull/2603))
 - Kotlin: The `NoPointer` placeholder object used to create fake interface instances has been renamed to `NoHandle`
+- Python: methods now have typing annotations for return values ([#2625](https://github.com/mozilla/uniffi-rs/issues/2625))
 
 ### ⚠️ Breaking Changes for external bindings authors ⚠️
 

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -655,4 +655,9 @@ pub fn validate_html(_source: String) -> Result<(), HTMLError> {
     Err(HTMLError::InvalidHTML)
 }
 
+#[uniffi::export]
+pub async fn async_bool(b: bool) -> bool {
+    b
+}
+
 uniffi::include_scaffolding!("coverall");

--- a/fixtures/coverall/tests/bindings/test_coverall.py
+++ b/fixtures/coverall/tests/bindings/test_coverall.py
@@ -506,5 +506,19 @@ class TraitsTest(unittest.TestCase):
         with self.assertRaises(HtmlError):
             validate_html("test")
 
+class Annotations(unittest.TestCase):
+    def test_annotations(self):
+        from typing import get_type_hints, Optional
+        from collections.abc import Awaitable
+        from coverall import NodeTraitImpl
+
+        self.assertEqual(get_type_hints(get_num_alive) , {"return": int})
+        self.assertEqual(get_type_hints(println), {"text": str, "return": type(None)})
+        self.assertEqual(get_type_hints(Coveralls.maybe_throw_into), {"should_throw": bool, "return": bool})
+        self.assertEqual(get_type_hints(Coveralls.panicking_new), {"message": str, "return": Coveralls})
+        self.assertEqual(get_type_hints(NodeTrait.get_parent), {"return": Optional[NodeTrait]})
+        self.assertEqual(get_type_hints(NodeTraitImpl.get_parent), {"return":  Optional[NodeTrait]})
+        self.assertEqual(get_type_hints(async_bool), {"return":  Awaitable[bool], "b": bool})
+
 if __name__=='__main__':
     unittest.main()

--- a/fixtures/futures/tests/bindings/test_futures.py
+++ b/fixtures/futures/tests/bindings/test_futures.py
@@ -2,7 +2,6 @@ from futures import *
 import unittest
 from datetime import datetime
 import asyncio
-import typing
 import futures
 
 def now():
@@ -280,12 +279,6 @@ class TestFutures(unittest.TestCase):
         async def test():
             await use_shared_resource(SharedResourceOptions(release_after_ms=100, timeout_ms=1000))
             await use_shared_resource(SharedResourceOptions(release_after_ms=0, timeout_ms=1000))
-        asyncio.run(test())
-
-    def test_function_annotations(self):
-        async def test():
-            self.assertEqual(typing.get_type_hints(sleep) , {"ms": int, "return": bool})
-            self.assertEqual(typing.get_type_hints(sleep_no_return), {"ms": int, "return": type(None)})
         asyncio.run(test())
 
 if __name__ == '__main__':

--- a/uniffi_bindgen/src/bindings/python/pipeline/types.rs
+++ b/uniffi_bindgen/src/bindings/python/pipeline/types.rs
@@ -37,11 +37,16 @@ pub fn pass(namespace: &mut Namespace) -> Result<()> {
         }
         ty.type_name = type_name(&ty.ty);
     });
-    namespace.visit_mut(|return_ty: &mut ReturnType| {
-        return_ty.type_name = match &return_ty.ty {
+    namespace.visit_mut(|callable: &mut Callable| {
+        let type_name = match &callable.return_type.ty {
             Some(type_node) => type_node.type_name.clone(),
             None => "None".to_string(),
-        }
+        };
+        callable.return_type.type_name = if callable.is_async {
+            format!("Awaitable[{type_name}]")
+        } else {
+            type_name
+        };
     });
     Ok(())
 }

--- a/uniffi_bindgen/src/bindings/python/templates/InterfaceTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/InterfaceTemplate.py
@@ -19,7 +19,7 @@ class {{ int.name }}({{ int.base_classes|join(", ") }}):
         {%- endfilter %}
 {%-     else %}
     @classmethod
-    {% if callable.is_async %}async {% endif %}def {{ callable.name }}(cls, {% include "CallableArgs.py" %}):
+    {% if callable.is_async %}async {% endif %}def {{ callable.name }}(cls, {% include "CallableArgs.py" %}) -> {{ callable.return_type.type_name }}:
         {{ cons.docstring|docstring(8) -}}
         {%- filter indent(8) %}
         {%- include "CallableBody.py" %}
@@ -53,7 +53,7 @@ class {{ int.name }}({{ int.base_classes|join(", ") }}):
 
 {%- for meth in int.methods -%}
 {%-     let callable = meth.callable %}
-    {% if callable.is_async %}async {% endif %}def {{ callable.name }}(self, {% include "CallableArgs.py" %}):
+    {% if callable.is_async %}async {% endif %}def {{ callable.name }}(self, {% include "CallableArgs.py" %}) -> {{ callable.return_type.type_name }}:
         {{ meth.docstring|docstring(8) -}}
         {%- filter indent(8) %}
         {%- include "CallableBody.py" %}

--- a/uniffi_bindgen/src/bindings/python/templates/Module.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Module.py
@@ -28,6 +28,7 @@ import traceback
 import typing
 {%- if has_async_fns %}
 import asyncio
+from collections.abc import Awaitable
 {%- endif %}
 import platform
 {%- for import in imports %}

--- a/uniffi_bindgen/src/bindings/python/templates/Protocol.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Protocol.py
@@ -3,7 +3,7 @@ class {{ protocol.name }}({{ protocol.base_classes|join(", ") }}):
     {{ protocol.docstring|docstring(4) -}}
     {%- for meth in protocol.methods.iter() %}
     {%- let callable = meth.callable %}
-    def {{ meth.callable.name }}(self, {% include "CallableArgs.py" %}):
+    {% if callable.is_async %}async {% endif %}def {{ meth.callable.name }}(self, {% include "CallableArgs.py" %}) -> {{ callable.return_type.type_name }}:
         {{ meth.docstring|docstring(8) -}}
         raise NotImplementedError
     {%- else %}


### PR DESCRIPTION
Fixes #2625