### PR TITLE
Remember original names

### DIFF
--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -10,8 +10,9 @@ use uniffi_meta::*;
 
 mod person {
     #[derive(uniffi::Record, Debug)]
+    #[uniffi(name = "PersonRenamed")]
     pub struct Person {
-        #[uniffi(default = "test")]
+        #[uniffi(default = "test", name = "name_renamed")]
         name: String,
         #[uniffi(default)]
         preferred_name: String,
@@ -21,9 +22,11 @@ mod person {
 
 mod weapon {
     #[derive(uniffi::Enum, Debug)]
+    #[uniffi(name = "WeaponRenamed")]
     pub enum Weapon {
         Rock,
         Paper,
+        #[uniffi(name = "ScissorsRenamed")]
         Scissors,
     }
 }
@@ -40,6 +43,7 @@ mod state {
 
     #[uniffi::export]
     impl State {
+        #[uniffi::method(name = "state_method_renamed")]
         fn state_method(&self) {}
     }
 }
@@ -85,6 +89,7 @@ mod error {
 
 mod calc {
     #[derive(uniffi::Object)]
+    #[uniffi(name = "CalculatorRenamed")]
     pub struct Calculator {}
 }
 
@@ -162,15 +167,15 @@ mod test_type_ids {
     fn test_user_types() {
         check_type_id::<Person>(Type::Record {
             module_path: "uniffi_fixture_metadata::tests::person".into(),
-            name: "Person".into(),
+            name: "PersonRenamed".into(),
         });
         check_type_id::<Weapon>(Type::Enum {
             module_path: "uniffi_fixture_metadata::tests::weapon".into(),
-            name: "Weapon".into(),
+            name: "WeaponRenamed".into(),
         });
         check_type_id::<Arc<Calculator>>(Type::Object {
             module_path: "uniffi_fixture_metadata::tests::calc".into(),
-            name: "Calculator".into(),
+            name: "CalculatorRenamed".into(),
             imp: ObjectImpl::Struct,
         });
     }
@@ -207,14 +212,16 @@ mod test_metadata {
     #[test]
     fn test_record() {
         check_metadata(
-            &person::UNIFFI_META_UNIFFI_FIXTURE_METADATA_RECORD_PERSON,
+            &person::UNIFFI_META_UNIFFI_FIXTURE_METADATA_RECORD_PERSONRENAMED,
             RecordMetadata {
                 module_path: "uniffi_fixture_metadata::tests::person".into(),
-                name: "Person".into(),
+                name: "PersonRenamed".into(),
+                orig_name: Some("Person".into()),
                 remote: false,
                 fields: vec![
                     FieldMetadata {
-                        name: "name".into(),
+                        name: "name_renamed".into(),
+                        orig_name: Some("name".into()),
                         ty: Type::String,
                         default: Some(DefaultValueMetadata::Literal(LiteralMetadata::String(
                             "test".to_owned(),
@@ -223,12 +230,14 @@ mod test_metadata {
                     },
                     FieldMetadata {
                         name: "preferred_name".into(),
+                        orig_name: None,
                         ty: Type::String,
                         default: Some(DefaultValueMetadata::Default),
                         docstring: None,
                     },
                     FieldMetadata {
                         name: "age".into(),
+                        orig_name: None,
                         ty: Type::Box {
                             inner_type: Box::new(Type::UInt16),
                         },
@@ -244,28 +253,32 @@ mod test_metadata {
     #[test]
     fn test_simple_enum() {
         check_metadata(
-            &weapon::UNIFFI_META_UNIFFI_FIXTURE_METADATA_ENUM_WEAPON,
+            &weapon::UNIFFI_META_UNIFFI_FIXTURE_METADATA_ENUM_WEAPONRENAMED,
             EnumMetadata {
                 module_path: "uniffi_fixture_metadata::tests::weapon".into(),
-                name: "Weapon".into(),
+                name: "WeaponRenamed".into(),
+                orig_name: Some("Weapon".into()),
                 shape: EnumShape::Enum,
                 remote: false,
                 discr_type: None,
                 variants: vec![
                     VariantMetadata {
                         name: "Rock".into(),
+                        orig_name: None,
                         discr: None,
                         fields: vec![],
                         docstring: None,
                     },
                     VariantMetadata {
                         name: "Paper".into(),
+                        orig_name: None,
                         discr: None,
                         fields: vec![],
                         docstring: None,
                     },
                     VariantMetadata {
-                        name: "Scissors".into(),
+                        name: "ScissorsRenamed".into(),
+                        orig_name: Some("Scissors".into()),
                         discr: None,
                         fields: vec![],
                         docstring: None,
@@ -284,21 +297,25 @@ mod test_metadata {
             EnumMetadata {
                 module_path: "uniffi_fixture_metadata::tests::state".into(),
                 name: "State".into(),
+                orig_name: None,
                 shape: EnumShape::Enum,
                 remote: false,
                 discr_type: None,
                 variants: vec![
                     VariantMetadata {
                         name: "Uninitialized".into(),
+                        orig_name: None,
                         discr: None,
                         fields: vec![],
                         docstring: None,
                     },
                     VariantMetadata {
                         name: "Initialized".into(),
+                        orig_name: None,
                         discr: None,
                         fields: vec![FieldMetadata {
                             name: "data".into(),
+                            orig_name: None,
                             ty: Type::String,
                             default: None,
                             docstring: None,
@@ -307,12 +324,14 @@ mod test_metadata {
                     },
                     VariantMetadata {
                         name: "Complete".into(),
+                        orig_name: None,
                         discr: None,
                         fields: vec![FieldMetadata {
                             name: "result".into(),
+                            orig_name: None,
                             ty: Type::Record {
                                 module_path: "uniffi_fixture_metadata::tests::person".into(),
-                                name: "Person".into(),
+                                name: "PersonRenamed".into(),
                             },
                             default: None,
                             docstring: None,
@@ -333,24 +352,28 @@ mod test_metadata {
             EnumMetadata {
                 module_path: "uniffi_fixture_metadata::tests::enum_repr".into(),
                 name: "ReprU8".into(),
+                orig_name: None,
                 shape: EnumShape::Enum,
                 remote: false,
                 discr_type: Some(Type::UInt8),
                 variants: vec![
                     VariantMetadata {
                         name: "One".into(),
+                        orig_name: None,
                         discr: Some(LiteralMetadata::new_uint(1)),
                         fields: vec![],
                         docstring: None,
                     },
                     VariantMetadata {
                         name: "Three".into(),
+                        orig_name: None,
                         discr: Some(LiteralMetadata::new_uint(3)),
                         fields: vec![],
                         docstring: None,
                     },
                     VariantMetadata {
                         name: "Fifteen".into(),
+                        orig_name: None,
                         discr: Some(LiteralMetadata::new_uint(15)),
                         fields: vec![],
                         docstring: None,
@@ -369,11 +392,13 @@ mod test_metadata {
             EnumMetadata {
                 module_path: "uniffi_fixture_metadata::tests::enum_repr".into(),
                 name: "NoRepr".into(),
+                orig_name: None,
                 shape: EnumShape::Enum,
                 remote: false,
                 discr_type: None,
                 variants: vec![VariantMetadata {
                     name: "One".into(),
+                    orig_name: None,
                     discr: Some(LiteralMetadata::new_uint(1)),
                     fields: vec![],
                     docstring: None,
@@ -387,18 +412,19 @@ mod test_metadata {
     #[test]
     fn test_enum_method() {
         check_metadata(
-            &state::UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_STATE_STATE_METHOD,
+            &state::UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_STATE_STATE_METHOD_RENAMED,
             MethodMetadata {
                 module_path: "uniffi_fixture_metadata::tests::state".into(),
                 self_name: "State".into(),
-                name: "state_method".into(),
+                name: "state_method_renamed".into(),
+                orig_name: Some("state_method".into()),
                 is_async: false,
                 inputs: vec![],
                 return_type: None,
                 throws: None,
                 takes_self_by_arc: false,
                 checksum: Some(
-                    state::uniffi_uniffi_fixture_metadata_checksum_method_state_state_method(),
+                    state::uniffi_uniffi_fixture_metadata_checksum_method_state_state_method_renamed(),
                 ),
                 docstring: None,
             },
@@ -412,18 +438,21 @@ mod test_metadata {
             EnumMetadata {
                 module_path: "uniffi_fixture_metadata::tests::error".into(),
                 name: "FlatError".into(),
+                orig_name: None,
                 shape: EnumShape::Error { flat: true },
                 remote: false,
                 discr_type: None,
                 variants: vec![
                     VariantMetadata {
                         name: "Overflow".into(),
+                        orig_name: None,
                         discr: None,
                         fields: vec![],
                         docstring: None,
                     },
                     VariantMetadata {
                         name: "DivideByZero".into(),
+                        orig_name: None,
                         discr: None,
                         fields: vec![],
                         docstring: None,
@@ -442,21 +471,25 @@ mod test_metadata {
             EnumMetadata {
                 module_path: "uniffi_fixture_metadata::tests::error".into(),
                 name: "ComplexError".into(),
+                orig_name: None,
                 shape: EnumShape::Error { flat: false },
                 remote: false,
                 discr_type: None,
                 variants: vec![
                     VariantMetadata {
                         name: "NotFound".into(),
+                        orig_name: None,
                         discr: None,
                         fields: vec![],
                         docstring: None,
                     },
                     VariantMetadata {
                         name: "PermissionDenied".into(),
+                        orig_name: None,
                         discr: None,
                         fields: vec![FieldMetadata {
                             name: "reason".into(),
+                            orig_name: None,
                             ty: Type::String,
                             default: None,
                             docstring: None,
@@ -465,12 +498,14 @@ mod test_metadata {
                     },
                     VariantMetadata {
                         name: "InvalidWeapon".into(),
+                        orig_name: None,
                         discr: None,
                         fields: vec![FieldMetadata {
                             name: "weapon".into(),
+                            orig_name: None,
                             ty: Type::Enum {
                                 module_path: "uniffi_fixture_metadata::tests::weapon".into(),
-                                name: "Weapon".into(),
+                                name: "WeaponRenamed".into(),
                             },
                             default: None,
                             docstring: None,
@@ -487,10 +522,11 @@ mod test_metadata {
     #[test]
     fn test_interface() {
         check_metadata(
-            &calc::UNIFFI_META_UNIFFI_FIXTURE_METADATA_INTERFACE_CALCULATOR,
+            &calc::UNIFFI_META_UNIFFI_FIXTURE_METADATA_INTERFACE_CALCULATORRENAMED,
             ObjectMetadata {
                 module_path: "uniffi_fixture_metadata::tests::calc".into(),
-                name: "Calculator".into(),
+                name: "CalculatorRenamed".into(),
+                orig_name: Some("Calculator".into()),
                 remote: false,
                 imp: ObjectImpl::Struct,
                 docstring: None,
@@ -575,7 +611,7 @@ mod test_function_metadata {
     use super::*;
     use std::sync::Arc;
 
-    #[uniffi::export]
+    #[uniffi::export(name = "test_func_renamed")]
     #[allow(unused)]
     pub fn test_func(person: Person, weapon: Weapon) -> String {
         unimplemented!()
@@ -609,11 +645,22 @@ mod test_function_metadata {
 
     #[uniffi::export]
     pub trait CalculatorDisplay: Send + Sync {
+        #[uniffi::method(name = "display_result_renamed")]
         fn display_result(&self, val: String);
     }
 
-    #[uniffi::export]
+    #[uniffi::export(name = "CalculatorRenamed")]
     impl Calculator {
+        #[uniffi::constructor]
+        pub fn new() -> Self {
+            Self {}
+        }
+
+        #[uniffi::constructor(name = "new_renamed")]
+        pub fn new2() -> Self {
+            Self {}
+        }
+
         #[allow(unused)]
         pub fn add(&self, a: u8, b: u8) -> u8 {
             unimplemented!()
@@ -642,30 +689,33 @@ mod test_function_metadata {
     #[test]
     fn test_function() {
         check_metadata(
-            &UNIFFI_META_UNIFFI_FIXTURE_METADATA_FUNC_TEST_FUNC,
+            &UNIFFI_META_UNIFFI_FIXTURE_METADATA_FUNC_TEST_FUNC_RENAMED,
             FnMetadata {
                 module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
-                name: "test_func".into(),
+                name: "test_func_renamed".into(),
+                orig_name: Some("test_func".into()),
                 is_async: false,
                 inputs: vec![
                     FnParamMetadata::simple(
                         "person",
                         Type::Record {
                             module_path: "uniffi_fixture_metadata::tests::person".into(),
-                            name: "Person".into(),
+                            name: "PersonRenamed".into(),
                         },
                     ),
                     FnParamMetadata::simple(
                         "weapon",
                         Type::Enum {
                             module_path: "uniffi_fixture_metadata::tests::weapon".into(),
-                            name: "Weapon".into(),
+                            name: "WeaponRenamed".into(),
                         },
                     ),
                 ],
                 return_type: Some(Type::String),
                 throws: None,
-                checksum: Some(UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_FUNC_TEST_FUNC.checksum()),
+                checksum: Some(
+                    UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_FUNC_TEST_FUNC_RENAMED.checksum(),
+                ),
                 docstring: None,
             },
         );
@@ -678,6 +728,7 @@ mod test_function_metadata {
             FnMetadata {
                 module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 name: "test_func_no_return".into(),
+                orig_name: None,
                 is_async: false,
                 inputs: vec![],
                 return_type: None,
@@ -697,6 +748,7 @@ mod test_function_metadata {
             FnMetadata {
                 module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 name: "test_func_that_throws".into(),
+                orig_name: None,
                 is_async: false,
                 inputs: vec![],
                 return_type: Some(Type::Enum {
@@ -722,6 +774,7 @@ mod test_function_metadata {
             FnMetadata {
                 module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 name: "test_func_no_return_that_throws".into(),
+                orig_name: None,
                 is_async: false,
                 inputs: vec![],
                 return_type: None,
@@ -741,11 +794,12 @@ mod test_function_metadata {
     #[test]
     fn test_method() {
         check_metadata(
-            &UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATOR_ADD,
+            &UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATORRENAMED_ADD,
             MethodMetadata {
                 module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
-                self_name: "Calculator".into(),
+                self_name: "CalculatorRenamed".into(),
                 name: "add".into(),
+                orig_name: None,
                 is_async: false,
                 inputs: vec![
                     FnParamMetadata::simple("a", Type::UInt8),
@@ -755,7 +809,46 @@ mod test_function_metadata {
                 throws: None,
                 takes_self_by_arc: false,
                 checksum: Some(
-                    UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATOR_ADD.checksum(),
+                    UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATORRENAMED_ADD
+                        .checksum(),
+                ),
+                docstring: None,
+            },
+        );
+    }
+
+    #[test]
+    fn test_constructor() {
+        check_metadata(
+            &UNIFFI_META_UNIFFI_FIXTURE_METADATA_CONSTRUCTOR_CALCULATORRENAMED_NEW,
+            ConstructorMetadata {
+                module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
+                self_name: "CalculatorRenamed".into(),
+                name: "new".into(),
+                orig_name: None,
+                is_async: false,
+                inputs: vec![],
+                throws: None,
+                checksum: Some(
+                    UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_CONSTRUCTOR_CALCULATORRENAMED_NEW
+                        .checksum(),
+                ),
+                docstring: None,
+            },
+        );
+        check_metadata(
+            &UNIFFI_META_UNIFFI_FIXTURE_METADATA_CONSTRUCTOR_CALCULATORRENAMED_NEW_RENAMED,
+            ConstructorMetadata {
+                module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
+                self_name: "CalculatorRenamed".into(),
+                name: "new_renamed".into(),
+                orig_name: Some("new2".into()),
+                is_async: false,
+                inputs: vec![],
+                throws: None,
+                checksum: Some(
+                    UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_CONSTRUCTOR_CALCULATORRENAMED_NEW_RENAMED
+                        .checksum(),
                 ),
                 docstring: None,
             },
@@ -769,20 +862,21 @@ mod test_function_metadata {
             FnMetadata {
                 module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 name: "test_async_func".into(),
+                orig_name: None,
                 is_async: true,
                 inputs: vec![
                     FnParamMetadata::simple(
                         "person",
                         Type::Record {
                             module_path: "uniffi_fixture_metadata::tests::person".into(),
-                            name: "Person".into(),
+                            name: "PersonRenamed".into(),
                         },
                     ),
                     FnParamMetadata::simple(
                         "weapon",
                         Type::Enum {
                             module_path: "uniffi_fixture_metadata::tests::weapon".into(),
-                            name: "Weapon".into(),
+                            name: "WeaponRenamed".into(),
                         },
                     ),
                 ],
@@ -803,6 +897,7 @@ mod test_function_metadata {
             FnMetadata {
                 module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 name: "test_async_func_that_throws".into(),
+                orig_name: None,
                 is_async: true,
                 inputs: vec![],
                 return_type: Some(Type::Enum {
@@ -825,11 +920,12 @@ mod test_function_metadata {
     #[test]
     fn test_async_method() {
         check_metadata(
-            &UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATOR_ASYNC_SUB,
+            &UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATORRENAMED_ASYNC_SUB,
             MethodMetadata {
                 module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
-                self_name: "Calculator".into(),
+                self_name: "CalculatorRenamed".into(),
                 name: "async_sub".into(),
+                orig_name: None,
                 is_async: true,
                 inputs: vec![
                     FnParamMetadata::simple("a", Type::UInt8),
@@ -839,7 +935,7 @@ mod test_function_metadata {
                 throws: None,
                 takes_self_by_arc: false,
                 checksum: Some(
-                    UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATOR_ASYNC_SUB
+                    UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATORRENAMED_ASYNC_SUB
                         .checksum(),
                 ),
                 docstring: None,
@@ -854,6 +950,7 @@ mod test_function_metadata {
             ObjectMetadata {
                 module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 name: "CalculatorDisplay".into(),
+                orig_name: None,
                 remote: false,
                 imp: ObjectImpl::Trait,
                 docstring: None,
@@ -868,6 +965,7 @@ mod test_function_metadata {
             ObjectMetadata {
                 module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 name: "TraitWithForeign".into(),
+                orig_name: None,
                 remote: false,
                 imp: ObjectImpl::CallbackTrait,
                 docstring: None,
@@ -878,7 +976,7 @@ mod test_function_metadata {
     #[test]
     fn test_trait_type_data() {
         check_metadata(
-            &UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATOR_GET_DISPLAY,
+            &UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATORRENAMED_GET_DISPLAY,
             MethodMetadata {
                 // The main point of this test is to check the `Type` value for a trait interface
                 return_type: Some(Type::Object {
@@ -887,14 +985,15 @@ mod test_function_metadata {
                     imp: ObjectImpl::Trait,
                 }),
                 module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
-                self_name: "Calculator".into(),
+                self_name: "CalculatorRenamed".into(),
                 name: "get_display".into(),
+                orig_name: None,
                 is_async: false,
                 inputs: vec![],
                 throws: None,
                 takes_self_by_arc: false,
                 checksum: Some(
-                    UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATOR_GET_DISPLAY
+                    UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATORRENAMED_GET_DISPLAY
                         .checksum(),
                 ),
                 docstring: None,
@@ -905,12 +1004,13 @@ mod test_function_metadata {
     #[test]
     fn test_trait_method() {
         check_metadata(
-            &UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATORDISPLAY_DISPLAY_RESULT,
+            &UNIFFI_META_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATORDISPLAY_DISPLAY_RESULT_RENAMED,
             TraitMethodMetadata {
                 module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 trait_name: "CalculatorDisplay".into(),
                 index: 0,
-                name: "display_result".into(),
+                name: "display_result_renamed".into(),
+                orig_name: Some("display_result".into()),
                 is_async: false,
                 inputs: vec![
                     FnParamMetadata::simple("val", Type::String),
@@ -918,7 +1018,7 @@ mod test_function_metadata {
                 return_type: None,
                 throws: None,
                 takes_self_by_arc: false,
-                checksum: Some(UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATORDISPLAY_DISPLAY_RESULT
+                checksum: Some(UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_METHOD_CALCULATORDISPLAY_DISPLAY_RESULT_RENAMED
                     .checksum()),
                 docstring: None,
             },
@@ -946,6 +1046,7 @@ mod test_function_metadata {
                 return_type: None,
                 module_path: "uniffi_fixture_metadata::tests::test_function_metadata".into(),
                 name: "input_trait_with_foreign".into(),
+                orig_name: None,
                 is_async: false,
                 throws: None,
                 checksum: Some(
@@ -974,6 +1075,7 @@ mod test_function_metadata {
                 trait_name: "Logger".into(),
                 index: 0,
                 name: "log".into(),
+                orig_name: None,
                 is_async: false,
                 inputs: vec![FnParamMetadata::simple("message", Type::String)],
                 return_type: None,
@@ -994,6 +1096,7 @@ mod test_function_metadata {
             ObjectMetadata {
                 module_path: "uniffi_fixture_metadata::tests".into(),
                 name: "RealLogger".into(),
+                orig_name: None,
                 imp: ObjectImpl::Struct,
                 remote: false,
                 docstring: None,
@@ -1033,6 +1136,7 @@ mod test_custom_types {
             CustomTypeMetadata {
                 module_path: "uniffi_fixture_metadata::tests::test_custom_types".into(),
                 name: "CustomString".into(),
+                orig_name: None,
                 builtin: Type::String,
                 docstring: None,
             },
@@ -1043,9 +1147,10 @@ mod test_custom_types {
             CustomTypeMetadata {
                 module_path: "uniffi_fixture_metadata::tests::test_custom_types".into(),
                 name: "CustomPerson".into(),
+                orig_name: None,
                 builtin: Type::Record {
                     module_path: "uniffi_fixture_metadata::tests::person".into(),
-                    name: "Person".into(),
+                    name: "PersonRenamed".into(),
                 },
                 docstring: None,
             },

--- a/uniffi_bindgen/src/interface/rename.rs
+++ b/uniffi_bindgen/src/interface/rename.rs
@@ -166,9 +166,11 @@ mod tests {
         let record_meta = RecordMetadata {
             module_path: "test_crate".to_string(),
             name: "OldRecord".to_string(),
+            orig_name: None,
             remote: false,
             fields: vec![FieldMetadata {
                 name: "field".to_string(),
+                orig_name: None,
                 ty: Type::Optional {
                     inner_type: Box::new(Type::Enum {
                         module_path: "test_crate".to_string(),
@@ -187,6 +189,7 @@ mod tests {
         let object_meta = ObjectMetadata {
             module_path: "test_crate".to_string(),
             name: "OldObject".to_string(),
+            orig_name: None,
             imp: ObjectImpl::Struct,
             remote: false,
             docstring: None,
@@ -198,14 +201,17 @@ mod tests {
         let enum_meta = EnumMetadata {
             module_path: "test_crate".to_string(),
             name: "OldEnum".to_string(),
+            orig_name: None,
             shape: EnumShape::Enum,
             discr_type: None,
             non_exhaustive: false,
             remote: false,
             variants: vec![VariantMetadata {
                 name: "WithRecord".to_string(),
+                orig_name: None,
                 fields: vec![FieldMetadata {
                     name: "record".to_string(),
+                    orig_name: None,
                     ty: Type::Optional {
                         inner_type: Box::new(Type::Record {
                             module_path: "test_crate".to_string(),
@@ -227,6 +233,7 @@ mod tests {
         let function_meta = FnMetadata {
             module_path: "test_crate".to_string(),
             name: "old_function".to_string(),
+            orig_name: None,
             is_async: false,
             inputs: vec![FnParamMetadata {
                 name: "arg".to_string(),

--- a/uniffi_bindgen/src/pipeline/general/callable.rs
+++ b/uniffi_bindgen/src/pipeline/general/callable.rs
@@ -14,6 +14,7 @@ pub fn function_callable(func: &initial::Function, context: &Context) -> Result<
 
     Ok(Callable {
         name,
+        orig_name: func.orig_name.clone(),
         async_data: function_async_data(func, context)?,
         kind,
         arguments,
@@ -51,6 +52,7 @@ pub fn method_callable_with_kind(
 
     Ok(Callable {
         name,
+        orig_name: meth.orig_name.clone(),
         arguments,
         return_type: ReturnType {
             ty: meth.return_type.clone().map_node(context)?,
@@ -85,6 +87,7 @@ pub fn constructor_callable(cons: &initial::Constructor, context: &Context) -> R
 
     Ok(Callable {
         name,
+        orig_name: cons.orig_name.clone(),
         async_data: constructor_async_data(cons, interface_name, imp, context)?,
         arguments,
         return_type: ReturnType {
@@ -113,6 +116,7 @@ pub fn map_func_args(
 
             context.update_from_arg(&arg)?;
             Ok(Argument {
+                orig_name: arg.name.clone(),
                 name: rename::func_arg(arg.name, fn_name, context)?,
                 ty: arg.ty.map_node(context)?,
                 optional: arg.optional,
@@ -136,6 +140,7 @@ pub fn map_method_args(
 
             context.update_from_arg(&arg)?;
             Ok(Argument {
+                orig_name: arg.name.clone(),
                 name: rename::method_arg(arg.name, fn_name, context)?,
                 ty: arg.ty.map_node(context)?,
                 optional: arg.optional,

--- a/uniffi_bindgen/src/pipeline/general/context.rs
+++ b/uniffi_bindgen/src/pipeline/general/context.rs
@@ -148,6 +148,7 @@ impl Context {
         self.current_type = Some(Type::Record {
             namespace: self.namespace_name()?,
             name: rec.name.clone(),
+            orig_name: rec.orig_name.clone(),
         });
         Ok(())
     }
@@ -156,6 +157,7 @@ impl Context {
         self.current_type = Some(Type::Enum {
             namespace: self.namespace_name()?,
             name: en.name.clone(),
+            orig_name: en.orig_name.clone(),
         });
         Ok(())
     }
@@ -175,6 +177,7 @@ impl Context {
         self.current_type = Some(Type::Interface {
             namespace: self.namespace_name()?,
             name: int.name.clone(),
+            orig_name: int.orig_name.clone(),
             imp: int.imp,
         });
         Ok(())
@@ -187,6 +190,7 @@ impl Context {
         self.current_type = Some(Type::CallbackInterface {
             namespace: self.namespace_name()?,
             name: cbi.name.clone(),
+            orig_name: cbi.orig_name.clone(),
         });
         Ok(())
     }
@@ -195,6 +199,7 @@ impl Context {
         self.current_type = Some(Type::Custom {
             namespace: self.namespace_name()?,
             name: custom.name.clone(),
+            orig_name: custom.orig_name.clone(),
             builtin: Box::new(custom.builtin.clone()),
         });
         Ok(())

--- a/uniffi_bindgen/src/pipeline/general/enums.rs
+++ b/uniffi_bindgen/src/pipeline/general/enums.rs
@@ -27,6 +27,7 @@ pub fn map_variants(
             Ok(Variant {
                 fields_kind: records::fields_kind(&v.fields),
                 discr,
+                orig_name: v.orig_name,
                 name: rename::variant(v.name, context)?,
                 fields: v.fields.map_node(context)?,
                 docstring: v.docstring,

--- a/uniffi_bindgen/src/pipeline/general/ffi_functions.rs
+++ b/uniffi_bindgen/src/pipeline/general/ffi_functions.rs
@@ -34,6 +34,7 @@ pub fn ffi_definitions(
         let self_type = Type::Interface {
             namespace: namespace_name.to_string(),
             name: int.name.clone(),
+            orig_name: int.orig_name.clone(),
             imp: int.imp,
         };
         int.try_visit(|meth: &initial::Method| {
@@ -55,6 +56,7 @@ pub fn ffi_definitions(
         let self_type = Type::Record {
             namespace: namespace_name.to_string(),
             name: record.name.clone(),
+            orig_name: record.orig_name.clone(),
         };
         record.try_visit(|meth: &initial::Method| {
             ffi_definitions.push(method_ffi_def(meth, &crate_name, &self_type, context)?);
@@ -62,12 +64,13 @@ pub fn ffi_definitions(
         })?;
         Ok(())
     })?;
-    namespace.try_visit(|record: &initial::Enum| {
+    namespace.try_visit(|en: &initial::Enum| {
         let self_type = Type::Enum {
             namespace: namespace_name.to_string(),
-            name: record.name.clone(),
+            name: en.name.clone(),
+            orig_name: en.orig_name.clone(),
         };
-        record.try_visit(|meth: &initial::Method| {
+        en.try_visit(|meth: &initial::Method| {
             ffi_definitions.push(method_ffi_def(meth, &crate_name, &self_type, context)?);
             Ok(())
         })?;

--- a/uniffi_bindgen/src/pipeline/general/ffi_types.rs
+++ b/uniffi_bindgen/src/pipeline/general/ffi_types.rs
@@ -33,12 +33,12 @@ pub fn ffi_type(ty: &Type, context: &Context) -> Result<FfiType> {
             ..
         } => interface_ffi_type(namespace, name, imp)?,
         // Callback interfaces are passed as opaque integer handles.
-        Type::CallbackInterface { namespace, name } => {
-            FfiType::Handle(HandleKind::TraitInterface {
-                namespace: namespace.clone(),
-                interface_name: name.clone(),
-            })
-        }
+        Type::CallbackInterface {
+            namespace, name, ..
+        } => FfiType::Handle(HandleKind::TraitInterface {
+            namespace: namespace.clone(),
+            interface_name: name.clone(),
+        }),
         // Other types are serialized into a bytebuffer and deserialized on the other side.
         Type::Enum { namespace, .. } | Type::Record { namespace, .. } => FfiType::RustBuffer(
             (*namespace != context.namespace_name()?).then_some(namespace.clone()),

--- a/uniffi_bindgen/src/pipeline/general/infer_recursive_enums.rs
+++ b/uniffi_bindgen/src/pipeline/general/infer_recursive_enums.rs
@@ -213,6 +213,7 @@ mod tests {
         let self_type = make_type_node(Type::Enum {
             namespace: "test".to_string(),
             name: name.to_string(),
+            orig_name: name.to_string(),
         });
         TypeDefinition::Enum(Enum {
             name: name.to_string(),
@@ -228,10 +229,12 @@ mod tests {
             recursive: false,
             variants: vec![Variant {
                 name: "Variant0".to_string(),
+                orig_name: "Variant0".to_string(),
                 discr: Literal::Int(0, Radix::Decimal, discr_type_node),
                 fields_kind: FieldsKind::Unnamed,
                 fields: vec![Field {
                     name: "value".to_string(),
+                    orig_name: "value".to_string(),
                     ty: make_type_node(field_ty),
                     default: None,
                     docstring: None,
@@ -246,6 +249,7 @@ mod tests {
         let self_type = make_type_node(Type::Enum {
             namespace: "test".to_string(),
             name: name.to_string(),
+            orig_name: name.to_string(),
         });
         TypeDefinition::Enum(Enum {
             name: name.to_string(),
@@ -261,6 +265,7 @@ mod tests {
             recursive: false,
             variants: vec![Variant {
                 name: "Unit".to_string(),
+                orig_name: "Unit".to_string(),
                 discr: Literal::Int(0, Radix::Decimal, discr_type_node),
                 fields_kind: FieldsKind::Unit,
                 fields: vec![],
@@ -273,6 +278,7 @@ mod tests {
         Type::Enum {
             namespace: "test".to_string(),
             name: name.to_string(),
+            orig_name: name.to_string(),
         }
     }
 
@@ -280,6 +286,7 @@ mod tests {
         Type::Record {
             namespace: "test".to_string(),
             name: name.to_string(),
+            orig_name: name.to_string(),
         }
     }
 
@@ -289,16 +296,19 @@ mod tests {
         let self_type = make_type_node(Type::Enum {
             namespace: "test".to_string(),
             name: name.to_string(),
+            orig_name: name.to_string(),
         });
         let variants = field_types
             .into_iter()
             .enumerate()
             .map(|(i, field_ty)| Variant {
                 name: format!("Variant{i}"),
+                orig_name: format!("Variant{i}"),
                 discr: Literal::Int(i as i64, Radix::Decimal, discr_type_node.clone()),
                 fields_kind: FieldsKind::Unnamed,
                 fields: vec![Field {
                     name: "value".to_string(),
+                    orig_name: "value".to_string(),
                     ty: make_type_node(field_ty),
                     default: None,
                     docstring: None,
@@ -326,6 +336,7 @@ mod tests {
         let self_type = make_type_node(Type::Record {
             namespace: "test".to_string(),
             name: name.to_string(),
+            orig_name: name.to_string(),
         });
         TypeDefinition::Record(Record {
             name: name.to_string(),
@@ -339,6 +350,7 @@ mod tests {
             recursive: false,
             fields: vec![Field {
                 name: "value".to_string(),
+                orig_name: "value".to_string(),
                 ty: make_type_node(field_ty),
                 default: None,
                 docstring: None,
@@ -428,6 +440,7 @@ mod tests {
                 Type::Interface {
                     namespace: "test".to_string(),
                     name: "Judge".to_string(),
+                    orig_name: "Judge".to_string(),
                     imp: ObjectImpl::Struct,
                 },
             ),

--- a/uniffi_bindgen/src/pipeline/general/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/general/nodes.rs
@@ -100,6 +100,7 @@ pub struct Method {
 #[derive(Debug, Clone, Node, MapNode)]
 pub struct Callable {
     pub name: String,
+    pub orig_name: String,
     pub async_data: Option<AsyncData>,
     pub kind: CallableKind,
     pub arguments: Vec<Argument>,
@@ -152,6 +153,7 @@ pub struct AsyncData {
 #[derive(Debug, Clone, Node)]
 pub struct Argument {
     pub name: String,
+    pub orig_name: String,
     pub ty: TypeNode,
     pub optional: bool,
     pub default: Option<DefaultValue>,
@@ -198,7 +200,6 @@ pub struct Record {
     pub fields_kind: FieldsKind,
     #[map_node(context.self_type()?)]
     pub self_type: TypeNode,
-    #[map_node(self.name.clone())]
     pub orig_name: String,
     #[map_node(rename::type_(&context.namespace_name()?, self.name, context)?)]
     pub name: String,
@@ -225,6 +226,7 @@ pub enum FieldsKind {
 #[map_node(from(initial::Field))]
 #[map_node(update_context(context.update_from_field(&self)?))]
 pub struct Field {
+    pub orig_name: String,
     #[map_node(rename::field(self.name, context)?)]
     pub name: String,
     pub ty: TypeNode,
@@ -248,7 +250,6 @@ pub struct Enum {
     pub discr_type: TypeNode,
     #[map_node(enums::map_variants(&self.discr_type, self.variants, context)?)]
     pub variants: Vec<Variant>,
-    #[map_node(self.name.clone())]
     pub orig_name: String,
     #[map_node(rename::type_(&context.namespace_name()?, self.name, context)?)]
     pub name: String,
@@ -268,6 +269,7 @@ pub struct Enum {
 #[derive(Debug, Clone, Node, MapNode)]
 pub struct Variant {
     pub name: String,
+    pub orig_name: String,
     /// Actual discriminant value.  If the source code doesn't specify a discriminant,
     /// this is determined using the Rust's rules for implicit discriminants:
     /// <https://doc.rust-lang.org/reference/items/enumerations.html#implicit-discriminants>
@@ -289,7 +291,6 @@ pub struct Interface {
     pub ffi_func_clone: RustFfiFunctionName,
     #[map_node(objects::ffi_free_name(&self.name, context)?)]
     pub ffi_func_free: RustFfiFunctionName,
-    #[map_node(self.name.clone())]
     pub orig_name: String,
     #[map_node(rename::type_(&context.namespace_name()?, self.name, context)?)]
     pub name: String,
@@ -313,7 +314,6 @@ pub struct CallbackInterface {
     pub vtable: VTable,
     #[map_node(context.self_type()?)]
     pub self_type: TypeNode,
-    #[map_node(self.name.clone())]
     pub orig_name: String,
     #[map_node(rename::type_(&context.namespace_name()?, self.name, context)?)]
     pub name: String,
@@ -359,7 +359,6 @@ pub struct ObjectTraitImpl {
 pub struct CustomType {
     #[map_node(context.self_type()?)]
     pub self_type: TypeNode,
-    #[map_node(self.name.clone())]
     pub orig_name: String,
     #[map_node(rename::type_(&context.namespace_name()?, self.name, context)?)]
     pub name: String,
@@ -402,6 +401,7 @@ pub struct ExternalType {
 /// Wrap `Type` so that we can add extra fields that are set for all variants.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Node, MapNode)]
 #[map_node(from(Type))]
+#[map_node(types::map_type_node)]
 pub struct TypeNode {
     /// Unique UpperCamelCase name for the type
     ///
@@ -409,13 +409,9 @@ pub struct TypeNode {
     ///   - Defining classes to handle things related to the type.
     ///     Many bindings will create a `UniffiConverter[canonical_name]` class.
     ///   - Creating a unique key for a type
-    #[map_node(types::canonical_name(&self))]
     pub canonical_name: String,
-    #[map_node(context.type_is_used_as_error(&self))]
     pub is_used_as_error: bool,
-    #[map_node(ffi_types::ffi_type(&self, context)?)]
     pub ffi_type: FfiType,
-    #[map_node(self.map_node(context)?)]
     pub ty: Type,
 }
 

--- a/uniffi_bindgen/src/pipeline/general/types.rs
+++ b/uniffi_bindgen/src/pipeline/general/types.rs
@@ -4,6 +4,15 @@
 
 use super::*;
 
+pub fn map_type_node(ty: Type, context: &Context) -> Result<TypeNode> {
+    Ok(TypeNode {
+        canonical_name: canonical_name(&ty),
+        is_used_as_error: context.type_is_used_as_error(&ty),
+        ffi_type: ffi_types::ffi_type(&ty, context)?,
+        ty: ty.map_node(context)?,
+    })
+}
+
 pub fn canonical_name(ty: &Type) -> String {
     match ty {
         Type::UInt8 => "UInt8".to_string(),

--- a/uniffi_bindgen/src/pipeline/initial/context.rs
+++ b/uniffi_bindgen/src/pipeline/initial/context.rs
@@ -26,6 +26,7 @@ pub struct Context {
         (String, String),
         BTreeMap<uniffi_meta::Type, uniffi_meta::ObjectTraitImplMetadata>,
     >,
+    pub orig_names: BTreeMap<(String, String), String>,
 }
 
 impl Context {
@@ -35,6 +36,14 @@ impl Context {
             .get(crate_name)
             .cloned()
             .ok_or_else(|| anyhow!("module lookup failed: {module_path:?}"))
+    }
+
+    pub fn get_orig_name(&self, module_path: &str, type_name: &str) -> String {
+        let key = (module_path.to_string(), type_name.to_string());
+        match self.orig_names.get(&key) {
+            Some(orig_name) => orig_name.to_string(),
+            None => type_name.to_string(),
+        }
     }
 
     pub fn methods_for_type(&self, module_path: &str, type_name: &str) -> Result<Vec<Method>> {

--- a/uniffi_bindgen/src/pipeline/initial/from_uniffi_meta.rs
+++ b/uniffi_bindgen/src/pipeline/initial/from_uniffi_meta.rs
@@ -38,6 +38,7 @@ pub struct UniffiMetaConverter {
         (String, String),
         BTreeMap<uniffi_meta::Type, uniffi_meta::ObjectTraitImplMetadata>,
     >,
+    orig_names: BTreeMap<(String, String), String>,
 }
 
 /// Utility trait used to insert metadata items into a BTreeMap, but bail on duplicates
@@ -90,36 +91,43 @@ impl UniffiMetaConverter {
                 )?;
             }
             uniffi_meta::Metadata::Func(func) => {
+                self.update_orig_names(&func.module_path, &func.orig_name, &func.name);
                 self.functions
                     .entry(module_path_to_crate_name(&func.module_path))
                     .or_default()
                     .insert_unique(func.name.clone(), func)?;
             }
             uniffi_meta::Metadata::Record(rec) => {
+                self.update_orig_names(&rec.module_path, &rec.orig_name, &rec.name);
                 self.records
                     .entry(module_path_to_crate_name(&rec.module_path))
                     .or_default()
                     .insert_unique(rec.name.clone(), rec)?;
             }
             uniffi_meta::Metadata::Enum(en) => {
+                self.update_orig_names(&en.module_path, &en.orig_name, &en.name);
                 self.enums
                     .entry(module_path_to_crate_name(&en.module_path))
                     .or_default()
                     .insert_unique(en.name.clone(), en)?;
             }
             uniffi_meta::Metadata::Object(int) => {
+                self.update_orig_names(&int.module_path, &int.orig_name, &int.name);
                 self.interfaces
                     .entry(module_path_to_crate_name(&int.module_path))
                     .or_default()
                     .insert_unique(int.name.clone(), int)?;
             }
             uniffi_meta::Metadata::CallbackInterface(cbi) => {
+                // No `update_orig_names` call, since callback interfaces don't support renaming
+                // yet
                 self.callback_interfaces
                     .entry(module_path_to_crate_name(&cbi.module_path))
                     .or_default()
                     .insert_unique(cbi.name.clone(), cbi)?;
             }
             uniffi_meta::Metadata::CustomType(custom) => {
+                // No `update_orig_names` call, since custom types don't support renaming yet
                 let by_crate = self
                     .custom_types
                     .entry(module_path_to_crate_name(&custom.module_path))
@@ -221,6 +229,15 @@ impl UniffiMetaConverter {
         Ok(())
     }
 
+    fn update_orig_names(&mut self, module_path: &str, orig_name: &Option<String>, name: &str) {
+        if let Some(orig_name) = orig_name {
+            self.orig_names.insert(
+                (module_path_to_crate_name(module_path), name.to_string()),
+                orig_name.clone(),
+            );
+        }
+    }
+
     pub fn add_module_config_toml(
         &mut self,
         module_name: String,
@@ -246,6 +263,7 @@ impl UniffiMetaConverter {
             trait_methods: self.trait_methods,
             uniffi_traits: self.uniffi_traits,
             trait_impls: self.trait_impls,
+            orig_names: self.orig_names,
         };
 
         let mut root = Root {

--- a/uniffi_bindgen/src/pipeline/initial/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/initial/nodes.rs
@@ -32,6 +32,8 @@ pub struct Namespace {
 #[derive(Debug, Clone, PartialEq, Eq, Node, MapNode)]
 #[map_node(from(uniffi_meta::FnMetadata))]
 pub struct Function {
+    #[map_node(self.orig_name.unwrap_or_else(|| self.name.clone()))]
+    pub orig_name: String,
     pub name: String,
     pub is_async: bool,
     pub inputs: Vec<Argument>,
@@ -53,6 +55,8 @@ pub enum TypeDefinition {
 #[derive(Debug, Clone, PartialEq, Eq, Node, MapNode)]
 #[map_node(from(uniffi_meta::ConstructorMetadata))]
 pub struct Constructor {
+    #[map_node(self.orig_name.unwrap_or_else(|| self.name.clone()))]
+    pub orig_name: String,
     pub name: String,
     pub is_async: bool,
     pub inputs: Vec<Argument>,
@@ -65,6 +69,8 @@ pub struct Constructor {
 #[map_node(from(uniffi_meta::MethodMetadata))]
 #[map_node(from(uniffi_meta::TraitMethodMetadata))]
 pub struct Method {
+    #[map_node(self.orig_name.unwrap_or_else(|| self.name.clone()))]
+    pub orig_name: String,
     pub name: String,
     pub is_async: bool,
     pub inputs: Vec<Argument>,
@@ -81,6 +87,8 @@ pub struct TraitMethod {
     // Note: the position of `index` is important since it causes callback interface methods to be
     // ordered correctly in MetadataGroup.items
     pub index: u32,
+    #[map_node(self.orig_name.unwrap_or_else(|| self.name.clone()))]
+    pub orig_name: String,
     pub name: String,
     pub is_async: bool,
     pub inputs: Vec<Argument>,
@@ -130,22 +138,23 @@ pub enum Literal {
 
 #[derive(Debug, Clone, PartialEq, Eq, Node, MapNode)]
 #[map_node(from(uniffi_meta::RecordMetadata))]
+#[map_node(types::map_record)]
 pub struct Record {
-    #[map_node(context.constructors_for_type(&self.module_path, &self.name)?)]
     pub constructors: Vec<Constructor>,
-    #[map_node(context.methods_for_type(&self.module_path, &self.name)?)]
     pub methods: Vec<Method>,
-    #[map_node(context.uniffi_traits_for_type(&self.module_path, &self.name)?)]
     pub uniffi_traits: Vec<UniffiTrait>,
     pub name: String,
+    pub orig_name: String,
     pub fields: Vec<Field>,
     pub docstring: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Node, MapNode)]
 #[map_node(from(uniffi_meta::FieldMetadata))]
+#[map_node(types::map_field)]
 pub struct Field {
     pub name: String,
+    pub orig_name: String,
     pub ty: Type,
     pub default: Option<DefaultValue>,
     pub docstring: Option<String>,
@@ -153,14 +162,13 @@ pub struct Field {
 
 #[derive(Debug, Clone, PartialEq, Eq, Node, MapNode)]
 #[map_node(from(uniffi_meta::EnumMetadata))]
+#[map_node(types::map_enum)]
 pub struct Enum {
-    #[map_node(context.constructors_for_type(&self.module_path, &self.name)?)]
     pub constructors: Vec<Constructor>,
-    #[map_node(context.methods_for_type(&self.module_path, &self.name)?)]
     pub methods: Vec<Method>,
-    #[map_node(context.uniffi_traits_for_type(&self.module_path, &self.name)?)]
     pub uniffi_traits: Vec<UniffiTrait>,
     pub name: String,
+    pub orig_name: String,
     pub shape: EnumShape,
     pub variants: Vec<Variant>,
     pub discr_type: Option<Type>,
@@ -169,8 +177,10 @@ pub struct Enum {
 
 #[derive(Debug, Clone, PartialEq, Eq, Node, MapNode)]
 #[map_node(from(uniffi_meta::VariantMetadata))]
+#[map_node(types::map_variant)]
 pub struct Variant {
     pub name: String,
+    pub orig_name: String,
     pub discr: Option<Literal>,
     pub fields: Vec<Field>,
     pub docstring: Option<String>,
@@ -178,26 +188,25 @@ pub struct Variant {
 
 #[derive(Debug, Clone, PartialEq, Eq, Node, MapNode)]
 #[map_node(from(uniffi_meta::ObjectMetadata))]
+#[map_node(types::map_interface)]
 pub struct Interface {
-    #[map_node(context.constructors_for_type(&self.module_path, &self.name)?)]
     pub constructors: Vec<Constructor>,
-    #[map_node(context.methods_for_type(&self.module_path, &self.name)?)]
     pub methods: Vec<Method>,
-    #[map_node(context.uniffi_traits_for_type(&self.module_path, &self.name)?)]
     pub uniffi_traits: Vec<UniffiTrait>,
-    #[map_node(context.trait_impls_for_type(&self.module_path, &self.name)?)]
     pub trait_impls: Vec<ObjectTraitImpl>,
     pub name: String,
+    pub orig_name: String,
     pub docstring: Option<String>,
     pub imp: ObjectImpl,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Node, MapNode)]
 #[map_node(from(uniffi_meta::CallbackInterfaceMetadata))]
+#[map_node(types::map_callback_interface)]
 pub struct CallbackInterface {
-    #[map_node(context.methods_for_type(&self.module_path, &self.name)?)]
     pub methods: Vec<Method>,
     pub name: String,
+    pub orig_name: String,
     pub docstring: Option<String>,
 }
 
@@ -221,8 +230,10 @@ pub struct ObjectTraitImpl {
 
 #[derive(Debug, Clone, PartialEq, Eq, Node, MapNode)]
 #[map_node(from(uniffi_meta::CustomTypeMetadata))]
+#[map_node(types::map_custom_type)]
 pub struct CustomType {
     pub name: String,
+    pub orig_name: String,
     pub builtin: Type,
     pub docstring: Option<String>,
 }
@@ -264,23 +275,28 @@ pub enum Type {
     Interface {
         namespace: String,
         name: String,
+        orig_name: String,
         imp: ObjectImpl,
     },
     Record {
         namespace: String,
         name: String,
+        orig_name: String,
     },
     Enum {
         namespace: String,
         name: String,
+        orig_name: String,
     },
     CallbackInterface {
         namespace: String,
         name: String,
+        orig_name: String,
     },
     Custom {
         namespace: String,
         name: String,
+        orig_name: String,
         builtin: Box<Type>,
     },
 }
@@ -305,6 +321,17 @@ impl Type {
             | Type::Interface { name, .. }
             | Type::CallbackInterface { name, .. }
             | Type::Custom { name, .. } => Some(name.as_str()),
+            _ => None,
+        }
+    }
+
+    pub fn orig_name(&self) -> Option<&str> {
+        match &self {
+            Type::Record { orig_name, .. }
+            | Type::Enum { orig_name, .. }
+            | Type::Interface { orig_name, .. }
+            | Type::CallbackInterface { orig_name, .. }
+            | Type::Custom { orig_name, .. } => Some(orig_name.as_str()),
             _ => None,
         }
     }

--- a/uniffi_bindgen/src/pipeline/initial/types.rs
+++ b/uniffi_bindgen/src/pipeline/initial/types.rs
@@ -43,19 +43,23 @@ pub fn map_type(ty: uniffi_meta::Type, context: &Context) -> Result<Type> {
             imp,
         } => Type::Interface {
             namespace: context.get_namespace_name(&module_path)?,
+            orig_name: context.get_orig_name(&module_path, &name),
             name,
             imp: imp.map_node(context)?,
         },
         uniffi_meta::Type::Record { module_path, name } => Type::Record {
             namespace: context.get_namespace_name(&module_path)?,
+            orig_name: context.get_orig_name(&module_path, &name),
             name,
         },
         uniffi_meta::Type::Enum { module_path, name } => Type::Enum {
             namespace: context.get_namespace_name(&module_path)?,
+            orig_name: context.get_orig_name(&module_path, &name),
             name,
         },
         uniffi_meta::Type::CallbackInterface { module_path, name } => Type::CallbackInterface {
             namespace: context.get_namespace_name(&module_path)?,
+            orig_name: context.get_orig_name(&module_path, &name),
             name,
         },
         uniffi_meta::Type::Custom {
@@ -64,8 +68,93 @@ pub fn map_type(ty: uniffi_meta::Type, context: &Context) -> Result<Type> {
             builtin,
         } => Type::Custom {
             namespace: context.get_namespace_name(&module_path)?,
+            orig_name: context.get_orig_name(&module_path, &name),
             name,
             builtin: builtin.map_node(context)?,
         },
+    })
+}
+
+pub fn map_record(input: uniffi_meta::RecordMetadata, context: &Context) -> Result<Record> {
+    Ok(Record {
+        constructors: context.constructors_for_type(&input.module_path, &input.name)?,
+        methods: context.methods_for_type(&input.module_path, &input.name)?,
+        uniffi_traits: context.uniffi_traits_for_type(&input.module_path, &input.name)?,
+        orig_name: input.orig_name.unwrap_or_else(|| input.name.clone()),
+        name: input.name,
+        fields: input.fields.map_node(context)?,
+        docstring: input.docstring,
+    })
+}
+
+pub fn map_enum(input: uniffi_meta::EnumMetadata, context: &Context) -> Result<Enum> {
+    Ok(Enum {
+        constructors: context.constructors_for_type(&input.module_path, &input.name)?,
+        methods: context.methods_for_type(&input.module_path, &input.name)?,
+        uniffi_traits: context.uniffi_traits_for_type(&input.module_path, &input.name)?,
+        orig_name: input.orig_name.unwrap_or_else(|| input.name.clone()),
+        name: input.name,
+        shape: input.shape,
+        variants: input.variants.map_node(context)?,
+        discr_type: input.discr_type.map_node(context)?,
+        docstring: input.docstring,
+    })
+}
+
+pub fn map_interface(input: uniffi_meta::ObjectMetadata, context: &Context) -> Result<Interface> {
+    Ok(Interface {
+        constructors: context.constructors_for_type(&input.module_path, &input.name)?,
+        methods: context.methods_for_type(&input.module_path, &input.name)?,
+        uniffi_traits: context.uniffi_traits_for_type(&input.module_path, &input.name)?,
+        trait_impls: context.trait_impls_for_type(&input.module_path, &input.name)?,
+        orig_name: input.orig_name.unwrap_or_else(|| input.name.clone()),
+        name: input.name,
+        docstring: input.docstring,
+        imp: input.imp,
+    })
+}
+
+pub fn map_callback_interface(
+    input: uniffi_meta::CallbackInterfaceMetadata,
+    context: &Context,
+) -> Result<CallbackInterface> {
+    Ok(CallbackInterface {
+        methods: context.methods_for_type(&input.module_path, &input.name)?,
+        // Renaming callback interfaces is not supported yet -- just copy name.
+        orig_name: input.name.clone(),
+        name: input.name,
+        docstring: input.docstring,
+    })
+}
+
+pub fn map_custom_type(
+    input: uniffi_meta::CustomTypeMetadata,
+    context: &Context,
+) -> Result<CustomType> {
+    Ok(CustomType {
+        orig_name: input.orig_name.unwrap_or(input.name.clone()),
+        name: input.name,
+        builtin: input.builtin.map_node(context)?,
+        docstring: input.docstring,
+    })
+}
+
+pub fn map_variant(input: uniffi_meta::VariantMetadata, context: &Context) -> Result<Variant> {
+    Ok(Variant {
+        orig_name: input.orig_name.unwrap_or_else(|| input.name.clone()),
+        name: input.name,
+        discr: input.discr.map_node(context)?,
+        fields: input.fields.map_node(context)?,
+        docstring: input.docstring,
+    })
+}
+
+pub fn map_field(input: uniffi_meta::FieldMetadata, context: &Context) -> Result<Field> {
+    Ok(Field {
+        orig_name: input.orig_name.unwrap_or_else(|| input.name.clone()),
+        name: input.name,
+        ty: input.ty.map_node(context)?,
+        default: input.default.map_node(context)?,
+        docstring: input.docstring,
     })
 }

--- a/uniffi_macros/src/enum_.rs
+++ b/uniffi_macros/src/enum_.rs
@@ -11,7 +11,8 @@ use crate::{
     record::FieldAttributeArguments,
     util::{
         create_metadata_items, either_attribute_arg, extract_docstring, ident_to_string, kw,
-        try_metadata_value_from_usize, try_read_field, AttributeSliceExt, UniffiAttributeArgs,
+        orig_name_metadata, try_metadata_value_from_usize, try_read_field, AttributeSliceExt,
+        UniffiAttributeArgs,
     },
     DeriveOptions,
 };
@@ -117,6 +118,10 @@ impl EnumItem {
             Some(name) => name.clone(),
             None => ident_to_string(&self.ident),
         }
+    }
+
+    pub fn orig_name_metadata(&self) -> TokenStream {
+        orig_name_metadata(self.attr.name.is_some(), &self.ident)
     }
 
     pub fn is_flat_error(&self) -> bool {
@@ -268,6 +273,7 @@ fn enum_or_error_ffi_converter_impl(
 
 pub(crate) fn enum_meta_static_var(item: &EnumItem) -> syn::Result<TokenStream> {
     let name = &item.foreign_name();
+    let orig_name_calls = &item.orig_name_metadata();
     let non_exhaustive = item.is_non_exhaustive();
     let docstring = item.docstring();
     let shape = EnumShape::Enum.as_u8();
@@ -276,6 +282,7 @@ pub(crate) fn enum_meta_static_var(item: &EnumItem) -> syn::Result<TokenStream> 
         ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::ENUM)
             .concat_str(module_path!())
             .concat_str(#name)
+            #orig_name_calls
             .concat_value(#shape)
     };
     metadata_expr.extend(match item.discr_type() {
@@ -360,53 +367,50 @@ pub fn variant_metadata(item: &EnumItem) -> syn::Result<Vec<TokenStream>> {
                 "UniFFI limits enum variants to 256 fields",
             )?;
 
-            let field_names = v
+            let field_metadata = v
                 .fields
                 .iter()
                 .map(|f| {
                     let attrs = f
                         .attrs
                         .parse_uniffi_attr_args::<FieldAttributeArguments>()?;
-                    Ok(attrs
+                    let field_orig_name = match &f.ident {
+                        Some(ident) => orig_name_metadata(attrs.name.is_some(), ident),
+                        None => quote! {
+                            .concat_bool(false)
+                        },
+                    };
+                    let name = attrs
                         .name
-                        .unwrap_or(f.ident.as_ref().map(ident_to_string).unwrap_or_default()))
-                })
-                .collect::<syn::Result<Vec<_>>>()?;
+                        .unwrap_or(f.ident.as_ref().map(ident_to_string).unwrap_or_default());
+                    let type_id = ffiops::type_id_meta(&f.ty);
+                    let default_calls = default_value_metadata_calls(&attrs.default)?;
+                    let docstring = extract_docstring(&f.attrs)?;
 
-            let field_defaults = v
-                .fields
-                .iter()
-                .map(|f| {
-                    let attrs = f
-                        .attrs
-                        .parse_uniffi_attr_args::<FieldAttributeArguments>()?;
-                    default_value_metadata_calls(&attrs.default)
+                    Ok(quote! {
+                        .concat_str(#name)
+                        #field_orig_name
+                        .concat(#type_id)
+                        #default_calls
+                        .concat_long_str(#docstring)
+                    })
                 })
                 .collect::<syn::Result<Vec<_>>>()?;
 
             let attrs = v.attrs.parse_uniffi_attr_args::<VariantAttr>()?;
 
+            let variant_orig_name = orig_name_metadata(attrs.name.is_some(), &v.ident);
             let name = attrs.name.unwrap_or(ident_to_string(&v.ident));
             let value_tokens = variant_value(v)?;
 
             let docstring = extract_docstring(&v.attrs)?;
-            let field_docstrings = v
-                .fields
-                .iter()
-                .map(|f| extract_docstring(&f.attrs))
-                .collect::<syn::Result<Vec<_>>>()?;
-            let field_type_id_metas = v.fields.iter().map(|f| ffiops::type_id_meta(&f.ty));
 
             Ok(quote! {
                 .concat_str(#name)
+                #variant_orig_name
                 #value_tokens
                 .concat_value(#fields_len)
-                    #(
-                        .concat_str(#field_names)
-                        .concat(#field_type_id_metas)
-                        #field_defaults
-                        .concat_long_str(#field_docstrings)
-                    )*
+                    #(#field_metadata)*
                 .concat_long_str(#docstring)
             })
         }))

--- a/uniffi_macros/src/error.rs
+++ b/uniffi_macros/src/error.rs
@@ -7,8 +7,8 @@ use crate::{
     enum_::{rich_error_ffi_converter_impl, variant_metadata, EnumItem, VariantAttr},
     ffiops,
     util::{
-        create_metadata_items, extract_docstring, ident_to_string, try_metadata_value_from_usize,
-        AttributeSliceExt,
+        create_metadata_items, extract_docstring, ident_to_string, orig_name_metadata,
+        try_metadata_value_from_usize, AttributeSliceExt,
     },
     DeriveOptions,
 };
@@ -172,6 +172,7 @@ fn flat_error_ffi_converter_impl(item: &EnumItem, options: &DeriveOptions) -> To
 
 pub(crate) fn error_meta_static_var(item: &EnumItem) -> syn::Result<TokenStream> {
     let name = &item.foreign_name();
+    let orig_name_calls = &item.orig_name_metadata();
     let non_exhaustive = item.is_non_exhaustive();
     let docstring = item.docstring();
     let flat = item.is_flat_error();
@@ -180,6 +181,7 @@ pub(crate) fn error_meta_static_var(item: &EnumItem) -> syn::Result<TokenStream>
             ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::ENUM)
                 .concat_str(module_path!())
                 .concat_str(#name)
+                #orig_name_calls
                 .concat_value(#shape)
                 .concat_bool(false) // discr_type: None
     };
@@ -202,11 +204,13 @@ pub fn flat_error_variant_metadata(item: &EnumItem) -> syn::Result<Vec<TokenStre
     std::iter::once(Ok(quote! { .concat_value(#variants_len) }))
         .chain(enum_.variants.iter().map(|v| {
             let attrs = v.attrs.parse_uniffi_attr_args::<VariantAttr>()?;
+            let orig_name = orig_name_metadata(attrs.name.is_some(), &v.ident);
             let name = attrs.name.unwrap_or(ident_to_string(&v.ident));
 
             let docstring = extract_docstring(&v.attrs)?;
             Ok(quote! {
                 .concat_str(#name)
+                #orig_name
                 .concat_long_str(#docstring)
             })
         }))

--- a/uniffi_macros/src/export/trait_interface.rs
+++ b/uniffi_macros/src/export/trait_interface.rs
@@ -102,8 +102,18 @@ pub(super) fn gen_trait_scaffolding(
         } else {
             ObjectImpl::Trait
         };
-        interface_meta_static_var(&ident_to_string(&self_ident), imp, docstring.as_str())
-            .unwrap_or_else(syn::Error::into_compile_error)
+        // We don't support renaming traits, so this is always false
+        let orig_name_metadata = quote! {
+            .concat_bool(false)
+        };
+
+        interface_meta_static_var(
+            &ident_to_string(&self_ident),
+            orig_name_metadata,
+            imp,
+            docstring.as_str(),
+        )
+        .unwrap_or_else(syn::Error::into_compile_error)
     });
     let ffi_converter_tokens = ffi_converter(&self_ident, with_foreign);
 

--- a/uniffi_macros/src/fnsig.rs
+++ b/uniffi_macros/src/fnsig.rs
@@ -6,7 +6,10 @@ use crate::{
     default::{default_value_metadata_calls, DefaultValue},
     export::{AsyncRuntime, DefaultMap, ExportFnArgs},
     ffiops,
-    util::{create_metadata_items, ident_to_string, mod_path, try_metadata_value_from_usize},
+    util::{
+        create_metadata_items, ident_to_string, mod_path, orig_name_metadata,
+        try_metadata_value_from_usize,
+    },
 };
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
@@ -20,6 +23,8 @@ pub(crate) struct FnSignature {
     pub ident: Ident,
     // The foreign name for this function, usually == ident.
     pub name: String,
+    // Did `self.name` come from an attribute
+    pub name_from_attrs: bool,
     pub is_async: bool,
     pub async_runtime: Option<AsyncRuntime>,
     pub receiver: Option<ReceiverArg>,
@@ -151,6 +156,7 @@ impl FnSignature {
             kind,
             span,
             mod_path: mod_path()?,
+            name_from_attrs: export_fn_args.name.is_some(),
             name: export_fn_args
                 .name
                 .unwrap_or_else(|| ident_to_string(&ident)),
@@ -256,6 +262,7 @@ impl FnSignature {
     pub(crate) fn metadata_expr(&self) -> syn::Result<TokenStream> {
         let Self {
             name,
+            name_from_attrs,
             return_ty,
             is_async,
             docstring,
@@ -275,11 +282,13 @@ impl FnSignature {
 
         let type_id_meta = ffiops::type_id_meta(return_ty);
 
+        let orig_name = orig_name_metadata(*name_from_attrs, &self.ident);
         match &self.kind {
             FnKind::Function => Ok(quote! {
                 ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::FUNC)
                     .concat_str(module_path!())
                     .concat_str(#name)
+                    #orig_name
                     .concat_bool(#is_async)
                     .concat_value(#args_len)
                     #(#arg_metadata_calls)*
@@ -296,6 +305,7 @@ impl FnSignature {
                         .concat_str(module_path!())
                         .concat_str(#object_name)
                         .concat_str(#name)
+                        #orig_name
                         .concat_bool(#is_async)
                         .concat_value(#args_len)
                         #(#arg_metadata_calls)*
@@ -312,6 +322,7 @@ impl FnSignature {
                         .concat_str(#object_name)
                         .concat_u32(#index)
                         .concat_str(#name)
+                        #orig_name
                         .concat_bool(#is_async)
                         .concat_value(#args_len)
                         #(#arg_metadata_calls)*
@@ -329,6 +340,7 @@ impl FnSignature {
                         .concat_str(module_path!())
                         .concat_str(#object_name)
                         .concat_str(#name)
+                        #orig_name
                         .concat_bool(#is_async)
                         .concat_value(#args_len)
                         #(#arg_metadata_calls)*

--- a/uniffi_macros/src/object.rs
+++ b/uniffi_macros/src/object.rs
@@ -6,7 +6,8 @@ use crate::{
     ffiops,
     util::{
         create_metadata_items, either_attribute_arg, extract_docstring, ident_to_string, kw,
-        mod_path, wasm_single_threaded_annotation, AttributeSliceExt, UniffiAttributeArgs,
+        mod_path, orig_name_metadata, wasm_single_threaded_annotation, AttributeSliceExt,
+        UniffiAttributeArgs,
     },
     DeriveOptions,
 };
@@ -93,8 +94,13 @@ pub fn expand_object(input: DeriveInput, options: DeriveOptions) -> syn::Result<
         Span::call_site(),
     );
     let meta_static_var = options.generate_metadata.then(|| {
-        interface_meta_static_var(name, ObjectImpl::Struct, object.docstring())
-            .unwrap_or_else(syn::Error::into_compile_error)
+        interface_meta_static_var(
+            name,
+            orig_name_metadata(object.attr.name.is_some(), ident),
+            ObjectImpl::Struct,
+            object.docstring(),
+        )
+        .unwrap_or_else(syn::Error::into_compile_error)
     });
     let interface_impl = interface_impl(&object, &options);
 
@@ -249,6 +255,7 @@ fn interface_impl(object: &ObjectItem, options: &DeriveOptions) -> TokenStream {
 
 pub(crate) fn interface_meta_static_var(
     name: &str,
+    orig_name_metadata: TokenStream,
     imp: ObjectImpl,
     docstring: &str,
 ) -> syn::Result<TokenStream> {
@@ -265,6 +272,7 @@ pub(crate) fn interface_meta_static_var(
             ::uniffi::MetadataBuffer::from_code(#code)
                 .concat_str(module_path!())
                 .concat_str(#name)
+                #orig_name_metadata
                 .concat_long_str(#docstring)
         },
         None,

--- a/uniffi_macros/src/record.rs
+++ b/uniffi_macros/src/record.rs
@@ -7,7 +7,8 @@ use crate::{
     ffiops,
     util::{
         create_metadata_items, either_attribute_arg, extract_docstring, ident_to_string, kw,
-        try_metadata_value_from_usize, try_read_field, AttributeSliceExt, UniffiAttributeArgs,
+        orig_name_metadata, try_metadata_value_from_usize, try_read_field, AttributeSliceExt,
+        UniffiAttributeArgs,
     },
     DeriveOptions,
 };
@@ -188,6 +189,7 @@ impl UniffiAttributeArgs for FieldAttributeArguments {
 
 fn record_meta_static_var(record: &RecordItem) -> syn::Result<TokenStream> {
     let name = &record.foreign_name();
+    let rec_orig_name_metadata = orig_name_metadata(record.attr.name.is_some(), &record.ident);
     let docstring = record.docstring();
     let fields_len = try_metadata_value_from_usize(
         record.struct_().fields.len(),
@@ -202,7 +204,12 @@ fn record_meta_static_var(record: &RecordItem) -> syn::Result<TokenStream> {
             let attrs = f
                 .attrs
                 .parse_uniffi_attr_args::<FieldAttributeArguments>()?;
-
+            let orig_name_metadata = match &f.ident {
+                Some(ident) => orig_name_metadata(attrs.name.is_some(), ident),
+                None => quote! {
+                    .concat_bool(false)
+                },
+            };
             let name = attrs
                 .name
                 .unwrap_or(ident_to_string(f.ident.as_ref().unwrap()));
@@ -214,6 +221,7 @@ fn record_meta_static_var(record: &RecordItem) -> syn::Result<TokenStream> {
             // TYPE_ID_META should be the same for both traits.
             Ok(quote! {
                 .concat_str(#name)
+                #orig_name_metadata
                 .concat(#type_id_meta)
                 #default
                 .concat_long_str(#docstring)
@@ -228,6 +236,7 @@ fn record_meta_static_var(record: &RecordItem) -> syn::Result<TokenStream> {
             ::uniffi::MetadataBuffer::from_code(::uniffi::metadata::codes::RECORD)
                 .concat_str(module_path!())
                 .concat_str(#name)
+                #rec_orig_name_metadata
                 .concat_value(#fields_len)
                 #concat_fields
                 .concat_long_str(#docstring)

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -136,6 +136,20 @@ pub fn create_metadata_items(
     }
 }
 
+pub fn orig_name_metadata(name_from_attrs: bool, ident: &Ident) -> TokenStream {
+    if name_from_attrs {
+        let orig_name = ident_to_string(ident);
+        quote! {
+            .concat_bool(true)
+            .concat_str(#orig_name)
+        }
+    } else {
+        quote! {
+            .concat_bool(false)
+        }
+    }
+}
+
 pub fn try_metadata_value_from_usize(value: usize, error_message: &str) -> syn::Result<u8> {
     value
         .try_into()

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -139,6 +139,8 @@ pub struct UdlFile {
 pub struct FnMetadata {
     pub module_path: String,
     pub name: String,
+    // Original name, if this was renamed
+    pub orig_name: Option<String>,
     pub is_async: bool,
     pub inputs: Vec<FnParamMetadata>,
     pub return_type: Option<Type>,
@@ -162,6 +164,8 @@ pub struct ConstructorMetadata {
     pub module_path: String,
     pub self_name: String,
     pub name: String,
+    // Original name, if this was renamed
+    pub orig_name: Option<String>,
     pub is_async: bool,
     pub inputs: Vec<FnParamMetadata>,
     pub throws: Option<Type>,
@@ -188,6 +192,8 @@ pub struct MethodMetadata {
     pub module_path: String,
     pub self_name: String,
     pub name: String,
+    // Original name, if this was renamed
+    pub orig_name: Option<String>,
     pub is_async: bool,
     pub inputs: Vec<FnParamMetadata>,
     pub return_type: Option<Type>,
@@ -215,6 +221,8 @@ pub struct TraitMethodMetadata {
     // ordered correctly in MetadataGroup.items
     pub index: u32,
     pub name: String,
+    // Original name, if this was renamed
+    pub orig_name: Option<String>,
     pub is_async: bool,
     pub inputs: Vec<FnParamMetadata>,
     pub return_type: Option<Type>,
@@ -240,6 +248,7 @@ impl From<TraitMethodMetadata> for MethodMetadata {
             module_path: meta.module_path,
             self_name: meta.trait_name,
             name: meta.name,
+            orig_name: meta.orig_name,
             is_async: meta.is_async,
             inputs: meta.inputs,
             return_type: meta.return_type,
@@ -323,6 +332,8 @@ pub enum DefaultValueMetadata {
 pub struct RecordMetadata {
     pub module_path: String,
     pub name: String,
+    // Original name, if this was renamed
+    pub orig_name: Option<String>,
     pub remote: bool, // only used when generating scaffolding from UDL
     pub fields: Vec<FieldMetadata>,
     pub docstring: Option<String>,
@@ -331,6 +342,8 @@ pub struct RecordMetadata {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FieldMetadata {
     pub name: String,
+    // Original name, if this was renamed
+    pub orig_name: Option<String>,
     pub ty: Type,
     pub default: Option<DefaultValueMetadata>,
     pub docstring: Option<String>,
@@ -369,6 +382,8 @@ impl EnumShape {
 pub struct EnumMetadata {
     pub module_path: String,
     pub name: String,
+    // Original name, if this was renamed
+    pub orig_name: Option<String>,
     pub shape: EnumShape,
     pub remote: bool, // only used when generating scaffolding from UDL
     pub variants: Vec<VariantMetadata>,
@@ -380,6 +395,8 @@ pub struct EnumMetadata {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct VariantMetadata {
     pub name: String,
+    // Original name, if this was renamed
+    pub orig_name: Option<String>,
     pub discr: Option<LiteralMetadata>,
     pub fields: Vec<FieldMetadata>,
     pub docstring: Option<String>,
@@ -389,6 +406,8 @@ pub struct VariantMetadata {
 pub struct ObjectMetadata {
     pub module_path: String,
     pub name: String,
+    // Original name, if this was renamed
+    pub orig_name: Option<String>,
     pub remote: bool, // only used when generating scaffolding from UDL
     pub imp: types::ObjectImpl,
     pub docstring: Option<String>,
@@ -519,6 +538,7 @@ impl Checksum for ObjectTraitImplMetadata {
 pub struct CustomTypeMetadata {
     pub module_path: String,
     pub name: String,
+    pub orig_name: Option<String>,
     pub builtin: Type,
     pub docstring: Option<String>,
 }

--- a/uniffi_meta/src/reader.rs
+++ b/uniffi_meta/src/reader.rs
@@ -119,6 +119,11 @@ impl<'a> MetadataReader<'a> {
         String::from_utf8(slice.into()).context("Invalid string data")
     }
 
+    fn read_optional_string(&mut self) -> Result<Option<String>> {
+        let is_some = self.read_bool()?;
+        is_some.then(|| self.read_string()).transpose()
+    }
+
     fn read_long_string(&mut self) -> Result<String> {
         let size = self.read_u16()? as usize;
         let slice;
@@ -232,6 +237,7 @@ impl<'a> MetadataReader<'a> {
     fn read_func(&mut self) -> Result<FnMetadata> {
         let module_path = self.read_string()?;
         let name = self.read_string()?;
+        let orig_name = self.read_optional_string()?;
         let is_async = self.read_bool()?;
         let inputs = self.read_inputs()?;
         let (return_type, throws) = self.read_return_type()?;
@@ -239,6 +245,7 @@ impl<'a> MetadataReader<'a> {
         Ok(FnMetadata {
             module_path,
             name,
+            orig_name,
             is_async,
             inputs,
             return_type,
@@ -252,6 +259,7 @@ impl<'a> MetadataReader<'a> {
         let module_path = self.read_string()?;
         let self_name = self.read_string()?;
         let name = self.read_string()?;
+        let orig_name = self.read_optional_string()?;
         let is_async = self.read_bool()?;
         let inputs = self.read_inputs()?;
         let (return_type, throws) = self.read_return_type()?;
@@ -271,6 +279,7 @@ impl<'a> MetadataReader<'a> {
             self_name,
             is_async,
             name,
+            orig_name,
             inputs,
             throws,
             checksum: self.calc_checksum(),
@@ -282,6 +291,7 @@ impl<'a> MetadataReader<'a> {
         let self_module_path = self.read_string()?;
         let self_name = self.read_string()?;
         let name = self.read_string()?;
+        let orig_name = self.read_optional_string()?;
         let is_async = self.read_bool()?;
         let inputs = self.read_inputs()?;
         let (return_type, throws) = self.read_return_type()?;
@@ -290,6 +300,7 @@ impl<'a> MetadataReader<'a> {
             module_path: self_module_path,
             self_name,
             name,
+            orig_name,
             is_async,
             inputs,
             return_type,
@@ -304,6 +315,7 @@ impl<'a> MetadataReader<'a> {
         Ok(RecordMetadata {
             module_path: self.read_string()?,
             name: self.read_string()?,
+            orig_name: self.read_optional_string()?,
             remote: false, // only used when generating scaffolding from UDL
             fields: self.read_fields()?,
             docstring: self.read_optional_long_string()?,
@@ -313,6 +325,7 @@ impl<'a> MetadataReader<'a> {
     fn read_enum(&mut self) -> Result<EnumMetadata> {
         let module_path = self.read_string()?;
         let name = self.read_string()?;
+        let orig_name = self.read_optional_string()?;
         let shape = EnumShape::from(self.read_u8()?)?;
         let discr_type = if self.read_bool()? {
             Some(self.read_type()?)
@@ -327,6 +340,7 @@ impl<'a> MetadataReader<'a> {
         Ok(EnumMetadata {
             module_path,
             name,
+            orig_name,
             shape,
             remote: false, // only used when generating scaffolding from UDL
             discr_type,
@@ -340,6 +354,7 @@ impl<'a> MetadataReader<'a> {
         Ok(ObjectMetadata {
             module_path: self.read_string()?,
             name: self.read_string()?,
+            orig_name: self.read_optional_string()?,
             remote: false, // only used when generating scaffolding from UDL
             imp,
             docstring: self.read_optional_long_string()?,
@@ -350,6 +365,9 @@ impl<'a> MetadataReader<'a> {
         Ok(CustomTypeMetadata {
             module_path: self.read_string()?,
             name: self.read_string()?,
+            // `orig_name` is always None since there's currently no way to change the name using
+            // the macro code
+            orig_name: None,
             builtin: self.read_type()?,
             docstring: self.read_optional_long_string()?,
         })
@@ -396,6 +414,7 @@ impl<'a> MetadataReader<'a> {
         let trait_name = self.read_string()?;
         let index = self.read_u32()?;
         let name = self.read_string()?;
+        let orig_name = self.read_optional_string()?;
         let is_async = self.read_bool()?;
         let inputs = self.read_inputs()?;
         let (return_type, throws) = self.read_return_type()?;
@@ -405,6 +424,7 @@ impl<'a> MetadataReader<'a> {
             trait_name,
             index,
             name,
+            orig_name,
             is_async,
             inputs,
             return_type,
@@ -427,10 +447,12 @@ impl<'a> MetadataReader<'a> {
         (0..len)
             .map(|_| {
                 let name = self.read_string()?;
+                let orig_name = self.read_optional_string()?;
                 let ty = self.read_type()?;
                 let default = self.read_optional_default(&name, &ty)?;
                 Ok(FieldMetadata {
                     name,
+                    orig_name,
                     ty,
                     default,
                     docstring: self.read_optional_long_string()?,
@@ -445,6 +467,7 @@ impl<'a> MetadataReader<'a> {
             .map(|_| {
                 Ok(VariantMetadata {
                     name: self.read_string()?,
+                    orig_name: self.read_optional_string()?,
                     discr: self.read_optional_literal("<variant-value>", &Type::UInt64)?,
                     fields: self.read_fields()?,
                     docstring: self.read_optional_long_string()?,
@@ -459,6 +482,7 @@ impl<'a> MetadataReader<'a> {
             .map(|_| {
                 Ok(VariantMetadata {
                     name: self.read_string()?,
+                    orig_name: self.read_optional_string()?,
                     discr: None,
                     fields: vec![],
                     docstring: self.read_optional_long_string()?,

--- a/uniffi_udl/src/collectors.rs
+++ b/uniffi_udl/src/collectors.rs
@@ -62,6 +62,7 @@ impl InterfaceCollector {
                     uniffi_meta::CustomTypeMetadata {
                         module_path: module_path.clone(),
                         name: name.clone(),
+                        orig_name: None,
                         builtin: *builtin.clone(),
                         docstring: None,
                     }

--- a/uniffi_udl/src/converters/callables.rs
+++ b/uniffi_udl/src/converters/callables.rs
@@ -35,6 +35,7 @@ impl APIConverter<FieldMetadata> for weedle::argument::SingleArgument<'_> {
         }
         Ok(FieldMetadata {
             name: self.identifier.0.to_string(),
+            orig_name: None,
             ty: type_,
             default: None,
             docstring: None,
@@ -99,6 +100,7 @@ impl APIConverter<FnMetadata> for weedle::namespace::OperationNamespaceMember<'_
         Ok(FnMetadata {
             module_path: ci.module_path(),
             name,
+            orig_name: None,
             is_async,
             return_type,
             inputs: self.args.body.list.convert(ci)?,
@@ -121,6 +123,7 @@ impl APIConverter<ConstructorMetadata> for weedle::interface::ConstructorInterfa
         Ok(ConstructorMetadata {
             module_path: ci.module_path(),
             name: String::from(attributes.get_name().unwrap_or("new")),
+            orig_name: None,
             // We don't know the name of the containing `Object` at this point, fill it in later.
             self_name: Default::default(),
             is_async: attributes.is_async(),
@@ -168,6 +171,7 @@ impl APIConverter<MethodMetadata> for weedle::interface::OperationInterfaceMembe
                     name
                 }
             },
+            orig_name: None,
             is_async,
             inputs: self.args.body.list.convert(ci)?,
             return_type,
@@ -214,6 +218,7 @@ impl APIConverter<TraitMethodMetadata> for weedle::interface::OperationInterface
                     name
                 }
             },
+            orig_name: None,
             is_async,
             inputs: self.args.body.list.convert(ci)?,
             return_type,

--- a/uniffi_udl/src/converters/enum_.rs
+++ b/uniffi_udl/src/converters/enum_.rs
@@ -22,6 +22,7 @@ impl APIConverter<EnumMetadata> for weedle::EnumDefinition<'_> {
         Ok(EnumMetadata {
             module_path: ci.module_path(),
             name: self.identifier.0.to_string(),
+            orig_name: None,
             shape,
             remote: attributes.contains_remote(),
             discr_type: None,
@@ -33,6 +34,7 @@ impl APIConverter<EnumMetadata> for weedle::EnumDefinition<'_> {
                 .map::<Result<_>, _>(|v| {
                     Ok(VariantMetadata {
                         name: v.value.0.to_string(),
+                        orig_name: None,
                         discr: None,
                         fields: vec![],
                         docstring: v.docstring.as_ref().map(|v| convert_docstring(&v.0)),
@@ -73,6 +75,7 @@ impl APIConverter<EnumMetadata> for weedle::InterfaceDefinition<'_> {
         Ok(EnumMetadata {
             module_path: ci.module_path(),
             name: self.identifier.0.to_string(),
+            orig_name: None,
             shape,
             remote: attributes.contains_remote(),
             variants: self

--- a/uniffi_udl/src/converters/interface.rs
+++ b/uniffi_udl/src/converters/interface.rs
@@ -64,6 +64,7 @@ impl APIConverter<ObjectMetadata> for weedle::InterfaceDefinition<'_> {
                 module_path: ci.module_path(),
                 self_name: object_name.to_string(),
                 name: name.to_string(),
+                orig_name: None,
                 is_async: false,
                 inputs,
                 return_type,
@@ -148,6 +149,7 @@ impl APIConverter<ObjectMetadata> for weedle::InterfaceDefinition<'_> {
         Ok(ObjectMetadata {
             module_path: ci.module_path(),
             name: object_name.to_string(),
+            orig_name: None,
             remote: attributes.contains_remote(),
             imp: object_impl,
             docstring: self.docstring.as_ref().map(|v| convert_docstring(&v.0)),

--- a/uniffi_udl/src/converters/mod.rs
+++ b/uniffi_udl/src/converters/mod.rs
@@ -78,6 +78,7 @@ impl APIConverter<VariantMetadata> for weedle::interface::OperationInterfaceMemb
         };
         Ok(VariantMetadata {
             name,
+            orig_name: None,
             discr: None,
             fields: self
                 .args
@@ -113,6 +114,7 @@ impl APIConverter<RecordMetadata> for weedle::DictionaryDefinition<'_> {
         Ok(RecordMetadata {
             module_path: ci.module_path(),
             name: self.identifier.0.to_string(),
+            orig_name: None,
             remote: attributes.contains_remote(),
             fields: self.members.body.convert(ci)?,
             docstring: self.docstring.as_ref().map(|v| convert_docstring(&v.0)),
@@ -134,6 +136,7 @@ impl APIConverter<FieldMetadata> for weedle::dictionary::DictionaryMember<'_> {
         };
         Ok(FieldMetadata {
             name: self.identifier.0.to_string(),
+            orig_name: None,
             ty: type_,
             default,
             docstring: self.docstring.as_ref().map(|v| convert_docstring(&v.0)),
@@ -194,6 +197,7 @@ fn make_uniffi_traits(
             module_path: module_path.to_string(),
             self_name: self_name.to_string(),
             name: name.to_string(),
+            orig_name: None,
             is_async: false,
             inputs,
             return_type,


### PR DESCRIPTION
Include original names in the metadata for renamed items and copy the values through the pipeline. This is needed if we want to use the pipeline for scaffolding generation.  With out it, there's no way to know the actual Rust type names.

The metadata stores an `Option<String>` and only has it set if the item was actually renamed.  This means we don't need to store a bunch of extra data in the metadata symbols.  The pipeline converts this to a non-optional string, which is simpler to use.

Made some pipeline nodes using a single map function rather than multiple functions to map each field.  It felt like there were too many attributes in the struct definitions before.