### PR TITLE
Allow bindings to exclude items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - `Box<T>` now automatically implements FFI traits when `T` implements them, allowing direct use in enum variants and function parameters without NewType wrappers ([#2808](https://github.com/mozilla/uniffi-rs/pull/2808))
 - Record fields can now be renamed with the proc-macro `name = "new_field_name"` attribute ([#2794](https://github.com/mozilla/uniffi-rs/pull/2794))
+- Items can be excluded from the generated bindings using `uniffi.toml`.
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.31.0...HEAD).
 

--- a/docs/manual/src/renaming.md
+++ b/docs/manual/src/renaming.md
@@ -1,4 +1,4 @@
-# Renaming
+# Renaming and excluding items
 
 UniFFI provides two ways to customize names in generated bindings:
 
@@ -31,6 +31,25 @@ MyRecord = "PythonRecord"
 ```
 
 The same pattern applies to all renameable items: records, record fields, enums, enum variants, enum variant fields, objects/callback interfaces/traits, and all "callables" and arguments.
+
+### Excluding items
+
+Items can be excluded altogether using the `exclude` value.
+For example:
+
+```toml
+[bindings.python]
+
+exclude = [
+    # Exclude types
+    "MyRecord",
+    # Exclude functions
+    "my_function",
+    # Exclude constructors and methods
+    "MyObject.new",
+    "MyObject.method",
+]
+```
 
 ### Notes
 

--- a/fixtures/rename/src/lib.rs
+++ b/fixtures/rename/src/lib.rs
@@ -49,8 +49,14 @@ mod submodule {
 
     #[uniffi::export(name = "RenamedObject")]
     impl Object {
-        #[uniffi::constructor(name = "renamed_constructor")]
+        // The primary constructor is excluded by the toml configuration
+        #[uniffi::constructor]
         pub fn new(value: i32) -> Self {
+            Object { value }
+        }
+
+        #[uniffi::constructor(name = "renamed_constructor")]
+        pub fn new_secondary(value: i32) -> Self {
             Object { value }
         }
 
@@ -58,6 +64,8 @@ mod submodule {
         pub fn method(&self) -> i32 {
             self.value
         }
+
+        pub fn method_to_exclude(&self) {}
     }
 
     // Can't rename traits yet, should be possible though, just trickier.
@@ -99,6 +107,11 @@ mod submodule {
     #[derive(uniffi::Record)]
     pub struct BindingRecord {
         item: i32,
+    }
+
+    #[derive(uniffi::Record)]
+    pub struct RecordToExclude {
+        field: bool,
     }
 
     #[derive(uniffi::Enum)]
@@ -160,6 +173,9 @@ mod submodule {
     pub fn create_binding_trait_impl(multiplier: i32) -> std::sync::Arc<dyn BindingTrait> {
         std::sync::Arc::new(BindingTraitImpl { multiplier })
     }
+
+    #[uniffi::export]
+    pub fn function_to_exclude() {}
 }
 
 pub use submodule::*;

--- a/fixtures/rename/tests/test_rename.kts
+++ b/fixtures/rename/tests/test_rename.kts
@@ -62,3 +62,6 @@ assert(ktEnum2 is KtEnum.KotlinRecord)
 // Test callback interface (trait) renaming.
 val ktTraitImpl = createBindingTraitImpl(3)
 assert(ktTraitImpl.kotlinTraitMethod(4) == 12)
+
+// We can't test excluded items directly, however the tests will fail if the code is not working
+// since that will result in items generated with "" as their name

--- a/fixtures/rename/tests/test_rename.py
+++ b/fixtures/rename/tests/test_rename.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import unittest
+import uniffi_fixture_rename
 from uniffi_fixture_rename import *
 
 class TestRename(unittest.TestCase):
@@ -63,6 +64,12 @@ class TestRename(unittest.TestCase):
         # Test trait method renaming
         trait = create_binding_trait_impl(5)
         self.assertEqual(trait.python_trait_method(10), 50)
+
+    def test_binding_excludes(self):
+        self.assertFalse(hasattr(uniffi_fixture_rename, 'function_to_exclude'))
+        self.assertFalse(hasattr(uniffi_fixture_rename, 'RecordToExclude'))
+        obj = RenamedObject.renamed_constructor(123)
+        self.assertFalse(hasattr(obj, 'method_to_exclude'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/fixtures/rename/tests/test_rename.swift
+++ b/fixtures/rename/tests/test_rename.swift
@@ -76,3 +76,7 @@ do {
 // Test renamed trait with renamed method via TOML
 let swiftTraitImpl = createBindingTraitImpl(multiplier: 3)
 assert(swiftTraitImpl.swiftTraitMethod(value: 7) == 21) // 7 * 3
+
+
+// We can't test excluded items directly, however the tests will fail if the code is not working
+// since that will result in items generated with "" as their name

--- a/fixtures/rename/uniffi.toml
+++ b/fixtures/rename/uniffi.toml
@@ -34,6 +34,25 @@ BindingObject = "KtObject"
 "BindingObject.method" = "kotlin_method"
 "BindingObject.method.arg" = "kotlinArg"
 
+# Item exclusions.
+#
+# Rename to an empty string and include an exclude entry.
+# This way if item isn't excluded we'll get a syntax error because the item will have an invalid
+# name.
+
+function_to_exclude = ""
+"RenamedObject.new" = ""
+"RenamedObject.method_to_exclude" = ""
+RecordToExclude = ""
+
+[bindings.kotlin]
+exclude = [
+    "function_to_exclude",
+    "RenamedObject.new",
+    "RenamedObject.method_to_exclude",
+    "RecordToExclude",
+]
+
 #
 # Python
 #
@@ -67,6 +86,25 @@ BindingObject = "PyObject"
 "BindingObject.method" = "python_method"
 "BindingObject.method.arg" = "python_arg"
 
+# Item exclusions.
+#
+# Rename to an empty string and include an exclude entry.
+# This way if item isn't excluded we'll get a syntax error because the item will have an invalid
+# name.
+
+function_to_exclude = ""
+"RenamedObject.new" = ""
+"RenamedObject.method_to_exclude" = ""
+RecordToExclude = ""
+
+[bindings.python]
+exclude = [
+    "function_to_exclude",
+    "RenamedObject.new",
+    "RenamedObject.method_to_exclude",
+    "RecordToExclude",
+]
+
 #
 # Swift
 #
@@ -99,3 +137,22 @@ BindingObject = "SwiftObject"
 # Swift method and arg renaming
 "BindingObject.method" = "swift_method"
 "BindingObject.method.arg" = "swiftArg"
+
+# Item exclusions.
+#
+# Rename to an empty string and include an exclude entry.
+# This way if item isn't excluded we'll get a syntax error because the item will have an invalid
+# name.
+
+function_to_exclude = ""
+"RenamedObject.new" = ""
+"RenamedObject.method_to_exclude" = ""
+RecordToExclude = ""
+
+[bindings.swift]
+exclude = [
+    "function_to_exclude",
+    "RenamedObject.new",
+    "RenamedObject.method_to_exclude",
+    "RecordToExclude",
+]

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -86,6 +86,8 @@ pub struct Config {
     disable_java_cleaner: bool,
     #[serde(default)]
     pub(super) rename: toml::Table,
+    #[serde(default)]
+    pub(super) exclude: Vec<String>,
 }
 
 impl Config {

--- a/uniffi_bindgen/src/bindings/kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/mod.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::{
-    bindings::GenerateOptions, interface::rename, BindgenLoader, Component, ComponentInterface,
-    Result,
+    bindings::GenerateOptions,
+    interface::{apply_exclusions, rename},
+    BindgenLoader, Component, ComponentInterface, Result,
 };
 use anyhow::bail;
 use camino::{Utf8Path, Utf8PathBuf};
@@ -91,6 +92,11 @@ fn parse_config(
 
 // A helper for renaming items.
 fn apply_renames(components: &mut Vec<Component<Config>>) {
+    // Remove excluded items, this happens before renaming
+    for c in components.iter_mut() {
+        apply_exclusions(&mut c.ci, &c.config.exclude);
+    }
+
     // Collect all rename configurations from all components, keyed by module_path
     let mut module_renames = HashMap::new();
     for c in components.iter() {

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -181,6 +181,8 @@ pub struct Config {
     #[serde(default)]
     link_frameworks: Vec<String>,
     #[serde(default)]
+    pub(super) exclude: Vec<String>,
+    #[serde(default)]
     pub(super) rename: toml::Table,
 }
 

--- a/uniffi_bindgen/src/bindings/swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/mod.rs
@@ -30,8 +30,9 @@
 //!
 
 use crate::{
-    bindings::GenerateOptions, interface::rename, BindgenLoader, BindgenPaths, Component,
-    ComponentInterface,
+    bindings::GenerateOptions,
+    interface::{apply_exclusions, rename},
+    BindgenLoader, BindgenPaths, Component, ComponentInterface,
 };
 use anyhow::{bail, Result};
 use camino::Utf8PathBuf;
@@ -229,6 +230,11 @@ pub struct SwiftBindingsOptions {
 
 // A helper for renaming items.
 fn apply_renames(components: &mut Vec<Component<Config>>) {
+    // Remove excluded items, this happens before renaming
+    for c in components.iter_mut() {
+        apply_exclusions(&mut c.ci, &c.config.exclude);
+    }
+
     let mut module_renames = HashMap::new();
     // Collect all rename configurations from all components, keyed by module_path
     for c in components.iter() {

--- a/uniffi_bindgen/src/interface/exclude.rs
+++ b/uniffi_bindgen/src/interface/exclude.rs
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Exclude CI items based on the TOML configuration.
+
+use std::collections::HashSet;
+
+use crate::interface::{AsType, ComponentInterface, Constructor, Function, Method, TypeUniverse};
+
+pub fn apply_exclusions(ci: &mut ComponentInterface, exclusions: &[String]) {
+    let exclusions: HashSet<&str> = exclusions.iter().map(String::as_str).collect();
+
+    remove_functions(&exclusions, &mut ci.functions);
+    remove_type_definitions(&exclusions, &mut ci.records, &mut ci.types);
+    remove_type_definitions(&exclusions, &mut ci.enums, &mut ci.types);
+    remove_type_definitions(&exclusions, &mut ci.objects, &mut ci.types);
+    remove_type_definitions(&exclusions, &mut ci.callback_interfaces, &mut ci.types);
+
+    for o in ci.objects.iter_mut() {
+        remove_constructors(&exclusions, &o.name, &mut o.constructors);
+        remove_methods(&exclusions, &o.name, &mut o.methods);
+    }
+    for rec in ci.records.iter_mut() {
+        remove_constructors(&exclusions, &rec.name, &mut rec.constructors);
+        remove_methods(&exclusions, &rec.name, &mut rec.methods);
+    }
+    for en in ci.enums.iter_mut() {
+        remove_constructors(&exclusions, &en.name, &mut en.constructors);
+        remove_methods(&exclusions, &en.name, &mut en.methods);
+    }
+    for cbi in ci.callback_interfaces.iter_mut() {
+        remove_methods(&exclusions, &cbi.name, &mut cbi.methods);
+    }
+}
+
+fn remove_functions(excludes: &HashSet<&str>, functions: &mut Vec<Function>) {
+    functions.retain(|f| !excludes.contains(f.name.as_str()))
+}
+
+fn remove_type_definitions<T: AsType>(
+    excludes: &HashSet<&str>,
+    items: &mut Vec<T>,
+    types: &mut TypeUniverse,
+) {
+    let mut removed_type_names = HashSet::new();
+    items.retain(|ty| {
+        let ty = ty.as_type();
+        let Some(name) = ty.name() else {
+            return true;
+        };
+
+        if excludes.contains(name) {
+            removed_type_names.insert(name.to_string());
+            false
+        } else {
+            true
+        }
+    });
+    types
+        .type_definitions
+        .retain(|name, _| !removed_type_names.contains(name.as_str()));
+    types.all_known_types.retain(|ty| match ty.name() {
+        None => true,
+        Some(name) => !removed_type_names.contains(name),
+    });
+}
+
+fn remove_constructors(
+    excludes: &HashSet<&str>,
+    type_name: &str,
+    constructors: &mut Vec<Constructor>,
+) {
+    constructors.retain(|cons| !excludes.contains(format!("{type_name}.{}", cons.name).as_str()));
+}
+
+fn remove_methods(excludes: &HashSet<&str>, type_name: &str, methods: &mut Vec<Method>) {
+    methods.retain(|meth| !excludes.contains(format!("{type_name}.{}", meth.name).as_str()));
+}

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -67,6 +67,8 @@ pub use object::{Constructor, Method, Object, UniffiTrait, UniffiTraitMethods};
 mod record;
 pub use record::{Field, Record};
 
+mod exclude;
+pub use exclude::apply_exclusions;
 mod rename;
 pub use rename::rename;
 

--- a/uniffi_bindgen/src/pipeline/general/context.rs
+++ b/uniffi_bindgen/src/pipeline/general/context.rs
@@ -18,6 +18,8 @@ pub struct Context {
     pub names_used_as_error: HashSet<String>,
     // Maps namespaces to rename tables from the TOML config
     pub rename_tables: HashMap<String, toml::Table>,
+    // Maps namespaces to exclude tables from the TOML config
+    pub exclude_sets: HashMap<String, HashSet<String>>,
 }
 
 impl Context {
@@ -31,6 +33,7 @@ impl Context {
             current_arg_or_field_type: None,
             names_used_as_error: HashSet::default(),
             rename_tables: HashMap::default(),
+            exclude_sets: HashMap::default(),
         }
     }
 
@@ -93,8 +96,12 @@ impl Context {
 
     pub fn update_from_root(&mut self, root: &initial::Root) -> Result<()> {
         for namespace in root.namespaces.values() {
-            let table = rename::extract_rename_table(namespace, &self.bindings_toml_key)?;
-            self.rename_tables.insert(namespace.name.clone(), table);
+            let rename_table = rename::extract_rename_table(namespace, &self.bindings_toml_key)?;
+            let exclude_set = exclude::extract_exclude_set(namespace, &self.bindings_toml_key)?;
+            self.rename_tables
+                .insert(namespace.name.clone(), rename_table);
+            self.exclude_sets
+                .insert(namespace.name.clone(), exclude_set);
         }
         Ok(())
     }

--- a/uniffi_bindgen/src/pipeline/general/exclude.rs
+++ b/uniffi_bindgen/src/pipeline/general/exclude.rs
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Exclude items based on TOML table lookups.
+//! Items can only be renamed in their own crate, so we use uniffi.toml from each crate
+//! Then skip items based on these lookups.
+
+use std::collections::HashSet;
+
+use super::*;
+
+pub fn extract_exclude_set(
+    namespace: &initial::Namespace,
+    bindings_toml_key: &str,
+) -> Result<HashSet<String>> {
+    let Some(config_toml) = &namespace.config_toml else {
+        return Ok(HashSet::default());
+    };
+    let config: toml::Table = toml::from_str(config_toml)?;
+    let exclude = config
+        .get("bindings")
+        .and_then(|b| b.as_table())
+        .and_then(|b| b.get(bindings_toml_key))
+        .and_then(|p| p.as_table())
+        .and_then(|p| p.get("exclude"))
+        .cloned();
+
+    Ok(match exclude {
+        Some(toml) => toml.try_into()?,
+        None => HashSet::default(),
+    })
+}
+
+pub fn should_exclude_toplevel_item(name: &str, context: &Context) -> Result<bool> {
+    let Some(exclude_set) = context.exclude_sets.get(&context.namespace_name()?) else {
+        return Ok(false);
+    };
+    Ok(exclude_set.contains(name))
+}
+
+pub fn should_exclude_method(method_name: &str, context: &Context) -> Result<bool> {
+    let Some(exclude_set) = context.exclude_sets.get(&context.namespace_name()?) else {
+        return Ok(false);
+    };
+    let key = format!("{}.{method_name}", context.current_type_name()?);
+    Ok(exclude_set.contains(&key))
+}

--- a/uniffi_bindgen/src/pipeline/general/mod.rs
+++ b/uniffi_bindgen/src/pipeline/general/mod.rs
@@ -10,6 +10,7 @@ mod checksums;
 mod context;
 mod default;
 mod enums;
+mod exclude;
 mod ffi_async_data;
 mod ffi_functions;
 mod ffi_types;

--- a/uniffi_bindgen/src/pipeline/general/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/general/nodes.rs
@@ -198,7 +198,9 @@ pub struct Record {
     #[map_node(from(uniffi_traits))]
     pub uniffi_trait_methods: UniffiTraitMethods,
     pub fields: Vec<Field>,
+    #[map_node(objects::constructors(self.constructors, context)?)]
     pub constructors: Vec<Constructor>,
+    #[map_node(objects::methods(self.methods, context)?)]
     pub methods: Vec<Method>,
     pub docstring: Option<String>,
 }
@@ -225,6 +227,7 @@ pub struct Field {
 #[map_node(from(initial::Enum))]
 #[map_node(update_context(context.update_from_enum(&self)?))]
 pub struct Enum {
+    /// Is this a "flat" enum -- one with no associated data
     #[map_node(enums::is_flat(&self))]
     pub is_flat: bool,
     #[map_node(context.self_type()?)]
@@ -240,10 +243,11 @@ pub struct Enum {
     pub name: String,
     #[map_node(from(uniffi_traits))]
     pub uniffi_trait_methods: UniffiTraitMethods,
-    /// Is this a "flat" enum -- one with no associated data
-    pub shape: EnumShape,
     /// Enum discriminant type to use in generated code.  If the source code doesn't specify a
+    pub shape: EnumShape,
+    #[map_node(objects::constructors(self.constructors, context)?)]
     pub constructors: Vec<Constructor>,
+    #[map_node(objects::methods(self.methods, context)?)]
     pub methods: Vec<Method>,
     pub docstring: Option<String>,
 }
@@ -278,7 +282,9 @@ pub struct Interface {
     #[map_node(from(uniffi_traits))]
     pub uniffi_trait_methods: UniffiTraitMethods,
     pub docstring: Option<String>,
+    #[map_node(objects::constructors(self.constructors, context)?)]
     pub constructors: Vec<Constructor>,
+    #[map_node(objects::methods(self.methods, context)?)]
     pub methods: Vec<Method>,
     pub trait_impls: Vec<ObjectTraitImpl>,
     pub imp: ObjectImpl,
@@ -295,6 +301,7 @@ pub struct CallbackInterface {
     #[map_node(rename::type_(&context.namespace_name()?, self.name, context)?)]
     pub name: String,
     pub docstring: Option<String>,
+    #[map_node(objects::methods(self.methods, context)?)]
     pub methods: Vec<Method>,
 }
 

--- a/uniffi_bindgen/src/pipeline/general/objects.rs
+++ b/uniffi_bindgen/src/pipeline/general/objects.rs
@@ -83,3 +83,32 @@ pub fn ffi_definitions(
     })?;
     Ok(ffi_defs)
 }
+
+pub fn constructors(
+    constructors: Vec<initial::Constructor>,
+    context: &Context,
+) -> Result<Vec<Constructor>> {
+    constructors
+        .into_iter()
+        .filter_map(
+            |cons| match exclude::should_exclude_method(&cons.name, context) {
+                Err(e) => Some(Err(e)),
+                Ok(true) => None,
+                Ok(false) => Some(cons.map_node(context)),
+            },
+        )
+        .collect()
+}
+
+pub fn methods(methods: Vec<initial::Method>, context: &Context) -> Result<Vec<Method>> {
+    methods
+        .into_iter()
+        .filter_map(
+            |meth| match exclude::should_exclude_method(&meth.name, context) {
+                Err(e) => Some(Err(e)),
+                Ok(true) => None,
+                Ok(false) => Some(meth.map_node(context)),
+            },
+        )
+        .collect()
+}

--- a/uniffi_bindgen/src/pipeline/initial/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/initial/nodes.rs
@@ -283,6 +283,18 @@ pub enum Type {
     },
 }
 
+impl TypeDefinition {
+    pub fn name(&self) -> &str {
+        match &self {
+            Self::Record(rec) => &rec.name,
+            Self::Enum(en) => &en.name,
+            Self::Interface(int) => &int.name,
+            Self::CallbackInterface(cbi) => &cbi.name,
+            Self::Custom(custom) => &custom.name,
+        }
+    }
+}
+
 impl Type {
     pub fn name(&self) -> Option<&str> {
         match &self {


### PR DESCRIPTION
The motivation for this is avoiding async constructors (https://github.com/mozilla/uniffi-rs/pull/2813).

We'd like things to fail at build time if you have an async constructor and are generating bindings for a language that doesn't support them. However, this prevents a valid use case: I want the async constructor on languages that do support them but not on ones that don't.

This change allows us to support that by allowing users to exclude the constructor on languages that don't support it.

Actually, now that think about it I don't think any built-in language supports async constructors, but maybe external binding generators could or this could be useful for some other feature.
