### PR TITLE
Fix wasm32 error

### DIFF
--- a/uniffi_core/src/ffi/rustfuture/mod.rs
+++ b/uniffi_core/src/ffi/rustfuture/mod.rs
@@ -47,12 +47,15 @@ pub trait FutureLowerReturn<UT>: LowerReturn<UT> {}
 
 /// The `Send` bound is required because the Foreign code may call the
 /// `rust_future_*` methods from different threads.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm-unstable-single-threaded")))]
 impl<T, F> UniffiCompatibleFuture<T> for F where F: Future<Output = T> + Send {}
 #[cfg(not(all(target_arch = "wasm32", feature = "wasm-unstable-single-threaded")))]
 impl<UT, LR> FutureLowerReturn<UT> for LR where LR: LowerReturn<UT> + Send {}
 
-/// `Future`'s on WASM32 are not `Send` because it's a single threaded environment.
+/// `Future`'s on WASM32 are typically not `Send` because it's a single threaded environment.
+///
+/// Users can opt into allowing non-Send futures by using the `wasm-unstable-single-threaded`
+/// feature.  This creates a `UniffiCompatibleFuture` impl for non-Send futures.
 ///
 /// # Safety:
 ///
@@ -91,8 +94,7 @@ impl<UT, LR> FutureLowerReturn<UT> for LR where LR: LowerReturn<UT> + Send {}
 /// [transferable]: (https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects
 #[cfg(all(target_arch = "wasm32", feature = "wasm-unstable-single-threaded"))]
 pub trait UniffiCompatibleFuture<T>: Future<Output = T> {}
-
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "wasm-unstable-single-threaded"))]
 impl<T, F> UniffiCompatibleFuture<T> for F where F: Future<Output = T> {}
 #[cfg(all(target_arch = "wasm32", feature = "wasm-unstable-single-threaded"))]
 impl<UT, LR> FutureLowerReturn<UT> for LR where LR: LowerReturn<UT> {}


### PR DESCRIPTION
The lack of this trait bound made it so uniffi-core failed to build on `wasm32-unknown-unknown` which made it so any crate that dependened on UniFFI also failed.  This happened even when the crates didn't export async functions.

Fixes #2828