### PR TITLE
Make metadata extraction functions pub

### DIFF
--- a/uniffi_bindgen/src/macro_metadata/extract.rs
+++ b/uniffi_bindgen/src/macro_metadata/extract.rs
@@ -24,7 +24,7 @@ pub fn extract_from_library(path: &Utf8Path) -> anyhow::Result<Vec<Metadata>> {
     extract_from_bytes(&fs::read(path)?)
 }
 
-fn extract_from_bytes(file_data: &[u8]) -> anyhow::Result<Vec<Metadata>> {
+pub fn extract_from_bytes(file_data: &[u8]) -> anyhow::Result<Vec<Metadata>> {
     match Object::parse(file_data)? {
         Object::Elf(elf) => extract_from_elf(elf, file_data),
         Object::PE(pe) => extract_from_pe(pe, file_data),
@@ -271,7 +271,7 @@ impl ExtractedItems {
     }
 }
 
-fn is_metadata_symbol(name: &str) -> bool {
+pub fn is_metadata_symbol(name: &str) -> bool {
     // Skip the "_" char that Darwin prepends, if present
     let name = name.strip_prefix('_').unwrap_or(name);
     name.starts_with("UNIFFI_META")


### PR DESCRIPTION
In https://github.com/mozilla/uniffi-rs/pull/2640/ I speculated that maybe external bindings would want to roll their own metadata-extraction functions.  I'm not sure if it'll work for that case, but it seems like a good thing in general.

Making these functions `pub` is a step in that direction.  I could see external bindings code try their specialized `extract_from_foo` function first, then fallback to calling `extract_from_bytes` to see if one of the standard cases works.