### PR TITLE
Fail when we can't generate async constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ## [[UnreleasedUniFFIVersion]] (backend crates: [[UnreleasedBackendVersion]]) - (_[[ReleaseDate]]_)
 
+### ⚠️ Breaking Changes ⚠️
+- Kotlin and Python now fail to generate bindings when there are async primary constructors.
+  Previously these languages skipped the constructor in this case or generated a constructor that always threw.
+  You can get similar behavior by adding the primary constructor to the uniffi.toml excludes list in uniffi.toml (e.g. `excludes = ["MyObject.new"])
+
 ### What's Fixed
 
 - Fixed bug that sometimes prevented renaming items inside a submodule [#2792](https://github.com/mozilla/uniffi-rs/pull/2792)

--- a/fixtures/futures/tests/bindings/test_futures.py
+++ b/fixtures/futures/tests/bindings/test_futures.py
@@ -76,11 +76,6 @@ class TestFutures(unittest.TestCase):
         asyncio.run(test())
 
     def test_async_constructors(self):
-        # Check the default constructor has been disabled.
-        with self.assertRaises(ValueError) as e:
-            Megaphone()
-        self.assertTrue(str(e.exception).startswith("async constructors not supported"))
-
         async def test():
             megaphone = await Megaphone.secondary()
             result_alice = await megaphone.say_after(0, 'Alice')

--- a/fixtures/futures/uniffi.toml
+++ b/fixtures/futures/uniffi.toml
@@ -1,2 +1,8 @@
+[bindings.python]
+# Python doesn't support async constructors
+exclude = ["Megaphone.new", "FallibleMegaphone.new", "TestObject.new", "UdlMegaphone.new"]
+
 [bindings.kotlin]
 package_name = "uniffi.fixture.futures"
+# Kotlin doesn't support async constructors
+exclude = ["Megaphone.new", "FallibleMegaphone.new", "TestObject.new", "UdlMegaphone.new"]

--- a/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/ObjectTemplate.kt
@@ -141,17 +141,11 @@ open class {{ impl_class_name }}: Disposable, AutoCloseable, {{ interface_name }
         this.cleanable = null
     }
 
-    {%- match obj.primary_constructor() %}
-    {%- when Some(cons) %}
-    {%-     if cons.is_async() %}
-    // Note no constructor generated for this object as it is async.
-    {%-     else %}
+    {%- if let Some(cons) = obj.primary_constructor() %}
     {%- call kt::docstring(cons, 4) %}
     constructor({% call kt::arg_list(cons, true) -%}) :
         this(UniffiWithHandle, {% call kt::to_ffi_call(cons) %})
-    {%-     endif %}
-    {%- when None %}
-    {%- endmatch %}
+    {%- endif %}
 
     protected val handle: Long
     protected val cleanable: UniffiCleaner.Cleanable?

--- a/uniffi_bindgen/src/bindings/python/pipeline/interfaces.rs
+++ b/uniffi_bindgen/src/bindings/python/pipeline/interfaces.rs
@@ -82,3 +82,19 @@ pub fn base_classes(int: &general::Interface, context: &Context) -> Result<Vec<S
     }
     Ok(base_classes)
 }
+
+pub fn map_constructors(
+    interface_name: &str,
+    constructors: Vec<general::Constructor>,
+    context: &Context,
+) -> Result<Vec<Constructor>> {
+    constructors
+        .into_iter()
+        .map(|c| {
+            if c.callable.is_primary_constructor() && c.callable.is_async() {
+                bail!("Async primary constructors not supported but {interface_name} has one");
+            }
+            c.map_node(context)
+        })
+        .collect()
+}

--- a/uniffi_bindgen/src/bindings/python/pipeline/nodes.rs
+++ b/uniffi_bindgen/src/bindings/python/pipeline/nodes.rs
@@ -239,6 +239,7 @@ pub struct Record {
     pub fields: Vec<Field>,
     pub docstring: Option<String>,
     pub self_type: TypeNode,
+    #[map_node(interfaces::map_constructors(&self.name, self.constructors, context)?)]
     pub constructors: Vec<Constructor>,
     pub methods: Vec<Method>,
     pub uniffi_trait_methods: UniffiTraitMethods,
@@ -267,6 +268,7 @@ pub struct Enum {
     pub discr_type: TypeNode,
     pub docstring: Option<String>,
     pub self_type: TypeNode,
+    #[map_node(interfaces::map_constructors(&self.name, self.constructors, context)?)]
     pub constructors: Vec<Constructor>,
     pub methods: Vec<Method>,
     pub uniffi_trait_methods: UniffiTraitMethods,
@@ -291,6 +293,7 @@ pub struct Interface {
     #[map_node(interfaces::protocol(&self, context)?)]
     pub protocol: Protocol,
     pub docstring: Option<String>,
+    #[map_node(interfaces::map_constructors(&self.name, self.constructors, context)?)]
     pub constructors: Vec<Constructor>,
     pub methods: Vec<Method>,
     pub uniffi_trait_methods: UniffiTraitMethods,

--- a/uniffi_bindgen/src/bindings/python/templates/InterfaceTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/InterfaceTemplate.py
@@ -8,10 +8,7 @@ class {{ int.name }}({{ int.base_classes|join(", ") }}):
 
 {%- for cons in int.constructors %}
 {%-     let callable = cons.callable %}
-{%-     if callable.is_primary_constructor() && callable.is_async() %}
-    def __init__(self, *args, **kw):
-        raise ValueError("async constructors not supported.")
-{%-     elif callable.is_primary_constructor() %}
+{%-     if callable.is_primary_constructor() %}
     def __init__(self, {% include "CallableArgs.py" %}):
         {{ cons.docstring|docstring(8) -}}
         {%- filter indent(8) %}


### PR DESCRIPTION
Rather than silently succeeding, fail to generate code when a constructor is async and the language doesn't support it.  Users can exclude these constructors from the bindings if they want the old behavior (see #2822).

Fixes #2804.