### PR TITLE
Fix python relative import

### DIFF
--- a/uniffi_bindgen/src/bindings/python/filters.rs
+++ b/uniffi_bindgen/src/bindings/python/filters.rs
@@ -30,3 +30,16 @@ pub fn docstring(docstring: &Option<String>, indent: usize) -> Result<String> {
     let indented = textwrap::indent(&escaped, &indent);
     Ok(format!("\"\"\"\n{indented}\n\"\"\"\n{indent}"))
 }
+
+/// Get the idiomatic Python import statement for a module
+pub fn import_statement(module: &str) -> Result<String> {
+    Ok(if module.starts_with('.') {
+        let Some((from, name)) = module.rsplit_once('.') else {
+            unreachable!()
+        };
+        let from = if from.is_empty() { "." } else { from };
+        format!("from {from} import {name}")
+    } else {
+        format!("import {module}")
+    })
+}

--- a/uniffi_bindgen/src/bindings/python/templates/Module.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Module.py
@@ -31,7 +31,7 @@ import asyncio
 {%- endif %}
 import platform
 {%- for import in imports %}
-import {{ import }}
+{{ import|import_statement }}
 {%- endfor %}
 
 


### PR DESCRIPTION
Python 3.9+ use `from . import module`, and `import .module` throws `SyntaxError`.