### PR TITLE
Ensure there's a benchmark with only native types

### DIFF
--- a/fixtures/benchmarks/benches/bindings/run_benchmarks.kts
+++ b/fixtures/benchmarks/benches/bindings/run_benchmarks.kts
@@ -17,16 +17,16 @@ class TestCallbackObj : TestCallbackInterface {
     }
 
     override fun runTest(testCase: TestCase, count: ULong): ULong {
-        val data = TestData("StringOne", "StringTwo")
         return when (testCase) {
             TestCase.FUNCTION -> measureNanoTime {
+                val data = TestData("StringOne", "StringTwo")
                 for (i in 0UL..count) {
                     testFunction(10, 20, data)
                 }
             }
             TestCase.VOID_RETURN -> measureNanoTime {
                 for (i in 0UL..count) {
-                    testVoidReturn(10, 20, data)
+                    testVoidReturn(10, 20)
                 }
             }
             TestCase.NO_ARGS_VOID_RETURN -> measureNanoTime {

--- a/fixtures/benchmarks/benches/bindings/run_benchmarks.py
+++ b/fixtures/benchmarks/benches/bindings/run_benchmarks.py
@@ -16,15 +16,15 @@ class TestCallbackObj(TestCallbackInterface):
         pass
 
     def run_test(self, test_case, count):
-        data = TestData(foo="StringOne", bar="StringTwo")
         if test_case == TestCase.FUNCTION:
+            data = TestData(foo="StringOne", bar="StringTwo")
             start = time.perf_counter_ns()
             for i in range(count):
                 test_function(10, 20, data)
         elif test_case == TestCase.VOID_RETURN:
             start = time.perf_counter_ns()
             for i in range(count):
-                test_void_return(10, 20, data)
+                test_void_return(10, 20)
         elif test_case == TestCase.NO_ARGS_VOID_RETURN:
             start = time.perf_counter_ns()
             for i in range(count):

--- a/fixtures/benchmarks/benches/bindings/run_benchmarks.swift
+++ b/fixtures/benchmarks/benches/bindings/run_benchmarks.swift
@@ -24,10 +24,10 @@ class TestCallbackObj: TestCallbackInterface {
     }
 
     func runTest(testCase: TestCase, count: UInt64) -> UInt64 {
-        let data = TestData(foo: "StringOne", bar: "StringTwo")
         let start: clock_t
         switch testCase {
         case TestCase.function:
+            let data = TestData(foo: "StringOne", bar: "StringTwo")
             start = clock()
             for _ in 0...count {
                 testFunction(a: 10, b: 20, data: data)
@@ -35,7 +35,7 @@ class TestCallbackObj: TestCallbackInterface {
         case TestCase.voidReturn:
             start = clock()
             for _ in 0...count {
-                testVoidReturn(a: 10, b: 20, data: data)
+                testVoidReturn(a: 10, b: 20)
             }
 
         case TestCase.noArgsVoidReturn:

--- a/fixtures/benchmarks/src/lib.rs
+++ b/fixtures/benchmarks/src/lib.rs
@@ -46,7 +46,8 @@ pub fn test_function(_a: i32, _b: i32, data: TestData) -> String {
 }
 
 #[uniffi::export]
-pub fn test_void_return(_a: i32, _b: i32, _data: TestData) {}
+pub fn test_void_return(_a: i32, _b: i32) {}
+
 #[uniffi::export]
 pub fn test_no_args_void_return() {}
 


### PR DESCRIPTION
Rustbuffer in the args meant we didn't see any improvement in #2229