### PR TITLE
Bump MSR to 1.87

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ commands:
   # Our minimum supported rust version is specified here.
   prepare-rust-min-version:
     steps:
-      - run: rustup override set 1.82.0
+      - run: rustup override set 1.87.0
       - run: rustup update
   build-api-docs:
     steps:
@@ -41,7 +41,7 @@ orbs:
 jobs:
   Check Rust formatting:
     docker:
-      - image: cimg/rust:1.77.1
+      - image: cimg/rust:1.90
     resource_class: small
     steps:
       - checkout
@@ -51,7 +51,7 @@ jobs:
       - run: cargo fmt -- --check
   Lint Rust with clippy:
     docker:
-      - image: cimg/rust:1.77.1
+      - image: cimg/rust:1.90
     resource_class: large
     steps:
       - checkout
@@ -68,7 +68,7 @@ jobs:
             done
   Lint Rust Docs:
     docker:
-      - image: cimg/rust:1.77.1
+      - image: cimg/rust:1.90
     resource_class: small
     steps:
       - checkout
@@ -132,7 +132,7 @@ jobs:
       - run: cargo test -- --skip trybuild_ui_tests
   Deploy website:
     docker:
-      - image: cimg/rust:1.77.1
+      - image: cimg/rust:1.90
     resource_class: small
     steps:
       - checkout


### PR DESCRIPTION
Also updates the "bootstrap" version used by CI, which shouldn't actually change anything as we always use rustup to get the "final" version anyway - but it might make a few things a bit faster as less things need updating.