### PR TITLE
Kotlin: expose `Object.uniffiIsDestroyed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Record fields can now be renamed with the proc-macro `name = "new_field_name"` attribute ([#2794](https://github.com/mozilla/uniffi-rs/pull/2794))
 - Items can be excluded from the generated bindings using `uniffi.toml`.
 - Added `mutable_records` configuration option to allow specific records to remain mutable even when `generate_immutable_records` is enabled (Kotlin and Swift).
+- Kotlin objects now have an `uniffiIsDestroyed` property that returns `true` if the Rust reference no longer exists ([#2825](https://github.com/mozilla/uniffi-rs/pull/2825))
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.31.0...HEAD).
 

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -159,6 +159,11 @@ open class {{ impl_class_name }}: Disposable, AutoCloseable, {{ interface_name }
     private val wasDestroyed = AtomicBoolean(false)
     private val callCounter = AtomicLong(1)
 
+    /**
+     * Whether the current object has been destroyed and its reference is gone in the Rust side.
+     */
+    val uniffiIsDestroyed: Boolean get() = wasDestroyed.get()
+
     override fun destroy() {
         // Only allow a single call to this method.
         // TODO: maybe we should log a warning if called more than once?


### PR DESCRIPTION
This can help us understand when an object has been destroyed so we can avoid using it, instead of try-catching its usage and recovering from any errors.