### PR TITLE
Kotlin: Call `write()` during `uniffiHandleError`

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceImpl.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/CallbackInterfaceImpl.kt
@@ -56,15 +56,14 @@ internal object {{ trait_impl }} {
                 uniffiFutureCallback.callback(uniffiCallbackData, uniffiResult)
             }
             val uniffiHandleError = { callStatus: UniffiRustCallStatus.ByValue ->
-                uniffiFutureCallback.callback(
-                    uniffiCallbackData,
-                    {{ meth.foreign_future_ffi_result_struct().name()|ffi_struct_name }}.UniffiByValue(
-                        {%- if let Some(return_type) = meth.return_type() %}
-                        {{ return_type.into()|ffi_default_value }},
-                        {%- endif %}
-                        callStatus,
-                    ),
-                )
+                val uniffiResult = {{ meth.foreign_future_ffi_result_struct().name()|ffi_struct_name }}.UniffiByValue(
+                    {%- if let Some(return_type) = meth.return_type() %}
+                    {{ return_type.into()|ffi_default_value }},
+                    {%- endif %}
+                    callStatus,
+                );
+                uniffiResult.write()
+                uniffiFutureCallback.callback(uniffiCallbackData, uniffiResult)
             }
 
             {%- match meth.throws_type() %}


### PR DESCRIPTION
Spotted over at
https://github.com/mozilla/uniffi-rs/issues/2624#issuecomment-3451575950.

I'm 50/50 on whether we actually need that call or not (not a JNA expert either), but we're already doing that for `uniffiHandleSuccess` and it cannot hurt, so.

Note that tests (`./docker/cargo-docker.sh test`) fail with:

```
test uniffi_foreign_language_testcase_test_py ... ok
/mounted_workdir/target/tmp/uniffi_unary_result_alias-81c252357d8743a6/unary_result_alias.swift:360:46: error: unknown attribute 'unchecked'
fileprivate final class UniffiHandleMap<T>: @unchecked Sendable {
                                             ^
/mounted_workdir/target/tmp/uniffi_unary_result_alias-81c252357d8743a6/unary_result_alias.swift:360:56: error: use of undeclared type 'Sendable'
fileprivate final class UniffiHandleMap<T>: @unchecked Sendable {
                                                       ^~~~~~~~
test uniffi_foreign_language_testcase_test_swift ... FAILED
test uniffi_foreign_language_testcase_test_kts ... ok

failures:

---- uniffi_foreign_language_testcase_test_swift stdout ----
Creating testing out_dir: /mounted_workdir/target/tmp/uniffi_unary_result_alias-81c252357d8743a6
Error: running `swiftc` to compile bindings failed (cd "/mounted_workdir/target/tmp/uniffi_unary_result_alias-81c252357d8743a6" && "swiftc" "-emit-module" "-module-name" "unary_result_alias" "-o" "libtestmod_unary_result_alias.so" "-emit-library" "-swift-version" "5" "-Xcc" "-fmodule-map-file=/mounted_workdir/target/tmp/uniffi_unary_result_alias-81c252357d8743a6/unary_result_aliasFFI.modulemap" "-I" "/mounted_workdir/target/tmp/uniffi_unary_result_alias-81c252357d8743a6" "-L" "/mounted_workdir/target/tmp/uniffi_unary_result_alias-81c252357d8743a6" "-luniffi_unary_result_alias" "/mounted_workdir/target/tmp/uniffi_unary_result_alias-81c252357d8743a6/unary_result_alias.swift")


failures:
    uniffi_foreign_language_testcase_test_swift
```

... but this doesn't seem related to the changes here 👀 