### PR TITLE
Fix `is_name_used_as_error` returning `false` for unused external errors

### DIFF
--- a/fixtures/ext-types/lib/src/lib.rs
+++ b/fixtures/ext-types/lib/src/lib.rs
@@ -233,4 +233,12 @@ pub enum ContainsExternalError {
     ExternalError(NotToThrowError),
 }
 
+#[derive(uniffi::Record)]
+pub struct ContainsExternalError2 {
+    error: NotToThrowError,
+}
+
+#[uniffi::export]
+fn takes_external_error(_error: NotToThrowError) {}
+
 uniffi::include_scaffolding!("ext-types-lib");

--- a/fixtures/ext-types/lib/src/lib.rs
+++ b/fixtures/ext-types/lib/src/lib.rs
@@ -8,7 +8,7 @@ use uniffi_one::{
     UniffiOneEnum, UniffiOneError, UniffiOneErrorInterface, UniffiOneInterface,
     UniffiOneProcMacroType, UniffiOneTLA, UniffiOneTrait, UniffiOneType, UniffiOneUDLTrait,
 };
-use uniffi_sublib::SubLibType;
+use uniffi_sublib::{NotToThrowError, SubLibType};
 use url::Url;
 
 // Remote types require a macro call in the Rust source
@@ -226,6 +226,11 @@ fn get_uniffi_one_udl_trait(
     t: Option<Arc<dyn UniffiOneUDLTrait>>,
 ) -> Option<Arc<dyn UniffiOneUDLTrait>> {
     t
+}
+
+#[derive(uniffi::Error)]
+pub enum ContainsExternalError {
+    ExternalError(NotToThrowError),
 }
 
 uniffi::include_scaffolding!("ext-types-lib");

--- a/fixtures/ext-types/sub-lib/src/lib.rs
+++ b/fixtures/ext-types/sub-lib/src/lib.rs
@@ -26,4 +26,19 @@ fn get_trait_impl() -> Arc<dyn UniffiOneTrait> {
     Arc::new(OneImpl {})
 }
 
+#[derive(uniffi::Error, Debug)]
+pub enum NotToThrowError {
+    Variant(u64),
+}
+
+impl std::fmt::Display for NotToThrowError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NotToThrowError::Variant(code) => {
+                write!(f, "NotToThrowError with code {code}")
+            }
+        }
+    }
+}
+
 uniffi::setup_scaffolding!("imported_types_sublib");

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -1021,6 +1021,10 @@ impl ComponentInterface {
 
     pub fn is_name_used_as_error(&self, name: &str) -> bool {
         self.errors.contains(name)
+            || self
+                .all_component_interfaces
+                .iter()
+                .any(|ci| ci.errors.contains(name))
     }
 
     /// Called by `APIBuilder` impls to add a newly-parsed callback interface definition to the `ComponentInterface`.


### PR DESCRIPTION
Fixes #2636 by making `ComponentInterface::is_name_used_as_error` return `true` for unused external errors using `all_component_interfaces` introduced in #2612. `self.errors.contains(name) ||` is still required for cases where library mode is not used, which is the reason why 422442381d3a21764eeca0de418655b2914a2d33 has failed.

### Why #2636 occurs

`self.error.insert` happens when the error enum itself is defined in the crate, or it is thrown from a function or a constructor. Since external errors are not defined in the crate, they are not registered through `self.error.insert` when it is not used. The check to determine whether an enum is an error requires an `EnumMetadata`, but `EnumMetadata` for external errors used in a variant of an enum is not being provided to CI.