### PR TITLE
Add `uniffi::generate` to generate bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,18 @@
 
 ## [[UnreleasedUniFFIVersion]] (backend crates: [[UnreleasedBackendVersion]]) - (_[[ReleaseDate]]_)
 
+### ⚠️ Breaking Changes ⚠️
+- The `uniffi-bindgen` command no longer accepts the `--lib-file` argument.  Instead, pass the
+  library directly without a UDL file.
+- Removed the `[Swift|Kotlin|Python|Ruby]BindingGenerator` types.  Use `uniffi::generate` instead
+  to generate these bindings.
+
 ### What's New?
 
+- Added the `uniffi::generate` function.  This implements the `uniffi-bindgen generate` command and
+  allows it to be run programmatically.
+- The `--library` argument of `uniffi-bindgen` is deprecated and no longer has an effect.
+ `uniffi-bindgen` will now auto-detect when the source path is a library rather than a UDL file.
 - All builtin bindings support renaming almost all of the interface (types, args, items, variants, etc) via TOML definitions -
   [see the docs](https://mozilla.github.io/uniffi-rs/next/renaming.html).
   ([#2715](https://github.com/mozilla/uniffi-rs/pull/2715))

--- a/fixtures/swift-bridging-header-compile/tests/clang.rs
+++ b/fixtures/swift-bridging-header-compile/tests/clang.rs
@@ -1,6 +1,6 @@
 use camino::Utf8PathBuf;
 use std::process::Command;
-use uniffi::SwiftBindingGenerator;
+use uniffi::{generate, GenerateOptions, TargetLanguage};
 use uniffi_testing::UniFFITestHelper;
 
 #[test]
@@ -11,15 +11,12 @@ fn clang() -> Result<(), anyhow::Error> {
     let test_helper = UniFFITestHelper::new(crate_name)?;
     let out_dir = test_helper.create_out_dir(tmp_dir, "clang.rs")?;
 
-    uniffi::generate_bindings(
-        &Utf8PathBuf::from("src/swift-bridging-header-compile.udl"),
-        None,
-        SwiftBindingGenerator,
-        Some(&out_dir),
-        None,
-        None,
-        false,
-    )?;
+    generate(GenerateOptions {
+        languages: vec![TargetLanguage::Swift],
+        source: Utf8PathBuf::from("src/swift-bridging-header-compile.udl"),
+        out_dir: out_dir.clone(),
+        ..GenerateOptions::default()
+    })?;
 
     let bridging_h = out_dir.join("swift_bridging_header_compileFFI.h");
 

--- a/uniffi/src/lib.rs
+++ b/uniffi/src/lib.rs
@@ -13,11 +13,13 @@ pub use uniffi_bindgen::bindings::{kotlin_test, python_test, ruby_test, swift_te
 #[cfg(all(feature = "cargo-metadata", feature = "bindgen"))]
 pub use uniffi_bindgen::cargo_metadata::CrateConfigSupplier as CargoMetadataConfigSupplier;
 #[cfg(feature = "bindgen")]
-pub use uniffi_bindgen::library_mode::generate_bindings as generate_bindings_library_mode;
-#[cfg(feature = "bindgen")]
 pub use uniffi_bindgen::{
-    bindings::{KotlinBindingGenerator, RubyBindingGenerator, SwiftBindingGenerator},
-    generate_bindings, print_repr,
+    bindings::{
+        generate, generate_swift_bindings, GenerateOptions, SwiftBindingsOptions, TargetLanguage,
+    },
+    generate_bindings,
+    library_mode::generate_bindings as generate_bindings_library_mode,
+    print_repr,
 };
 #[cfg(feature = "build")]
 pub use uniffi_build::{generate_scaffolding, generate_scaffolding_for_crate};

--- a/uniffi_bindgen/src/bindings/kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/mod.rs
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::{interface::rename, BindingGenerator, Component, GenerationSettings, Result};
+use crate::{
+    bindings::GenerateOptions, interface::rename, BindgenLoader, Component, ComponentInterface,
+    Result,
+};
 use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
 use std::collections::HashMap;
@@ -13,98 +16,97 @@ use gen_kotlin::{generate_bindings, Config};
 #[cfg(feature = "bindgen-tests")]
 pub mod test;
 
-pub struct KotlinBindingGenerator;
-impl BindingGenerator for KotlinBindingGenerator {
-    type Config = Config;
+/// Generate Kotlin bindings
+pub fn generate(loader: &BindgenLoader<'_>, options: GenerateOptions) -> Result<()> {
+    let metadata = loader.load_metadata(&options.source)?;
+    let cis = loader.load_cis(metadata)?;
+    let cdylib = loader.library_name(&options.source).map(|l| l.to_string());
+    let mut components =
+        loader.load_components(cis, |ci, toml| parse_config(ci, toml, cdylib.clone()))?;
+    apply_renames(&mut components);
 
-    fn new_config(&self, root_toml: &toml::Value) -> Result<Self::Config> {
-        Ok(
-            match root_toml.get("bindings").and_then(|b| b.get("kotlin")) {
-                Some(v) => v.clone().try_into()?,
-                None => Default::default(),
-            },
-        )
+    for c in components.iter_mut() {
+        // Call derive_ffi_functions after `apply_renames`
+        c.ci.derive_ffi_funcs()?;
     }
 
-    fn update_component_configs(
-        &self,
-        settings: &GenerationSettings,
-        components: &mut Vec<Component<Self::Config>>,
-    ) -> Result<()> {
-        for c in &mut *components {
-            c.config
-                .package_name
-                .get_or_insert_with(|| format!("uniffi.{}", c.ci.namespace()));
-            c.config.cdylib_name.get_or_insert_with(|| {
-                settings
-                    .cdylib
-                    .clone()
-                    .unwrap_or_else(|| format!("uniffi_{}", c.ci.namespace()))
-            });
-        }
-
-        // Collect all rename configurations from all components, keyed by module_path
-        let mut module_renames = HashMap::new();
-        for c in components.iter() {
-            if !c.config.rename.is_empty() {
-                let module_path = c.ci.crate_name().to_string();
-                module_renames.insert(module_path, c.config.rename.clone());
-            }
-        }
-
-        // Apply rename configurations to all components
-        if !module_renames.is_empty() {
-            for c in &mut *components {
-                rename(&mut c.ci, &module_renames);
-            }
-        }
-        // We need to update package names
-        let packages = HashMap::<String, String>::from_iter(
-            components
-                .iter()
-                .map(|c| (c.ci.crate_name().to_string(), c.config.package_name())),
-        );
-        for c in components {
-            for (ext_crate, ext_package) in &packages {
-                if ext_crate != c.ci.crate_name()
-                    && !c.config.external_packages.contains_key(ext_crate)
-                {
-                    c.config
-                        .external_packages
-                        .insert(ext_crate.to_string(), ext_package.clone());
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn write_bindings(
-        &self,
-        settings: &GenerationSettings,
-        components: &[Component<Self::Config>],
-    ) -> Result<()> {
-        for Component { ci, config, .. } in components {
-            let mut kt_file = full_bindings_path(config, &settings.out_dir);
-            fs::create_dir_all(&kt_file)?;
-            kt_file.push(format!("{}.kt", ci.namespace()));
-            fs::write(&kt_file, generate_bindings(config, ci)?)?;
-            if settings.try_format_code {
+    for Component { ci, config, .. } in components {
+        let mut kt_file = full_bindings_path(&config, &options.out_dir);
+        fs::create_dir_all(&kt_file)?;
+        kt_file.push(format!("{}.kt", ci.namespace()));
+        fs::write(&kt_file, generate_bindings(&config, &ci)?)?;
+        if options.format {
+            println!(
+                "Code generation complete, formatting with ktlint (use --no-format to disable)"
+            );
+            if let Err(e) = Command::new("ktlint").arg("-F").arg(&kt_file).output() {
                 println!(
-                    "Code generation complete, formatting with ktlint (use --no-format to disable)"
+                    "Warning: Unable to auto-format {} using ktlint: {e:?}",
+                    kt_file.file_name().unwrap(),
                 );
-                if let Err(e) = Command::new("ktlint").arg("-F").arg(&kt_file).output() {
-                    println!(
-                        "Warning: Unable to auto-format {} using ktlint: {e:?}",
-                        kt_file.file_name().unwrap(),
-                    );
-                }
             }
         }
-        Ok(())
     }
+    Ok(())
 }
 
 fn full_bindings_path(config: &Config, out_dir: &Utf8Path) -> Utf8PathBuf {
     let package_path: Utf8PathBuf = config.package_name().split('.').collect();
     Utf8PathBuf::from(out_dir).join(package_path)
+}
+
+fn parse_config(
+    ci: &ComponentInterface,
+    root_toml: toml::Value,
+    cdylib: Option<String>,
+) -> Result<Config> {
+    let mut config: Config = match root_toml.get("bindings").and_then(|b| b.get("kotlin")) {
+        Some(v) => v.clone().try_into()?,
+        None => Default::default(),
+    };
+    config
+        .package_name
+        .get_or_insert_with(|| format!("uniffi.{}", ci.namespace()));
+    config.cdylib_name.get_or_insert_with(|| {
+        cdylib
+            .clone()
+            .unwrap_or_else(|| format!("uniffi_{}", ci.namespace()))
+    });
+
+    Ok(config)
+}
+
+// A helper for renaming items.
+fn apply_renames(components: &mut Vec<Component<Config>>) {
+    // Collect all rename configurations from all components, keyed by module_path
+    let mut module_renames = HashMap::new();
+    for c in components.iter() {
+        if !c.config.rename.is_empty() {
+            let module_path = c.ci.crate_name().to_string();
+            module_renames.insert(module_path, c.config.rename.clone());
+        }
+    }
+
+    // Apply rename configurations to all components
+    if !module_renames.is_empty() {
+        for c in &mut *components {
+            rename(&mut c.ci, &module_renames);
+        }
+    }
+    // We need to update package names
+    let packages = HashMap::<String, String>::from_iter(
+        components
+            .iter()
+            .map(|c| (c.ci.crate_name().to_string(), c.config.package_name())),
+    );
+    for c in components {
+        for (ext_crate, ext_package) in &packages {
+            if ext_crate != c.ci.crate_name() && !c.config.external_packages.contains_key(ext_crate)
+            {
+                c.config
+                    .external_packages
+                    .insert(ext_crate.to_string(), ext_package.clone());
+            }
+        }
+    }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/test.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/test.rs
@@ -3,8 +3,9 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::{
-    bail, bindings::RunScriptOptions, cargo_metadata::CrateConfigSupplier,
-    library_mode::generate_bindings, Context, Result,
+    bail,
+    bindings::{generate, GenerateOptions, RunScriptOptions, TargetLanguage},
+    Context, Result,
 };
 use camino::{Utf8Path, Utf8PathBuf};
 use std::env;
@@ -37,15 +38,13 @@ pub fn run_script(
     let out_dir = test_helper.create_out_dir(tmp_dir, script_path)?;
     let cdylib_path = test_helper.copy_cdylib_to_out_dir(&out_dir)?;
 
-    generate_bindings(
-        &cdylib_path,
-        None,
-        &super::KotlinBindingGenerator,
-        &CrateConfigSupplier::from(test_helper.cargo_metadata()),
-        None,
-        &out_dir,
-        false,
-    )?;
+    generate(GenerateOptions {
+        languages: vec![TargetLanguage::Kotlin],
+        source: cdylib_path.to_path_buf(),
+        out_dir: out_dir.to_path_buf(),
+        crate_filter: Some(crate_name.to_string()),
+        ..GenerateOptions::default()
+    })?;
     let jar_file = build_jar(crate_name, &out_dir, options)?;
 
     let mut command = kotlinc_command(options);

--- a/uniffi_bindgen/src/bindings/python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/mod.rs
@@ -7,12 +7,23 @@ use askama::Template;
 use camino::Utf8Path;
 use fs_err as fs;
 
+use crate::{bindings::GenerateOptions, BindgenLoader};
+
 pub mod filters;
 mod pipeline;
 pub use pipeline::pipeline;
 
 #[cfg(feature = "bindgen-tests")]
 pub mod test;
+
+/// Generate Python bindings
+pub fn generate(loader: &BindgenLoader<'_>, options: GenerateOptions) -> Result<()> {
+    let metadata = loader.load_metadata(&options.source)?;
+    let root = loader.load_pipeline_initial_root(&options.source, metadata)?;
+    run_pipeline(root, &options.out_dir)?;
+
+    Ok(())
+}
 
 pub fn run_pipeline(initial_root: pipeline::initial::Root, out_dir: &Utf8Path) -> Result<()> {
     let python_root = pipeline().execute(initial_root)?;

--- a/uniffi_bindgen/src/bindings/ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/mod.rs
@@ -4,7 +4,7 @@
 
 use std::process::Command;
 
-use crate::{BindingGenerator, Component, ComponentInterface, GenerationSettings};
+use crate::{bindings::GenerateOptions, BindgenLoader, Component, ComponentInterface};
 use anyhow::{Context, Result};
 use fs_err as fs;
 
@@ -13,55 +13,29 @@ mod gen_ruby;
 pub mod test;
 use gen_ruby::{Config, RubyWrapper};
 
-pub struct RubyBindingGenerator;
-impl BindingGenerator for RubyBindingGenerator {
-    type Config = Config;
-
-    fn new_config(&self, root_toml: &toml::Value) -> Result<Self::Config> {
-        Ok(
-            match root_toml.get("bindings").and_then(|b| b.get("ruby")) {
-                Some(v) => v.clone().try_into()?,
-                None => Default::default(),
-            },
-        )
+pub fn generate(loader: &BindgenLoader<'_>, options: GenerateOptions) -> Result<()> {
+    let metadata = loader.load_metadata(&options.source)?;
+    let cis = loader.load_cis(metadata)?;
+    let cdylib = loader.library_name(&options.source).map(|l| l.to_string());
+    let mut components =
+        loader.load_components(cis, |ci, toml| parse_config(ci, toml, cdylib.clone()))?;
+    for c in components.iter_mut() {
+        c.ci.derive_ffi_funcs()?;
     }
+    for Component { ci, config, .. } in components {
+        let rb_file = options.out_dir.join(format!("{}.rb", ci.namespace()));
+        fs::write(&rb_file, generate_ruby_bindings(&config, &ci)?)?;
 
-    fn update_component_configs(
-        &self,
-        settings: &GenerationSettings,
-        components: &mut Vec<Component<Self::Config>>,
-    ) -> Result<()> {
-        for c in &mut *components {
-            c.config.cdylib_name.get_or_insert_with(|| {
-                settings
-                    .cdylib
-                    .clone()
-                    .unwrap_or_else(|| format!("uniffi_{}", c.ci.namespace()))
-            });
-        }
-        Ok(())
-    }
-
-    fn write_bindings(
-        &self,
-        settings: &GenerationSettings,
-        components: &[Component<Self::Config>],
-    ) -> Result<()> {
-        for Component { ci, config, .. } in components {
-            let rb_file = settings.out_dir.join(format!("{}.rb", ci.namespace()));
-            fs::write(&rb_file, generate_ruby_bindings(config, ci)?)?;
-
-            if settings.try_format_code {
-                if let Err(e) = Command::new("rubocop").arg("-A").arg(&rb_file).output() {
-                    println!(
-                        "Warning: Unable to auto-format {} using rubocop: {e:?}",
-                        rb_file.file_name().unwrap(),
-                    )
-                }
+        if options.format {
+            if let Err(e) = Command::new("rubocop").arg("-A").arg(&rb_file).output() {
+                println!(
+                    "Warning: Unable to auto-format {} using rubocop: {e:?}",
+                    rb_file.file_name().unwrap(),
+                )
             }
         }
-        Ok(())
     }
+    Ok(())
 }
 
 // Generate ruby bindings for the given ComponentInterface, as a string.
@@ -70,4 +44,21 @@ pub fn generate_ruby_bindings(config: &Config, ci: &ComponentInterface) -> Resul
     RubyWrapper::new(config.clone(), ci)
         .render()
         .context("failed to render ruby bindings")
+}
+
+fn parse_config(
+    ci: &ComponentInterface,
+    root_toml: toml::Value,
+    cdylib: Option<String>,
+) -> Result<Config> {
+    let mut config: Config = match root_toml.get("bindings").and_then(|b| b.get("ruby")) {
+        Some(v) => v.clone().try_into()?,
+        None => Default::default(),
+    };
+    config.cdylib_name.get_or_insert_with(|| {
+        cdylib
+            .clone()
+            .unwrap_or_else(|| format!("uniffi_{}", ci.namespace()))
+    });
+    Ok(config)
 }

--- a/uniffi_bindgen/src/bindings/ruby/test.rs
+++ b/uniffi_bindgen/src/bindings/ruby/test.rs
@@ -2,8 +2,7 @@
 License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::cargo_metadata::CrateConfigSupplier;
-use crate::library_mode::generate_bindings;
+use crate::bindings::{generate, GenerateOptions, TargetLanguage};
 use anyhow::{bail, Context, Result};
 use camino::Utf8Path;
 use std::env;
@@ -34,15 +33,12 @@ pub fn test_script_command(
     let test_helper = UniFFITestHelper::new(fixture_name)?;
     let out_dir = test_helper.create_out_dir(tmp_dir, &script_path)?;
     let cdylib_path = test_helper.copy_cdylib_to_out_dir(&out_dir)?;
-    generate_bindings(
-        &cdylib_path,
-        None,
-        &super::RubyBindingGenerator,
-        &CrateConfigSupplier::from(test_helper.cargo_metadata()),
-        None,
-        &out_dir,
-        false,
-    )?;
+    generate(GenerateOptions {
+        languages: vec![TargetLanguage::Ruby],
+        source: cdylib_path.to_path_buf(),
+        out_dir: out_dir.to_path_buf(),
+        ..GenerateOptions::default()
+    })?;
 
     let rubypath = env::var_os("RUBYLIB").unwrap_or_else(|| OsString::from(""));
     let rubypath = env::join_paths(

--- a/uniffi_bindgen/src/bindings/swift/test.rs
+++ b/uniffi_bindgen/src/bindings/swift/test.rs
@@ -2,13 +2,13 @@
 License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bindings::RunScriptOptions;
-use crate::cargo_metadata::CrateConfigSupplier;
-use crate::library_mode::generate_bindings;
+use crate::{
+    bindings::{swift::generate, BindgenLoader, GenerateOptions, RunScriptOptions, TargetLanguage},
+    cargo_metadata::CrateConfigSupplier,
+};
 
 use anyhow::{bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
-use cargo_metadata::Metadata;
 use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
 use std::ffi::OsStr;
 use std::fs::{read_to_string, File};
@@ -41,12 +41,8 @@ pub fn run_script(
     let test_helper = UniFFITestHelper::new(package_name)?;
     let out_dir = test_helper.create_out_dir(tmp_dir, &script_path)?;
     let cdylib_path = test_helper.copy_cdylib_to_out_dir(&out_dir)?;
-    let generated_sources = GeneratedSources::new(
-        test_helper.crate_name(),
-        &cdylib_path,
-        test_helper.cargo_metadata(),
-        &out_dir,
-    )?;
+    let generated_sources =
+        GeneratedSources::new(test_helper.crate_name(), &cdylib_path, &out_dir)?;
 
     // We need something better than this env var, but it's a reasonable start.
     let swift_version = std::env::var("UNIFFI_TEST_SWIFT_VERSION").unwrap_or("5".to_string());
@@ -142,21 +138,20 @@ struct GeneratedSources {
 }
 
 impl GeneratedSources {
-    fn new(
-        crate_name: &str,
-        cdylib_path: &Utf8Path,
-        cargo_metadata: Metadata,
-        out_dir: &Utf8Path,
-    ) -> Result<Self> {
-        let sources = generate_bindings(
-            cdylib_path,
-            None,
-            &super::SwiftBindingGenerator,
-            &CrateConfigSupplier::from(cargo_metadata),
-            None,
-            out_dir,
-            false,
+    fn new(crate_name: &str, cdylib_path: &Utf8Path, out_dir: &Utf8Path) -> Result<Self> {
+        let config_supplier = CrateConfigSupplier::from_cargo_metadata_command(false)?;
+        let loader = BindgenLoader::new(&config_supplier);
+        let sources = generate(
+            &loader,
+            GenerateOptions {
+                languages: vec![TargetLanguage::Swift],
+                source: cdylib_path.to_path_buf(),
+                out_dir: out_dir.to_path_buf(),
+                crate_filter: Some(crate_name.to_string()),
+                ..GenerateOptions::default()
+            },
         )?;
+
         let main_source = sources
             .iter()
             .find(|s| s.ci.crate_name() == crate_name)

--- a/uniffi_bindgen/src/cargo_metadata.rs
+++ b/uniffi_bindgen/src/cargo_metadata.rs
@@ -18,6 +18,7 @@ pub struct CrateConfigSupplier {
 }
 
 impl CrateConfigSupplier {
+    /// Create a new `CrateConfigSupplier` by running `cargo metadata`
     pub fn from_cargo_metadata_command(no_deps: bool) -> Result<Self> {
         let mut cmd = cargo_metadata::MetadataCommand::new();
         if no_deps {

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -140,6 +140,9 @@ pub struct GenerationSettings {
 ///
 /// External crates that implement binding generators, should implement this type
 /// and call the [`generate_external_bindings`] using a type that implements this trait.
+///
+/// Deprecated: External crates are encouraged to use the `BindgenLoader` type instead, which lets
+/// you control the binding generation process more directly.
 pub trait BindingGenerator: Sized {
     /// Handles configuring the bindings
     type Config;
@@ -275,6 +278,20 @@ pub trait BindgenCrateConfigSupplier {
 pub struct EmptyCrateConfigSupplier;
 impl BindgenCrateConfigSupplier for EmptyCrateConfigSupplier {}
 
+impl BindgenCrateConfigSupplier for &&dyn BindgenCrateConfigSupplier {
+    fn get_toml(&self, crate_name: &str) -> Result<Option<toml::value::Table>> {
+        (**self).get_toml(crate_name)
+    }
+
+    fn get_toml_path(&self, crate_name: &str) -> Option<Utf8PathBuf> {
+        (**self).get_toml_path(crate_name)
+    }
+
+    fn get_udl(&self, crate_name: &str, udl_name: &str) -> Result<String> {
+        (**self).get_udl(crate_name, udl_name)
+    }
+}
+
 /// A convenience function for the CLI to help avoid using static libs
 /// in places cdylibs are required.
 pub fn is_cdylib(library_file: impl AsRef<Utf8Path>) -> bool {
@@ -293,6 +310,9 @@ pub fn is_cdylib(library_file: impl AsRef<Utf8Path>) -> bool {
 /// - `out_dir_override`: The path to write the bindings to. If [`None`], it will be the path to the parent directory of the `udl_file`
 /// - `library_file`: The path to a dynamic library to attempt to extract the definitions from and extend the component interface with. No extensions to component interface occur if it's [`None`]
 /// - `crate_name`: Override the default crate name that is guessed from UDL file path.
+///
+/// Deprecated: External crates are encouraged to use the `BindgenLoader` type instead, which lets
+/// you control the binding generation process more directly.
 pub fn generate_external_bindings<T: BindingGenerator>(
     binding_generator: &T,
     udl_file: impl AsRef<Utf8Path>,
@@ -394,6 +414,9 @@ fn generate_component_scaffolding_inner(
 
 // Generate the bindings in the target languages that call the scaffolding
 // Rust code.
+///
+/// Deprecated: External crates are encouraged to use the `BindgenLoader` type instead, which lets
+/// you control the binding generation process more directly.
 pub fn generate_bindings<T: BindingGenerator>(
     udl_file: &Utf8Path,
     config_file_override: Option<&Utf8Path>,

--- a/uniffi_bindgen/src/library_mode.rs
+++ b/uniffi_bindgen/src/library_mode.rs
@@ -34,6 +34,9 @@ use uniffi_meta::{
 /// interface and allows for more flexibility in how the external bindings are generated.
 ///
 /// Returns the list of sources used to generate the bindings, in no particular order.
+///
+/// Deprecated: External crates are encouraged to use the `BindgenLoader` type instead, which lets
+/// you control the binding generation process more directly.
 pub fn generate_bindings<T: BindingGenerator>(
     library_path: &Utf8Path,
     crate_name: Option<String>,


### PR DESCRIPTION
This is essentially a way to run `uniffi-bindgen generate` programmatically.

It uses `BindingsLoader` rather than `generate_bindings` and `BindingGenerator`. I think the new system is easier to extend, see https://github.com/mozilla/uniffi-rs/pull/2648 for details.