### PR TITLE
Support throwing external Kotlin error

### DIFF
--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.kts
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.kts
@@ -63,5 +63,21 @@ assert(getMaybeUniffiOneEnum(null) == null)
 assert(getUniffiOneEnums(listOf(uoe)) == listOf(uoe))
 assert(getMaybeUniffiOneEnums(listOf(uoe, null)) == listOf(uoe, null))
 
+try {
+    throwUniffiOneError()
+    throw RuntimeException("Should have thrown a UniffiOne exception!")
+} catch (e: UniffiOneException) {
+    assert(e is UniffiOneException.Oops)
+    e as UniffiOneException.Oops
+    assert(e.v1 == "oh no")
+}
+
+try {
+    throwUniffiOneErrorInterface()
+    throw RuntimeException("Should have thrown a UniffiOneErrorInterface exception!")
+} catch (e: UniffiOneErrorInterface) {
+    assert(e.message() == "interface oops")
+}
+
 assert(ct.ecd.sval == "ecd")
 assert(getExternalCrateInterface("foo").value() == "foo")

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -604,15 +604,6 @@ impl<T: AsType> AsCodeType for T {
     }
 }
 
-// A work around for #2392 - we can't handle functions with external errors.
-fn can_render_callable(callable: &dyn Callable, ci: &ComponentInterface) -> bool {
-    // can't handle external errors.
-    callable
-        .throws_type()
-        .map(|t| !ci.is_external(t))
-        .unwrap_or(true)
-}
-
 mod filters {
     use super::*;
     use uniffi_meta::LiteralMetadata;

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ExternalTypeTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ExternalTypeTemplate.kt
@@ -8,3 +8,19 @@
 {{- self.add_import(fully_qualified_type_name) }}
 {{- self.add_import(fully_qualified_ffi_converter_name) }}
 {{ self.add_import_as(fully_qualified_rustbuffer_name, local_rustbuffer_name) }}
+
+{%- if ci.is_name_used_as_error(name) %}
+{%- let class_name = name|class_name(ci) %}
+
+object {{ class_name }}ExternalErrorHandler : UniffiRustCallStatusErrorHandler<{{ class_name }}> {
+    override fun lift(error_buf: RustBuffer.ByValue): {{ class_name }} =
+        {{ fully_qualified_type_name }}.ErrorHandler.lift(
+            {{ local_rustbuffer_name }}.ByValue().apply {
+                capacity = error_buf.capacity
+                len = error_buf.len
+                data = error_buf.data
+            }
+        )
+}
+
+{%- endif %}


### PR DESCRIPTION
Fixes: #2392

This PR adds support for throwing external Kotlin errors by generating additional "delegating" error handlers in `ExternalTypeTemplate.kt`. If a function throws an external error, the "delegating" error handler is passed to `uniffiRustCallWithError` or `uniffiRustCallAsync` instead of the original one.