### PR TITLE
Ignore any other doc annotation when trying to parse doc comments

### DIFF
--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -20,6 +20,9 @@ mod one {
         fn get_inner_value(&self) -> i32 {
             self.inner
         }
+
+        #[doc(hidden)]
+        fn parses_with_doc_attribute(&self) {}
     }
 }
 pub use one::*;


### PR DESCRIPTION
Fixes #2776

---

This fixes the immediate issue.
Looking at the code we maybe might be able to change it further and completely remove the error case there.
I don't think it can even occur still?