### PR TITLE
Capture metadata for constructors and methods on Records and Enums.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### What's New?
 
+- Some support for methods and constructors on dataclasses for Python. ([#2706](https://
+  github.com/mozilla/uniffi-rs/pull/2706)).
 - Kotlin: Rust enums with nested payload types are generated using the inner type’s fully qualified
   name, avoiding naming conflicts and allowing payloads to reuse the variant name ([#2698](https://
   github.com/mozilla/uniffi-rs/pull/2698)).

--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -37,6 +37,11 @@ mod state {
         Initialized { data: String },
         Complete { result: Person },
     }
+
+    #[uniffi::export]
+    impl State {
+        fn state_method(&self) {}
+    }
 }
 
 mod enum_repr {
@@ -369,6 +374,27 @@ mod test_metadata {
                     docstring: None,
                 }],
                 non_exhaustive: false,
+                docstring: None,
+            },
+        );
+    }
+
+    #[test]
+    fn test_enum_method() {
+        check_metadata(
+            &state::UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_STATE_STATE_METHOD,
+            MethodMetadata {
+                module_path: "uniffi_fixture_metadata::tests::state".into(),
+                self_name: "State".into(),
+                name: "state_method".into(),
+                is_async: false,
+                inputs: vec![],
+                return_type: None,
+                throws: None,
+                takes_self_by_arc: false,
+                checksum: Some(
+                    state::uniffi_uniffi_fixture_metadata_checksum_method_state_state_method(),
+                ),
                 docstring: None,
             },
         );

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -14,6 +14,13 @@ pub struct One {
 }
 
 #[uniffi::export]
+impl One {
+    fn get_inner(&self) -> i32 {
+        self.inner
+    }
+}
+
+#[uniffi::export]
 pub fn one_inner_by_ref(one: &One) -> i32 {
     one.inner
 }
@@ -228,6 +235,17 @@ pub enum MaybeBool {
     Uncertain,
 }
 
+#[uniffi::export]
+impl MaybeBool {
+    fn next(&self) -> Self {
+        match self {
+            MaybeBool::True => MaybeBool::False,
+            MaybeBool::False => MaybeBool::Uncertain,
+            MaybeBool::Uncertain => MaybeBool::True,
+        }
+    }
+}
+
 #[derive(uniffi::Enum)]
 pub enum MixedEnum {
     None,
@@ -236,6 +254,13 @@ pub enum MixedEnum {
     Both(String, i64),
     All { s: String, i: i64 },
     Vec(Vec<String>),
+}
+
+#[uniffi::export]
+impl MixedEnum {
+    fn is_not_none(&self) -> bool {
+        !matches!(self, Self::None)
+    }
 }
 
 #[uniffi::export]

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.py
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.py
@@ -8,6 +8,7 @@ from proc_macro import TraitWithForeignImpl
 one = make_one(123)
 assert one.inner == 123
 assert one_inner_by_ref(one) == 123
+assert one.get_inner() == 123
 
 two = Two(a="a")
 assert take_two(two) == "a"
@@ -175,6 +176,8 @@ assert(MixedEnum.BOTH("hello", 1)[1] == 1)
 assert(MixedEnum.BOTH("hello", 1)[:] == ('hello', 1))
 assert(MixedEnum.BOTH("hello", 1)[-1] == 1)
 assert(str(MixedEnum.BOTH("hello", 2)) == "MixedEnum.BOTH('hello', 2)")
+assert(MixedEnum.STRING("").is_not_none())
+assert(not MixedEnum.NONE().is_not_none())
 
 # In #2270 we realized confusion about whether we generated our
 # variant checker as, eg, `is_ALL()` vs `is_all()` so decided to do both.

--- a/uniffi_bindgen/src/bindings/python/pipeline/nodes.rs
+++ b/uniffi_bindgen/src/bindings/python/pipeline/nodes.rs
@@ -227,6 +227,8 @@ pub struct Record {
     pub fields: Vec<Field>,
     pub docstring: Option<String>,
     pub self_type: TypeNode,
+    pub constructors: Vec<Constructor>,
+    pub methods: Vec<Method>,
     pub uniffi_trait_methods: UniffiTraitMethods,
 }
 
@@ -262,6 +264,8 @@ pub struct Enum {
     pub discr_type: TypeNode,
     pub docstring: Option<String>,
     pub self_type: TypeNode,
+    pub constructors: Vec<Constructor>,
+    pub methods: Vec<Method>,
     pub uniffi_trait_methods: UniffiTraitMethods,
 }
 

--- a/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
@@ -114,6 +114,15 @@ class {{ type_name }}:
     {%- endif %}
     {% endfor %}
 
+    {%- for meth in e.methods -%}
+    {%- let callable = meth.callable %}
+    {% if callable.is_async %}async {% endif %}def {{ callable.name }}(self, {% include "CallableArgs.py" %}) -> {{ callable.return_type.type_name }}:
+        {{ meth.docstring|docstring(8) -}}
+        {%- filter indent(8) %}
+        {%- include "CallableBody.py" %}
+        {%- endfilter %}
+    {%- endfor %}
+
 # Now, a little trick - we make each nested variant class be a subclass of the main
 # enum class, so that method calls and instance checks etc will work intuitively.
 # We might be able to do this a little more neatly with a metaclass, but this'll do.

--- a/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
@@ -30,6 +30,15 @@ class {{ rec.self_type.type_name }}:
     {% include "UniffiTraitImpls.py" %}
     {% endfilter %}
 
+{%- for meth in rec.methods -%}
+{%-     let callable = meth.callable %}
+    {% if callable.is_async %}async {% endif %}def {{ callable.name }}(self, {% include "CallableArgs.py" %}) -> {{ callable.return_type.type_name }}:
+        {{ meth.docstring|docstring(8) -}}
+        {%- filter indent(8) %}
+        {%- include "CallableBody.py" %}
+        {%- endfilter %}
+{%- endfor %}
+
     {# "builtin" methods not handled by a uniffi_trait #}
     {%- if uniffi_trait_methods.display_fmt.is_none() %}
     def __str__(self):

--- a/uniffi_bindgen/src/interface/enum_.rs
+++ b/uniffi_bindgen/src/interface/enum_.rs
@@ -162,8 +162,12 @@
 use anyhow::Result;
 use uniffi_meta::{Checksum, EnumShape};
 
+use super::function::Callable;
 use super::record::Field;
-use super::{AsType, FfiFunction, Literal, Type, TypeIterator, UniffiTrait, UniffiTraitMethods};
+use super::{
+    AsType, Constructor, FfiFunction, Literal, Method, Type, TypeIterator, UniffiTrait,
+    UniffiTraitMethods,
+};
 
 /// Represents an enum with named variants, each of which may have named
 /// and typed fields.
@@ -179,6 +183,8 @@ pub struct Enum {
     pub(super) variants: Vec<Variant>,
     pub(super) shape: EnumShape,
     pub(super) non_exhaustive: bool,
+    pub(super) constructors: Vec<Constructor>,
+    pub(super) methods: Vec<Method>,
     // The "uniffi trait" methods - eg, `Eq`, `Display` etc.
     uniffi_traits: Vec<UniffiTrait>,
     #[checksum_ignore]
@@ -200,6 +206,14 @@ impl Enum {
 
     pub fn variants(&self) -> &[Variant] {
         &self.variants
+    }
+
+    pub fn constructors(&self) -> &[Constructor] {
+        &self.constructors
+    }
+
+    pub fn methods(&self) -> &[Method] {
+        &self.methods
     }
 
     // Get the literal value to use for the specified variant's discriminant.
@@ -259,7 +273,13 @@ impl Enum {
     }
 
     pub fn iter_types(&self) -> TypeIterator<'_> {
-        Box::new(self.variants.iter().flat_map(Variant::iter_types))
+        Box::new(
+            self.variants
+                .iter()
+                .flat_map(Variant::iter_types)
+                .chain(self.constructors.iter().flat_map(Constructor::iter_types))
+                .chain(self.methods.iter().flat_map(Method::iter_types)),
+        )
     }
 
     pub fn docstring(&self) -> Option<&str> {
@@ -286,17 +306,22 @@ impl Enum {
     }
 
     pub fn iter_ffi_function_definitions(&self) -> impl Iterator<Item = &FfiFunction> {
-        // no "user defined" methods yet, so just uniffi_traits
-        self.uniffi_traits
+        self.constructors
             .iter()
-            .flat_map(|ut| match ut {
-                UniffiTrait::Display { fmt: m }
-                | UniffiTrait::Debug { fmt: m }
-                | UniffiTrait::Hash { hash: m }
-                | UniffiTrait::Ord { cmp: m } => vec![m],
-                UniffiTrait::Eq { eq, ne } => vec![eq, ne],
-            })
-            .map(|m| &m.ffi_func)
+            .map(|f| &f.ffi_func)
+            .chain(self.methods.iter().map(|f| &f.ffi_func))
+            .chain(
+                self.uniffi_traits
+                    .iter()
+                    .flat_map(|ut| match ut {
+                        UniffiTrait::Display { fmt: m }
+                        | UniffiTrait::Debug { fmt: m }
+                        | UniffiTrait::Hash { hash: m }
+                        | UniffiTrait::Ord { cmp: m } => vec![m],
+                        UniffiTrait::Eq { eq, ne } => vec![eq, ne],
+                    })
+                    .map(|m| &m.ffi_func),
+            )
     }
 }
 
@@ -316,6 +341,8 @@ impl TryFrom<uniffi_meta::EnumMetadata> for Enum {
                 .collect::<Result<_>>()?,
             shape: meta.shape,
             non_exhaustive: meta.non_exhaustive,
+            constructors: vec![],
+            methods: vec![],
             uniffi_traits: vec![],
             docstring: meta.docstring.clone(),
         })
@@ -715,6 +742,8 @@ mod test {
             variants: vec![],
             shape: EnumShape::Enum,
             non_exhaustive: false,
+            constructors: vec![],
+            methods: vec![],
             uniffi_traits: vec![],
             docstring: None,
         };

--- a/uniffi_bindgen/src/pipeline/general/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/general/nodes.rs
@@ -200,6 +200,8 @@ pub struct Record {
     pub name: String,
     pub fields_kind: FieldsKind,
     pub fields: Vec<Field>,
+    pub constructors: Vec<Constructor>,
+    pub methods: Vec<Method>,
     pub docstring: Option<String>,
     pub self_type: TypeNode,
     pub uniffi_traits: Vec<UniffiTrait>,
@@ -242,6 +244,8 @@ pub struct Enum {
     /// values. We try to mimic what `rustc` does, but there's no guarantee that this will be
     /// exactly the same type.
     pub discr_type: TypeNode,
+    pub constructors: Vec<Constructor>,
+    pub methods: Vec<Method>,
     pub docstring: Option<String>,
     pub self_type: TypeNode,
     pub uniffi_traits: Vec<UniffiTrait>,

--- a/uniffi_bindgen/src/pipeline/initial/from_uniffi_meta.rs
+++ b/uniffi_bindgen/src/pipeline/initial/from_uniffi_meta.rs
@@ -211,6 +211,12 @@ impl UniffiMetaConverter {
                     list.into_values()
                         .map(|mut r| {
                             let key = (module_path.clone(), r.name.clone());
+                            if let Some(methods) = self.methods.remove(&key) {
+                                r.methods.extend(methods.into_values());
+                            }
+                            if let Some(constructors) = self.constructors.remove(&key) {
+                                r.constructors.extend(constructors.into_values())
+                            }
                             if let Some(uniffi_traits) = self.uniffi_traits.remove(&key) {
                                 r.uniffi_traits.extend(uniffi_traits.into_values())
                             }
@@ -226,6 +232,12 @@ impl UniffiMetaConverter {
                     list.into_values()
                         .map(|mut e| {
                             let key = (module_path.clone(), e.name.clone());
+                            if let Some(methods) = self.methods.remove(&key) {
+                                e.methods.extend(methods.into_values());
+                            }
+                            if let Some(constructors) = self.constructors.remove(&key) {
+                                e.constructors.extend(constructors.into_values())
+                            }
                             if let Some(uniffi_traits) = self.uniffi_traits.remove(&key) {
                                 e.uniffi_traits.extend(uniffi_traits.into_values())
                             }

--- a/uniffi_bindgen/src/pipeline/initial/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/initial/nodes.rs
@@ -136,6 +136,8 @@ pub enum Radix {
 pub struct Record {
     pub name: String,
     pub fields: Vec<Field>,
+    pub constructors: Vec<Constructor>,
+    pub methods: Vec<Method>,
     pub uniffi_traits: Vec<UniffiTrait>,
     pub docstring: Option<String>,
 }
@@ -162,6 +164,8 @@ pub struct Enum {
     pub shape: EnumShape,
     pub variants: Vec<Variant>,
     pub discr_type: Option<Type>,
+    pub constructors: Vec<Constructor>,
+    pub methods: Vec<Method>,
     pub uniffi_traits: Vec<UniffiTrait>,
     pub docstring: Option<String>,
 }


### PR DESCRIPTION
Without this, methods on data classes fail to generate any bindings with obscure errors. With this patch the metadata for these items is collected, but not necessarily used.

This also implements methods, but not constructors, for Python, and nothing at all for Swift and Kotlin. But now the blockers to implementing all of this is in the templates and not in the core.

Towards #2704, #1935, #1470.