### PR TITLE
Apply the offset when picking data from a multi-arch file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,6 +1867,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-fixture-multi-arch-extract"
+version = "0.22.0"
+dependencies = [
+ "tempfile",
+ "uniffi_bindgen",
+ "xshell",
+]
+
+[[package]]
 name = "uniffi-fixture-proc-macro"
 version = "0.22.0"
 dependencies = [
@@ -2487,3 +2496,18 @@ checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "xshell"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e7290c623014758632efe00737145b6867b66292c42167f2ec381eb566a373d"
+dependencies = [
+ "xshell-macros",
+]
+
+[[package]]
+name = "xshell-macros"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ members = [
   "fixtures/large-error",
   "fixtures/enum-types",
   "fixtures/wasm-unstable-single-threaded",
+  "fixtures/multi-arch-extract",
 ]
 
 resolver = "2"

--- a/fixtures/multi-arch-extract/Cargo.toml
+++ b/fixtures/multi-arch-extract/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "uniffi-fixture-multi-arch-extract"
+version = "0.22.0"
+edition = "2021"
+license = "MPL-2.0"
+publish = false
+
+[dev-dependencies]
+uniffi_bindgen = { path = "../../uniffi_bindgen" }
+xshell = "0.2.7"
+tempfile = "3"

--- a/fixtures/multi-arch-extract/README.md
+++ b/fixtures/multi-arch-extract/README.md
@@ -1,0 +1,17 @@
+# A test for component extraction from a multi-arch library
+
+UniFFI reads component information from shared libraries.
+On macOS these can be multi-arch libraries ("fat mach"),
+a single file containing libraries for multiple architectures.
+
+This was actually broken until recently, as the file offset wasn't applied.
+This test now generates a library on the fly from a minimal piece of C code.
+It then runs the extraction to check it works without crashes.
+
+Note: This test only runs on macOS, as we can't guarantee that cross-compiling for the two macOS targets actually works anywhere else.
+
+## Run the test
+
+```sh
+cargo test
+```

--- a/fixtures/multi-arch-extract/tests/it.rs
+++ b/fixtures/multi-arch-extract/tests/it.rs
@@ -1,0 +1,66 @@
+// Needs macOS so we can compile for both x86_64-apple-darwin and aarch64-apple-darwin
+#![cfg(target_os = "macos")]
+
+use std::fs;
+
+use tempfile::{Builder, NamedTempFile};
+use xshell::{cmd, Shell};
+
+type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
+
+// The most minimal code equivalent to what UniFFI generates:
+// A single custom type for a crate named `fixture` with a type name of `custom`.
+static C_CODE: &str = r#"
+unsigned char UNIFFI_META_FIXTURE_CUSTOM_TYPE_CUSTOM[18] = {
+  15,
+  7, 'f', 'i', 'x', 't', 'u', 'r', 'e',
+  6, 'c', 'u', 's', 't', 'o', 'm',
+  0, 0
+};
+"#;
+
+fn tempfile(prefix: &str, suffix: &str) -> Result<NamedTempFile, std::io::Error> {
+    Builder::new().prefix(prefix).suffix(suffix).tempfile()
+}
+
+#[test]
+fn extraction_from_multi_arch_lib_works() -> Result<()> {
+    let code_file = tempfile("custom", ".c")?;
+    let code_file_path = code_file.path();
+    fs::write(code_file_path, C_CODE)?;
+
+    let x64 = tempfile("x64", ".dylib")?;
+    let x64_path = x64.path();
+    let arm64 = tempfile("arm64", ".dylib")?;
+    let arm64_path = arm64.path();
+    let multiarch = tempfile("multiarch", ".dylib")?;
+    let multiarch_path = multiarch.path();
+
+    // We build 2 dylibs (for x86_64 and arm64),
+    // then combine them into a multi-arch dylib (using `lipo`)
+
+    let sh = Shell::new()?;
+    cmd!(
+        sh,
+        "cc -shared -O3 -target x86_64-apple-darwin -o {x64_path} {code_file_path}"
+    )
+    .run()?;
+    cmd!(
+        sh,
+        "cc -shared -O3 -target aarch64-apple-darwin -o {arm64_path} {code_file_path}"
+    )
+    .run()?;
+
+    cmd!(
+        sh,
+        "lipo -create -output {multiarch_path} {x64_path} {arm64_path}"
+    )
+    .run()?;
+
+    let dylib_bytes = fs::read(multiarch_path)?;
+
+    let metadata = uniffi_bindgen::macro_metadata::extract_from_bytes(&dylib_bytes)?;
+    assert_eq!(1, metadata.len());
+
+    Ok(())
+}


### PR DESCRIPTION
In a multi-arch file multiple archs are in the file back-to-back The Mach header tells us at which offset they start, but offsets _within_ that part are not global, but for that part only. Thus we need to pass on the file data from that offset on, otherwise we're looking at random other data.

Currently a Mach-O multi-arch file fails to properly parse:

    Error: finding components in 'your_library.dylib'

    Caused by:
        0: extracting metadata for '_UNIFFI_META_GLEAN_CORE_CUSTOM_TYPE_YOUR_TYPE'
        1: Unexpected metadata code: 209

I decided to also add a test that compiles enough C code on-the-fly to generate a library that UniFFI can parse. The test combines two of these libraries into a multi-arch file for parsing and calls the API.

---

The bug showed up as a build failure for Glean when we were trying to publish the universal2 file: https://bugzilla.mozilla.org/show_bug.cgi?id=2004934