### PR TITLE
Update BindgenPathsLayer so it supplies the TOML directly rather than…

### DIFF
--- a/uniffi_bindgen/src/loader.rs
+++ b/uniffi_bindgen/src/loader.rs
@@ -210,12 +210,12 @@ impl BindgenLoader {
     ) -> Result<pipeline::initial::Root> {
         let mut metadata_converter = pipeline::initial::UniffiMetaConverter::default();
         for metadata_group in metadata.into_values() {
-            if let Some(path) = self
+            let table = self
                 .bindgen_paths
-                .get_config_path(&metadata_group.namespace.crate_name)
-            {
+                .get_config(&metadata_group.namespace.crate_name)?;
+            if !table.is_empty() {
                 metadata_converter
-                    .add_module_config_toml(metadata_group.namespace.name.clone(), &path)?;
+                    .add_module_config_toml(metadata_group.namespace.name.clone(), table)?;
             }
             if let Some(docstring) = metadata_group.namespace_docstring {
                 metadata_converter

--- a/uniffi_bindgen/src/pipeline/initial/mod.rs
+++ b/uniffi_bindgen/src/pipeline/initial/mod.rs
@@ -42,8 +42,9 @@ impl Root {
                     ));
                 }
                 uniffi_meta::Metadata::Namespace(namespace) => {
-                    if let Some(path) = bindgen_paths.get_config_path(&namespace.crate_name) {
-                        metadata_converter.add_module_config_toml(namespace.name.clone(), &path)?;
+                    let table = bindgen_paths.get_config(&namespace.crate_name)?;
+                    if !table.is_empty() {
+                        metadata_converter.add_module_config_toml(namespace.name.clone(), table)?;
                     }
                     metadata_converter
                         .add_metadata_item(uniffi_meta::Metadata::Namespace(namespace))?;
@@ -101,10 +102,10 @@ impl Root {
                 .add_module_docstring(metadata_group.namespace.name.clone(), docstring)?;
         }
         if !library_mode {
-            if let Some(path) = bindgen_paths.get_config_path(&metadata_group.namespace.crate_name)
-            {
+            let table = bindgen_paths.get_config(&metadata_group.namespace.crate_name)?;
+            if !table.is_empty() {
                 metadata_converter
-                    .add_module_config_toml(metadata_group.namespace.name.clone(), &path)?;
+                    .add_module_config_toml(metadata_group.namespace.name.clone(), table)?;
             }
         }
         metadata_converter


### PR DESCRIPTION
… a path

As Ben and I discussed - at least I think this is what we said 😅 

This has kinda made the name `BindgenPathsLayer` not ideal, but I think it's OK - the intent is still that it abstracts away the need for uniffi to know all the paths, even if this method isn't working directly with paths. Renaming might make sense though if you think?

This seems to work fine with gecko, although I've another issue there I think is unrelated.
