### PR TITLE
Config file support improvements

### DIFF
--- a/uniffi/src/cli/swift.rs
+++ b/uniffi/src/cli/swift.rs
@@ -37,6 +37,13 @@ struct Cli {
     /// What frameworks to link against when generating the modulemap file.
     #[arg(long)]
     link_frameworks: Vec<String>,
+    /// Path to optional uniffi config file. This config is merged with the `uniffi.toml` config present in each crate, with its values taking precedence.
+    #[clap(long, short)]
+    config: Option<Utf8PathBuf>,
+
+    /// Path to optional crate config file
+    #[clap(long)]
+    crate_metadata: Option<Utf8PathBuf>,
 }
 
 #[derive(Debug, Args)]
@@ -73,6 +80,8 @@ impl From<Cli> for SwiftBindingsOptions {
             modulemap_filename: cli.modulemap_filename,
             metadata_no_deps: cli.metadata_no_deps,
             link_frameworks: cli.link_frameworks,
+            config_override: cli.config,
+            crate_metadata: cli.crate_metadata,
         }
     }
 }

--- a/uniffi/src/cli/uniffi_bindgen.rs
+++ b/uniffi/src/cli/uniffi_bindgen.rs
@@ -75,6 +75,10 @@ enum Commands {
         #[clap(long, short)]
         config: Option<Utf8PathBuf>,
 
+        /// Path to optional crate config file
+        #[clap(long)]
+        crate_metadata: Option<Utf8PathBuf>,
+
         /// Deprecated
         ///
         /// This used to signal that a source file is a library rather than a UDL file.
@@ -171,6 +175,7 @@ pub fn run_main() -> anyhow::Result<()> {
             out_dir,
             no_format,
             config,
+            crate_metadata,
             source,
             crate_name,
             metadata_no_deps,
@@ -186,6 +191,7 @@ pub fn run_main() -> anyhow::Result<()> {
                     .expect("--out-dir is required when generating {language} bindings"),
                 source,
                 config_override: config,
+                crate_metadata,
                 crate_filter: crate_name,
                 metadata_no_deps,
                 format: !no_format,

--- a/uniffi_bindgen/src/bindgen_paths.rs
+++ b/uniffi_bindgen/src/bindgen_paths.rs
@@ -37,6 +37,14 @@ impl BindgenPaths {
         self.add_layer(ConfigOverrideLayer { path })
     }
 
+    /// Add a layer that uses a "crate metadata", a kind of "meta toml" file to lookup path locations for crate names.
+    ///
+    /// Used to implement the `--crate-metadata` CLI flag.
+    pub fn add_crate_metadata_layer(&mut self, path: &Utf8PathBuf) -> Result<()> {
+        self.add_layer(crate::crate_metadata::TomlCrateConfigSupplier::new(path)?);
+        Ok(())
+    }
+
     /// Add a layer using a [BindgenPathsLayer]
     ///
     /// This can be used to add custom path finding logic.

--- a/uniffi_bindgen/src/bindings/mod.rs
+++ b/uniffi_bindgen/src/bindings/mod.rs
@@ -57,6 +57,10 @@ pub fn generate_with_bindgen_paths(
         paths.add_config_override_layer(path.clone());
     }
 
+    if let Some(path) = &options.crate_metadata {
+        paths.add_crate_metadata_layer(path)?;
+    }
+
     #[cfg(feature = "cargo-metadata")]
     paths.add_cargo_metadata_layer(options.metadata_no_deps)?;
 
@@ -93,6 +97,8 @@ pub struct GenerateOptions {
     /// Path to the config file to use, if None bindings generators will load
     /// `[crate-root]/uniffi.toml`
     pub config_override: Option<Utf8PathBuf>,
+    /// Path to an optional config file with metadata about each crate.
+    pub crate_metadata: Option<Utf8PathBuf>,
     /// Run the generated code through a source code formatter
     pub format: bool,
     /// Limit binding generate to a single crate

--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -133,11 +133,15 @@ pub fn generate(
 /// In the future, we may want to replace the generalized `uniffi-bindgen` with a set of
 /// specialized `uniffi-bindgen-[language]` commands.
 pub fn generate_swift_bindings(options: SwiftBindingsOptions) -> Result<()> {
-    #[cfg(not(feature = "cargo-metadata"))]
-    let paths = BindgenPaths::default();
-
-    #[cfg(feature = "cargo-metadata")]
     let mut paths = BindgenPaths::default();
+
+    if let Some(path) = &options.config_override {
+        paths.add_config_override_layer(path.clone());
+    }
+
+    if let Some(path) = &options.crate_metadata {
+        paths.add_crate_metadata_layer(path)?;
+    }
 
     #[cfg(feature = "cargo-metadata")]
     paths.add_cargo_metadata_layer(options.metadata_no_deps)?;
@@ -220,6 +224,8 @@ pub struct SwiftBindingsOptions {
     pub modulemap_filename: Option<String>,
     pub metadata_no_deps: bool,
     pub link_frameworks: Vec<String>,
+    pub config_override: Option<Utf8PathBuf>,
+    pub crate_metadata: Option<Utf8PathBuf>,
 }
 
 // A helper for renaming items.

--- a/uniffi_bindgen/src/crate_metadata.rs
+++ b/uniffi_bindgen/src/crate_metadata.rs
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Helpers which allow metadata for crate locations to be specified in TOML.
+//! Returns what `cargo_metadata` does, but useful in environments where `cargo_metadata`
+//! isn't available or doesn't work.
+//!
+//! For example, you might have TOML with:
+//! ```toml
+//! [my_crate]
+//! crate_root = "path/to/my_crate"
+//!
+//! [other_crate]
+//! config = "path/to/other_crate/other.toml"
+//! "other_crate.udl" = "path/to/other_crate/src/other_crate.udl"
+//! ```
+//! In the first example, `uniffi.toml` and any requested UDL files will be located relative to the `crate_root`
+//! In the second example, the explicit paths to files are specified.
+//! In all cases, paths can be relative to the TOML file itself, or absolute.
+
+use anyhow::{anyhow, Context, Result};
+use camino::Utf8PathBuf;
+use std::fs;
+
+use crate::BindgenPathsLayer;
+
+#[derive(Debug, Clone, Default)]
+pub struct TomlCrateConfigSupplier {
+    // any relative paths in the TOML will be considered relative to this.
+    root: Utf8PathBuf,
+    // the content of the .toml file we loaded.
+    toml: toml::Table,
+}
+
+impl TomlCrateConfigSupplier {
+    pub fn new(path: &Utf8PathBuf) -> Result<Self> {
+        let contents =
+            fs::read_to_string(path).with_context(|| format!("read file: {:?}", path))?;
+        let toml =
+            toml::de::from_str(&contents).with_context(|| format!("parse toml: {:?}", path))?;
+        let root = path
+            .parent()
+            .ok_or_else(|| anyhow!(format!("No parent parent of {path:?}")))?
+            .to_owned();
+        Ok(Self { root, toml })
+    }
+
+    fn make_path(&self, path_val: &toml::Value) -> Result<Utf8PathBuf> {
+        let path_str = path_val
+            .as_str()
+            .ok_or(anyhow!("toml value is not a string"))?;
+        Ok(Utf8PathBuf::from(&self.root).join(path_str))
+    }
+}
+
+impl BindgenPathsLayer for TomlCrateConfigSupplier {
+    fn get_config(&self, crate_name: &str) -> Result<Option<toml::value::Table>> {
+        // The toml can just specify the crate root, or individually each of the config and udl.
+        let Some(crate_metadata) = self.toml.get(crate_name) else {
+            return Ok(None);
+        };
+
+        let config_path = match crate_metadata.get("config") {
+            Some(config_path) => self
+                .make_path(config_path)
+                .with_context(|| format!("loading `config` entry for crate `{crate_name}`"))?,
+            None => {
+                let Some(crate_root) = crate_metadata.get("crate_root") else {
+                    return Ok(None);
+                };
+                let config_path = self
+                    .make_path(crate_root)
+                    .with_context(|| {
+                        format!("loading `crate_root` entry for crate `{crate_name}`")
+                    })?
+                    .join("uniffi.toml");
+                if !config_path.exists() {
+                    return Ok(None);
+                }
+                config_path
+            }
+        };
+        let contents = fs::read_to_string(&config_path)
+            .with_context(|| format!("read file: {:?}", config_path))?;
+        let toml = toml::de::from_str(&contents)
+            .with_context(|| format!("parse toml: {:?}", config_path))?;
+        Ok(Some(toml))
+    }
+
+    fn get_udl_path(&self, crate_name: &str, udl_name: &str) -> Option<Utf8PathBuf> {
+        // The toml can just specify the crate root, or individually each of the config and udl.
+        let crate_metadata = self.toml.get(crate_name)?;
+        match crate_metadata.get(udl_name) {
+            Some(path) => self
+                .make_path(path)
+                .with_context(|| format!("loading `{udl_name}` entry for crate `{crate_name}`"))
+                .ok(),
+            None => match crate_metadata.get("crate_root") {
+                Some(p) => Some(
+                    self.make_path(p)
+                        .with_context(|| {
+                            format!("locating udl via `crate_root` entry for `{crate_name}`")
+                        })
+                        .ok()?
+                        .join("src")
+                        .join(format!("{udl_name}.udl")),
+                ),
+                None => None,
+            },
+        }
+    }
+}

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -113,6 +113,8 @@ pub mod scaffolding;
 #[cfg(feature = "cargo-metadata")]
 pub mod cargo_metadata;
 
+mod crate_metadata;
+
 use crate::interface::CallbackInterface;
 use crate::interface::{
     Argument, Constructor, Enum, FfiArgument, FfiField, Field, Function, Method, Object, Record,


### PR DESCRIPTION
* For swift, allow `--config` to be used to override all config options, like currently supported for all other languages.
* For all bindings, allow a new `--crate-metadata` option, which takes a path to a TOML file where you can specify the location of crates. In theory, this would allow you to avoid using cargo-metadata at the cost of maintaining yet another TOML file with crate locations.

As described in [this comment](https://github.com/mozilla/uniffi-rs/issues/2653#issuecomment-3765884106). Needs docs, but thought I'd get it up to see what people thought.