### PR TITLE
Kotlin: Initialization functions now have a stable ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - Kotlin: Enums and errors now support exporting trait methods (Display, Debug, Eq, Hash, Ord) via `toString()`,
   `equals()`, `hashCode()`, and `compareTo()` implementations. Flat enums only support exporting `Display`. ([#2700](https://github.com/mozilla/uniffi-rs/pull/2700)).
+- Kotlin: Initialization functions now have a stable ordering ([#2718](https://github.com/mozilla/uniffi-rs/pull/2718))
 
 ## v0.30.0 (backend crates: v0.30.0) - (_2025-10-08_)
 

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -4,7 +4,7 @@
 
 use std::borrow::Borrow;
 use std::cell::RefCell;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::fmt::Debug;
 
 use askama::Template;
@@ -356,7 +356,8 @@ impl<'a> KotlinWrapper<'a> {
                     .external_package_name(crate_name, Some(namespace));
                 format!("{package_name}.uniffiEnsureInitialized()")
             })
-            .collect::<HashSet<_>>();
+            // Collect into a btree set to de-dup and order
+            .collect::<BTreeSet<_>>();
 
         init_fns.chain(extern_module_init_fns).collect()
     }


### PR DESCRIPTION
Fixes #2714