### PR TITLE
test: reproduce #2659

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,6 +1813,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "uniffi",
+ "uniffi-fixture-ext-types-lib-one",
 ]
 
 [[package]]

--- a/fixtures/futures/Cargo.toml
+++ b/fixtures/futures/Cargo.toml
@@ -21,6 +21,7 @@ futures = "0.3"
 thiserror = "2"
 tokio = { version = "1.38.2", features = ["time", "sync"] }
 once_cell = "1.18.0"
+uniffi-fixture-ext-types-lib-one = { version = "0.22.0", path = "../ext-types/uniffi-one" }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build", "scaffolding-ffi-buffer-fns"] }

--- a/fixtures/futures/tests/bindings/test_futures.py
+++ b/fixtures/futures/tests/bindings/test_futures.py
@@ -154,7 +154,9 @@ class TestFutures(unittest.TestCase):
 
         async def test():
             trait_obj = PyAsyncParser()
+            print("DEBUGPRINT[82]: test_futures.py:159 (before self.assertEqual(await as_string_using_t…)")
             self.assertEqual(await as_string_using_trait(trait_obj, 1, 42), "42")
+            print("DEBUGPRINT[83]: test_futures.py:160 (after self.assertEqual(await as_string_using_t…)")
             self.assertEqual(await try_from_string_using_trait(trait_obj, 1, "42"), 42)
             with self.assertRaises(ParserError.NotAnInt):
                 await try_from_string_using_trait(trait_obj, 1, "fourty-two")

--- a/fixtures/futures/uniffi.toml
+++ b/fixtures/futures/uniffi.toml
@@ -1,2 +1,9 @@
 [bindings.kotlin]
 package_name = "uniffi.fixture.futures"
+
+[bindings.python.external_packages]
+# This fixture does not create a Python package, so we want all modules to be top-level modules.
+custom_types = ""
+ext_types_custom = ""
+uniffi_one_ns = ""
+

--- a/uniffi_bindgen/src/bindings/python/test.rs
+++ b/uniffi_bindgen/src/bindings/python/test.rs
@@ -19,7 +19,7 @@ pub fn run_test(tmp_dir: &str, fixture_name: &str, script_file: &str) -> Result<
         tmp_dir,
         fixture_name,
         script_file,
-        vec![],
+        vec!["-v".to_string()],
         &RunScriptOptions::default(),
     )
 }


### PR DESCRIPTION
Minimal reproduction of the issue in #2659 

I want to highlight that the error occurs when adding the definition to the crate. **Not even using the trait in python** results in the error from the issue when calling a trait that was previously working. 

Video of the behavior:

https://github.com/user-attachments/assets/c1954171-f4d1-41f6-9a95-9c8d4840f8b7


