### PR TITLE
fix: Resolve memory leak in rust_future_free by properly consuming handle

### DIFF
--- a/uniffi_core/src/ffi/rustfuture/mod.rs
+++ b/uniffi_core/src/ffi/rustfuture/mod.rs
@@ -180,5 +180,5 @@ where
 /// The [Handle] must not previously have been passed to [rust_future_free]
 pub unsafe fn rust_future_free<FfiType>(handle: Handle) {
     trace!("rust_future_free: {handle:?}");
-    Handle::into_arc_borrowed::<RustFuture<FfiType>>(handle).free()
+    Handle::into_arc::<RustFuture<FfiType>>(handle).free()
 }


### PR DESCRIPTION
### Problem
When calling Rust async functions from Swift, memory leaks occur on each invocation (256 bytes per call on M4 Mac). This issue was first introduced in UniFFI 0.30.0.

Fixes #2758

### Root Cause
In `uniffi_core/src/ffi/rustfuture/mod.rs`, the `rust_future_free` function incorrectly uses `Handle::into_arc_borrowed` instead of `Handle::into_arc`.

- `into_arc_borrowed` is for APIs where the handle stays valid after the call: it calls `Arc::increment_strong_count` on the handle’s pointer, then `Arc::from_raw`. When the temporary `Arc` is dropped at the end of the call, the count returns to what it was, so the foreign side still holds the last strong reference.
- `rust_future_free` must **fully consume** that last reference. Using `into_arc_borrowed` here leaves **one extra strong count** on the allocation after `free` finishes. Nothing else drops it, so the `Arc` (and the whole `RustFuture`) is never deallocated.
- `into_arc` only does `Arc::from_raw` (no bump). It takes ownership of the handle’s single strong reference; dropping the `Arc` at the end of `free` drives the count to zero.

Because `RustFuture` owns two `Mutex` fields (and the rest of the future state), each leaked handle keeps that entire allocation alive—matching the steady per-call growth seen from Swift.

### Fix
Change the method call in `rust_future_free` to use `into_arc`, so the handle’s ownership is transferred and the allocation is dropped when the function returns.

```rust
// Before (0.30.0+)
pub unsafe fn rust_future_free<FfiType>(handle: Handle) {
    trace!("rust_future_free: {handle:?}");
    Handle::into_arc_borrowed::<RustFuture<FfiType>>(handle).free()
}

// After
pub unsafe fn rust_future_free<FfiType>(handle: Handle) {
    trace!("rust_future_free: {handle:?}");
    Handle::into_arc::<RustFuture<FfiType>>(handle).free()
}