### PR TITLE
Update default Rust version to 1.90.0

### DIFF
--- a/examples/custom-types/src/lib.rs
+++ b/examples/custom-types/src/lib.rs
@@ -19,11 +19,9 @@ impl From<Handle> for i64 {
     }
 }
 
-impl TryFrom<i64> for Handle {
-    type Error = std::convert::Infallible;
-
-    fn try_from(val: i64) -> Result<Handle, Self::Error> {
-        Ok(Handle(val))
+impl From<i64> for Handle {
+    fn from(val: i64) -> Handle {
+        Handle(val)
     }
 }
 

--- a/fixtures/coverall/src/lib.rs
+++ b/fixtures/coverall/src/lib.rs
@@ -253,6 +253,7 @@ pub struct DictWithDefaults {
     item_map: HashMap<String, String>,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum MaybeSimpleDict {
     Yeah { d: SimpleDict },

--- a/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
+++ b/fixtures/uitests/tests/ui/interface_not_sync_and_send.stderr
@@ -1,22 +1,80 @@
 error[E0277]: `Cell<u32>` cannot be shared between threads safely
  --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
   |
-  | struct r#Counter { }
-  |        ^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
-  |
-  = help: within `Counter`, the trait `Sync` is not implemented for `Cell<u32>`
-  = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicU32` instead
+ 34 | #[::uniffi::udl_derive(Object)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
+    |
+    = help: within `Counter`, the trait `Sync` is not implemented for `Cell<u32>`
+    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicU32` instead
 note: required because it appears within the type `Counter`
- --> tests/ui/interface_not_sync_and_send.rs:9:12
-  |
-9 | pub struct Counter {
-  |            ^^^^^^^
-note: required by a bound in `_::{closure#0}::assert_impl_all`
+   --> tests/ui/interface_not_sync_and_send.rs:9:12
+    |
+  9 | pub struct Counter {
+    |            ^^^^^^^
+note: required by a bound in `FfiConverterArc`
+   --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
+    |
+    | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
+    |                                              ^^^^ required by this bound in `FfiConverterArc`
+    = note: this error originates in the attribute macro `::uniffi::udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `Cell<u32>` cannot be shared between threads safely
  --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
   |
-  | #[::uniffi::udl_derive(Object)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
-  = note: this error originates in the macro `::uniffi::deps::static_assertions::assert_impl_all` which comes from the expansion of the attribute macro `::uniffi::udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
+ 35 | struct r#Counter { }
+    |        ^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
+    |
+    = help: within `Counter`, the trait `Sync` is not implemented for `Cell<u32>`
+    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicU32` instead
+note: required because it appears within the type `Counter`
+   --> tests/ui/interface_not_sync_and_send.rs:9:12
+    |
+  9 | pub struct Counter {
+    |            ^^^^^^^
+note: required by a bound in `FfiConverterArc`
+   --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
+    |
+    | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
+    |                                              ^^^^ required by this bound in `FfiConverterArc`
+
+error[E0277]: `Cell<u32>` cannot be shared between threads safely
+ --> tests/ui/interface_not_sync_and_send.rs:26:10
+  |
+ 26 | #[derive(uniffi::Object)]
+    |          ^^^^^^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
+    |
+    = help: within `ProcMacroCounter`, the trait `Sync` is not implemented for `Cell<u32>`
+    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicU32` instead
+note: required because it appears within the type `ProcMacroCounter`
+   --> tests/ui/interface_not_sync_and_send.rs:27:12
+    |
+ 27 | pub struct ProcMacroCounter {
+    |            ^^^^^^^^^^^^^^^^
+note: required by a bound in `FfiConverterArc`
+   --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
+    |
+    | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
+    |                                              ^^^^ required by this bound in `FfiConverterArc`
+    = note: this error originates in the derive macro `uniffi::Object` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `Cell<u32>` cannot be shared between threads safely
+ --> tests/ui/interface_not_sync_and_send.rs:27:12
+  |
+ 27 | pub struct ProcMacroCounter {
+    |            ^^^^^^^^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
+    |
+    = help: within `ProcMacroCounter`, the trait `Sync` is not implemented for `Cell<u32>`
+    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicU32` instead
+note: required because it appears within the type `ProcMacroCounter`
+   --> tests/ui/interface_not_sync_and_send.rs:27:12
+    |
+ 27 | pub struct ProcMacroCounter {
+    |            ^^^^^^^^^^^^^^^^
+note: required by a bound in `FfiConverterArc`
+   --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
+    |
+    | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
+    |                                              ^^^^ required by this bound in `FfiConverterArc`
 
 error[E0277]: `Cell<u32>` cannot be shared between threads safely
  --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
@@ -29,13 +87,14 @@ error[E0277]: `Cell<u32>` cannot be shared between threads safely
 note: required because it appears within the type `Counter`
  --> tests/ui/interface_not_sync_and_send.rs:9:12
   |
-9 | pub struct Counter {
-  |            ^^^^^^^
-note: required by a bound in `FfiConverterArc`
- --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
-  |
-  | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
-  |                                              ^^^^ required by this bound in `FfiConverterArc`
+ 9 | pub struct Counter {
+   |            ^^^^^^^
+note: required by a bound in `_::{closure#0}::assert_impl_all`
+  --> $OUT_DIR[uniffi_uitests]/counter.uniffi.rs
+   |
+   | #[::uniffi::udl_derive(Object)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   = note: this error originates in the macro `::uniffi::deps::static_assertions::assert_impl_all` which comes from the expansion of the attribute macro `::uniffi::udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Cell<u32>` cannot be shared between threads safely
   --> tests/ui/interface_not_sync_and_send.rs:27:12
@@ -56,22 +115,3 @@ note: required by a bound in `_::{closure#0}::assert_impl_all`
 26 | #[derive(uniffi::Object)]
    |          ^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the macro `::uniffi::deps::static_assertions::assert_impl_all` which comes from the expansion of the derive macro `uniffi::Object` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: `Cell<u32>` cannot be shared between threads safely
-  --> tests/ui/interface_not_sync_and_send.rs:27:12
-   |
-27 | pub struct ProcMacroCounter {
-   |            ^^^^^^^^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
-   |
-   = help: within `ProcMacroCounter`, the trait `Sync` is not implemented for `Cell<u32>`
-   = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicU32` instead
-note: required because it appears within the type `ProcMacroCounter`
-  --> tests/ui/interface_not_sync_and_send.rs:27:12
-   |
-27 | pub struct ProcMacroCounter {
-   |            ^^^^^^^^^^^^^^^^
-note: required by a bound in `FfiConverterArc`
-  --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
-   |
-   | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
-   |                                              ^^^^ required by this bound in `FfiConverterArc`

--- a/fixtures/uitests/tests/ui/interface_trait_not_sync_and_send.stderr
+++ b/fixtures/uitests/tests/ui/interface_trait_not_sync_and_send.stderr
@@ -1,3 +1,59 @@
+error[E0277]: `(dyn Trait + 'static)` cannot be sent between threads safely
+ --> $OUT_DIR[uniffi_uitests]/trait.uniffi.rs
+  |
+ 33 | #[::uniffi::export_for_udl]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Trait + 'static)` cannot be sent between threads safely
+    |
+    = help: the trait `Send` is not implemented for `(dyn Trait + 'static)`
+note: required by a bound in `FfiConverterArc`
+   --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
+    |
+    | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
+    |                                       ^^^^ required by this bound in `FfiConverterArc`
+    = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `(dyn Trait + 'static)` cannot be shared between threads safely
+ --> $OUT_DIR[uniffi_uitests]/trait.uniffi.rs
+  |
+ 33 | #[::uniffi::export_for_udl]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Trait + 'static)` cannot be shared between threads safely
+    |
+    = help: the trait `Sync` is not implemented for `(dyn Trait + 'static)`
+note: required by a bound in `FfiConverterArc`
+   --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
+    |
+    | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
+    |                                              ^^^^ required by this bound in `FfiConverterArc`
+    = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `(dyn ProcMacroTrait + 'static)` cannot be sent between threads safely
+ --> tests/ui/interface_trait_not_sync_and_send.rs:12:1
+  |
+ 12 | #[uniffi::export]
+    | ^^^^^^^^^^^^^^^^^ `(dyn ProcMacroTrait + 'static)` cannot be sent between threads safely
+    |
+    = help: the trait `Send` is not implemented for `(dyn ProcMacroTrait + 'static)`
+note: required by a bound in `FfiConverterArc`
+   --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
+    |
+    | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
+    |                                       ^^^^ required by this bound in `FfiConverterArc`
+    = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `(dyn ProcMacroTrait + 'static)` cannot be shared between threads safely
+ --> tests/ui/interface_trait_not_sync_and_send.rs:12:1
+  |
+ 12 | #[uniffi::export]
+    | ^^^^^^^^^^^^^^^^^ `(dyn ProcMacroTrait + 'static)` cannot be shared between threads safely
+    |
+    = help: the trait `Sync` is not implemented for `(dyn ProcMacroTrait + 'static)`
+note: required by a bound in `FfiConverterArc`
+   --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
+    |
+    | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
+    |                                              ^^^^ required by this bound in `FfiConverterArc`
+    = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: `dyn Trait` cannot be shared between threads safely
  --> $OUT_DIR[uniffi_uitests]/trait.uniffi.rs
   |
@@ -26,34 +82,6 @@ note: required by a bound in `_::{closure#0}::assert_impl_all`
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
   = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `(dyn Trait + 'static)` cannot be shared between threads safely
- --> $OUT_DIR[uniffi_uitests]/trait.uniffi.rs
-  |
-  | #[::uniffi::export_for_udl]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Trait + 'static)` cannot be shared between threads safely
-  |
-  = help: the trait `Sync` is not implemented for `(dyn Trait + 'static)`
-note: required by a bound in `FfiConverterArc`
- --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
-  |
-  | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
-  |                                              ^^^^ required by this bound in `FfiConverterArc`
-  = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: `(dyn Trait + 'static)` cannot be sent between threads safely
- --> $OUT_DIR[uniffi_uitests]/trait.uniffi.rs
-  |
-  | #[::uniffi::export_for_udl]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Trait + 'static)` cannot be sent between threads safely
-  |
-  = help: the trait `Send` is not implemented for `(dyn Trait + 'static)`
-note: required by a bound in `FfiConverterArc`
- --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
-  |
-  | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
-  |                                       ^^^^ required by this bound in `FfiConverterArc`
-  = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0277]: `dyn ProcMacroTrait` cannot be shared between threads safely
   --> tests/ui/interface_trait_not_sync_and_send.rs:12:1
    |
@@ -80,32 +108,4 @@ note: required by a bound in `_::{closure#0}::assert_impl_all`
    |
 12 | #[uniffi::export]
    | ^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
-   = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: `(dyn ProcMacroTrait + 'static)` cannot be shared between threads safely
-  --> tests/ui/interface_trait_not_sync_and_send.rs:12:1
-   |
-12 | #[uniffi::export]
-   | ^^^^^^^^^^^^^^^^^ `(dyn ProcMacroTrait + 'static)` cannot be shared between threads safely
-   |
-   = help: the trait `Sync` is not implemented for `(dyn ProcMacroTrait + 'static)`
-note: required by a bound in `FfiConverterArc`
-  --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
-   |
-   | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
-   |                                              ^^^^ required by this bound in `FfiConverterArc`
-   = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: `(dyn ProcMacroTrait + 'static)` cannot be sent between threads safely
-  --> tests/ui/interface_trait_not_sync_and_send.rs:12:1
-   |
-12 | #[uniffi::export]
-   | ^^^^^^^^^^^^^^^^^ `(dyn ProcMacroTrait + 'static)` cannot be sent between threads safely
-   |
-   = help: the trait `Send` is not implemented for `(dyn ProcMacroTrait + 'static)`
-note: required by a bound in `FfiConverterArc`
-  --> $WORKSPACE/uniffi_core/src/ffi_converter_traits.rs
-   |
-   | pub unsafe trait FfiConverterArc<UT>: Send + Sync {
-   |                                       ^^^^ required by this bound in `FfiConverterArc`
    = note: this error originates in the attribute macro `uniffi::export` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
+++ b/fixtures/uitests/tests/ui/non_hashable_record_key.stderr
@@ -1,3 +1,43 @@
+error[E0277]: the trait bound `f32: Hash` is not satisfied
+ --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
+  |
+  | #[::uniffi::export_for_udl]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Hash` is not implemented for `f32`
+  |
+  = help: the following other types implement trait `Hash`:
+            i128
+            i16
+            i32
+            i64
+            i8
+            isize
+            u128
+            u16
+          and $N others
+  = note: required for `HashMap<f32, u64>` to implement `uniffi::Lower<UniFfiTag>`
+  = note: required for `HashMap<f32, u64>` to implement `LowerReturn<UniFfiTag>`
+  = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
+ --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
+  |
+  | #[::uniffi::export_for_udl]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `f32`
+  |
+  = help: the following other types implement trait `std::cmp::Eq`:
+            i128
+            i16
+            i32
+            i64
+            i8
+            isize
+            u128
+            u16
+          and $N others
+  = note: required for `HashMap<f32, u64>` to implement `uniffi::Lower<UniFfiTag>`
+  = note: required for `HashMap<f32, u64>` to implement `LowerReturn<UniFfiTag>`
+  = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
  --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
   |
@@ -43,46 +83,6 @@ note: required by a bound in `assert_impl_all`
   | uniffi::deps::static_assertions::assert_impl_all!(f32: ::std::cmp::Eq, ::std::hash::Hash); // record<f32, u64>
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
   = note: this error originates in the macro `uniffi::deps::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `f32: Hash` is not satisfied
- --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
-  |
-  | #[::uniffi::export_for_udl]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Hash` is not implemented for `f32`
-  |
-  = help: the following other types implement trait `Hash`:
-            i128
-            i16
-            i32
-            i64
-            i8
-            isize
-            u128
-            u16
-          and $N others
-  = note: required for `HashMap<f32, u64>` to implement `uniffi::Lower<UniFfiTag>`
-  = note: required for `HashMap<f32, u64>` to implement `LowerReturn<UniFfiTag>`
-  = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `f32: std::cmp::Eq` is not satisfied
- --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs
-  |
-  | #[::uniffi::export_for_udl]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `f32`
-  |
-  = help: the following other types implement trait `std::cmp::Eq`:
-            i128
-            i16
-            i32
-            i64
-            i8
-            isize
-            u128
-            u16
-          and $N others
-  = note: required for `HashMap<f32, u64>` to implement `uniffi::Lower<UniFfiTag>`
-  = note: required for `HashMap<f32, u64>` to implement `LowerReturn<UniFfiTag>`
-  = note: this error originates in the attribute macro `::uniffi::export_for_udl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `f32: Hash` is not satisfied
  --> $OUT_DIR[uniffi_uitests]/records.uniffi.rs

--- a/fixtures/uitests/tests/ui/trait_methods_no_trait.stderr
+++ b/fixtures/uitests/tests/ui/trait_methods_no_trait.stderr
@@ -1,11 +1,20 @@
 error[E0277]: `UdlEnum` doesn't implement `std::fmt::Display`
  --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
   |
-  | enum r#UdlEnum {
-  |      ^^^^^^^^^ `UdlEnum` cannot be formatted with the default formatter
+  | #[::uniffi::export_for_udl_derive(Display)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UdlEnum` cannot be formatted with the default formatter
   |
   = help: the trait `std::fmt::Display` is not implemented for `UdlEnum`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+  = note: required for `&UdlEnum` to implement `std::fmt::Display`
+  = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the attribute macro `::uniffi::export_for_udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `UdlEnum` doesn't implement `std::fmt::Display`
+ --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
+  |
+  | enum r#UdlEnum {
+  |      ^^^^^^^^^ the trait `std::fmt::Display` is not implemented for `UdlEnum`
+  |
 note: required by a bound in `UdlEnum::uniffi_trait_display::_::{closure#0}::assert_impl_all`
  --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
   |
@@ -16,34 +25,23 @@ note: required by a bound in `UdlEnum::uniffi_trait_display::_::{closure#0}::ass
 error[E0277]: `TraitMethods` doesn't implement `std::fmt::Display`
  --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
   |
-  | struct r#TraitMethods { }
-  |        ^^^^^^^^^^^^^^ `TraitMethods` cannot be formatted with the default formatter
+  | #[::uniffi::export_for_udl_derive(Display)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `TraitMethods` cannot be formatted with the default formatter
   |
   = help: the trait `std::fmt::Display` is not implemented for `TraitMethods`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+  = note: required for `&TraitMethods` to implement `std::fmt::Display`
+  = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the attribute macro `::uniffi::export_for_udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `TraitMethods` doesn't implement `std::fmt::Display`
+ --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
+  |
+  | struct r#TraitMethods { }
+  |        ^^^^^^^^^^^^^^ the trait `std::fmt::Display` is not implemented for `TraitMethods`
+  |
 note: required by a bound in `TraitMethods::uniffi_trait_display::_::{closure#0}::assert_impl_all`
  --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
   |
   | #[::uniffi::export_for_udl_derive(Display)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
   = note: this error originates in the macro `::uniffi::deps::static_assertions::assert_impl_all` which comes from the expansion of the attribute macro `::uniffi::export_for_udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: `UdlEnum` doesn't implement `std::fmt::Display`
- --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
-  |
-  | #[::uniffi::export_for_udl_derive(Display)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UdlEnum` cannot be formatted with the default formatter
-  |
-  = help: the trait `std::fmt::Display` is not implemented for `UdlEnum`
-  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-  = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the attribute macro `::uniffi::export_for_udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: `TraitMethods` doesn't implement `std::fmt::Display`
- --> $OUT_DIR[uniffi_uitests]/trait_methods.uniffi.rs
-  |
-  | #[::uniffi::export_for_udl_derive(Display)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `TraitMethods` cannot be formatted with the default formatter
-  |
-  = help: the trait `std::fmt::Display` is not implemented for `TraitMethods`
-  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-  = note: this error originates in the macro `$crate::__export::format_args` which comes from the expansion of the attribute macro `::uniffi::export_for_udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # * ./.circleci/config.yml which also specifies the rust versions used in CI.
 
 [toolchain]
-channel = "1.85.0"
+channel = "1.90.0"
 targets = [
     "aarch64-linux-android",
     "armv7-linux-androideabi",

--- a/uniffi/tests/ui/proc_macro_arc.stderr
+++ b/uniffi/tests/ui/proc_macro_arc.stderr
@@ -78,5 +78,5 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 22 ~         match &*foo {
 23 +             _ => todo!(),
-24 +         }
+24 ~         }
    |

--- a/uniffi/tests/ui/version_mismatch.stderr
+++ b/uniffi/tests/ui/version_mismatch.stderr
@@ -1,7 +1,7 @@
-error[E0080]: evaluation of constant value failed
+error[E0080]: attempt to compute `0_usize - 1_usize`, which would overflow
  --> tests/ui/version_mismatch.rs:2:1
   |
 2 | uniffi::assert_compatible_version!("0.0.1"); // An error message would go here.
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_::{constant#0}` failed here
   |
   = note: this error originates in the macro `uniffi::deps::static_assertions::const_assert` which comes from the expansion of the macro `uniffi::assert_compatible_version` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -441,9 +441,11 @@ impl KotlinCodeOracle {
     fn class_name(&self, ci: &ComponentInterface, nm: &str) -> String {
         let name = nm.to_string().to_upper_camel_case();
         // fixup errors.
-        ci.is_name_used_as_error(nm)
-            .then(|| self.convert_error_suffix(&name))
-            .unwrap_or(name)
+        if ci.is_name_used_as_error(nm) {
+            self.convert_error_suffix(&name)
+        } else {
+            name
+        }
     }
 
     fn convert_error_suffix(&self, nm: &str) -> String {

--- a/uniffi_bindgen/src/bindings/python/pipeline/nodes.rs
+++ b/uniffi_bindgen/src/bindings/python/pipeline/nodes.rs
@@ -116,6 +116,7 @@ pub struct Callable {
     pub ffi_func: RustFfiFunctionName,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Node, Eq, PartialEq, Hash)]
 pub enum CallableKind {
     /// Toplevel function

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -636,6 +636,7 @@ impl Method {
 }
 
 /// The list of traits we support generating helper methods for.
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Checksum)]
 pub enum UniffiTrait {
     Debug { fmt: Method },

--- a/uniffi_bindgen/src/pipeline/general/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/general/nodes.rs
@@ -313,6 +313,7 @@ pub struct VTableMethod {
     pub ffi_type: FfiTypeNode,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Node)]
 pub enum UniffiTrait {
     Debug { fmt: Method },

--- a/uniffi_bindgen/src/pipeline/initial/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/initial/nodes.rs
@@ -199,6 +199,7 @@ pub struct CallbackInterface {
     pub methods: Vec<Method>,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Node, PartialEq, Eq)]
 #[node(from(UniffiTraitMetadata))]
 pub enum UniffiTrait {

--- a/uniffi_internal_macros/src/checksum.rs
+++ b/uniffi_internal_macros/src/checksum.rs
@@ -101,7 +101,7 @@ pub fn expand_derive(input: DeriveInput) -> TokenStream {
                 .fields
                 .iter()
                 .enumerate()
-                .filter(|&(_num, field)| (!has_ignore_attribute(&field.attrs)))
+                .filter(|&(_num, field)| !has_ignore_attribute(&field.attrs))
                 .map(|(num, field)| match field.ident.as_ref() {
                     Some(ident) => quote! { Checksum::checksum(&self.#ident, state); },
                     None => {

--- a/uniffi_internal_macros/src/ir/ast.rs
+++ b/uniffi_internal_macros/src/ir/ast.rs
@@ -19,6 +19,7 @@ pub struct Node {
     pub def: NodeDef,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
 pub enum NodeDef {
     Struct(Struct),

--- a/uniffi_macros/src/fnsig.rs
+++ b/uniffi_macros/src/fnsig.rs
@@ -415,6 +415,7 @@ pub(crate) struct Arg {
     pub(crate) kind: ArgKind,
 }
 
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum ArgKind {
     Receiver(ReceiverArg),
     Named(NamedArg),

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -416,6 +416,7 @@ impl ObjectMetadata {
 /// The list of "builtin" traits we support generating helper methods for.
 /// Some interesting overlap with ObjectTraitImplMetadata, but quite different
 /// implementations for now.
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Node)]
 pub enum UniffiTraitMetadata {
     Debug {
@@ -528,6 +529,7 @@ pub fn checksum<T: Checksum>(val: &T) -> u16 {
 }
 
 /// Enum covering all the possible metadata types
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Node)]
 pub enum Metadata {
     Namespace(NamespaceMetadata),

--- a/uniffi_testing/src/lib.rs
+++ b/uniffi_testing/src/lib.rs
@@ -64,7 +64,7 @@ impl UniFFITestHelper {
         let cdylib_targets: Vec<&Target> = package
             .targets
             .iter()
-            .filter(|t| t.crate_types.iter().any(|t| *t == CrateType::CDyLib))
+            .filter(|t| t.crate_types.contains(&CrateType::CDyLib))
             .collect();
         let target = match cdylib_targets.len() {
             1 => cdylib_targets[0],


### PR DESCRIPTION
This caused quite a few warnings for `large_enum_variant` - these aren't entirely trivial to fix, but seem worth avoiding in the future, so I whitelisted all individually.