### PR TITLE
Checksum refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
   `equals()`, `hashCode()`, and `compareTo()` implementations. Flat enums only support exporting `Display`. ([#2700](https://github.com/mozilla/uniffi-rs/pull/2700)).
 - Kotlin: Initialization functions now have a stable ordering ([#2718](https://github.com/mozilla/uniffi-rs/pull/2718))
 
+### ⚠️ Breaking Changes ⚠️
+- Method checksums no longer include the self type.  This shouldn't affect normal use.  However
+  checksum comparisons will fail if bindings built with `0.30.x` and the Rust code is built with
+  `0.31.x`, or vice-versa.
+
 ### ⚠️ Breaking Changes for external bindings authors ⚠️
 - The `module_path` field now stores full module paths rather than crate names only.
   External bindings authors will probably need to make some minor changes to work with this.

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -131,6 +131,10 @@ impl Function {
     pub fn docstring(&self) -> Option<&str> {
         self.docstring.as_deref()
     }
+
+    pub fn checksum_from_metadata(meta: uniffi_meta::FnMetadata) -> u16 {
+        uniffi_meta::checksum(&Self::from(meta))
+    }
 }
 
 impl From<uniffi_meta::FnParamMetadata> for Argument {

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -446,6 +446,10 @@ impl Constructor {
         self.ffi_func
             .init(Some(FfiType::Handle), self.arguments.iter().map(Into::into));
     }
+
+    pub fn checksum_from_metadata(meta: uniffi_meta::ConstructorMetadata) -> u16 {
+        uniffi_meta::checksum(&Self::from(meta))
+    }
 }
 
 impl From<uniffi_meta::ConstructorMetadata> for Constructor {
@@ -488,6 +492,9 @@ impl From<uniffi_meta::ConstructorMetadata> for Constructor {
 pub struct Method {
     pub(super) name: String,
     pub(super) is_async: bool,
+    // Ignore `self_type` for the checksum, we never compare the method checksums for methods from
+    // different objects.
+    #[checksum_ignore]
     pub(super) self_type: Type,
     pub(super) arguments: Vec<Argument>,
     pub(super) return_type: Option<Type>,
@@ -620,6 +627,11 @@ impl Method {
             checksum_fn_name,
             checksum: meta.checksum,
         }
+    }
+
+    pub fn checksum_from_metadata(meta: uniffi_meta::MethodMetadata) -> u16 {
+        // We can use an arbitrary `self_type` for this, since it's ignored for the checksum
+        uniffi_meta::checksum(&Self::from_metadata(meta, Type::UInt8))
     }
 }
 


### PR DESCRIPTION
Added `calc_checksum_from_metadata` methods to several types. Removed `self_type` from the checksum calculation.  This simplifies the `BindgenLoader` code a bit.

Note: this commit should only be included `0.31.0` not a patch release, since the new checksums won't match the old ones.