### PR TITLE
Replace more BindgenCrateConfigSupplier with BindgenPaths, and allow …

### DIFF
--- a/uniffi_bindgen/src/bindings/mod.rs
+++ b/uniffi_bindgen/src/bindings/mod.rs
@@ -43,9 +43,16 @@ impl Default for RunScriptOptions {
 
 /// Generate bindings
 ///
-/// This implements the uniffi-bindgen command
+/// This implements the default uniffi-bindgen command
 pub fn generate(options: GenerateOptions) -> Result<()> {
-    let mut paths = BindgenPaths::default();
+    generate_with_bindgen_paths(options, BindgenPaths::default())
+}
+
+/// Generate bindings with custom bindgen paths.
+pub fn generate_with_bindgen_paths(
+    options: GenerateOptions,
+    mut paths: BindgenPaths,
+) -> Result<()> {
     if let Some(path) = &options.config_override {
         paths.add_config_override_layer(path.clone());
     }

--- a/uniffi_bindgen/src/bindings/python/test.rs
+++ b/uniffi_bindgen/src/bindings/python/test.rs
@@ -40,8 +40,9 @@ pub fn run_script(
     let cdylib_path = test_helper.copy_cdylib_to_out_dir(&out_dir)?;
 
     // Generate bindings
-    let config_supplier = CrateConfigSupplier::from(test_helper.cargo_metadata());
-    let root = initial::Root::from_library(config_supplier, &cdylib_path, None)?;
+    let mut paths = crate::BindgenPaths::default();
+    paths.add_layer(CrateConfigSupplier::from(test_helper.cargo_metadata()));
+    let root = initial::Root::from_library(paths, &cdylib_path, None)?;
     run_pipeline(root, &out_dir)?;
 
     // Run the python script


### PR DESCRIPTION
…BindgenPaths to be specified when generating.

The real thing we care about for a-s is the new `generate_with_bindgen_paths`, but I also noted the pipeline printer still used the deprecated `BindgenCrateConfigSupplier`, so I changed that to also use `BindgenPaths`.