### PR TITLE
Prevent kotlin generating hundreds of blank lines

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
@@ -51,7 +51,7 @@ internal open class {{ ffi_struct.name()|ffi_struct_name }}(
 
 }
 {%- when FfiDefinition::Function(_) %}
-{# functions are handled below #}
+{#- functions are handled below #}
 {%- endmatch %}
 {%- endfor %}
 


### PR DESCRIPTION
Eg, when testing coverall I saw about 250 blank lines. This trivial patch removes them.