### PR TITLE
Kotlin: define constructors that throw for async functions

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -141,17 +141,19 @@ open class {{ impl_class_name }}: Disposable, AutoCloseable, {{ interface_name }
         this.cleanable = null
     }
 
-    {%- match obj.primary_constructor() %}
-    {%- when Some(cons) %}
+    {%- if let Some(cons) = obj.primary_constructor() %}
     {%-     if cons.is_async() %}
+    {%- call kt::docstring(cons, 4) %}
+    constructor({% call kt::arg_list(cons, true) -%}) {
+        throw InternalException("async primary constructors are not supported on Kotlin");
+    }
     // Note no constructor generated for this object as it is async.
     {%-     else %}
     {%- call kt::docstring(cons, 4) %}
     constructor({% call kt::arg_list(cons, true) -%}) :
         this(UniffiWithHandle, {% call kt::to_ffi_call(cons) %})
     {%-     endif %}
-    {%- when None %}
-    {%- endmatch %}
+    {%- endif %}
 
     protected val handle: Long
     protected val cleanable: UniffiCleaner.Cleanable?


### PR DESCRIPTION
These constructors always just throw an exception, since Kotlin doesn't supprot async constructors.  This is less confusing for users than just skipping the codegen (#2804).