### PR TITLE
Performance improvement by fixing python loop over bytes

### DIFF
--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferTemplate.py
@@ -168,7 +168,7 @@ class _UniffiRustBufferBuilder:
             self.rbuf = _UniffiRustBuffer.reserve(self.rbuf, num_bytes)
         yield None
         self.rbuf.len += num_bytes
-    
+
     def _pack_into(self, size, format, value):
         with self._reserve(size):
             packed = struct.pack(format, value)


### PR DESCRIPTION
Improving performance significantly by not looping over bytes individually but just allocating buffer directly. For detailed description see here: https://github.com/n0-computer/iroh-ffi/issues/229, I noticed this when working with iroh where the loop reduces transfer speeds significantly.