### PR TITLE
CLI: make it possible to opt-out from cargo-metadata

### DIFF
--- a/uniffi/Cargo.toml
+++ b/uniffi/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["ffi", "bindgen"]
 readme = "../README.md"
 
 [dependencies]
-uniffi_bindgen = { path = "../uniffi_bindgen", version = "=0.30.0", optional = true }
+uniffi_bindgen = { path = "../uniffi_bindgen", version = "=0.30.0", default-features = false, optional = true }
 uniffi_build = { path = "../uniffi_build", version = "=0.30.0", optional = true }
 uniffi_core = { path = "../uniffi_core", version = "=0.30.0" }
 uniffi_macros = { path = "../uniffi_macros", version = "=0.30.0" }


### PR DESCRIPTION
As of now, if the feature `cli` is enabled on uniffi crate, it starts to depend on `cargo-metadata` unconditionally and there's no way to opt-out, because `cargo-metadata` is featched by the default feature of `uniffi-bindgen`.

This change makes it possible to build the `uniffi-bindgen` binary without depending on `cargo metadata`, like this

```
cargo build --no-default-features --bin uniffi-bindgen
```