### PR TITLE
Count an async constructor as an async method for an async-exported impl

### DIFF
--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -499,4 +499,16 @@ async fn cancel_delay_using_trait(obj: Arc<dyn AsyncParser>, delay_ms: i32) {
     assert_eq!(future.await, Err(Aborted));
 }
 
+/// A test object with no (async) methods.
+#[derive(uniffi::Object)]
+pub struct TestObject;
+
+#[uniffi::export(async_runtime = "tokio")]
+impl TestObject {
+    #[uniffi::constructor]
+    pub async fn new() -> Self {
+        Self
+    }
+}
+
 uniffi::include_scaffolding!("futures");

--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -55,10 +55,12 @@ pub(crate) fn expand_export(
             trait_,
         } => {
             if let Some(rt) = &args.async_runtime {
-                if items
-                    .iter()
-                    .all(|item| !matches!(item, ImplItem::Method(sig) if sig.is_async))
-                {
+                let has_async_methods = items.iter().any(|item| {
+                    matches!(item, ImplItem::Method(sig) if sig.is_async)
+                        || matches!(item, ImplItem::Constructor(sig) if sig.is_async)
+                });
+
+                if !has_async_methods {
                     return Err(syn::Error::new_spanned(
                         rt,
                         "no async methods in this impl block",


### PR DESCRIPTION
Fixes #2775