### PR TITLE
callables should only go through the pipeline once

### DIFF
--- a/uniffi_bindgen/src/pipeline/general/mod.rs
+++ b/uniffi_bindgen/src/pipeline/general/mod.rs
@@ -40,7 +40,6 @@ pub fn pipeline() -> Pipeline<initial::Root, Root> {
     new_pipeline()
         .convert_ir_pass::<Root>()
         .pass(modules::pass)
-        .pass(callable::pass)
         .pass(rust_buffer::pass)
         .pass(rust_future::pass)
         .pass(self_types::pass)


### PR DESCRIPTION
`callable::pass` called twice. I noticed this when playing with renames, and it's mildly confusing.