### PR TITLE
Adding uniffi_meta::Type::Box

### DIFF
--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -15,7 +15,7 @@ mod person {
         name: String,
         #[uniffi(default)]
         preferred_name: String,
-        age: u16,
+        age: Box<u16>,
     }
 }
 
@@ -180,6 +180,9 @@ mod test_type_ids {
         check_type_id::<Option<u8>>(Type::Optional {
             inner_type: Box::new(Type::UInt8),
         });
+        check_type_id::<Box<u8>>(Type::Box {
+            inner_type: Box::new(Type::UInt8),
+        });
         check_type_id::<Vec<u8>>(Type::Bytes);
         check_type_id::<Vec<u16>>(Type::Sequence {
             inner_type: Box::new(Type::UInt16),
@@ -226,7 +229,9 @@ mod test_metadata {
                     },
                     FieldMetadata {
                         name: "age".into(),
-                        ty: Type::UInt16,
+                        ty: Type::Box {
+                            inner_type: Box::new(Type::UInt16),
+                        },
                         default: None,
                         docstring: None,
                     },

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -637,6 +637,7 @@ impl<T: AsType> AsCodeType for T {
             Type::Custom { name, builtin, .. } => {
                 Box::new(custom::CustomCodeType::new(name, builtin.as_codetype()))
             }
+            Type::Box { inner_type } => inner_type.as_codetype(),
         }
     }
 }

--- a/uniffi_bindgen/src/bindings/python/pipeline/nodes.rs
+++ b/uniffi_bindgen/src/bindings/python/pipeline/nodes.rs
@@ -88,6 +88,7 @@ pub enum TypeDefinition {
     /// Type that doesn't contain any other type
     Simple(TypeNode),
     /// Compound types
+    Box(BoxedType),
     Optional(OptionalType),
     Sequence(SequenceType),
     Map(MapType),
@@ -373,6 +374,13 @@ pub struct CustomType {
     pub config: Option<CustomTypeConfig>,
     pub builtin: TypeNode,
     pub docstring: Option<String>,
+    pub self_type: TypeNode,
+}
+
+#[derive(Debug, Clone, Node, MapNode)]
+#[map_node(from(general::BoxedType))]
+pub struct BoxedType {
+    pub inner: TypeNode,
     pub self_type: TypeNode,
 }
 

--- a/uniffi_bindgen/src/bindings/python/pipeline/types.rs
+++ b/uniffi_bindgen/src/bindings/python/pipeline/types.rs
@@ -5,7 +5,12 @@
 use super::*;
 
 pub fn map_type(mut ty: Type, _: &Context) -> Result<Type> {
-    match &mut ty {
+    rename_type(&mut ty);
+    Ok(ty)
+}
+
+fn rename_type(ty: &mut Type) {
+    match ty {
         Type::Enum { name, .. }
         | Type::Record { name, .. }
         | Type::Interface { name, .. }
@@ -13,9 +18,20 @@ pub fn map_type(mut ty: Type, _: &Context) -> Result<Type> {
         | Type::Custom { name, .. } => {
             *name = names::type_name(name);
         }
+        Type::Optional { inner_type }
+        | Type::Sequence { inner_type }
+        | Type::Box { inner_type } => {
+            rename_type(inner_type);
+        }
+        Type::Map {
+            key_type,
+            value_type,
+        } => {
+            rename_type(key_type);
+            rename_type(value_type);
+        }
         _ => (),
     }
-    Ok(ty)
 }
 
 pub fn map_return_type(return_type: general::ReturnType, context: &Context) -> Result<ReturnType> {
@@ -85,6 +101,7 @@ pub fn type_name(ty: &Type, context: &Context) -> Result<String> {
             type_name(key_type, context)?,
             type_name(value_type, context)?
         ),
+        Type::Box { inner_type } => type_name(inner_type, context)?,
     })
 }
 

--- a/uniffi_bindgen/src/bindings/python/templates/BoxTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/BoxTemplate.py
@@ -1,0 +1,12 @@
+class {{ box_.self_type.ffi_converter_name }}(_UniffiConverterRustBuffer):
+    @classmethod
+    def check_lower(cls, value):
+        {{ box_.inner.ffi_converter_name }}.check_lower(value)
+
+    @classmethod
+    def write(cls, value, buf):
+        {{ box_.inner.ffi_converter_name }}.write(value, buf)
+
+    @classmethod
+    def read(cls, buf):
+        return {{ box_.inner.ffi_converter_name }}.read(buf)

--- a/uniffi_bindgen/src/bindings/python/templates/Types.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Types.py
@@ -63,6 +63,9 @@
 {# Type::Simple shouldn't hold any other Type variants #}
 {%- endmatch %}
 
+{%- when TypeDefinition::Box(box_) %}
+{%- include "BoxTemplate.py" %}
+
 {%- when TypeDefinition::Optional(opt) %}
 {%- include "OptionalTemplate.py" %}
 

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -72,6 +72,7 @@ pub fn canonical_name(t: &Type) -> String {
             canonical_name(value_type).to_upper_camel_case()
         ),
         Type::Custom { name, .. } => format!("Type{name}"),
+        Type::Box { inner_type } => canonical_name(inner_type),
     }
 }
 
@@ -281,6 +282,7 @@ mod filters {
                     )
                 }
             }
+            Type::Box { inner_type } => coerce_rb_inner(nm, ns, inner_type)?,
             Type::Custom { .. } => panic!("No support for custom types, yet"),
         })
     }
@@ -313,8 +315,11 @@ mod filters {
     pub fn lower_rb(
         nm: &str,
         _: &dyn askama::Values,
-        type_: &Type,
+        mut type_: &Type,
     ) -> Result<String, askama::Error> {
+        while let Type::Box { inner_type } = type_ {
+            type_ = &**inner_type;
+        }
         Ok(match type_ {
             Type::Int8
             | Type::UInt8
@@ -346,6 +351,7 @@ mod filters {
                 class_name_rb_inner(&canonical_name(type_))?,
                 nm
             ),
+            Type::Box { .. } => unreachable!(),
             Type::Custom { .. } => panic!("No support for lowering custom types, yet"),
         })
     }
@@ -354,8 +360,11 @@ mod filters {
     pub fn lift_rb(
         nm: &str,
         _: &dyn askama::Values,
-        type_: &Type,
+        mut type_: &Type,
     ) -> Result<String, askama::Error> {
+        while let Type::Box { inner_type } = type_ {
+            type_ = &**inner_type;
+        }
         Ok(match type_ {
             Type::Int8
             | Type::UInt8
@@ -392,6 +401,7 @@ mod filters {
                 nm,
                 class_name_rb_inner(&canonical_name(type_))?
             ),
+            Type::Box { .. } => unreachable!(),
             Type::Custom { .. } => panic!("No support for lifting custom types, yet"),
         })
     }

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -763,6 +763,7 @@ impl SwiftCodeOracle {
                 name,
                 self.create_code_type(*builtin),
             )),
+            Type::Box { inner_type } => self.create_code_type(*inner_type),
         }
     }
 

--- a/uniffi_bindgen/src/interface/ffi.rs
+++ b/uniffi_bindgen/src/interface/ffi.rs
@@ -154,6 +154,7 @@ impl From<&Type> for FfiType {
                     t => t,
                 }
             }
+            Type::Box { inner_type } => (&**inner_type).into(),
         }
     }
 }

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -1390,9 +1390,9 @@ fn throws_name(throws: &Option<Type>) -> Option<&str> {
 fn type_names_in_type(ty: &Type) -> Vec<String> {
     match ty {
         Type::Enum { name, .. } | Type::Record { name, .. } => vec![name.clone()],
-        Type::Optional { inner_type } | Type::Sequence { inner_type } => {
-            type_names_in_type(inner_type)
-        }
+        Type::Box { inner_type }
+        | Type::Optional { inner_type }
+        | Type::Sequence { inner_type } => type_names_in_type(inner_type),
         Type::Map {
             key_type,
             value_type,

--- a/uniffi_bindgen/src/interface/universe.rs
+++ b/uniffi_bindgen/src/interface/universe.rs
@@ -186,6 +186,7 @@ fn normalize_type_module_path(ty: &Type) -> Type {
             name: name.clone(),
             builtin: Box::new(normalize_type_module_path(builtin)),
         },
+        Type::Box { inner_type } => normalize_type_module_path(inner_type),
     }
 }
 

--- a/uniffi_bindgen/src/pipeline/general/ffi_types.rs
+++ b/uniffi_bindgen/src/pipeline/general/ffi_types.rs
@@ -62,6 +62,7 @@ pub fn ffi_type(ty: &Type, context: &Context) -> Result<FfiType> {
                 ffi_type => ffi_type,
             }
         }
+        Type::Box { inner_type } => ffi_type(inner_type, context)?,
     })
 }
 

--- a/uniffi_bindgen/src/pipeline/general/infer_recursive_enums.rs
+++ b/uniffi_bindgen/src/pipeline/general/infer_recursive_enums.rs
@@ -124,9 +124,9 @@ fn dfs<T>(
 fn type_names_in_type(ty: &Type) -> Vec<String> {
     match ty {
         Type::Enum { name, .. } | Type::Record { name, .. } => vec![name.clone()],
-        Type::Optional { inner_type } | Type::Sequence { inner_type } => {
-            type_names_in_type(inner_type)
-        }
+        Type::Box { inner_type }
+        | Type::Optional { inner_type }
+        | Type::Sequence { inner_type } => type_names_in_type(inner_type),
         Type::Map {
             key_type,
             value_type,

--- a/uniffi_bindgen/src/pipeline/general/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/general/nodes.rs
@@ -68,6 +68,8 @@ pub enum TypeDefinition {
     Simple(TypeNode),
     /// Compound types
     #[map_node(added)]
+    Box(BoxedType),
+    #[map_node(added)]
     Optional(OptionalType),
     #[map_node(added)]
     Sequence(SequenceType),
@@ -360,6 +362,12 @@ pub struct CustomType {
     pub name: String,
     pub builtin: TypeNode,
     pub docstring: Option<String>,
+}
+
+#[derive(Debug, Clone, Node, MapNode)]
+pub struct BoxedType {
+    pub inner: TypeNode,
+    pub self_type: TypeNode,
 }
 
 #[derive(Debug, Clone, Node, MapNode)]

--- a/uniffi_bindgen/src/pipeline/general/sort.rs
+++ b/uniffi_bindgen/src/pipeline/general/sort.rs
@@ -136,6 +136,7 @@ impl DependencyLogic for TypeDefinitionDependencyLogic {
     fn item_name(&self, type_def: &TypeDefinition) -> String {
         match type_def {
             TypeDefinition::Simple(self_type)
+            | TypeDefinition::Box(BoxedType { self_type, .. })
             | TypeDefinition::Optional(OptionalType { self_type, .. })
             | TypeDefinition::Sequence(SequenceType { self_type, .. })
             | TypeDefinition::Map(MapType { self_type, .. })
@@ -153,7 +154,8 @@ impl DependencyLogic for TypeDefinitionDependencyLogic {
     fn dependency_names(&self, type_def: &TypeDefinition) -> Vec<String> {
         match type_def {
             TypeDefinition::Simple(_) => vec![],
-            TypeDefinition::Optional(OptionalType { inner, .. })
+            TypeDefinition::Box(BoxedType { inner, .. })
+            | TypeDefinition::Optional(OptionalType { inner, .. })
             | TypeDefinition::Sequence(SequenceType { inner, .. }) => {
                 vec![inner.canonical_name.clone()]
             }

--- a/uniffi_bindgen/src/pipeline/general/type_definitions_from_api.rs
+++ b/uniffi_bindgen/src/pipeline/general/type_definitions_from_api.rs
@@ -42,6 +42,12 @@ pub fn type_definitions(
             | Type::Duration => {
                 type_definitions.push(TypeDefinition::Simple(ty.map_node(context)?));
             }
+            Type::Box { inner_type } => {
+                type_definitions.push(TypeDefinition::Box(BoxedType {
+                    inner: (*inner_type).map_node(context)?,
+                    self_type,
+                }));
+            }
             Type::Optional { inner_type } => {
                 type_definitions.push(TypeDefinition::Optional(OptionalType {
                     inner: (*inner_type).map_node(context)?,

--- a/uniffi_bindgen/src/pipeline/general/types.rs
+++ b/uniffi_bindgen/src/pipeline/general/types.rs
@@ -43,6 +43,7 @@ pub fn canonical_name(ty: &Type) -> String {
             canonical_name(key_type),
             canonical_name(value_type),
         ),
+        Type::Box { inner_type } => format!("Box{}", canonical_name(inner_type)),
     }
 }
 

--- a/uniffi_bindgen/src/pipeline/initial/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/initial/nodes.rs
@@ -247,7 +247,9 @@ pub enum Type {
     Bytes,
     Timestamp,
     Duration,
-    // Structurally recursive types.
+    Box {
+        inner_type: Box<Type>,
+    },
     Optional {
         inner_type: Box<Type>,
     },

--- a/uniffi_bindgen/src/pipeline/initial/types.rs
+++ b/uniffi_bindgen/src/pipeline/initial/types.rs
@@ -21,6 +21,9 @@ pub fn map_type(ty: uniffi_meta::Type, context: &Context) -> Result<Type> {
         uniffi_meta::Type::Bytes => Type::Bytes,
         uniffi_meta::Type::Timestamp => Type::Timestamp,
         uniffi_meta::Type::Duration => Type::Duration,
+        uniffi_meta::Type::Box { inner_type } => Type::Box {
+            inner_type: inner_type.map_node(context)?,
+        },
         uniffi_meta::Type::Optional { inner_type } => Type::Optional {
             inner_type: inner_type.map_node(context)?,
         },

--- a/uniffi_bindgen/src/scaffolding/mod.rs
+++ b/uniffi_bindgen/src/scaffolding/mod.rs
@@ -50,6 +50,9 @@ mod filters {
                 format!("::std::sync::Arc<{}>", imp.rust_name_for(name))
             }
             Type::CallbackInterface { name, .. } => format!("Box<dyn r#{name}>"),
+            Type::Box { inner_type } => {
+                format!("::std::boxed::Box<{}>", type_rs_inner(inner_type)?,)
+            }
             Type::Optional { inner_type } => {
                 format!("::std::option::Option<{}>", type_rs_inner(inner_type)?)
             }

--- a/uniffi_core/src/ffi_converter_impls.rs
+++ b/uniffi_core/src/ffi_converter_impls.rs
@@ -321,7 +321,8 @@ unsafe impl<UT, T: Lift<UT>> Lift<UT> for Box<T> {
 }
 
 impl<UT, T: TypeId<UT>> TypeId<UT> for Box<T> {
-    const TYPE_ID_META: MetadataBuffer = T::TYPE_ID_META;
+    const TYPE_ID_META: MetadataBuffer =
+        MetadataBuffer::from_code(metadata::codes::TYPE_BOX).concat(T::TYPE_ID_META);
 }
 
 // Support for passing vectors of values via the FFI.

--- a/uniffi_core/src/metadata.rs
+++ b/uniffi_core/src/metadata.rs
@@ -70,6 +70,7 @@ pub mod codes {
     pub const TYPE_RESULT: u8 = 23;
     pub const TYPE_TRAIT_INTERFACE: u8 = 24;
     pub const TYPE_CALLBACK_TRAIT_INTERFACE: u8 = 25;
+    pub const TYPE_BOX: u8 = 26;
     pub const TYPE_UNIT: u8 = 255;
 
     // Literal codes for LiteralMetadata

--- a/uniffi_meta/src/metadata.rs
+++ b/uniffi_meta/src/metadata.rs
@@ -53,6 +53,7 @@ pub mod codes {
     pub const TYPE_RESULT: u8 = 23;
     pub const TYPE_TRAIT_INTERFACE: u8 = 24;
     pub const TYPE_CALLBACK_TRAIT_INTERFACE: u8 = 25;
+    pub const TYPE_BOX: u8 = 26;
     pub const TYPE_UNIT: u8 = 255;
 
     // Literal codes

--- a/uniffi_meta/src/reader.rs
+++ b/uniffi_meta/src/reader.rs
@@ -182,6 +182,9 @@ impl<'a> MetadataReader<'a> {
             codes::TYPE_OPTION => Type::Optional {
                 inner_type: Box::new(self.read_type()?),
             },
+            codes::TYPE_BOX => Type::Box {
+                inner_type: Box::new(self.read_type()?),
+            },
             codes::TYPE_VEC => {
                 let inner_type = self.read_type()?;
                 if inner_type == Type::UInt8 {

--- a/uniffi_meta/src/types.rs
+++ b/uniffi_meta/src/types.rs
@@ -98,7 +98,12 @@ pub enum Type {
         module_path: String,
         name: String,
     },
-    // Structurally recursive types.
+    /// Used for a Box<T> type.
+    /// This only matters for scaffolding generation.
+    /// Bindings can ignore this and just use the inner type.
+    Box {
+        inner_type: Box<Type>,
+    },
     Optional {
         inner_type: Box<Type>,
     },


### PR DESCRIPTION
Remember store metadata about which types were boxed.  This is needed if we want to generate scaffolding using the pipeline.  Bindings can mostly ignore it.