### PR TITLE
Fail when we see no metadata

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     bindings::GenerateOptions, interface::rename, BindgenLoader, Component, ComponentInterface,
     Result,
 };
+use anyhow::bail;
 use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
 use std::collections::HashMap;
@@ -19,6 +20,12 @@ pub mod test;
 /// Generate Kotlin bindings
 pub fn generate(loader: &BindgenLoader, options: GenerateOptions) -> Result<()> {
     let metadata = loader.load_metadata(&options.source)?;
+    if let Some(crate_filter) = &options.crate_filter {
+        if !metadata.contains_key(crate_filter) {
+            bail!("No UniFFI metadata found for crate {crate_filter}");
+        }
+    }
+
     let cis = loader.load_cis(metadata)?;
     let cdylib = loader.library_name(&options.source).map(|l| l.to_string());
     let mut components =

--- a/uniffi_bindgen/src/bindings/python/mod.rs
+++ b/uniffi_bindgen/src/bindings/python/mod.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use askama::Template;
 use camino::Utf8Path;
 use fs_err as fs;
@@ -19,6 +19,11 @@ pub mod test;
 /// Generate Python bindings
 pub fn generate(loader: &BindgenLoader, options: GenerateOptions) -> Result<()> {
     let metadata = loader.load_metadata(&options.source)?;
+    if let Some(crate_filter) = &options.crate_filter {
+        if !metadata.contains_key(crate_filter) {
+            bail!("No UniFFI metadata found for crate {crate_filter}");
+        }
+    }
     let root = loader.load_pipeline_initial_root(&options.source, metadata)?;
     run_pipeline(root, &options.out_dir, options.crate_filter.as_deref())?;
 

--- a/uniffi_bindgen/src/bindings/ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/mod.rs
@@ -5,7 +5,7 @@
 use std::process::Command;
 
 use crate::{bindings::GenerateOptions, BindgenLoader, Component, ComponentInterface};
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use fs_err as fs;
 
 mod gen_ruby;
@@ -15,6 +15,11 @@ use gen_ruby::{Config, RubyWrapper};
 
 pub fn generate(loader: &BindgenLoader, options: GenerateOptions) -> Result<()> {
     let metadata = loader.load_metadata(&options.source)?;
+    if let Some(crate_filter) = &options.crate_filter {
+        if !metadata.contains_key(crate_filter) {
+            bail!("No UniFFI metadata found for crate {crate_filter}");
+        }
+    }
     let cis = loader.load_cis(metadata)?;
     let cdylib = loader.library_name(&options.source).map(|l| l.to_string());
     let mut components =

--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -33,7 +33,7 @@ use crate::{
     bindings::GenerateOptions, interface::rename, BindgenLoader, BindgenPaths, Component,
     ComponentInterface,
 };
-use anyhow::Result;
+use anyhow::{bail, Result};
 use camino::Utf8PathBuf;
 use fs_err as fs;
 use std::collections::HashMap;
@@ -64,6 +64,11 @@ pub fn generate(
     options: GenerateOptions,
 ) -> Result<Vec<Component<Config>>> {
     let metadata = loader.load_metadata(&options.source)?;
+    if let Some(crate_filter) = &options.crate_filter {
+        if !metadata.contains_key(crate_filter) {
+            bail!("No UniFFI metadata found for crate {crate_filter}");
+        }
+    }
     let cis = loader.load_cis(metadata)?;
     let mut components = loader.load_components(cis, parse_config)?;
     apply_renames(&mut components);

--- a/uniffi_bindgen/src/loader.rs
+++ b/uniffi_bindgen/src/loader.rs
@@ -69,6 +69,9 @@ impl BindgenLoader {
                 Some(items) => items,
                 None => macro_metadata::extract_from_bytes(&data)?,
             };
+            if items.is_empty() {
+                bail!("No UniFFI metadata found in {source_path}");
+            }
             let mut metadata_groups = create_metadata_groups(&items);
             group_metadata(&mut metadata_groups, items)?;
 


### PR DESCRIPTION
We recently had issues because a library had its symbols stripped, which made metadata generation fail.  It would have been easier to spot these issues if `uniffi-bindgen` failed loudly rather than returning `0` but with no output.  I tested this code with `cargo run -p uniffi-bindgen-cli` and it does indeed fail with code `1` when run against a library with no UniFFI metadata or with a crate filter that doesn't match any crates.