### PR TITLE
Misc build fixes

### DIFF
--- a/examples/app/uniffi-bindgen-cli/Cargo.toml
+++ b/examples/app/uniffi-bindgen-cli/Cargo.toml
@@ -5,7 +5,9 @@ edition = "2021"
 publish = false
 
 [[bin]]
-name = "uniffi-bindgen"
+# Note: in the real-world you probably want this to be named `uniffi-bindgen`, but we can't do that
+# in the UniFFI repository since we have a different binary named `uniffi-bindgen`
+name = "uniffi-bindgen-cli"
 path = "uniffi-bindgen.rs"
 
 [dependencies]

--- a/uniffi_bindgen/src/pipeline/initial/mod.rs
+++ b/uniffi_bindgen/src/pipeline/initial/mod.rs
@@ -33,7 +33,7 @@ impl Root {
 
         let mut udl_to_load = vec![];
 
-        for meta in macro_metadata::extract_from_library(path)? {
+        for meta in all_metadata {
             match meta {
                 uniffi_meta::Metadata::UdlFile(udl) => {
                     udl_to_load.push((


### PR DESCRIPTION
Rename the `uniffi-bindgen` binary from
`examples/apps/uniffi-bindgen-cli`.  This prevents a cargo warning about multiple crates with the same binary name (there's also one in `uniffi`).  Long-term, I think we probably want to update this app and the documentation around it.

Fixed the pipeline code to not call
`macro_metadata::extract_from_library` twice and ignore the result of the first call.