### PR TITLE
Fix the --crate flag (try 2)

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/mod.rs
@@ -31,6 +31,12 @@ pub fn generate(loader: &BindgenLoader, options: GenerateOptions) -> Result<()> 
     }
 
     for Component { ci, config, .. } in components {
+        if let Some(crate_filter) = &options.crate_filter {
+            if ci.crate_name() != crate_filter {
+                continue;
+            }
+        }
+
         let mut kt_file = full_bindings_path(&config, &options.out_dir);
         fs::create_dir_all(&kt_file)?;
         kt_file.push(format!("{}.kt", ci.namespace()));

--- a/uniffi_bindgen/src/bindings/kotlin/test.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/test.rs
@@ -42,7 +42,6 @@ pub fn run_script(
         languages: vec![TargetLanguage::Kotlin],
         source: cdylib_path.to_path_buf(),
         out_dir: out_dir.to_path_buf(),
-        crate_filter: Some(crate_name.to_string()),
         ..GenerateOptions::default()
     })?;
     let jar_file = build_jar(crate_name, &out_dir, options)?;

--- a/uniffi_bindgen/src/bindings/python/test.rs
+++ b/uniffi_bindgen/src/bindings/python/test.rs
@@ -43,7 +43,7 @@ pub fn run_script(
     let mut paths = crate::BindgenPaths::default();
     paths.add_layer(CrateConfigSupplier::from(test_helper.cargo_metadata()));
     let root = initial::Root::from_library(paths, &cdylib_path, None)?;
-    run_pipeline(root, &out_dir)?;
+    run_pipeline(root, &out_dir, None)?;
 
     // Run the python script
     let pythonpath = env::var_os("PYTHONPATH").unwrap_or_else(|| OsString::from(""));

--- a/uniffi_bindgen/src/bindings/ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/mod.rs
@@ -23,6 +23,11 @@ pub fn generate(loader: &BindgenLoader, options: GenerateOptions) -> Result<()> 
         c.ci.derive_ffi_funcs()?;
     }
     for Component { ci, config, .. } in components {
+        if let Some(crate_filter) = &options.crate_filter {
+            if ci.crate_name() != crate_filter {
+                continue;
+            }
+        }
         let rb_file = options.out_dir.join(format!("{}.rb", ci.namespace()));
         fs::write(&rb_file, generate_ruby_bindings(&config, &ci)?)?;
 

--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -73,6 +73,11 @@ pub fn generate(
     }
 
     for Component { ci, config, .. } in components.iter_mut() {
+        if let Some(crate_filter) = &options.crate_filter {
+            if ci.crate_name() != crate_filter {
+                continue;
+            }
+        }
         let Bindings {
             header,
             library,

--- a/uniffi_bindgen/src/bindings/swift/test.rs
+++ b/uniffi_bindgen/src/bindings/swift/test.rs
@@ -148,7 +148,6 @@ impl GeneratedSources {
                 languages: vec![TargetLanguage::Swift],
                 source: cdylib_path.to_path_buf(),
                 out_dir: out_dir.to_path_buf(),
-                crate_filter: Some(crate_name.to_string()),
                 ..GenerateOptions::default()
             },
         )?;

--- a/uniffi_bindgen/src/loader.rs
+++ b/uniffi_bindgen/src/loader.rs
@@ -261,8 +261,4 @@ impl BindgenLoader {
         let is_library = !self.is_udl(source_path);
         is_library.then(|| self.source_basename(source_path))
     }
-
-    pub fn filter_metadata_by_crate_name(&self, metadata: &mut MetadataGroupMap, crate_name: &str) {
-        metadata.retain(|_, metadata_group| metadata_group.namespace.crate_name == crate_name)
-    }
 }


### PR DESCRIPTION
Better fix for the --crate flag.  Don't filter things until later on, once external type info has been setup.
