### PR TITLE
feat: add union_capable field to Enum

### DIFF
--- a/uniffi_bindgen/src/pipeline/general/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/general/nodes.rs
@@ -246,6 +246,7 @@ pub struct Enum {
     pub self_type: TypeNode,
     pub uniffi_traits: Vec<UniffiTrait>,
     pub uniffi_trait_methods: UniffiTraitMethods,
+    pub union_capable: bool,
 }
 
 #[derive(Debug, Clone, Node)]


### PR DESCRIPTION
See https://github.com/mozilla/uniffi-rs/issues/2652 for rationale. Support needs to be added to the python binding template

Edit: I realized that this needs to be done in the language specific pipeline because not only do all the types need to be unique on the rust side, they all need to be unique for the binding language. For example, both `u64` and `u32` are `int` in python, so if you have a enum with both of those values you can't use a union to represent the type properly because you'll have no way to differentiate them when lowering.