### PR TITLE
Fix: Wrap Swift async poll callback in closure

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/Async.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Async.swift
@@ -23,7 +23,9 @@ fileprivate func uniffiRustCallAsync<F, T>(
         pollResult = await withUnsafeContinuation {
             pollFunc(
                 rustFuture,
-                uniffiFutureContinuationCallback,
+                { handle, pollResult in
+                    uniffiFutureContinuationCallback(handle: handle, pollResult: pollResult)
+                },
                 uniffiContinuationHandleMap.insert(obj: $0)
             )
         }


### PR DESCRIPTION
  Fix Xcode’s “A C function pointer can only be formed…” error by wrapping the Swift async poll callback in a literal closure that forwards to uniffiFutureContinuationCallback.


Referenced in #2662
(I was also facing the same problem, and ended up using a terminal patching script for a while before filing this PR)