### PR TITLE
Python: Fix async functions that return external types (#2659)

### DIFF
--- a/uniffi_bindgen/src/bindings/python/pipeline/external_types.rs
+++ b/uniffi_bindgen/src/bindings/python/pipeline/external_types.rs
@@ -59,6 +59,18 @@ pub fn pass(namespace: &mut Namespace) -> Result<()> {
             _ => (),
         };
     });
+    // Transform RustBuffer namespaces to concrete Python module names
+    namespace.visit_mut(|ffi_type: &mut FfiType| {
+        if let FfiType::RustBuffer(Some(ref mut namespace)) = ffi_type {
+            match namespace_config.external_packages.get(namespace) {
+                Some(package_name) if !package_name.is_empty() => {
+                    *namespace = package_name.clone();
+                }
+                _ => (),
+            }
+        }
+    });
+
     namespace.imports.extend(module_imports);
     Ok(())
 }

--- a/uniffi_bindgen/src/pipeline/general/ffi_async_data.rs
+++ b/uniffi_bindgen/src/pipeline/general/ffi_async_data.rs
@@ -42,6 +42,11 @@ fn generate_async_data(crate_name: &str, ffi_return_type: Option<&FfiTypeNode>) 
         None => "void",
         ty => panic!("Invalid future return type: {ty:?}"),
     };
+    let struct_crate_name = match &ffi_return_type.map(|ffi_type| &ffi_type.ty) {
+        Some(FfiType::RustBuffer(Some(rust_buffer_crate))) => rust_buffer_crate,
+        _ => "",
+    };
+
     AsyncData {
         ffi_rust_future_poll: RustFfiFunctionName(format!(
             "ffi_{crate_name}_rust_future_poll_{return_type_name}"
@@ -56,11 +61,11 @@ fn generate_async_data(crate_name: &str, ffi_return_type: Option<&FfiTypeNode>) 
             "ffi_{crate_name}_rust_future_free_{return_type_name}"
         )),
         ffi_foreign_future_result: FfiStructName(format!(
-            "ForeignFutureResult{}",
+            "ForeignFutureResult{struct_crate_name}{}",
             return_type_name.to_upper_camel_case()
         )),
         ffi_foreign_future_complete: FfiFunctionTypeName(format!(
-            "ForeignFutureComplete{return_type_name}"
+            "ForeignFutureComplete{struct_crate_name}{return_type_name}"
         )),
     }
 }


### PR DESCRIPTION
The issue was that we were using the same name for both the local and external types, which lead to the one of them being lost when they were de-duped.