### PR TITLE
Avoid shadowing param names with internal variabes in Python, fixes #2628

### DIFF
--- a/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceImpl.py
+++ b/uniffi_bindgen/src/bindings/python/templates/CallbackInterfaceImpl.py
@@ -21,9 +21,9 @@ class {{ trait_impl }}:
         ):
         uniffi_obj = {{ ffi_converter_name }}._handle_map.get(uniffi_handle)
         def make_call():
-            args = ({% for arg in callable.arguments %}{{ arg.ty.ffi_converter_name }}.lift({{ arg.name }}), {% endfor %})
-            method = uniffi_obj.{{ callable.name }}
-            return method(*args)
+            uniffi_args = ({% for arg in callable.arguments %}{{ arg.ty.ffi_converter_name }}.lift({{ arg.name }}), {% endfor %})
+            uniffi_method = uniffi_obj.{{ callable.name }}
+            return uniffi_method(*uniffi_args)
 
         {%- match callable.async_data %}
         {%- when None %}


### PR DESCRIPTION
#2628