### PR TITLE
Use root object protocol conformance

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -295,6 +295,7 @@ impl Config {
 
         let uniffi_trait_methods = rec.uniffi_trait_methods();
 
+        // We auto-generate `Equatable, Hashable`, but only if we have no objects. We could do better - see #2409
         if !contains_object_references || uniffi_trait_methods.eq_eq.is_some() {
             conformances.push("Equatable");
         }
@@ -372,6 +373,7 @@ impl Config {
 
         let mut conformances = vec!["Sendable"];
 
+        // We auto-generate `Equatable, Hashable`, but only if we have no objects. We could do better - see #2409
         if !contains_object_references || uniffi_trait_methods.eq_eq.is_some() {
             conformances.push("Equatable");
         }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -285,13 +285,22 @@ impl Config {
         self.link_frameworks.clone()
     }
 
+    /// Does the given Record have protocol conformances to list?
+    ///
+    /// This isn't the most efficient way to do this, but it should be fast enough.
+    pub fn record_has_conformances(&self, rec: &Record, contains_object_references: &bool) -> bool {
+        !self
+            .conformance_list_for_record(rec, contains_object_references)
+            .is_empty()
+    }
+
     /// Programmatically generate the conformances for Record
     pub fn conformance_list_for_record(
         &self,
         rec: &Record,
         contains_object_references: &bool,
     ) -> String {
-        let mut conformances = vec!["Sendable"];
+        let mut conformances = vec![];
 
         let uniffi_trait_methods = rec.uniffi_trait_methods();
 
@@ -324,11 +333,20 @@ impl Config {
         conformances.join(", ")
     }
 
+    /// Does the given Enum have protocol conformances to list?
+    ///
+    /// This isn't the most efficient way to do this, but it should be fast enough.
+    pub fn enum_has_conformances(&self, e: &Enum, contains_object_references: &bool) -> bool {
+        !self
+            .conformance_list_for_enum(e, contains_object_references)
+            .is_empty()
+    }
+
     /// Programmatically generate the conformances for an Enum
     pub fn conformance_list_for_enum(&self, e: &Enum, contains_object_references: &bool) -> String {
         let uniffi_trait_methods = e.uniffi_trait_methods();
 
-        let mut conformances = vec!["Sendable"];
+        let mut conformances = vec![];
 
         // We auto-generate `Equatable, Hashable`, but only if we have no objects. We could do better - see #2409
         if !contains_object_references || uniffi_trait_methods.eq_eq.is_some() {
@@ -364,14 +382,28 @@ impl Config {
         conformances.join(", ")
     }
 
-    pub fn conformance_list_for_error(
+    /// Does the given Error have protocol conformances to list? (aside from the default `Swift.Error`)
+    ///
+    /// This isn't the most efficient way to do this, but it should be fast enough.
+    pub fn error_has_additional_conformances(
+        &self,
+        e: &Enum,
+        contains_object_references: &bool,
+    ) -> bool {
+        !self
+            .additional_conformance_list_for_error(e, contains_object_references)
+            .is_empty()
+    }
+
+    /// Programmatically generate the additional conformances for an Error (aside from the default `Swift.Error`)
+    pub fn additional_conformance_list_for_error(
         &self,
         e: &Enum,
         contains_object_references: &bool,
     ) -> String {
         let uniffi_trait_methods = e.uniffi_trait_methods();
 
-        let mut conformances = vec!["Sendable"];
+        let mut conformances = vec![];
 
         // We auto-generate `Equatable, Hashable`, but only if we have no objects. We could do better - see #2409
         if !contains_object_references || uniffi_trait_methods.eq_eq.is_some() {
@@ -399,6 +431,7 @@ impl Config {
         conformances.join(", ")
     }
 
+    /// Programmatically generate the conformances for an Object
     pub fn conformance_list_for_object(&self, _o: &Object, is_error: &bool) -> String {
         let mut conformances = vec!["@unchecked Sendable"];
 

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -374,8 +374,7 @@ impl Config {
             conformances.push("Codable");
         }
 
-        if self.generate_case_iterable_conformance() && e.is_flat() && !e.contains_variant_fields()
-        {
+        if self.generate_case_iterable_conformance() && !e.contains_variant_fields() {
             conformances.push("CaseIterable");
         }
 
@@ -414,6 +413,10 @@ impl Config {
             conformances.push("Hashable");
         }
 
+        if uniffi_trait_methods.ord_cmp.is_some() {
+            conformances.push("Comparable");
+        }
+
         // Objects can't be Codable at the moment, so we can't derive `Codable` conformance if this Error references one
         if !contains_object_references && self.generate_codable_conformance() {
             conformances.push("Codable");
@@ -423,7 +426,7 @@ impl Config {
             conformances.push("Foundation.LocalizedError");
         }
 
-        if self.generate_case_iterable_conformance() && e.is_flat() && !e.contains_variant_fields()
+        if self.generate_case_iterable_conformance() && !e.is_flat() && !e.contains_variant_fields()
         {
             conformances.push("CaseIterable");
         }
@@ -443,6 +446,18 @@ impl Config {
             if !self.omit_localized_error_conformance() {
                 conformances.push("Foundation.LocalizedError");
             }
+        }
+
+        if uniffi_trait_methods.eq_eq.is_some() {
+            conformances.push("Equatable");
+        }
+
+        if uniffi_trait_methods.hash_hash.is_some() {
+            conformances.push("Hashable");
+        }
+
+        if uniffi_trait_methods.ord_cmp.is_some() {
+            conformances.push("Comparable");
         }
 
         if uniffi_trait_methods.debug_fmt.is_some() {

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -432,7 +432,9 @@ impl Config {
     }
 
     /// Programmatically generate the conformances for an Object
-    pub fn conformance_list_for_object(&self, _o: &Object, is_error: &bool) -> String {
+    pub fn conformance_list_for_object(&self, o: &Object, is_error: &bool) -> String {
+        let uniffi_trait_methods = o.uniffi_trait_methods();
+
         let mut conformances = vec!["@unchecked Sendable"];
 
         if *is_error {
@@ -441,6 +443,14 @@ impl Config {
             if !self.omit_localized_error_conformance() {
                 conformances.push("Foundation.LocalizedError");
             }
+        }
+
+        if uniffi_trait_methods.debug_fmt.is_some() {
+            conformances.push("CustomDebugStringConvertible");
+        }
+
+        if uniffi_trait_methods.display_fmt.is_some() {
+            conformances.push("CustomStringConvertible");
         }
 
         conformances.join(", ")

--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -4,7 +4,7 @@
 {%- let uniffi_trait_methods = e.uniffi_trait_methods() %}
 {% match e.variant_discr_type() %}
 {% when None %}
-public enum {{ type_name }} {
+public enum {{ type_name }}: {{ config.conformance_list_for_enum(e, contains_object_references) }} {
     {% for variant in e.variants() %}
     {%- call swift::docstring(variant, 4) %}
     case {{ variant.name()|enum_variant_swift_quoted }}{% if variant.fields().len() > 0 %}(
@@ -12,7 +12,7 @@ public enum {{ type_name }} {
     ){% endif -%}
     {% endfor %}
 {% when Some(variant_discr_type) %}
-public enum {{ type_name }} : {{ variant_discr_type|type_name }} {
+public enum {{ type_name }}: {{ variant_discr_type|type_name }}, {{ config.conformance_list_for_enum(e, contains_object_references) }} {
     {% for variant in e.variants() %}
     {%- call swift::docstring(variant, 4) %}
     case {{ variant.name()|enum_variant_swift_quoted }} = {{ e|variant_discr_literal(loop.index0) }}{% if variant.fields().len() > 0 %}(
@@ -20,10 +20,9 @@ public enum {{ type_name }} : {{ variant_discr_type|type_name }} {
     ){% endif -%}
     {% endfor %}
 {% endmatch %}
+
+{% call swift::uniffi_trait_impls(uniffi_trait_methods) %}
 }
-#if compiler(>=6)
-extension {{ type_name }}: Sendable {}
-#endif
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -85,21 +84,3 @@ public func {{ ffi_converter_name }}_lift(_ buf: RustBuffer) throws -> {{ type_n
 public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> RustBuffer {
     return {{ ffi_converter_name }}.lower(value)
 }
-
-{% call swift::uniffi_trait_impls(uniffi_trait_methods) %}
-
-{%- if !contains_object_references %}
-{# We auto-generate `Equatable, Hashable`, but only if we have no objects. We could do better - see #2409 #}
-{% if !(contains_object_references || uniffi_trait_methods.eq_eq.is_some() || uniffi_trait_methods.hash_hash.is_some()) %}
-extension {{ type_name }}: Equatable, Hashable {}
-{% endif %}
-
-{# Not clear if `generate_codable_conformance` actually needs to avoid objects too? #}
-{%-     if config.generate_codable_conformance() %}
-extension {{ type_name }}: Codable {}
-{%-     endif %}
-{% endif %}
-
-{% if config.generate_case_iterable_conformance() && !e.contains_variant_fields() %}
-extension {{ type_name }}: CaseIterable {}
-{% endif %}

--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -4,7 +4,11 @@
 {%- let uniffi_trait_methods = e.uniffi_trait_methods() %}
 {% match e.variant_discr_type() %}
 {% when None %}
+{%- if config.enum_has_conformances(e, contains_object_references) %}
 public enum {{ type_name }}: {{ config.conformance_list_for_enum(e, contains_object_references) }} {
+{%- else %}
+public enum {{ type_name }} {
+{%- endif %}
     {% for variant in e.variants() %}
     {%- call swift::docstring(variant, 4) %}
     case {{ variant.name()|enum_variant_swift_quoted }}{% if variant.fields().len() > 0 %}(
@@ -23,6 +27,10 @@ public enum {{ type_name }}: {{ variant_discr_type|type_name }}, {{ config.confo
 
 {% call swift::uniffi_trait_impls(uniffi_trait_methods) %}
 }
+
+#if compiler(>=6)
+extension {{ type_name }}: Sendable {}
+#endif
 
 #if swift(>=5.8)
 @_documentation(visibility: private)

--- a/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
@@ -1,5 +1,9 @@
 {%- call swift::docstring(e, 0) %}
-public enum {{ type_name }}: Swift.Error, {{ config.conformance_list_for_error(e, contains_object_references) }} {
+{%- if config.error_has_additional_conformances(e, contains_object_references) %}
+public enum {{ type_name }}: Swift.Error, {{ config.additional_conformance_list_for_error(e, contains_object_references) }} {
+{%- else %}
+public enum {{ type_name }}: Swift.Error {
+{%- endif %}
 
     {% if e.is_flat() %}
     {% for variant in e.variants() %}
@@ -26,6 +30,9 @@ public enum {{ type_name }}: Swift.Error, {{ config.conformance_list_for_error(e
     {% endif %}
 }
 
+#if compiler(>=6)
+extension {{ type_name }}: Sendable {}
+#endif
 
 #if swift(>=5.8)
 @_documentation(visibility: private)

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -1,7 +1,11 @@
 {%- let rec = ci.get_record_definition(name).unwrap() %}
 {%- let uniffi_trait_methods = rec.uniffi_trait_methods() %}
 {%- call swift::docstring(rec, 0) %}
+{%- if config.record_has_conformances(rec, contains_object_references) %}
 public struct {{ type_name }}: {{ config.conformance_list_for_record(rec, contains_object_references) }} {
+{%- else %}
+public struct {{ type_name }} {
+{%- endif %}
     {%- for field in rec.fields() %}
     {%- call swift::docstring(field, 4) %}
     public {% if config.generate_immutable_records() %}let{% else %}var{% endif %} {{ field.name()|var_name }}: {{ field|type_name }}
@@ -17,6 +21,10 @@ public struct {{ type_name }}: {{ config.conformance_list_for_record(rec, contai
 
     {% call swift::uniffi_trait_impls(uniffi_trait_methods) %}
 }
+
+#if compiler(>=6)
+extension {{ type_name }}: Sendable {}
+#endif
 
 #if swift(>=5.8)
 @_documentation(visibility: private)

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -1,7 +1,7 @@
 {%- let rec = ci.get_record_definition(name).unwrap() %}
 {%- let uniffi_trait_methods = rec.uniffi_trait_methods() %}
 {%- call swift::docstring(rec, 0) %}
-public struct {{ type_name }} {
+public struct {{ type_name }}: {{ config.conformance_list_for_record(rec, contains_object_references) }} {
     {%- for field in rec.fields() %}
     {%- call swift::docstring(field, 4) %}
     public {% if config.generate_immutable_records() %}let{% else %}var{% endif %} {{ field.name()|var_name }}: {{ field|type_name }}
@@ -14,36 +14,9 @@ public struct {{ type_name }} {
         self.{{ field.name()|var_name }} = {{ field.name()|var_name }}
         {%- endfor %}
     }
+
+    {% call swift::uniffi_trait_impls(uniffi_trait_methods) %}
 }
-
-#if compiler(>=6)
-extension {{ type_name }}: Sendable {}
-#endif
-
-{% call swift::uniffi_trait_impls(uniffi_trait_methods) %}
-
-{# see comments in EnumTemplate re #2409 and whether we could do better here #}
-{% if !(contains_object_references || uniffi_trait_methods.eq_eq.is_some() || uniffi_trait_methods.hash_hash.is_some()) %}
-extension {{ type_name }}: Equatable, Hashable {
-    public static func ==(lhs: {{ type_name }}, rhs: {{ type_name }}) -> Bool {
-        {%- for field in rec.fields() %}
-        if lhs.{{ field.name()|var_name }} != rhs.{{ field.name()|var_name }} {
-            return false
-        }
-        {%- endfor %}
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        {%- for field in rec.fields() %}
-        hasher.combine({{ field.name()|var_name }})
-        {%- endfor %}
-    }
-}
-{% if config.generate_codable_conformance() %}
-extension {{ type_name }}: Codable {}
-{% endif %}
-{% endif %}
 
 #if swift(>=5.8)
 @_documentation(visibility: private)

--- a/uniffi_bindgen/src/bindings/swift/templates/macros.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/macros.swift
@@ -187,53 +187,43 @@ v{{- field_num -}}
 {% macro uniffi_trait_impls(uniffi_trait_methods) %}
 {%- if let Some(fmt) = uniffi_trait_methods.debug_fmt %}
 // The local Rust `Debug` implementation.
-extension {{ fmt.object_name() }}: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        return {% call is_try(fmt) %} {{ fmt.return_type().unwrap()|lift_fn }}(
-            {% call to_ffi_call(fmt) %}
-        )
-    }
+public var debugDescription: String {
+    return {% call is_try(fmt) %} {{ fmt.return_type().unwrap()|lift_fn }}(
+        {% call to_ffi_call(fmt) %}
+    )
 }
 {%- endif %}
 {%- if let Some(fmt) = uniffi_trait_methods.display_fmt %}
 // The local Rust `Display` implementation.
-extension {{ fmt.object_name() }}: CustomStringConvertible {
-    public var description: String {
-        return {% call is_try(fmt) %} {{ fmt.return_type().unwrap()|lift_fn }}(
-            {% call to_ffi_call(fmt) %}
-        )
+public var description: String {
+    return {% call is_try(fmt) %} {{ fmt.return_type().unwrap()|lift_fn }}(
+        {% call to_ffi_call(fmt) %}
     }
 }
 {%- endif %}
 {%- if let Some(eq) = uniffi_trait_methods.eq_eq %}
 // The local Rust `Eq` implementation - only `eq` is used.
-extension {{ eq.object_name() }}: Equatable {
-    public static func == (self: {{ eq.object_name() }}, other: {{ eq.object_name() }}) -> Bool {
-        return {% call is_try(eq) %} {{ eq.return_type().unwrap()|lift_fn }}(
-            {% call to_ffi_call(eq) %}
-        )
-    }
+public static func == (self: {{ eq.object_name() }}, other: {{ eq.object_name() }}) -> Bool {
+    return {% call is_try(eq) %} {{ eq.return_type().unwrap()|lift_fn }}(
+        {% call to_ffi_call(eq) %}
+    )
 }
 {%- endif %}
 {%- if let Some(hash) = uniffi_trait_methods.hash_hash %}
 // The local Rust `Hash` implementation
-extension {{ hash.object_name() }}: Hashable {
-    public func hash(into hasher: inout Hasher) {
-        let val = {% call is_try(hash) %} {{ hash.return_type().unwrap()|lift_fn }}(
-            {% call to_ffi_call(hash) %}
-        )
-        hasher.combine(val)
-    }
+public func hash(into hasher: inout Hasher) {
+    let val = {% call is_try(hash) %} {{ hash.return_type().unwrap()|lift_fn }}(
+        {% call to_ffi_call(hash) %}
+    )
+    hasher.combine(val)
 }
 {%- endif %}
 {%- if let Some(cmp) = uniffi_trait_methods.ord_cmp %}
 // The local Rust `Ord` implementation
-extension {{ cmp.object_name() }}: Comparable {
-    public static func < (self: {{ cmp.object_name() }}, other: {{ cmp.object_name() }}) -> Bool {
-        return {% call is_try(cmp) %} {{ cmp.return_type().unwrap()|lift_fn }}(
-            {% call to_ffi_call(cmp) %}
-        ) < 0
-    }
+public static func < (self: {{ cmp.object_name() }}, other: {{ cmp.object_name() }}) -> Bool {
+    return {% call is_try(cmp) %} {{ cmp.return_type().unwrap()|lift_fn }}(
+        {% call to_ffi_call(cmp) %}
+    ) < 0
 }
 {%- endif %}
 {%- endmacro %}

--- a/uniffi_bindgen/src/bindings/swift/templates/macros.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/macros.swift
@@ -198,7 +198,7 @@ public var debugDescription: String {
 public var description: String {
     return {% call is_try(fmt) %} {{ fmt.return_type().unwrap()|lift_fn }}(
         {% call to_ffi_call(fmt) %}
-    }
+    )
 }
 {%- endif %}
 {%- if let Some(eq) = uniffi_trait_methods.eq_eq %}


### PR DESCRIPTION
In Swift, extension protocol conformance cannot be made public – it’s tied to the original module (and conformance can’t be re-declared later).

This has implications for cases where types from this library are part of the public API of another library.

For example, in the following setup:

```
+-----------------------------------------------------------+
| Application                                               |
|  (calls public API of FooLibrary)                         |
|                                                           |
|  +---------------------------------------------+          |
|  | FooLibrary (Library A)                      |          |
|  |  - Exports select Rust types                |          |
|  |  - Associated some free-floating functions  |          |
|  |    with types using `public extension`      |          |
|  |   +-------------------------------------+   |          |
|  |   | UniFFIWrapper                           |          |
|  |   +-------------------------------------+   |          |
|  +---------------------------------------------+          |
|                                                           |
+-----------------------------------------------------------+
```

Extension-based Protocol Conformances in `UniFFIWrapper` cannot be made `public` (Swift will say `'public' modifier cannot be used with extensions that declare protocol conformances`). To avoid breaking encapsulation (and thus needing `Application` to import both `FooLibrary` and `UniFFIWrapper` the protocol conformance must be part of the type declaration which _is_ public. 

Trying to take advantage of `Equatable` in `Application` in a file where `import FooLibrary` is present but we haven't imported `UniFFIWrapper`, Swift will emit the following error:

> Cannot use conformance of 'MyObject' to 'Equatable' here; 'UniFFIWrapper' was not imported by this file

for the following code:

```swift
extension MyObject: Comparable {
    public static func < (lhs: FooObject, rhs: FooObject) -> Bool {
        false
    }
}
```

A few things to note:
- This PR moves the conformance listing out of the template into code because the combinatorial complexity makes the template a bit of a mess – it's a lot cleaner to do it this way. The `CustomTypeConfig` might not be the right place for this code to live, but it seemed nicely aligned with a lot of the properties we needed to read.
- This PR removes the conditional `Sendable` conformance used elsewhere, because it's inconsistently applied – in much of the rest of the codebase we're not checking the compiler version so this is now aligned.
- There was previously a note about `Codable` conformance – questioning whether it was applied correctly – this implementation is conservative, only applying it where it's explicitly requested by the configuration but also where there are no class-based members. Class-based members are not themselves `Codable` so it's unlikely they could benefit from automated conformance.
- This PR switches to automatically-derived `Hashable` and `Equatable` by the Swift compiler except in cases where the UniFFI traits `eq` or `hash` are applied – in that case the Rust implementation is used instead.
