### PR TITLE
Prevent completing foreign futures twice

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/Async.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Async.kt
@@ -52,9 +52,17 @@ internal inline fun<T> uniffiTraitInterfaceCallAsync(
     // Uniffi does its best to support structured concurrency across the FFI.
     // If the Rust future is dropped, `uniffiForeignFutureDroppedCallbackImpl` is called, which will cancel the Kotlin coroutine if it's still running.
     @OptIn(DelicateCoroutinesApi::class)
-    val job = GlobalScope.launch {
-        try {
-            handleSuccess(makeCall())
+    val job = GlobalScope.launch coroutineBlock@ {
+        // Note: it's important we call either `handleSuccess` or `handleError` exactly once.  Each
+        // call consumes an Arc reference, which means there should be no possibility of a double
+        // call.  The following code is structured so that will will never call both `handleSuccess`
+        // and `handleError`, even in the face of weird exceptions.
+        //
+        // In extreme circumstances we may not call either, for example if we fail to make the JNA
+        // call to `handleSuccess`.  This means we will leak the Arc reference, which is better than
+        // double-freeing it.
+        val callResult = try {
+            makeCall()
         } catch(e: kotlin.Exception) {
             handleError(
                 UniffiRustCallStatus.create(
@@ -62,7 +70,9 @@ internal inline fun<T> uniffiTraitInterfaceCallAsync(
                     {{ Type::String.borrow()|lower_fn }}(e.toString()),
                 )
             )
+            return@coroutineBlock
         }
+        handleSuccess(callResult)
     }
     val handle = uniffiForeignFutureHandleMap.insert(job)
     uniffiOutDroppedCallback.uniffiSetValue(UniffiForeignFutureDroppedCallbackStruct(handle, uniffiForeignFutureDroppedCallbackImpl))
@@ -77,9 +87,11 @@ internal inline fun<T, reified E: Throwable> uniffiTraitInterfaceCallAsyncWithEr
 ) {
     // See uniffiTraitInterfaceCallAsync for details on `DelicateCoroutinesApi`
     @OptIn(DelicateCoroutinesApi::class)
-    val job = GlobalScope.launch {
-        try {
-            handleSuccess(makeCall())
+    val job = GlobalScope.launch coroutineBlock@ {
+        // See the note in uniffiTraitInterfaceCallAsync for details on `handleSuccess` and
+        // `handleError`.
+        val callResult = try {
+            makeCall()
         } catch(e: kotlin.Exception) {
             if (e is E) {
                 handleError(
@@ -96,7 +108,9 @@ internal inline fun<T, reified E: Throwable> uniffiTraitInterfaceCallAsyncWithEr
                     )
                 )
             }
+            return@coroutineBlock
         }
+        handleSuccess(callResult)
     }
     val handle = uniffiForeignFutureHandleMap.insert(job)
     uniffiOutDroppedCallback.uniffiSetValue(UniffiForeignFutureDroppedCallbackStruct(handle, uniffiForeignFutureDroppedCallbackImpl))

--- a/uniffi_bindgen/src/bindings/python/templates/Async.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Async.py
@@ -65,8 +65,16 @@ async def _uniffi_rust_call_async(rust_future, ffi_poll, ffi_complete, ffi_free,
 {%- if has_async_callback_method %}
 def _uniffi_trait_interface_call_async(make_call, uniffi_out_dropped_callback, handle_success, handle_error):
     async def make_call_and_call_callback():
+        # Note: it's important we call either `handle_success` or `handle_error` exactly once.  Each
+        # call consumes an Arc reference, which means there should be no possibility of a double
+        # call.  The following code is structured so that will will never call both `handle_success`
+        # and `handle_error`, even in the face of weird exceptions.
+        #
+        # In extreme circumstances we may not call either, for example if we fail to make the ctypes
+        # call to `handle_success`.  This means we will leak the Arc reference, which is better than
+        # double-freeing it.
         try:
-            handle_success(await make_call())
+            call_result = await make_call()
         except Exception as e:
             print("UniFFI: Unhandled exception in trait interface call", file=sys.stderr)
             traceback.print_exc(file=sys.stderr)
@@ -74,6 +82,8 @@ def _uniffi_trait_interface_call_async(make_call, uniffi_out_dropped_callback, h
                 _UniffiRustCallStatus.CALL_UNEXPECTED_ERROR,
                 {{ string_type_node.ffi_converter_name }}.lower(repr(e)),
             )
+        else:
+            handle_success(call_result)
     eventloop = _uniffi_get_event_loop()
     task = asyncio.run_coroutine_threadsafe(make_call_and_call_callback(), eventloop)
     handle = _UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.insert((eventloop, task))
@@ -81,14 +91,18 @@ def _uniffi_trait_interface_call_async(make_call, uniffi_out_dropped_callback, h
 
 def _uniffi_trait_interface_call_async_with_error(make_call, uniffi_out_dropped_callback, handle_success, handle_error, error_type, lower_error):
     async def make_call_and_call_callback():
+        # See the note in _uniffi_trait_interface_call_async for details on `handle_success` and
+        # `handle_error`.
         try:
             try:
-                handle_success(await make_call())
+                call_result = await make_call()
             except error_type as e:
                 handle_error(
                     _UniffiRustCallStatus.CALL_ERROR,
                     lower_error(e),
                 )
+            else:
+                handle_success(call_result)
         except Exception as e:
             print("UniFFI: Unhandled exception in trait interface call", file=sys.stderr)
             traceback.print_exc(file=sys.stderr)

--- a/uniffi_bindgen/src/bindings/swift/templates/Async.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Async.swift
@@ -55,11 +55,22 @@ private func uniffiTraitInterfaceCallAsync<T>(
     droppedCallback: UnsafeMutablePointer<UniffiForeignFutureDroppedCallbackStruct>
 ) {
     let task = Task {
+        // Note: it's important we call either `handleSuccess` or `handleError` exactly once.  Each
+        // call consumes an Arc reference, which means there should be no possibility of a double
+        // call.  The following code is structured so that will will never call both `handleSuccess`
+        // and `handleError`, even in the face of weird errors.
+        //
+        // On platforms that need extra machinery to make C-ABI calls, like JNA or ctypes, it's
+        // possible that we fail to make either call.  However, it doesn't seem like this is
+        // possible on Swift since swift can just make the C call directly.
+        var callResult: T
         do {
-            handleSuccess(try await makeCall())
+            callResult = try await makeCall()
         } catch {
             handleError(CALL_UNEXPECTED_ERROR, {{ Type::String.borrow()|lower_fn }}(String(describing: error)))
+            return
         }
+        handleSuccess(callResult)
     }
     let handle = UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.insert(obj: task)
     droppedCallback.pointee = UniffiForeignFutureDroppedCallbackStruct(
@@ -76,13 +87,19 @@ private func uniffiTraitInterfaceCallAsyncWithError<T, E>(
     droppedCallback: UnsafeMutablePointer<UniffiForeignFutureDroppedCallbackStruct>
 ) {
     let task = Task {
+        // See the note in uniffiTraitInterfaceCallAsync for details on `handleSuccess` and
+        // `handleError`.
+        var callResult: T
         do {
-            handleSuccess(try await makeCall())
+            callResult = try await makeCall()
         } catch let error as E {
             handleError(CALL_ERROR, lowerError(error))
+            return
         } catch {
             handleError(CALL_UNEXPECTED_ERROR, {{ Type::String.borrow()|lower_fn }}(String(describing: error)))
+            return
         }
+        handleSuccess(callResult)
     }
     let handle = UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.insert(obj: task)
     droppedCallback.pointee = UniffiForeignFutureDroppedCallbackStruct(


### PR DESCRIPTION
We've been seeing segfaults related to freeing the oneshot Sender instance on older mobile phones in Firefox Android. I'm not sure why this is, but my best guess is that we're calling the complete function twice, which will attempt to free the same arc reference twice.

My theory on how this happens is we call `handleSuccess` then an exception is thrown and we also call `handleError`. I haven't been able to reproduce this on my machine, except when I add manual throw statements.  However, it seems like it's theoretically possible and
maybe on older phones we're running into this.   For example the
following lines could throw after invoking the complete callback:

https://github.com/java-native-access/jna/blob/0deb54b46dc04f655e3c1d46e848fd26bf47c09a/src/com/sun/jna/Function.java#L489-L492