### PR TITLE
Reimplement support for --config on Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Removed the `[Swift|Kotlin|Python|Ruby]BindingGenerator` types.  Use `uniffi::generate` instead
   to generate these bindings.
 
+### What's Deprecated?
+- `BindgenCrateConfigSupplier`.  Use the new `BindgenPaths` type instead.
+
 ### What's New?
 
 - Added the `uniffi::generate` function.  This implements the `uniffi-bindgen generate` command and
@@ -23,6 +26,7 @@
   ([#2715](https://github.com/mozilla/uniffi-rs/pull/2715))
 - Support for methods on records and enums
   ([#2706](https://github.com/mozilla/uniffi-rs/pull/2706), [#2724](https://github.com/mozilla/uniffi-rs/pull/2724), [#2739](https://github.com/mozilla/uniffi-rs/pull/2739)).
+- Added the `BindgenPaths` type, which is the new way to find UDL and TOML data.
 
 ### What's Fixed
 

--- a/uniffi_bindgen/src/bindgen_paths.rs
+++ b/uniffi_bindgen/src/bindgen_paths.rs
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::fs;
+
+use anyhow::{bail, Context};
+use camino::Utf8PathBuf;
+
+use crate::Result;
+
+/// Responsible for looking up UDL and config paths
+///
+/// This uses a layered approach supporting multiple ways to find the paths.
+/// The first added layer takes precedence.
+#[derive(Default)]
+pub struct BindgenPaths {
+    layers: Vec<Box<dyn BindgenPathsLayer>>,
+}
+
+impl BindgenPaths {
+    #[cfg(feature = "cargo-metadata")]
+    /// Add a layer that finds paths using `cargo metadata`
+    ///
+    /// Requires the `cargo-metadata` feature.
+    pub fn add_cargo_metadata_layer(&mut self, no_deps: bool) -> Result<()> {
+        self.add_layer(
+            crate::cargo_metadata::CrateConfigSupplier::from_cargo_metadata_command(no_deps)?,
+        );
+        Ok(())
+    }
+
+    /// Add a layer that always uses the same path for config files
+    ///
+    /// Used to implement the `--config` CLI flag.
+    pub fn add_config_override_layer(&mut self, path: Utf8PathBuf) {
+        self.add_layer(ConfigOverrideLayer { path })
+    }
+
+    /// Add a layer using a [BindgenPathsLayer]
+    ///
+    /// This can be used to add custom path finding logic.
+    pub fn add_layer(&mut self, layer: impl BindgenPathsLayer + 'static) {
+        self.layers.push(Box::new(layer));
+    }
+
+    /// Get the config path for a crate
+    pub fn get_config_path(&self, crate_name: &str) -> Option<Utf8PathBuf> {
+        self.layers
+            .iter()
+            .find_map(|l| l.get_config_path(crate_name))
+    }
+
+    /// Get the config table for a crate
+    pub fn get_config(&self, crate_name: &str) -> Result<toml::value::Table> {
+        match self.get_config_path(crate_name) {
+            Some(path) => {
+                let contents =
+                    fs::read_to_string(&path).with_context(|| format!("read file: {:?}", path))?;
+                let toml = toml::de::from_str(&contents)
+                    .with_context(|| format!("parse toml: {:?}", path))?;
+                Ok(toml)
+            }
+            None => Ok(toml::value::Table::default()),
+        }
+    }
+
+    /// Get the UDL path for a crate
+    pub fn get_udl_path(&self, crate_name: &str, udl_name: &str) -> Option<Utf8PathBuf> {
+        self.layers
+            .iter()
+            .find_map(|l| l.get_udl_path(crate_name, udl_name))
+    }
+
+    /// Get the UDL source for a crate
+    pub fn get_udl(&self, crate_name: &str, udl_name: &str) -> Result<String> {
+        match self.get_udl_path(crate_name, udl_name) {
+            Some(path) => Ok(fs::read_to_string(path)?),
+            None => bail!("UDL file {udl_name:?} not found for crate {crate_name:?}"),
+        }
+    }
+}
+
+/// Trait for finding UDL and config paths
+pub trait BindgenPathsLayer {
+    /// Lookup the config TOML file path.
+    ///
+    /// This is usually `[crate-root]/uniffi.toml`
+    fn get_config_path(&self, _crate_name: &str) -> Option<Utf8PathBuf> {
+        None
+    }
+
+    /// Lookup the a UDL file path.
+    ///
+    /// This is usually the `[crate-root]/src/[udl_name].udl`
+    fn get_udl_path(&self, _crate_name: &str, _udl_name: &str) -> Option<Utf8PathBuf> {
+        None
+    }
+}
+
+struct ConfigOverrideLayer {
+    path: Utf8PathBuf,
+}
+
+impl BindgenPathsLayer for ConfigOverrideLayer {
+    fn get_config_path(&self, _crate_name: &str) -> Option<Utf8PathBuf> {
+        Some(self.path.clone())
+    }
+}

--- a/uniffi_bindgen/src/bindings/kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/mod.rs
@@ -17,7 +17,7 @@ use gen_kotlin::{generate_bindings, Config};
 pub mod test;
 
 /// Generate Kotlin bindings
-pub fn generate(loader: &BindgenLoader<'_>, options: GenerateOptions) -> Result<()> {
+pub fn generate(loader: &BindgenLoader, options: GenerateOptions) -> Result<()> {
     let metadata = loader.load_metadata(&options.source)?;
     let cis = loader.load_cis(metadata)?;
     let cdylib = loader.library_name(&options.source).map(|l| l.to_string());

--- a/uniffi_bindgen/src/bindings/python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/mod.rs
@@ -17,7 +17,7 @@ pub use pipeline::pipeline;
 pub mod test;
 
 /// Generate Python bindings
-pub fn generate(loader: &BindgenLoader<'_>, options: GenerateOptions) -> Result<()> {
+pub fn generate(loader: &BindgenLoader, options: GenerateOptions) -> Result<()> {
     let metadata = loader.load_metadata(&options.source)?;
     let root = loader.load_pipeline_initial_root(&options.source, metadata)?;
     run_pipeline(root, &options.out_dir)?;

--- a/uniffi_bindgen/src/bindings/ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/mod.rs
@@ -13,7 +13,7 @@ mod gen_ruby;
 pub mod test;
 use gen_ruby::{Config, RubyWrapper};
 
-pub fn generate(loader: &BindgenLoader<'_>, options: GenerateOptions) -> Result<()> {
+pub fn generate(loader: &BindgenLoader, options: GenerateOptions) -> Result<()> {
     let metadata = loader.load_metadata(&options.source)?;
     let cis = loader.load_cis(metadata)?;
     let cdylib = loader.library_name(&options.source).map(|l| l.to_string());

--- a/uniffi_bindgen/src/bindings/swift/test.rs
+++ b/uniffi_bindgen/src/bindings/swift/test.rs
@@ -4,7 +4,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 
 use crate::{
     bindings::{swift::generate, BindgenLoader, GenerateOptions, RunScriptOptions, TargetLanguage},
-    cargo_metadata::CrateConfigSupplier,
+    BindgenPaths,
 };
 
 use anyhow::{bail, Context, Result};
@@ -139,8 +139,9 @@ struct GeneratedSources {
 
 impl GeneratedSources {
     fn new(crate_name: &str, cdylib_path: &Utf8Path, out_dir: &Utf8Path) -> Result<Self> {
-        let config_supplier = CrateConfigSupplier::from_cargo_metadata_command(false)?;
-        let loader = BindgenLoader::new(&config_supplier);
+        let mut paths = BindgenPaths::default();
+        paths.add_cargo_metadata_layer(false)?;
+        let loader = BindgenLoader::new(paths);
         let sources = generate(
             &loader,
             GenerateOptions {

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -101,6 +101,7 @@ use std::io::prelude::*;
 use std::io::ErrorKind;
 use std::process::Command;
 
+mod bindgen_paths;
 pub mod bindings;
 pub mod interface;
 pub mod library_mode;
@@ -117,6 +118,7 @@ use crate::interface::{
     Argument, Constructor, Enum, FfiArgument, FfiField, Field, Function, Method, Object, Record,
     Variant,
 };
+pub use bindgen_paths::{BindgenPaths, BindgenPathsLayer};
 pub use interface::ComponentInterface;
 pub use library_mode::find_components;
 use scaffolding::RustScaffolding;


### PR DESCRIPTION
This flag's behavior is a bit weird in the current world of library mode and multiple crates, since it overrides the config for all crates.  We should probably update how it works at some point, but for now we can at least restore how it worked before.

Refactored the UDL/config path handling to help enable this.  I wanted to do this now to help enable future config flags, like one to specify different paths by crate.  One assumption the new code makes is that UDL data lives in a file, but I think that's safe to make.

Fixes #2703