### PR TITLE
Normalize module paths for `TypeUniverse`

### DIFF
--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -8,17 +8,21 @@ mod callback_interface;
 
 use callback_interface::TestCallbackInterface;
 
-#[derive(uniffi::Record)]
-pub struct One {
-    inner: i32,
-}
+// Test proc-macro definitions in a submodule (#2728)
+mod one {
+    #[derive(uniffi::Record)]
+    pub struct One {
+        pub inner: i32,
+    }
 
-#[uniffi::export]
-impl One {
-    fn get_inner(&self) -> i32 {
-        self.inner
+    #[uniffi::export]
+    impl One {
+        fn get_inner(&self) -> i32 {
+            self.inner
+        }
     }
 }
+pub use one::*;
 
 #[uniffi::export]
 pub fn one_inner_by_ref(one: &One) -> i32 {

--- a/fixtures/proc-macro/src/proc-macro.udl
+++ b/fixtures/proc-macro/src/proc-macro.udl
@@ -10,7 +10,7 @@ typedef interface Object;
 typedef trait Trait;
 typedef trait_with_foreign TraitWithForeign;
 
-// Then stuff defined here but referencing the imported types.
+// Then stuff defined in UDL but referencing proc-macro types.
 dictionary Externals {
     One? one;
     MaybeBool? bool;


### PR DESCRIPTION
If a type was referenced in both the UDL and proc-macro code, then the `TypeUniverse` code could fail because the module paths didn't match up. See the proc-macro fixture changes for an example of this.

To fix things, I made the TypeUniverse code normalize the `module_path` to be just the crate name.  This is unfortunate, but at least we can use full module paths in the pipeline code.

Fixes #2728.