### PR TITLE
Remove redundant toLong() conversion method call

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RustBufferTemplate.kt
@@ -47,7 +47,7 @@ open class RustBuffer : Structure() {
 
     @Suppress("TooGenericExceptionThrown")
     fun asByteBuffer() =
-        this.data?.getByteBuffer(0, this.len.toLong())?.also {
+        this.data?.getByteBuffer(0, this.len)?.also {
             it.order(ByteOrder.BIG_ENDIAN)
         }
 }


### PR DESCRIPTION
Fixes a new warning introduced in Kotlin 2.3.

I just merged @ryanvm's PR into the 0.29 branch, let's also get it on main.