### PR TITLE
Disable `clippy::exhaustive_structs` on `UniFfiTag`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### What's Fixed
 
 - Fixed bug that sometimes prevented renaming items inside a submodule [#2792](https://github.com/mozilla/uniffi-rs/pull/2792)
+- Exempted `UniFfiTag` from `clippy::exhaustive_structs` since downstream projects may depend on it [#2809](https://github.com/mozilla/uniffi-rs/pull/2809)
 
 ### What's New?
 

--- a/uniffi_macros/src/setup_scaffolding.rs
+++ b/uniffi_macros/src/setup_scaffolding.rs
@@ -34,6 +34,7 @@ pub fn setup_scaffolding(namespace: String) -> Result<TokenStream> {
         // for details.
         //
         // This is pub, since we need to access it to support external types
+        #[allow(clippy::exhaustive_structs)]
         #[doc(hidden)]
         pub struct UniFfiTag;
 


### PR DESCRIPTION
This exempts the `UniFfiTag` struct from `clippy::exhaustive_structs`. This avoids clippy errors in downstream projects which cannot add the exemption themselves because the struct is hidden behind the macro.

See also https://github.com/ruma/ruma/pull/2338#issuecomment-3835061395.