### PR TITLE
Added note about renaming with other configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,6 +1965,7 @@ version = "0.22.0"
 dependencies = [
  "thiserror",
  "uniffi",
+ "url",
 ]
 
 [[package]]

--- a/docs/manual/src/renaming.md
+++ b/docs/manual/src/renaming.md
@@ -58,3 +58,6 @@ exclude = [
   For example, renaming `my_func` to `renamed_func` would cause the final name to be `renamedFunc` in those languages.
 - All builtin bindings support this but external bindings may not.
 - Renaming the primary constructor "works", but will have no impact in bindings as the name isn't used.
+- Renaming interacts inconsistently with other configuration options that use type names like the [custom types](./types/custom_types.md) configuration.
+  - On Python, use the original Rust name
+  - On Swift and Kotlin, use the renamed name

--- a/fixtures/rename/Cargo.toml
+++ b/fixtures/rename/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 uniffi = { workspace = true }
+url = "2"
 thiserror = "2"
 
 [build-dependencies]

--- a/fixtures/rename/src/lib.rs
+++ b/fixtures/rename/src/lib.rs
@@ -176,6 +176,19 @@ mod submodule {
 
     #[uniffi::export]
     pub fn function_to_exclude() {}
+
+    // Used to renaming a custom type that also has binding configuration
+    pub use url::Url;
+    uniffi::custom_type!(Url, String, {
+        remote,
+        lower: |url| url.to_string(),
+        try_lift: |raw_url| Ok(Url::parse(&raw_url)?),
+    });
+
+    #[uniffi::export]
+    pub fn roundtrip_url(url: Url) -> Url {
+        url
+    }
 }
 
 pub use submodule::*;

--- a/fixtures/rename/tests/test_rename.kts
+++ b/fixtures/rename/tests/test_rename.kts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import java.net.URL
 import uniffi.uniffi_fixture_rename.*;
 
 // Test renamed types - should be accessible by their custom names
@@ -62,6 +63,10 @@ assert(ktEnum2 is KtEnum.KotlinRecord)
 // Test callback interface (trait) renaming.
 val ktTraitImpl = createBindingTraitImpl(3)
 assert(ktTraitImpl.kotlinTraitMethod(4) == 12)
+
+// Test renamed custom type that also has binding configuration
+val url = URL("https://example.com/test")
+assert(roundtripUrl(url) == url)
 
 // We can't test excluded items directly, however the tests will fail if the code is not working
 // since that will result in items generated with "" as their name

--- a/fixtures/rename/tests/test_rename.py
+++ b/fixtures/rename/tests/test_rename.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import unittest
+from urllib.parse import urlsplit, urlunsplit
 import uniffi_fixture_rename
 from uniffi_fixture_rename import *
 
@@ -64,6 +65,10 @@ class TestRename(unittest.TestCase):
         # Test trait method renaming
         trait = create_binding_trait_impl(5)
         self.assertEqual(trait.python_trait_method(10), 50)
+
+    def test_custom_type(self):
+        url = urlsplit("https://example.com/test")
+        self.assertEqual(roundtrip_url(url), url)
 
     def test_binding_excludes(self):
         self.assertFalse(hasattr(uniffi_fixture_rename, 'function_to_exclude'))

--- a/fixtures/rename/tests/test_rename.swift
+++ b/fixtures/rename/tests/test_rename.swift
@@ -77,6 +77,9 @@ do {
 let swiftTraitImpl = createBindingTraitImpl(multiplier: 3)
 assert(swiftTraitImpl.swiftTraitMethod(value: 7) == 21) // 7 * 3
 
+// Test renamed custom type that also has binding configuration
+let url = URL(string: "https://example.com/test")!
+assert(roundtripUrl(url: url) == url)
 
 // We can't test excluded items directly, however the tests will fail if the code is not working
 // since that will result in items generated with "" as their name

--- a/fixtures/rename/uniffi.toml
+++ b/fixtures/rename/uniffi.toml
@@ -34,6 +34,8 @@ BindingObject = "KtObject"
 "BindingObject.method" = "kotlin_method"
 "BindingObject.method.arg" = "kotlinArg"
 
+Url = "RenamedUrl"
+
 # Item exclusions.
 #
 # Rename to an empty string and include an exclude entry.
@@ -85,6 +87,8 @@ BindingObject = "PyObject"
 
 "BindingObject.method" = "python_method"
 "BindingObject.method.arg" = "python_arg"
+
+Url = "RenamedUrl"
 
 # Item exclusions.
 #
@@ -138,6 +142,8 @@ BindingObject = "SwiftObject"
 "BindingObject.method" = "swift_method"
 "BindingObject.method.arg" = "swiftArg"
 
+Url = "RenamedUrl"
+
 # Item exclusions.
 #
 # Rename to an empty string and include an exclude entry.
@@ -156,3 +162,26 @@ exclude = [
     "RenamedObject.method_to_exclude",
     "RecordToExclude",
 ]
+
+# Custom type config for a renamed item
+#
+# Python uses the original name.  This is what we prefer and the pipeline makes it work like that.
+#
+# Swift and Kotlin uses the renamed name.  This is not ideal, but it's not so easy to fix either.
+
+[bindings.python.custom_types.Url]
+type_name = "urllib.parse.SplitResult"
+imports = [ "urllib.parse" ]
+lift = "urllib.parse.urlsplit({})"
+lower = "urllib.parse.urlunsplit({})"
+
+[bindings.kotlin.custom_types.RenamedUrl]
+type_name = "URL"
+imports = [ "java.net.URL" ]
+lift = "URL({})"
+lower = "{}.toString()"
+
+[bindings.swift.custom_types.RenamedUrl]
+type_name = "URL"
+lift = "URL(string: {})!"
+lower = "{}.absoluteString"

--- a/uniffi_bindgen/src/bindings/python/pipeline/context.rs
+++ b/uniffi_bindgen/src/bindings/python/pipeline/context.rs
@@ -65,6 +65,6 @@ impl Context {
         &self,
         custom: &general::CustomType,
     ) -> Result<Option<CustomTypeConfig>> {
-        Ok(self.config()?.custom_types.get(&custom.name).cloned())
+        Ok(self.config()?.custom_types.get(&custom.orig_name).cloned())
     }
 }

--- a/uniffi_bindgen/src/pipeline/general/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/general/nodes.rs
@@ -193,6 +193,8 @@ pub struct Record {
     pub fields_kind: FieldsKind,
     #[map_node(context.self_type()?)]
     pub self_type: TypeNode,
+    #[map_node(self.name.clone())]
+    pub orig_name: String,
     #[map_node(rename::type_(&context.namespace_name()?, self.name, context)?)]
     pub name: String,
     #[map_node(from(uniffi_traits))]
@@ -239,6 +241,8 @@ pub struct Enum {
     pub discr_type: TypeNode,
     #[map_node(enums::map_variants(&self.discr_type, self.variants, context)?)]
     pub variants: Vec<Variant>,
+    #[map_node(self.name.clone())]
+    pub orig_name: String,
     #[map_node(rename::type_(&context.namespace_name()?, self.name, context)?)]
     pub name: String,
     #[map_node(from(uniffi_traits))]
@@ -276,6 +280,8 @@ pub struct Interface {
     pub ffi_func_clone: RustFfiFunctionName,
     #[map_node(objects::ffi_free_name(&self.name, context)?)]
     pub ffi_func_free: RustFfiFunctionName,
+    #[map_node(self.name.clone())]
+    pub orig_name: String,
     #[map_node(rename::type_(&context.namespace_name()?, self.name, context)?)]
     pub name: String,
     // This `map_node` works because we've implemented a map from Vec<UniffiTrait> -> UniffiTraitMethods
@@ -298,6 +304,8 @@ pub struct CallbackInterface {
     pub vtable: VTable,
     #[map_node(context.self_type()?)]
     pub self_type: TypeNode,
+    #[map_node(self.name.clone())]
+    pub orig_name: String,
     #[map_node(rename::type_(&context.namespace_name()?, self.name, context)?)]
     pub name: String,
     pub docstring: Option<String>,
@@ -342,6 +350,9 @@ pub struct ObjectTraitImpl {
 pub struct CustomType {
     #[map_node(context.self_type()?)]
     pub self_type: TypeNode,
+    #[map_node(self.name.clone())]
+    pub orig_name: String,
+    #[map_node(rename::type_(&context.namespace_name()?, self.name, context)?)]
     pub name: String,
     pub builtin: TypeNode,
     pub docstring: Option<String>,


### PR DESCRIPTION
Added a test to see how the renaming config code interacts with other configuration that targets type names.

Updated Python to rename custom types, but use the original name for looking up custom type config. This way feels better to me, since it feels more consistent to always specify things using the Rust name.  I'm not that sure about this though. If others feel different, let's discuss in the PR.

In any case, this documents what the current state of affairs is and adds tests for it.