### PR TITLE
Make namespace_for_module_path use the crate name

### DIFF
--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -369,12 +369,10 @@ impl ComponentInterface {
     }
 
     pub fn namespace_for_module_path(&self, module_path: &str) -> Result<&str> {
+        let crate_name = module_path.split("::").next().unwrap_or(module_path);
         self.crate_to_namespace
-            .get(module_path)
-            .map(|n| {
-                assert!(n.crate_name == module_path); // an invariant redundancy worth dieing for.
-                n.name.as_ref()
-            })
+            .get(crate_name)
+            .map(|n| n.name.as_ref())
             // incase not library mode and we've not been told
             .or_else(|| (module_path == self.crate_name()).then(|| self.namespace()))
             .ok_or_else(|| anyhow!("unresolved module path {module_path}"))


### PR DESCRIPTION
This should have been changed as part of #2695, but we didn't notice it because it didn't seem to cause any issues.  However, @praveenperera pointed out that it was causing issues for him in https://github.com/mozilla/uniffi-rs/pull/2695#issuecomment-3402475701.

I believe we can fix it by calculating crate_name from the module_path. That makes the assert! unneeded.