### PR TITLE
Python: Check that other value has the same type in `__eq__` for enum

### DIFF
--- a/fixtures/enum-types/tests/bindings/test_enum_types.py
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.py
@@ -44,5 +44,8 @@ class TestErrorTypes(unittest.TestCase):
         self.assertEqual(e.d, 0)
         self.assertEqual(e.e, 2)
 
+    def test_eq(self):
+        self.assertNotEqual(get_animal_enum(Animal.DOG), {})
+
 if __name__=='__main__':
     unittest.main()

--- a/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/EnumTemplate.py
@@ -49,6 +49,8 @@ class {{ type_name }}:
 
     {%-     if uniffi_trait_methods.eq_eq.is_none() %}
         def __eq__(self, other):
+            if not isinstance(other, {{ type_name }}):
+                return NotImplemented
             if not other.is_{{ variant.name }}():
                 return False
             return self._values == other._values
@@ -89,6 +91,8 @@ class {{ type_name }}:
     {%-     endif %}
     {%-     if uniffi_trait_methods.eq_eq.is_none() %}
         def __eq__(self, other):
+            if not isinstance(other, {{ type_name }}):
+                return NotImplemented
             if not other.is_{{ variant.name }}():
                 return False
             {%- for field in variant.fields %}


### PR DESCRIPTION
Before this change, comparing an enum value against some other value likely resulted in an `AttributeError` because the value lacks the called `is_<variant>` method.