### PR TITLE
Store full module path in the metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ## [[UnreleasedUniFFIVersion]] (backend crates: [[UnreleasedBackendVersion]]) - (_[[ReleaseDate]]_)
 
+### ⚠️ Breaking Changes for external bindings authors ⚠️
+- The `module_path` field now stores full module paths rather than crate names only.
+  External bindings authors will probably need to make some minor changes to work with this.
+  See https://github.com/mozilla/uniffi-rs/pull/2695/ for examples.
+
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.30.0...HEAD).
 
 ## v0.30.0 (backend crates: v0.30.0) - (_2025-10-08_)

--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -156,15 +156,15 @@ mod test_type_ids {
     #[test]
     fn test_user_types() {
         check_type_id::<Person>(Type::Record {
-            module_path: "uniffi_fixture_metadata".into(),
+            module_path: "uniffi_fixture_metadata::tests::person".into(),
             name: "Person".into(),
         });
         check_type_id::<Weapon>(Type::Enum {
-            module_path: "uniffi_fixture_metadata".into(),
+            module_path: "uniffi_fixture_metadata::tests::weapon".into(),
             name: "Weapon".into(),
         });
         check_type_id::<Arc<Calculator>>(Type::Object {
-            module_path: "uniffi_fixture_metadata".into(),
+            module_path: "uniffi_fixture_metadata::tests::calc".into(),
             name: "Calculator".into(),
             imp: ObjectImpl::Struct,
         });
@@ -201,7 +201,7 @@ mod test_metadata {
         check_metadata(
             &person::UNIFFI_META_UNIFFI_FIXTURE_METADATA_RECORD_PERSON,
             RecordMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::person".into(),
                 name: "Person".into(),
                 remote: false,
                 fields: vec![
@@ -236,7 +236,7 @@ mod test_metadata {
         check_metadata(
             &weapon::UNIFFI_META_UNIFFI_FIXTURE_METADATA_ENUM_WEAPON,
             EnumMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::weapon".into(),
                 name: "Weapon".into(),
                 shape: EnumShape::Enum,
                 remote: false,
@@ -272,7 +272,7 @@ mod test_metadata {
         check_metadata(
             &state::UNIFFI_META_UNIFFI_FIXTURE_METADATA_ENUM_STATE,
             EnumMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::state".into(),
                 name: "State".into(),
                 shape: EnumShape::Enum,
                 remote: false,
@@ -301,7 +301,7 @@ mod test_metadata {
                         fields: vec![FieldMetadata {
                             name: "result".into(),
                             ty: Type::Record {
-                                module_path: "uniffi_fixture_metadata".into(),
+                                module_path: "uniffi_fixture_metadata::tests::person".into(),
                                 name: "Person".into(),
                             },
                             default: None,
@@ -321,7 +321,7 @@ mod test_metadata {
         check_metadata(
             &enum_repr::UNIFFI_META_UNIFFI_FIXTURE_METADATA_ENUM_REPRU8,
             EnumMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::enum_repr".into(),
                 name: "ReprU8".into(),
                 shape: EnumShape::Enum,
                 remote: false,
@@ -357,7 +357,7 @@ mod test_metadata {
         check_metadata(
             &enum_repr::UNIFFI_META_UNIFFI_FIXTURE_METADATA_ENUM_NOREPR,
             EnumMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::enum_repr".into(),
                 name: "NoRepr".into(),
                 shape: EnumShape::Enum,
                 remote: false,
@@ -379,7 +379,7 @@ mod test_metadata {
         check_metadata(
             &error::UNIFFI_META_UNIFFI_FIXTURE_METADATA_ERROR_FLATERROR,
             EnumMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::error".into(),
                 name: "FlatError".into(),
                 shape: EnumShape::Error { flat: true },
                 remote: false,
@@ -409,7 +409,7 @@ mod test_metadata {
         check_metadata(
             &error::UNIFFI_META_UNIFFI_FIXTURE_METADATA_ERROR_COMPLEXERROR,
             EnumMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::error".into(),
                 name: "ComplexError".into(),
                 shape: EnumShape::Error { flat: false },
                 remote: false,
@@ -438,7 +438,7 @@ mod test_metadata {
                         fields: vec![FieldMetadata {
                             name: "weapon".into(),
                             ty: Type::Enum {
-                                module_path: "uniffi_fixture_metadata".into(),
+                                module_path: "uniffi_fixture_metadata::tests::weapon".into(),
                                 name: "Weapon".into(),
                             },
                             default: None,
@@ -458,7 +458,7 @@ mod test_metadata {
         check_metadata(
             &calc::UNIFFI_META_UNIFFI_FIXTURE_METADATA_INTERFACE_CALCULATOR,
             ObjectMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::calc".into(),
                 name: "Calculator".into(),
                 remote: false,
                 imp: ObjectImpl::Struct,
@@ -472,21 +472,21 @@ mod test_metadata {
         assert!(matches!(
             uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIAL_DEBUG).unwrap(),
             Metadata::UniffiTrait(UniffiTraitMetadata::Debug { fmt })
-                if fmt.module_path == "uniffi_fixture_metadata" &&
+                if fmt.module_path == "uniffi_fixture_metadata::tests::uniffi_traits" &&
                    fmt.self_name == "Special"
         ));
         assert!(matches!(
             uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIAL_EQ).unwrap(),
             Metadata::UniffiTrait(UniffiTraitMetadata::Eq { eq, ne })
-                if eq.module_path == "uniffi_fixture_metadata" &&
+                if eq.module_path == "uniffi_fixture_metadata::tests::uniffi_traits" &&
                    eq.self_name == "Special" &&
-                   ne.module_path == "uniffi_fixture_metadata" &&
+                   ne.module_path == "uniffi_fixture_metadata::tests::uniffi_traits" &&
                    ne.self_name == "Special"
         ));
         assert!(matches!(
             uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIAL_ORD).unwrap(),
             Metadata::UniffiTrait(UniffiTraitMetadata::Ord { cmp })
-                if cmp.module_path == "uniffi_fixture_metadata" &&
+                if cmp.module_path == "uniffi_fixture_metadata::tests::uniffi_traits" &&
                    cmp.self_name == "Special"
         ));
     }
@@ -496,21 +496,21 @@ mod test_metadata {
         assert!(matches!(
             uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIALENUM_DEBUG).unwrap(),
             Metadata::UniffiTrait(UniffiTraitMetadata::Debug { fmt })
-                if fmt.module_path == "uniffi_fixture_metadata" &&
+                if fmt.module_path == "uniffi_fixture_metadata::tests::uniffi_traits" &&
                    fmt.self_name == "SpecialEnum"
         ));
         assert!(matches!(
             uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIALENUM_EQ).unwrap(),
             Metadata::UniffiTrait(UniffiTraitMetadata::Eq { eq, ne })
-                if eq.module_path == "uniffi_fixture_metadata" &&
+                if eq.module_path == "uniffi_fixture_metadata::tests::uniffi_traits" &&
                    eq.self_name == "SpecialEnum" &&
-                   ne.module_path == "uniffi_fixture_metadata" &&
+                   ne.module_path == "uniffi_fixture_metadata::tests::uniffi_traits" &&
                    ne.self_name == "SpecialEnum"
         ));
         assert!(matches!(
             uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIALENUM_ORD).unwrap(),
             Metadata::UniffiTrait(UniffiTraitMetadata::Ord { cmp })
-                if cmp.module_path == "uniffi_fixture_metadata" &&
+                if cmp.module_path == "uniffi_fixture_metadata::tests::uniffi_traits" &&
                    cmp.self_name == "SpecialEnum"
         ));
     }
@@ -520,21 +520,21 @@ mod test_metadata {
         assert!(matches!(
             uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIALRECORD_DEBUG).unwrap(),
             Metadata::UniffiTrait(UniffiTraitMetadata::Debug { fmt })
-                if fmt.module_path == "uniffi_fixture_metadata" &&
+                if fmt.module_path == "uniffi_fixture_metadata::tests::uniffi_traits" &&
                    fmt.self_name == "SpecialRecord"
         ));
         assert!(matches!(
             uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIALRECORD_EQ).unwrap(),
             Metadata::UniffiTrait(UniffiTraitMetadata::Eq { eq, ne })
-                if eq.module_path == "uniffi_fixture_metadata" &&
+                if eq.module_path == "uniffi_fixture_metadata::tests::uniffi_traits" &&
                    eq.self_name == "SpecialRecord" &&
-                   ne.module_path == "uniffi_fixture_metadata" &&
+                   ne.module_path == "uniffi_fixture_metadata::tests::uniffi_traits" &&
                    ne.self_name == "SpecialRecord"
         ));
         assert!(matches!(
             uniffi_meta::read_metadata(&uniffi_traits::UNIFFI_META_UNIFFI_FIXTURE_METADATA_UNIFFI_TRAIT_SPECIALRECORD_ORD).unwrap(),
             Metadata::UniffiTrait(UniffiTraitMetadata::Ord { cmp })
-                if cmp.module_path == "uniffi_fixture_metadata" &&
+                if cmp.module_path == "uniffi_fixture_metadata::tests::uniffi_traits" &&
                    cmp.self_name == "SpecialRecord"
         ));
     }
@@ -613,21 +613,21 @@ mod test_function_metadata {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_FUNC_TEST_FUNC,
             FnMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 name: "test_func".into(),
                 is_async: false,
                 inputs: vec![
                     FnParamMetadata::simple(
                         "person",
                         Type::Record {
-                            module_path: "uniffi_fixture_metadata".into(),
+                            module_path: "uniffi_fixture_metadata::tests::person".into(),
                             name: "Person".into(),
                         },
                     ),
                     FnParamMetadata::simple(
                         "weapon",
                         Type::Enum {
-                            module_path: "uniffi_fixture_metadata".into(),
+                            module_path: "uniffi_fixture_metadata::tests::weapon".into(),
                             name: "Weapon".into(),
                         },
                     ),
@@ -645,7 +645,7 @@ mod test_function_metadata {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_FUNC_TEST_FUNC_NO_RETURN,
             FnMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 name: "test_func_no_return".into(),
                 is_async: false,
                 inputs: vec![],
@@ -664,16 +664,16 @@ mod test_function_metadata {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_FUNC_TEST_FUNC_THAT_THROWS,
             FnMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 name: "test_func_that_throws".into(),
                 is_async: false,
                 inputs: vec![],
                 return_type: Some(Type::Enum {
-                    module_path: "uniffi_fixture_metadata".into(),
+                    module_path: "uniffi_fixture_metadata::tests::state".into(),
                     name: "State".into(),
                 }),
                 throws: Some(Type::Enum {
-                    module_path: "uniffi_fixture_metadata".into(),
+                    module_path: "uniffi_fixture_metadata::tests::error".into(),
                     name: "FlatError".into(),
                 }),
                 checksum: Some(
@@ -689,13 +689,13 @@ mod test_function_metadata {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_FUNC_TEST_FUNC_NO_RETURN_THAT_THROWS,
             FnMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 name: "test_func_no_return_that_throws".into(),
                 is_async: false,
                 inputs: vec![],
                 return_type: None,
                 throws: Some(Type::Enum {
-                    module_path: "uniffi_fixture_metadata".into(),
+                    module_path: "uniffi_fixture_metadata::tests::error".into(),
                     name: "FlatError".into(),
                 }),
                 checksum: Some(
@@ -712,7 +712,7 @@ mod test_function_metadata {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATOR_ADD,
             MethodMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 self_name: "Calculator".into(),
                 name: "add".into(),
                 is_async: false,
@@ -736,21 +736,21 @@ mod test_function_metadata {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_FUNC_TEST_ASYNC_FUNC,
             FnMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 name: "test_async_func".into(),
                 is_async: true,
                 inputs: vec![
                     FnParamMetadata::simple(
                         "person",
                         Type::Record {
-                            module_path: "uniffi_fixture_metadata".into(),
+                            module_path: "uniffi_fixture_metadata::tests::person".into(),
                             name: "Person".into(),
                         },
                     ),
                     FnParamMetadata::simple(
                         "weapon",
                         Type::Enum {
-                            module_path: "uniffi_fixture_metadata".into(),
+                            module_path: "uniffi_fixture_metadata::tests::weapon".into(),
                             name: "Weapon".into(),
                         },
                     ),
@@ -770,16 +770,16 @@ mod test_function_metadata {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_FUNC_TEST_ASYNC_FUNC_THAT_THROWS,
             FnMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 name: "test_async_func_that_throws".into(),
                 is_async: true,
                 inputs: vec![],
                 return_type: Some(Type::Enum {
-                    module_path: "uniffi_fixture_metadata".into(),
+                    module_path: "uniffi_fixture_metadata::tests::state".into(),
                     name: "State".into(),
                 }),
                 throws: Some(Type::Enum {
-                    module_path: "uniffi_fixture_metadata".into(),
+                    module_path: "uniffi_fixture_metadata::tests::error".into(),
                     name: "FlatError".into(),
                 }),
                 checksum: Some(
@@ -796,7 +796,7 @@ mod test_function_metadata {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATOR_ASYNC_SUB,
             MethodMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 self_name: "Calculator".into(),
                 name: "async_sub".into(),
                 is_async: true,
@@ -821,7 +821,7 @@ mod test_function_metadata {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_INTERFACE_CALCULATORDISPLAY,
             ObjectMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 name: "CalculatorDisplay".into(),
                 remote: false,
                 imp: ObjectImpl::Trait,
@@ -835,7 +835,7 @@ mod test_function_metadata {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_INTERFACE_TRAITWITHFOREIGN,
             ObjectMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 name: "TraitWithForeign".into(),
                 remote: false,
                 imp: ObjectImpl::CallbackTrait,
@@ -851,11 +851,11 @@ mod test_function_metadata {
             MethodMetadata {
                 // The main point of this test is to check the `Type` value for a trait interface
                 return_type: Some(Type::Object {
-                    module_path: "uniffi_fixture_metadata".into(),
+                    module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                     name: "CalculatorDisplay".into(),
                     imp: ObjectImpl::Trait,
                 }),
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 self_name: "Calculator".into(),
                 name: "get_display".into(),
                 is_async: false,
@@ -876,7 +876,7 @@ mod test_function_metadata {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATORDISPLAY_DISPLAY_RESULT,
             TraitMethodMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 trait_name: "CalculatorDisplay".into(),
                 index: 0,
                 name: "display_result".into(),
@@ -904,7 +904,8 @@ mod test_function_metadata {
                     FnParamMetadata::simple(
                         "val",
                         Type::Object {
-                            module_path: "uniffi_fixture_metadata".into(),
+                            module_path: "uniffi_fixture_metadata::tests::test_function_metadata"
+                                .into(),
                             name: "TraitWithForeign".into(),
                             imp: ObjectImpl::CallbackTrait,
                         },
@@ -912,7 +913,7 @@ mod test_function_metadata {
                 ],
                 // We might as well test other fields too though
                 return_type: None,
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 name: "input_trait_with_foreign".into(),
                 is_async: false,
                 throws: None,
@@ -930,7 +931,7 @@ mod test_function_metadata {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_CALLBACK_INTERFACE_LOGGER,
             CallbackInterfaceMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests".into(),
                 name: "Logger".into(),
                 docstring: None,
             },
@@ -938,7 +939,7 @@ mod test_function_metadata {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_LOGGER_LOG,
             TraitMethodMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests".into(),
                 trait_name: "Logger".into(),
                 index: 0,
                 name: "log".into(),
@@ -960,7 +961,7 @@ mod test_function_metadata {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_INTERFACE_REALLOGGER,
             ObjectMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests".into(),
                 name: "RealLogger".into(),
                 imp: ObjectImpl::Struct,
                 remote: false,
@@ -972,12 +973,12 @@ mod test_function_metadata {
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_OBJECT_TRAIT_IMPL_REALLOGGER_LOGGER,
             ObjectTraitImplMetadata {
                 ty: Type::Object {
-                    module_path: "uniffi_fixture_metadata".into(),
+                    module_path: "uniffi_fixture_metadata::tests".into(),
                     name: "RealLogger".into(),
                     imp: ObjectImpl::Struct,
                 },
                 trait_ty: Type::CallbackInterface {
-                    module_path: "uniffi_fixture_metadata".into(),
+                    module_path: "uniffi_fixture_metadata::tests".into(),
                     name: "Logger".into(),
                 },
             },
@@ -999,7 +1000,7 @@ mod test_custom_types {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_CUSTOM_TYPE_CUSTOMSTRING,
             CustomTypeMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::test_custom_types".into(),
                 name: "CustomString".into(),
                 builtin: Type::String,
                 docstring: None,
@@ -1009,10 +1010,10 @@ mod test_custom_types {
         check_metadata(
             &UNIFFI_META_UNIFFI_FIXTURE_METADATA_CUSTOM_TYPE_CUSTOMPERSON,
             CustomTypeMetadata {
-                module_path: "uniffi_fixture_metadata".into(),
+                module_path: "uniffi_fixture_metadata::tests::test_custom_types".into(),
                 name: "CustomPerson".into(),
                 builtin: Type::Record {
-                    module_path: "uniffi_fixture_metadata".into(),
+                    module_path: "uniffi_fixture_metadata::tests::person".into(),
                     name: "Person".into(),
                 },
                 docstring: None,

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -476,7 +476,7 @@ impl Config {
 // This differs based on whether the trait supports foreign impls (ie,
 // whether is has a "callback interface".
 fn trait_protocol_name(ci: &ComponentInterface, trait_ty: &Type) -> Result<String> {
-    let Some(module_path) = &trait_ty.module_path() else {
+    let Some(module_path) = &trait_ty.crate_name() else {
         anyhow::bail!("Invalid trait_type: {trait_ty:?}");
     };
     let Some(ci_look) = ci.find_component_interface(module_path) else {
@@ -685,7 +685,7 @@ impl<'a> SwiftWrapper<'a> {
         let extern_module_init_fns = self
             .ci
             .iter_external_types()
-            .filter_map(|t| t.module_path())
+            .filter_map(|t| t.crate_name())
             .map(|module_path| {
                 format!(
                     "uniffiEnsure{}Initialized",

--- a/uniffi_bindgen/src/interface/ffi.rs
+++ b/uniffi_bindgen/src/interface/ffi.rs
@@ -164,6 +164,12 @@ pub struct ExternalFfiMetadata {
     pub module_path: String,
 }
 
+impl ExternalFfiMetadata {
+    pub fn crate_name(&self) -> &str {
+        self.module_path.split("::").next().unwrap()
+    }
+}
+
 // Needed for rust scaffolding askama template
 impl From<Type> for FfiType {
     fn from(ty: Type) -> Self {

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -363,7 +363,7 @@ impl ComponentInterface {
 
     pub fn namespace_for_type(&self, ty: &Type) -> Result<&str> {
         let mod_path = ty
-            .module_path()
+            .crate_name()
             .ok_or_else(|| anyhow!("type {ty:?} has no module path"))?;
         self.namespace_for_module_path(mod_path)
     }

--- a/uniffi_bindgen/src/interface/universe.rs
+++ b/uniffi_bindgen/src/interface/universe.rs
@@ -92,7 +92,7 @@ impl TypeUniverse {
     }
 
     pub fn is_external(&self, t: &Type) -> bool {
-        t.module_path()
+        t.crate_name()
             .map(|p| p != self.namespace.crate_name)
             .unwrap_or(false)
     }

--- a/uniffi_bindgen/src/pipeline/initial/from_uniffi_meta.rs
+++ b/uniffi_bindgen/src/pipeline/initial/from_uniffi_meta.rs
@@ -358,8 +358,9 @@ fn get_namespace_name<'a>(
     module_path_map: &'a BTreeMap<String, String>,
     module_path: &str,
 ) -> Result<&'a str> {
+    let crate_name = module_path.split("::").next().unwrap();
     module_path_map
-        .get(module_path)
+        .get(crate_name)
         .map(String::as_str)
         .ok_or_else(|| anyhow!("module lookup failed: {module_path:?}"))
 }

--- a/uniffi_macros/src/custom.rs
+++ b/uniffi_macros/src/custom.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::util::{
-    create_metadata_items, either_attribute_arg, ident_to_string, kw, mod_path,
-    parse_comma_separated, UniffiAttributeArgs,
+    create_metadata_items, either_attribute_arg, ident_to_string, kw, parse_comma_separated,
+    UniffiAttributeArgs,
 };
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, ToTokens};
@@ -168,7 +168,6 @@ pub(crate) fn expand_custom_type(args: CustomTypeArgs) -> syn::Result<TokenStrea
     }
     .map_err(|msg| syn::Error::new(custom_type.span(), msg))?;
 
-    let mod_path = mod_path()?;
     let (impl_spec, derive_ffi_traits) = if options.is_remote() {
         (
             quote! { unsafe impl ::uniffi::FfiConverter<crate::UniFfiTag> for #custom_type },
@@ -250,7 +249,7 @@ pub(crate) fn expand_custom_type(args: CustomTypeArgs) -> syn::Result<TokenStrea
             }
 
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_CUSTOM)
-                .concat_str(#mod_path)
+                .concat_str(module_path!())
                 .concat_str(#name)
                 .concat(<#uniffi_type as ::uniffi::TypeId<crate::UniFfiTag>>::TYPE_ID_META);
         }
@@ -292,11 +291,10 @@ pub(crate) fn custom_type_meta_static_var(
     builtin: &Type,
     docstring: &str,
 ) -> syn::Result<TokenStream> {
-    let module_path = mod_path()?;
     let builtin = crate::ffiops::type_id_meta(builtin);
     let metadata_expr = quote! {
             ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::CUSTOM_TYPE)
-                .concat_str(#module_path)
+                .concat_str(module_path!())
                 .concat_str(#name)
                 .concat(#builtin)
                 .concat_long_str(#docstring)

--- a/uniffi_macros/src/enum_.rs
+++ b/uniffi_macros/src/enum_.rs
@@ -11,8 +11,7 @@ use crate::{
     record::FieldAttributeArguments,
     util::{
         create_metadata_items, either_attribute_arg, extract_docstring, ident_to_string, kw,
-        mod_path, try_metadata_value_from_usize, try_read_field, AttributeSliceExt,
-        UniffiAttributeArgs,
+        try_metadata_value_from_usize, try_read_field, AttributeSliceExt, UniffiAttributeArgs,
     },
     DeriveOptions,
 };
@@ -172,10 +171,6 @@ fn enum_or_error_ffi_converter_impl(
     let ident = item.ident();
     let impl_spec = options.ffi_impl_header("FfiConverter", ident);
     let derive_ffi_traits = options.derive_all_ffi_traits(ident);
-    let mod_path = match mod_path() {
-        Ok(p) => p,
-        Err(e) => return e.into_compile_error(),
-    };
     let mut write_match_arms: Vec<_> = item
         .enum_()
         .variants
@@ -263,7 +258,7 @@ fn enum_or_error_ffi_converter_impl(
             }
 
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(#metadata_type_code)
-                .concat_str(#mod_path)
+                .concat_str(module_path!())
                 .concat_str(#name);
         }
 
@@ -273,14 +268,13 @@ fn enum_or_error_ffi_converter_impl(
 
 pub(crate) fn enum_meta_static_var(item: &EnumItem) -> syn::Result<TokenStream> {
     let name = &item.foreign_name();
-    let module_path = mod_path()?;
     let non_exhaustive = item.is_non_exhaustive();
     let docstring = item.docstring();
     let shape = EnumShape::Enum.as_u8();
 
     let mut metadata_expr = quote! {
         ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::ENUM)
-            .concat_str(#module_path)
+            .concat_str(module_path!())
             .concat_str(#name)
             .concat_value(#shape)
     };

--- a/uniffi_macros/src/error.rs
+++ b/uniffi_macros/src/error.rs
@@ -7,7 +7,7 @@ use crate::{
     enum_::{rich_error_ffi_converter_impl, variant_metadata, EnumItem},
     ffiops,
     util::{
-        chain, create_metadata_items, extract_docstring, ident_to_string, mod_path,
+        chain, create_metadata_items, extract_docstring, ident_to_string,
         try_metadata_value_from_usize, AttributeSliceExt,
     },
     DeriveOptions,
@@ -62,10 +62,6 @@ fn flat_error_ffi_converter_impl(item: &EnumItem, options: &DeriveOptions) -> To
     let lift_impl_spec = options.ffi_impl_header("Lift", ident);
     let type_id_impl_spec = options.ffi_impl_header("TypeId", ident);
     let derive_ffi_traits = options.derive_ffi_traits(ident, &["LowerError", "ConvertError"]);
-    let mod_path = match mod_path() {
-        Ok(p) => p,
-        Err(e) => return e.into_compile_error(),
-    };
 
     let lower_impl = {
         let mut match_arms: Vec<_> = item
@@ -169,7 +165,7 @@ fn flat_error_ffi_converter_impl(item: &EnumItem, options: &DeriveOptions) -> To
         #[automatically_derived]
         #type_id_impl_spec {
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_ENUM)
-                .concat_str(#mod_path)
+                .concat_str(module_path!())
                 .concat_str(#name);
         }
 
@@ -179,14 +175,13 @@ fn flat_error_ffi_converter_impl(item: &EnumItem, options: &DeriveOptions) -> To
 
 pub(crate) fn error_meta_static_var(item: &EnumItem) -> syn::Result<TokenStream> {
     let name = &item.foreign_name();
-    let module_path = mod_path()?;
     let non_exhaustive = item.is_non_exhaustive();
     let docstring = item.docstring();
     let flat = item.is_flat_error();
     let shape = EnumShape::Error { flat }.as_u8();
     let mut metadata_expr = quote! {
             ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::ENUM)
-                .concat_str(#module_path)
+                .concat_str(module_path!())
                 .concat_str(#name)
                 .concat_value(#shape)
                 .concat_bool(false) // discr_type: None

--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -96,7 +96,7 @@ pub(crate) fn expand_export(
                 let metadata_expr = quote! {
                     ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::OBJECT_TRAIT_IMPL)
                         .concat(::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_INTERFACE))
-                        .concat_str(#mod_path)
+                        .concat_str(module_path!())
                         .concat_str(#object_name)
                         .concat(<dyn #t as ::uniffi::TypeId<crate::UniFfiTag>>::TYPE_ID_META)
                 };
@@ -137,9 +137,8 @@ pub(crate) fn expand_export(
             let trait_impl = callback_interface::trait_impl(&mod_path, &self_ident, &items, false)
                 .unwrap_or_else(|e| e.into_compile_error());
             let metadata_items = (!udl_mode).then(|| {
-                let items =
-                    callback_interface::metadata_items(&self_ident, &items, &mod_path, docstring)
-                        .unwrap_or_else(|e| vec![e.into_compile_error()]);
+                let items = callback_interface::metadata_items(&self_ident, &items, docstring)
+                    .unwrap_or_else(|e| vec![e.into_compile_error()]);
                 quote! { #(#items)* }
             });
             let ffi_converter_tokens =

--- a/uniffi_macros/src/export/callback_interface.rs
+++ b/uniffi_macros/src/export/callback_interface.rs
@@ -8,7 +8,7 @@ use crate::{
     fnsig::{FnKind, FnSignature, ReceiverArg},
     util::{
         async_trait_annotation, create_metadata_items, derive_ffi_traits, ident_to_string,
-        mod_path, tagged_impl_header, wasm_single_threaded_annotation,
+        tagged_impl_header, wasm_single_threaded_annotation,
     },
 };
 use proc_macro2::{Span, TokenStream};
@@ -162,10 +162,6 @@ pub fn ffi_converter_callback_interface_impl(
     ]
     .into_iter();
     let derive_ffi_traits = derive_ffi_traits(&box_dyn_trait, remote, &["LiftRef", "LiftReturn"]);
-    let mod_path = match mod_path() {
-        Ok(p) => p,
-        Err(e) => return e.into_compile_error(),
-    };
     let try_lift_self = ffiops::try_lift(quote! { Self });
 
     quote! {
@@ -192,7 +188,7 @@ pub fn ffi_converter_callback_interface_impl(
                 const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(
                     ::uniffi::metadata::codes::TYPE_CALLBACK_INTERFACE,
                 )
-                .concat_str(#mod_path)
+                .concat_str(module_path!())
                 .concat_str(#trait_name);
             }
         )*
@@ -277,7 +273,6 @@ fn gen_method_impl(sig: &FnSignature, vtable_cell: &Ident) -> syn::Result<TokenS
 pub(super) fn metadata_items(
     self_ident: &Ident,
     items: &[ImplItem],
-    module_path: &str,
     docstring: String,
 ) -> syn::Result<Vec<TokenStream>> {
     let trait_name = ident_to_string(self_ident);
@@ -286,7 +281,7 @@ pub(super) fn metadata_items(
         &trait_name,
         quote! {
             ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::CALLBACK_INTERFACE)
-                .concat_str(#module_path)
+                .concat_str(module_path!())
                 .concat_str(#trait_name)
                 .concat_long_str(#docstring)
         },

--- a/uniffi_macros/src/export/trait_interface.rs
+++ b/uniffi_macros/src/export/trait_interface.rs
@@ -102,15 +102,10 @@ pub(super) fn gen_trait_scaffolding(
         } else {
             ObjectImpl::Trait
         };
-        interface_meta_static_var(
-            &ident_to_string(&self_ident),
-            imp,
-            mod_path,
-            docstring.as_str(),
-        )
-        .unwrap_or_else(syn::Error::into_compile_error)
+        interface_meta_static_var(&ident_to_string(&self_ident), imp, docstring.as_str())
+            .unwrap_or_else(syn::Error::into_compile_error)
     });
-    let ffi_converter_tokens = ffi_converter(mod_path, &self_ident, with_foreign);
+    let ffi_converter_tokens = ffi_converter(&self_ident, with_foreign);
 
     Ok(quote_spanned! { self_ident.span() =>
         #meta_static_var
@@ -121,11 +116,7 @@ pub(super) fn gen_trait_scaffolding(
     })
 }
 
-pub(crate) fn ffi_converter(
-    mod_path: &str,
-    trait_ident: &Ident,
-    with_foreign: bool,
-) -> TokenStream {
+pub(crate) fn ffi_converter(trait_ident: &Ident, with_foreign: bool) -> TokenStream {
     // TODO: support defining remote trait interfaces
     let remote = false;
     let impl_spec = tagged_impl_header("FfiConverterArc", &quote! { dyn #trait_ident }, remote);
@@ -230,7 +221,7 @@ pub(crate) fn ffi_converter(
             }
 
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(#metadata_code)
-                .concat_str(#mod_path)
+                .concat_str(module_path!())
                 .concat_str(#trait_name);
         }
 
@@ -238,7 +229,7 @@ pub(crate) fn ffi_converter(
         #[automatically_derived]
         #type_id_impl_spec {
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(#metadata_code)
-                .concat_str(#mod_path)
+                .concat_str(module_path!())
                 .concat_str(#trait_name);
         }
 

--- a/uniffi_macros/src/fnsig.rs
+++ b/uniffi_macros/src/fnsig.rs
@@ -258,7 +258,6 @@ impl FnSignature {
             name,
             return_ty,
             is_async,
-            mod_path,
             docstring,
             ..
         } = &self;
@@ -279,7 +278,7 @@ impl FnSignature {
         match &self.kind {
             FnKind::Function => Ok(quote! {
                 ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::FUNC)
-                    .concat_str(#mod_path)
+                    .concat_str(module_path!())
                     .concat_str(#name)
                     .concat_bool(#is_async)
                     .concat_value(#args_len)
@@ -294,7 +293,7 @@ impl FnSignature {
                 let object_name = ident_to_string(foreign_self_ident);
                 Ok(quote! {
                     ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::METHOD)
-                        .concat_str(#mod_path)
+                        .concat_str(module_path!())
                         .concat_str(#object_name)
                         .concat_str(#name)
                         .concat_bool(#is_async)
@@ -309,7 +308,7 @@ impl FnSignature {
                 let object_name = ident_to_string(self_ident);
                 Ok(quote! {
                     ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TRAIT_METHOD)
-                        .concat_str(#mod_path)
+                        .concat_str(module_path!())
                         .concat_str(#object_name)
                         .concat_u32(#index)
                         .concat_str(#name)
@@ -327,7 +326,7 @@ impl FnSignature {
                 let object_name = ident_to_string(foreign_self_ident);
                 Ok(quote! {
                     ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::CONSTRUCTOR)
-                        .concat_str(#mod_path)
+                        .concat_str(module_path!())
                         .concat_str(#object_name)
                         .concat_str(#name)
                         .concat_bool(#is_async)

--- a/uniffi_macros/src/record.rs
+++ b/uniffi_macros/src/record.rs
@@ -7,8 +7,7 @@ use crate::{
     ffiops,
     util::{
         create_metadata_items, either_attribute_arg, extract_docstring, ident_to_string, kw,
-        mod_path, try_metadata_value_from_usize, try_read_field, AttributeSliceExt,
-        UniffiAttributeArgs,
+        try_metadata_value_from_usize, try_read_field, AttributeSliceExt, UniffiAttributeArgs,
     },
     DeriveOptions,
 };
@@ -112,7 +111,6 @@ fn record_ffi_converter_impl(
     let impl_spec = options.ffi_impl_header("FfiConverter", ident);
     let derive_ffi_traits = options.derive_all_ffi_traits(ident);
     let name = &record.foreign_name();
-    let mod_path = mod_path()?;
     let write_impl: TokenStream = record.struct_().fields.iter().map(write_field).collect();
     let try_read_fields: TokenStream = record.struct_().fields.iter().map(try_read_field).collect();
 
@@ -130,7 +128,7 @@ fn record_ffi_converter_impl(
             }
 
             const TYPE_ID_META: ::uniffi::MetadataBuffer = ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::TYPE_RECORD)
-                .concat_str(#mod_path)
+                .concat_str(module_path!())
                 .concat_str(#name);
         }
 
@@ -176,7 +174,6 @@ impl UniffiAttributeArgs for FieldAttributeArguments {
 fn record_meta_static_var(record: &RecordItem) -> syn::Result<TokenStream> {
     let name = &record.foreign_name();
     let docstring = record.docstring();
-    let module_path = mod_path()?;
     let fields_len = try_metadata_value_from_usize(
         record.struct_().fields.len(),
         "UniFFI limits structs to 256 fields",
@@ -212,7 +209,7 @@ fn record_meta_static_var(record: &RecordItem) -> syn::Result<TokenStream> {
         name,
         quote! {
             ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::RECORD)
-                .concat_str(#module_path)
+                .concat_str(module_path!())
                 .concat_str(#name)
                 .concat_value(#fields_len)
                 #concat_fields

--- a/uniffi_meta/src/ffi_names.rs
+++ b/uniffi_meta/src/ffi_names.rs
@@ -13,71 +13,77 @@
 //! set the UDL namespace to the name of another crate. This seems so pathological that it's not
 //! worth the code complexity to prevent it.
 
+use crate::crate_name;
+
 /// FFI symbol name for a top-level function
-pub fn fn_symbol_name(namespace: &str, name: &str) -> String {
-    let namespace = namespace.replace("::", "__");
+pub fn fn_symbol_name(module_path: &str, name: &str) -> String {
+    let namespace = crate_name(module_path).replace("::", "__");
     let name = name.to_ascii_lowercase();
     format!("uniffi_{namespace}_fn_func_{name}")
 }
 
 /// FFI symbol name for an object constructor
-pub fn constructor_symbol_name(namespace: &str, object_name: &str, name: &str) -> String {
-    let namespace = namespace.replace("::", "__");
+pub fn constructor_symbol_name(module_path: &str, object_name: &str, name: &str) -> String {
+    let namespace = crate_name(module_path).replace("::", "__");
     let object_name = object_name.to_ascii_lowercase();
     let name = name.to_ascii_lowercase();
     format!("uniffi_{namespace}_fn_constructor_{object_name}_{name}")
 }
 
 /// FFI symbol name for an object method
-pub fn method_symbol_name(namespace: &str, object_name: &str, name: &str) -> String {
-    let namespace = namespace.replace("::", "__");
+pub fn method_symbol_name(module_path: &str, object_name: &str, name: &str) -> String {
+    let namespace = crate_name(module_path).replace("::", "__");
     let object_name = object_name.to_ascii_lowercase();
     let name = name.to_ascii_lowercase();
     format!("uniffi_{namespace}_fn_method_{object_name}_{name}")
 }
 
 /// FFI symbol name for the `clone` function for an object.
-pub fn clone_fn_symbol_name(namespace: &str, object_name: &str) -> String {
-    let namespace = namespace.replace("::", "__");
+pub fn clone_fn_symbol_name(module_path: &str, object_name: &str) -> String {
+    let namespace = crate_name(module_path).replace("::", "__");
     let object_name = object_name.to_ascii_lowercase();
     format!("uniffi_{namespace}_fn_clone_{object_name}")
 }
 
 /// FFI symbol name for the `free` function for an object.
-pub fn free_fn_symbol_name(namespace: &str, object_name: &str) -> String {
-    let namespace = namespace.replace("::", "__");
+pub fn free_fn_symbol_name(module_path: &str, object_name: &str) -> String {
+    let namespace = crate_name(module_path).replace("::", "__");
     let object_name = object_name.to_ascii_lowercase();
     format!("uniffi_{namespace}_fn_free_{object_name}")
 }
 
 /// FFI symbol name for the `init_callback` function for a callback interface
 pub fn init_callback_vtable_fn_symbol_name(
-    namespace: &str,
+    module_path: &str,
     callback_interface_name: &str,
 ) -> String {
-    let namespace = namespace.replace("::", "__");
+    let namespace = crate_name(module_path).replace("::", "__");
     let callback_interface_name = callback_interface_name.to_ascii_lowercase();
     format!("uniffi_{namespace}_fn_init_callback_vtable_{callback_interface_name}")
 }
 
 /// FFI checksum symbol name for a top-level function
-pub fn fn_checksum_symbol_name(namespace: &str, name: &str) -> String {
-    let namespace = namespace.replace("::", "__");
+pub fn fn_checksum_symbol_name(module_path: &str, name: &str) -> String {
+    let namespace = crate_name(module_path).replace("::", "__");
     let name = name.to_ascii_lowercase();
     format!("uniffi_{namespace}_checksum_func_{name}")
 }
 
 /// FFI checksum symbol name for an object constructor
-pub fn constructor_checksum_symbol_name(namespace: &str, object_name: &str, name: &str) -> String {
-    let namespace = namespace.replace("::", "__");
+pub fn constructor_checksum_symbol_name(
+    module_path: &str,
+    object_name: &str,
+    name: &str,
+) -> String {
+    let namespace = crate_name(module_path).replace("::", "__");
     let object_name = object_name.to_ascii_lowercase();
     let name = name.to_ascii_lowercase();
     format!("uniffi_{namespace}_checksum_constructor_{object_name}_{name}")
 }
 
 /// FFI checksum symbol name for an object method
-pub fn method_checksum_symbol_name(namespace: &str, object_name: &str, name: &str) -> String {
-    let namespace = namespace.replace("::", "__");
+pub fn method_checksum_symbol_name(module_path: &str, object_name: &str, name: &str) -> String {
+    let namespace = crate_name(module_path).replace("::", "__");
     let object_name = object_name.to_ascii_lowercase();
     let name = name.to_ascii_lowercase();
     format!("uniffi_{namespace}_checksum_method_{object_name}_{name}")

--- a/uniffi_meta/src/group.rs
+++ b/uniffi_meta/src/group.rs
@@ -47,7 +47,7 @@ pub fn group_metadata(group_map: &mut MetadataGroupMap, items: Vec<Metadata>) ->
             continue;
         }
 
-        let crate_name = calc_crate_name(item.module_path()).to_owned();
+        let crate_name = crate_name(item.module_path()).to_owned();
         let group = match group_map.get_mut(&crate_name) {
             Some(ns) => ns,
             None => bail!("Unknown namespace for {item:?} ({crate_name})"),
@@ -71,8 +71,4 @@ impl MetadataGroup {
     pub fn add_item(&mut self, item: Metadata) {
         self.items.insert(item);
     }
-}
-
-fn calc_crate_name(module_path: &str) -> &str {
-    module_path.split("::").next().unwrap()
 }

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -564,7 +564,7 @@ impl Metadata {
             Metadata::TraitMethod(meta) => &meta.module_path,
             Metadata::CustomType(meta) => &meta.module_path,
             Metadata::UniffiTrait(meta) => meta.module_path(),
-            Metadata::ObjectTraitImpl(t) => t.ty.module_path().expect("type has no module"),
+            Metadata::ObjectTraitImpl(t) => t.ty.crate_name().expect("type has no crate name"),
         }
     }
 }
@@ -645,4 +645,8 @@ impl From<ObjectTraitImplMetadata> for Metadata {
     fn from(t: ObjectTraitImplMetadata) -> Self {
         Self::ObjectTraitImpl(t)
     }
+}
+
+pub fn crate_name(module_path: &str) -> &str {
+    module_path.split("::").next().unwrap()
 }

--- a/uniffi_meta/src/types.rs
+++ b/uniffi_meta/src/types.rs
@@ -155,6 +155,11 @@ impl Type {
         }
     }
 
+    pub fn crate_name(&self) -> Option<&str> {
+        self.module_path()
+            .map(|module_path| module_path.split("::").next().unwrap())
+    }
+
     fn rename(&mut self, new_name: String) {
         match self {
             Type::Object { name, .. } => *name = new_name,


### PR DESCRIPTION
We don't use it yet, but I'm hoping to use it in the future and I think it's good to start distinguishing between crate and module names.