### PR TITLE
meta: Bump siphasher version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"

--- a/uniffi_meta/Cargo.toml
+++ b/uniffi_meta/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 
 [dependencies]
 anyhow = "1"
-siphasher = "0.3"
+siphasher = "1"
 uniffi_internal_macros = { version = "0.30.0", path = "../uniffi_internal_macros" }
 uniffi_pipeline = { version = "0.30.0", path = "../uniffi_pipeline" }
 


### PR DESCRIPTION
No API change but this prevents us from duplicating the dependency in mozilla-central.