### PR TITLE
HandleKind::Interface now carries an ObjectImpl, because JS cares wha…

### DIFF
--- a/uniffi_bindgen/src/bindings/python/pipeline/nodes.rs
+++ b/uniffi_bindgen/src/bindings/python/pipeline/nodes.rs
@@ -617,7 +617,11 @@ pub enum HandleKind {
     RustFuture,
     ForeignFuture,
     ForeignFutureCallbackData,
-    Interface {
+    StructInterface {
+        module_name: String,
+        interface_name: String,
+    },
+    TraitInterface {
         module_name: String,
         interface_name: String,
     },

--- a/uniffi_bindgen/src/pipeline/general/callable.rs
+++ b/uniffi_bindgen/src/pipeline/general/callable.rs
@@ -56,7 +56,7 @@ pub fn pass(root: &mut Root) -> Result<()> {
         let namespace_name = namespace.name.clone();
         namespace.visit_mut(|int: &mut Interface| {
             let interface_name = int.name.clone();
-            let interface_imp = int.imp.clone();
+            let interface_imp = int.imp;
             let self_type = int.self_type.clone();
             int.visit_mut(|cons: &mut Constructor| {
                 cons.callable = Callable {
@@ -72,7 +72,7 @@ pub fn pass(root: &mut Root) -> Result<()> {
                             ty: Type::Interface {
                                 namespace: namespace_name.clone(),
                                 name: interface_name.clone(),
-                                imp: interface_imp.clone(),
+                                imp: interface_imp,
                             },
                             ..TypeNode::default()
                         }),

--- a/uniffi_bindgen/src/pipeline/general/callback_interfaces.rs
+++ b/uniffi_bindgen/src/pipeline/general/callback_interfaces.rs
@@ -102,7 +102,7 @@ fn add_vtable_ffi_definitions(namespace: &mut Namespace) -> Result<()> {
     let module_name = namespace.name.clone();
     namespace.try_visit(|vtable: &VTable| {
         let interface_name = &vtable.interface_name;
-        let handle_type = FfiType::Handle(HandleKind::Interface {
+        let handle_type = FfiType::Handle(HandleKind::TraitInterface {
             namespace: module_name.to_string(),
             interface_name: interface_name.to_string(),
         });
@@ -265,7 +265,7 @@ fn vtable_method(
         name: FfiFunctionTypeName(method_name),
         arguments: std::iter::once(FfiArgument {
             name: "uniffi_handle".into(),
-            ty: FfiType::Handle(HandleKind::Interface {
+            ty: FfiType::Handle(HandleKind::TraitInterface {
                 namespace: module_name.to_string(),
                 interface_name: interface_name.to_string(),
             })
@@ -303,7 +303,7 @@ fn vtable_method_async(
         name: FfiFunctionTypeName(method_name),
         arguments: std::iter::once(FfiArgument {
             name: "uniffi_handle".into(),
-            ty: FfiType::Handle(HandleKind::Interface {
+            ty: FfiType::Handle(HandleKind::TraitInterface {
                 namespace: module_name.to_string(),
                 interface_name: interface_name.to_string(),
             })

--- a/uniffi_bindgen/src/pipeline/general/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/general/nodes.rs
@@ -441,7 +441,7 @@ pub enum Type {
     },
 }
 
-#[derive(Debug, Clone, Node, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Node, PartialEq, Eq, Hash)]
 pub enum ObjectImpl {
     // A single Rust type
     Struct,
@@ -586,7 +586,11 @@ pub enum HandleKind {
     ForeignFuture,
     ForeignFutureCallbackData,
     // Interface, trait interface, or callback interface
-    Interface {
+    StructInterface {
+        namespace: String,
+        interface_name: String,
+    },
+    TraitInterface {
         namespace: String,
         interface_name: String,
     },
@@ -683,5 +687,9 @@ impl Type {
 impl ObjectImpl {
     pub fn has_callback_interface(&self) -> bool {
         matches!(self, Self::CallbackTrait)
+    }
+
+    pub fn has_struct(&self) -> bool {
+        matches!(self, Self::Struct)
     }
 }

--- a/uniffi_bindgen/src/pipeline/general/objects.rs
+++ b/uniffi_bindgen/src/pipeline/general/objects.rs
@@ -21,17 +21,31 @@ pub fn pass(namespace: &mut Namespace) -> Result<()> {
                 is_async: false,
                 arguments: vec![FfiArgument {
                     name: "ptr".to_string(),
-                    ty: FfiType::Handle(HandleKind::Interface {
-                        namespace: namespace_name.clone(),
-                        interface_name: int.name.to_string(),
+                    ty: FfiType::Handle(if int.imp.has_struct() {
+                        HandleKind::StructInterface {
+                            namespace: namespace_name.clone(),
+                            interface_name: int.name.to_string(),
+                        }
+                    } else {
+                        HandleKind::TraitInterface {
+                            namespace: namespace_name.clone(),
+                            interface_name: int.name.to_string(),
+                        }
                     })
                     .into(),
                 }],
                 return_type: FfiReturnType {
                     ty: Some(
-                        FfiType::Handle(HandleKind::Interface {
-                            namespace: namespace_name.clone(),
-                            interface_name: int.name.to_string(),
+                        FfiType::Handle(if int.imp.has_struct() {
+                            HandleKind::StructInterface {
+                                namespace: namespace_name.clone(),
+                                interface_name: int.name.to_string(),
+                            }
+                        } else {
+                            HandleKind::TraitInterface {
+                                namespace: namespace_name.clone(),
+                                interface_name: int.name.to_string(),
+                            }
                         })
                         .into(),
                     ),
@@ -48,9 +62,16 @@ pub fn pass(namespace: &mut Namespace) -> Result<()> {
                 is_async: false,
                 arguments: vec![FfiArgument {
                     name: "ptr".to_string(),
-                    ty: FfiType::Handle(HandleKind::Interface {
-                        namespace: namespace_name.clone(),
-                        interface_name: int.name.to_string(),
+                    ty: FfiType::Handle(if int.imp.has_struct() {
+                        HandleKind::StructInterface {
+                            namespace: namespace_name.clone(),
+                            interface_name: int.name.to_string(),
+                        }
+                    } else {
+                        HandleKind::TraitInterface {
+                            namespace: namespace_name.clone(),
+                            interface_name: int.name.to_string(),
+                        }
                     })
                     .into(),
                 }],

--- a/uniffi_bindgen/src/pipeline/general/rust_future.rs
+++ b/uniffi_bindgen/src/pipeline/general/rust_future.rs
@@ -57,7 +57,14 @@ pub fn pass(namespace: &mut Namespace) -> Result<()> {
         (Some(FfiType::Float32), "f32"),
         (Some(FfiType::Float64), "f64"),
         (
-            Some(FfiType::Handle(HandleKind::Interface {
+            Some(FfiType::Handle(HandleKind::StructInterface {
+                namespace: "".into(),
+                interface_name: "".into(),
+            })),
+            "u64",
+        ),
+        (
+            Some(FfiType::Handle(HandleKind::TraitInterface {
                 namespace: "".into(),
                 interface_name: "".into(),
             })),

--- a/uniffi_bindgen/src/pipeline/general/self_types.rs
+++ b/uniffi_bindgen/src/pipeline/general/self_types.rs
@@ -32,7 +32,7 @@ pub fn pass(namespace: &mut Namespace) -> Result<()> {
             ty: Type::Interface {
                 namespace: namespace_name.clone(),
                 name: int.name.clone(),
-                imp: int.imp.clone(),
+                imp: int.imp,
             },
             ..TypeNode::default()
         };


### PR DESCRIPTION
…t the impl is

@bendk I think this is what we discussed - as you'll see in the patch, I think that either using `ObjectImpl` is wrong, or what this patch needs more work so that it always gets the precise variant in the places where today it doesn't know what it is.

Seems to work with js, although I've not actually tested it 😅 