### PR TITLE
Replace `java.time` with `kotlin.time` for duration and instant

### DIFF
--- a/fixtures/uniffi-fixture-time/tests/bindings/test_chronological.kts
+++ b/fixtures/uniffi-fixture-time/tests/bindings/test_chronological.kts
@@ -1,36 +1,37 @@
 import uniffi.chronological.*;
-import java.time.Duration
-import java.time.Instant
-import java.time.DateTimeException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 // Test passing timestamp and duration while returning timestamp
-assert(add(Instant.ofEpochSecond(100, 100), Duration.ofSeconds(1, 1))
-        .equals(Instant.ofEpochSecond(101, 101)))
+assert(add(Instant.fromEpochSeconds(100, 100), 1.seconds + 1.nanoseconds)
+        .equals(Instant.fromEpochSeconds(101, 101)))
 
 // Test passing timestamp while returning duration
-assert(diff(Instant.ofEpochSecond(101, 101), Instant.ofEpochSecond(100, 100))
-        .equals(Duration.ofSeconds(1, 1)))
+assert(diff(Instant.fromEpochSeconds(101, 101), Instant.fromEpochSeconds(100, 100))
+        .equals(1.seconds + 1.nanoseconds))
 
 // Test pre-epoch timestamps
-assert(add(Instant.parse("1955-11-05T00:06:00.283000001Z"), Duration.ofSeconds(1, 1))
+assert(add(Instant.parse("1955-11-05T00:06:00.283000001Z"), 1.seconds + 1.nanoseconds)
         .equals(Instant.parse("1955-11-05T00:06:01.283000002Z")))
 
 // Test exceptions are propagated
 try {
-        diff(Instant.ofEpochSecond(100), Instant.ofEpochSecond(101))
+        diff(Instant.fromEpochSeconds(100), Instant.fromEpochSeconds(101))
         throw RuntimeException("Should have thrown a TimeDiffError exception!")
 } catch (e: ChronologicalException) {
         // It's okay!
 }
 
 // Test max Instant upper bound
-assert(add(Instant.MAX, Duration.ofSeconds(0)).equals(Instant.MAX))
+assert(add(Instant.MAX, 0.seconds).equals(Instant.MAX))
 
 // Test max Instant upper bound overflow
 try {
-        add(Instant.MAX, Duration.ofSeconds(1))
-        throw RuntimeException("Should have thrown a DateTimeException exception!")
-} catch (e: DateTimeException) {
+        add(Instant.MAX, 1.seconds)
+        throw RuntimeException("Should have thrown an IllegalArgumentException exception!")
+} catch (e: IllegalArgumentException) {
         // It's okay!
 }
 
@@ -47,6 +48,6 @@ assert(kotlinBefore.isBefore(rustNow))
 assert(kotlinAfter.isAfter(rustNow))
 
 // Test optional values work
-assert(optional(Instant.MAX, Duration.ofSeconds(0)))
-assert(optional(null, Duration.ofSeconds(0)) == false)
+assert(optional(Instant.MAX, 0.seconds))
+assert(optional(null, 0.seconds) == false)
 assert(optional(Instant.MAX, null) == false)

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/miscellany.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/miscellany.rs
@@ -22,6 +22,6 @@ macro_rules! impl_code_type_for_miscellany {
     };
 }
 
-impl_code_type_for_miscellany!(TimestampCodeType, "java.time.Instant", "Timestamp");
+impl_code_type_for_miscellany!(TimestampCodeType, "kotlin.time.Instant", "Timestamp");
 
-impl_code_type_for_miscellany!(DurationCodeType, "java.time.Duration", "Duration");
+impl_code_type_for_miscellany!(DurationCodeType, "kotlin.time.Duration", "Duration");

--- a/uniffi_bindgen/src/bindings/kotlin/templates/DurationHelper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/DurationHelper.kt
@@ -1,39 +1,40 @@
 /**
  * @suppress
  */
-public object FfiConverterDuration: FfiConverterRustBuffer<java.time.Duration> {
-    override fun read(buf: ByteBuffer): java.time.Duration {
+public object FfiConverterDuration: FfiConverterRustBuffer<kotlin.time.Duration> {
+    override fun read(buf: ByteBuffer): kotlin.time.Duration {
         // Type mismatch (should be u64) but we check for overflow/underflow below
         val seconds = buf.getLong()
         // Type mismatch (should be u32) but we check for overflow/underflow below
         val nanoseconds = buf.getInt().toLong()
         if (seconds < 0) {
-            throw java.time.DateTimeException("Duration exceeds minimum or maximum value supported by uniffi")
+            throw IllegalArgumentException("Duration exceeds minimum or maximum value supported by uniffi")
         }
         if (nanoseconds < 0) {
-            throw java.time.DateTimeException("Duration nanoseconds exceed minimum or maximum supported by uniffi")
+            throw IllegalArgumentException("Duration nanoseconds exceed minimum or maximum supported by uniffi")
         }
-        return java.time.Duration.ofSeconds(seconds, nanoseconds)
+        return seconds.toDuration(kotlin.time.DurationUnit.SECONDS) + nanoseconds.toDuration(kotlin.time.DurationUnit.NANOSECONDS)
     }
 
     // 8 bytes for seconds, 4 bytes for nanoseconds
-    override fun allocationSize(value: java.time.Duration) = 12UL
+    override fun allocationSize(value: kotlin.time.Duration) = 12UL
 
-    override fun write(value: java.time.Duration, buf: ByteBuffer) {
-        if (value.seconds < 0) {
+    override fun write(value: kotlin.time.Duration, buf: ByteBuffer) {
+        val seconds = value.inWholeSeconds
+        if (seconds < 0) {
             // Rust does not support negative Durations
             throw IllegalArgumentException("Invalid duration, must be non-negative")
         }
 
-        if (value.nano < 0) {
-            // Java docs provide guarantee that nano will always be positive, so this should be impossible
-            // See: https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html
+        val nanoseconds = value.inWholeNanoseconds
+        if (nanoseconds < 0) {
+            // This should be impossible for valid durations
             throw IllegalArgumentException("Invalid duration, nano value must be non-negative")
         }
 
         // Type mismatch (should be u64) but since Rust doesn't support negative durations we should be OK
-        buf.putLong(value.seconds)
+        buf.putLong(seconds)
         // Type mismatch (should be u32) but since values will always be between 0 and 999,999,999 it should be OK
-        buf.putInt(value.nano)
+        buf.putInt(nanoseconds.toInt())
     }
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/wrapper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/wrapper.kt
@@ -32,6 +32,7 @@ import java.nio.CharBuffer
 import java.nio.charset.CodingErrorAction
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.toDuration
 
 {%- for req in self.imports() %}
 {{ req.render() }}


### PR DESCRIPTION
Switch from `java.time.Duration` and `java.time.Instant` to `kotlin.time.Duration` and `kotlin.time.Instant` to avoid requiring Android API 26+.

Ref https://github.com/rust-nostr/nostr-sdk-ffi/issues/66