### PR TITLE
bindgen-tests updates

### DIFF
--- a/bindgen-tests/external-types/Cargo.toml
+++ b/bindgen-tests/external-types/Cargo.toml
@@ -8,4 +8,4 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
 thiserror = "2"
-uniffi = { workspace = true }
+uniffi = { path = "../../uniffi", default-features = false }

--- a/bindgen-tests/external-types/src/lib.rs
+++ b/bindgen-tests/external-types/src/lib.rs
@@ -6,7 +6,7 @@ uniffi::setup_scaffolding!("uniffi_bindgen_tests_external_types_source");
 
 #[derive(uniffi::Record)]
 pub struct ExternalRec {
-    a: u8,
+    pub a: u8,
 }
 
 #[derive(uniffi::Enum)]
@@ -24,11 +24,11 @@ pub struct ExternalInterface {
 #[uniffi::export]
 impl ExternalInterface {
     #[uniffi::constructor]
-    fn new(value: u32) -> Self {
+    pub fn new(value: u32) -> Self {
         Self { value }
     }
 
-    fn get_value(&self) -> u32 {
+    pub fn get_value(&self) -> u32 {
         self.value
     }
 }

--- a/bindgen-tests/lib/Cargo.toml
+++ b/bindgen-tests/lib/Cargo.toml
@@ -11,14 +11,14 @@ async-trait = "0.1"
 camino = "1"
 glob = "0.3"
 thiserror = "2"
-uniffi = { workspace = true, features = ["bindgen", "ffi-trace"] }
+uniffi = { path = "../../uniffi", features = ["bindgen", "ffi-trace", "cargo-metadata"], default-features = false }
 url = "2.5"
 
 uniffi-bindgen-tests-external-types-source = { path = "../external-types" }
 
 [features]
 default = ["simple_fns", "primitive_types", "records", "enums", "compound_types", "interfaces",
-    "custom_types", "errors", "callback_interfaces", "trait_interfaces", "complex_fns", "futures",
+    "custom_types", "errors", "callback_interfaces", "futures", "trait_interfaces", "complex_fns",
     "external-types", "renames", "recursive_types"]
 simple_fns = []
 primitive_types = []

--- a/bindgen-tests/lib/src/callback_interfaces.rs
+++ b/bindgen-tests/lib/src/callback_interfaces.rs
@@ -29,24 +29,30 @@ pub struct CallbackInterfaceNumbers {
 }
 
 #[uniffi::export]
-fn invoke_test_callback_interface_noop(cbi: Box<dyn TestCallbackInterface>) {
+pub fn invoke_test_callback_interface_noop(cbi: Box<dyn TestCallbackInterface>) {
     cbi.noop()
 }
 
 #[uniffi::export]
-fn invoke_test_callback_interface_get_value(cbi: Box<dyn TestCallbackInterface>) -> u32 {
+pub fn invoke_test_callback_interface_get_value(cbi: Box<dyn TestCallbackInterface>) -> u32 {
     cbi.get_value()
 }
 
 #[uniffi::export]
-fn invoke_test_callback_interface_set_value(cbi: Box<dyn TestCallbackInterface>, value: u32) {
+pub fn invoke_test_callback_interface_set_value(cbi: Box<dyn TestCallbackInterface>, value: u32) {
     cbi.set_value(value)
 }
 
 #[uniffi::export]
-fn invoke_test_callback_interface_throw_if_equal(
+pub fn invoke_test_callback_interface_throw_if_equal(
     cbi: Box<dyn TestCallbackInterface>,
     numbers: CallbackInterfaceNumbers,
 ) -> Result<CallbackInterfaceNumbers, TestError> {
     cbi.throw_if_equal(numbers)
+}
+
+impl From<uniffi::UnexpectedUniFFICallbackError> for TestError {
+    fn from(e: uniffi::UnexpectedUniFFICallbackError) -> Self {
+        Self::Failure2 { data: e.reason }
+    }
 }

--- a/bindgen-tests/lib/src/complex_fns.rs
+++ b/bindgen-tests/lib/src/complex_fns.rs
@@ -16,8 +16,8 @@ pub fn func_with_multi_word_arg(the_argument: String) -> String {
     the_argument
 }
 
-#[derive(uniffi::Object)]
-struct ComplexMethods;
+#[derive(uniffi::Object, Default)]
+pub struct ComplexMethods;
 
 #[uniffi::export]
 impl ComplexMethods {

--- a/bindgen-tests/lib/src/futures.rs
+++ b/bindgen-tests/lib/src/futures.rs
@@ -11,77 +11,77 @@ use crate::errors::TestError;
 use std::{collections::HashMap, sync::Arc};
 
 #[uniffi::export]
-async fn async_roundtrip_u8(v: u8) -> u8 {
+pub async fn async_roundtrip_u8(v: u8) -> u8 {
     v
 }
 
 #[uniffi::export]
-async fn async_roundtrip_i8(v: i8) -> i8 {
+pub async fn async_roundtrip_i8(v: i8) -> i8 {
     v
 }
 
 #[uniffi::export]
-async fn async_roundtrip_u16(v: u16) -> u16 {
+pub async fn async_roundtrip_u16(v: u16) -> u16 {
     v
 }
 
 #[uniffi::export]
-async fn async_roundtrip_i16(v: i16) -> i16 {
+pub async fn async_roundtrip_i16(v: i16) -> i16 {
     v
 }
 
 #[uniffi::export]
-async fn async_roundtrip_u32(v: u32) -> u32 {
+pub async fn async_roundtrip_u32(v: u32) -> u32 {
     v
 }
 
 #[uniffi::export]
-async fn async_roundtrip_i32(v: i32) -> i32 {
+pub async fn async_roundtrip_i32(v: i32) -> i32 {
     v
 }
 
 #[uniffi::export]
-async fn async_roundtrip_u64(v: u64) -> u64 {
+pub async fn async_roundtrip_u64(v: u64) -> u64 {
     v
 }
 
 #[uniffi::export]
-async fn async_roundtrip_i64(v: i64) -> i64 {
+pub async fn async_roundtrip_i64(v: i64) -> i64 {
     v
 }
 
 #[uniffi::export]
-async fn async_roundtrip_f32(v: f32) -> f32 {
+pub async fn async_roundtrip_f32(v: f32) -> f32 {
     v
 }
 
 #[uniffi::export]
-async fn async_roundtrip_f64(v: f64) -> f64 {
+pub async fn async_roundtrip_f64(v: f64) -> f64 {
     v
 }
 
 #[uniffi::export]
-async fn async_roundtrip_string(v: String) -> String {
+pub async fn async_roundtrip_string(v: String) -> String {
     v
 }
 
 #[uniffi::export]
-async fn async_roundtrip_vec(v: Vec<u32>) -> Vec<u32> {
+pub async fn async_roundtrip_vec(v: Vec<u32>) -> Vec<u32> {
     v
 }
 
 #[uniffi::export]
-async fn async_roundtrip_map(v: HashMap<String, String>) -> HashMap<String, String> {
+pub async fn async_roundtrip_map(v: HashMap<String, String>) -> HashMap<String, String> {
     v
 }
 
 #[uniffi::export]
-async fn async_throw_error() -> Result<(), TestError> {
+pub async fn async_throw_error() -> Result<(), TestError> {
     Err(TestError::Failure1)
 }
 
 #[derive(uniffi::Object)]
-struct AsyncInterface {
+pub struct AsyncInterface {
     name: String,
 }
 
@@ -98,7 +98,7 @@ impl AsyncInterface {
 }
 
 #[uniffi::export]
-async fn async_roundtrip_obj(v: Arc<AsyncInterface>) -> Arc<AsyncInterface> {
+pub async fn async_roundtrip_obj(v: Arc<AsyncInterface>) -> Arc<AsyncInterface> {
     v
 }
 
@@ -116,19 +116,19 @@ pub trait TestAsyncCallbackInterface: Send + Sync {
 }
 
 #[uniffi::export]
-async fn invoke_test_async_callback_interface_noop(cbi: Box<dyn TestAsyncCallbackInterface>) {
+pub async fn invoke_test_async_callback_interface_noop(cbi: Box<dyn TestAsyncCallbackInterface>) {
     cbi.noop().await
 }
 
 #[uniffi::export]
-async fn invoke_test_async_callback_interface_get_value(
+pub async fn invoke_test_async_callback_interface_get_value(
     cbi: Box<dyn TestAsyncCallbackInterface>,
 ) -> u32 {
     cbi.get_value().await
 }
 
 #[uniffi::export]
-async fn invoke_test_async_callback_interface_set_value(
+pub async fn invoke_test_async_callback_interface_set_value(
     cbi: Box<dyn TestAsyncCallbackInterface>,
     value: u32,
 ) {
@@ -136,7 +136,7 @@ async fn invoke_test_async_callback_interface_set_value(
 }
 
 #[uniffi::export]
-async fn invoke_test_async_callback_interface_throw_if_equal(
+pub async fn invoke_test_async_callback_interface_throw_if_equal(
     cbi: Box<dyn TestAsyncCallbackInterface>,
     numbers: CallbackInterfaceNumbers,
 ) -> Result<CallbackInterfaceNumbers, TestError> {

--- a/bindgen-tests/lib/src/interfaces.rs
+++ b/bindgen-tests/lib/src/interfaces.rs
@@ -36,8 +36,8 @@ pub fn clone_interface(interface: Arc<TestInterface>) -> Arc<TestInterface> {
 // Test interfaces in records
 #[derive(uniffi::Record)]
 pub struct TwoTestInterfaces {
-    first: Arc<TestInterface>,
-    second: Arc<TestInterface>,
+    pub first: Arc<TestInterface>,
+    pub second: Arc<TestInterface>,
 }
 
 #[uniffi::export]

--- a/bindgen-tests/lib/src/primitive_types.rs
+++ b/bindgen-tests/lib/src/primitive_types.rs
@@ -178,6 +178,7 @@ pub fn sum_with_many_types(
     j: f64,
     negate: bool,
 ) -> f64 {
+    uniffi::trace!("sum_with_many_types: {a} {b} {c} {d} {e} {f} {g} {h} {i} {j} {negate}");
     let all_values = [
         a as f64, b as f64, c as f64, d as f64, e as f64, f as f64, g as f64, h as f64, i as f64, j,
     ];

--- a/bindgen-tests/lib/src/records.rs
+++ b/bindgen-tests/lib/src/records.rs
@@ -4,30 +4,30 @@
 
 #[derive(uniffi::Record)]
 pub struct SimpleRec {
-    a: u8,
+    pub a: u8,
 }
 
 #[derive(uniffi::Record)]
 pub struct RecWithDefault {
     #[uniffi(default = 42)]
-    a: u8,
+    pub a: u8,
 }
 
 #[derive(uniffi::Record)]
 pub struct ComplexRec {
-    field_u8: u8,
-    field_i8: i8,
-    field_u16: u16,
-    field_i16: i16,
-    field_u32: u32,
-    field_i32: i32,
-    field_u64: u64,
-    field_i64: i64,
-    field_f32: f32,
-    field_f64: f64,
+    pub field_u8: u8,
+    pub field_i8: i8,
+    pub field_u16: u16,
+    pub field_i16: i16,
+    pub field_u32: u32,
+    pub field_i32: i32,
+    pub field_u64: u64,
+    pub field_i64: i64,
+    pub field_f32: f32,
+    pub field_f64: f64,
     #[uniffi(default = "DefaultString")]
-    field_string: String,
-    field_rec: SimpleRec,
+    pub field_string: String,
+    pub field_rec: SimpleRec,
 }
 
 #[uniffi::export]

--- a/bindgen-tests/lib/src/recursive_types.rs
+++ b/bindgen-tests/lib/src/recursive_types.rs
@@ -39,7 +39,7 @@ pub enum LinkedList {
 }
 
 #[uniffi::export]
-fn list_sum(list: LinkedList) -> i32 {
+pub fn list_sum(list: LinkedList) -> i32 {
     match list {
         LinkedList::Nil => 0,
         LinkedList::Cons { head, tail } => head + tail.map(|t| list_sum(*t)).unwrap_or(0),
@@ -56,7 +56,7 @@ pub enum Trie {
 }
 
 #[uniffi::export]
-fn trie_sum(trie: Trie) -> i32 {
+pub fn trie_sum(trie: Trie) -> i32 {
     match trie {
         Trie::Leaf(v) => v,
         Trie::Branch { children } => children.into_values().map(|t| trie_sum(*t)).sum(),
@@ -77,7 +77,7 @@ pub struct RoseData {
 }
 
 #[uniffi::export]
-fn sum_rose_tree(tree: RoseTree) -> i32 {
+pub fn sum_rose_tree(tree: RoseTree) -> i32 {
     match tree {
         RoseTree::Leaf(v) => v,
         RoseTree::Branch(data) => {
@@ -87,7 +87,7 @@ fn sum_rose_tree(tree: RoseTree) -> i32 {
 }
 
 #[uniffi::export]
-fn sum_tree(tree: Tree) -> i32 {
+pub fn sum_tree(tree: Tree) -> i32 {
     match tree {
         Tree::Leaf(v) => v,
         Tree::Node { left, right } => sum_tree(*left) + sum_tree(*right),
@@ -95,7 +95,7 @@ fn sum_tree(tree: Tree) -> i32 {
 }
 
 #[uniffi::export]
-fn eval_expr(expr: Expr) -> i32 {
+pub fn eval_expr(expr: Expr) -> i32 {
     match expr {
         Expr::Lit(v) => v,
         Expr::If { cond, then_, else_ } => {
@@ -109,7 +109,7 @@ fn eval_expr(expr: Expr) -> i32 {
 }
 
 #[uniffi::export]
-fn eval_bool(expr: BoolExpr) -> bool {
+pub fn eval_bool(expr: BoolExpr) -> bool {
     match expr {
         BoolExpr::True_ => true,
         BoolExpr::False_ => false,
@@ -139,7 +139,7 @@ impl std::fmt::Display for EvalError {
 impl std::error::Error for EvalError {}
 
 #[uniffi::export]
-fn maybe_throw_error(should_throw: bool) -> Result<i32, EvalError> {
+pub fn maybe_throw_error(should_throw: bool) -> Result<i32, EvalError> {
     if should_throw {
         Err(EvalError::Nested {
             inner: Box::new(EvalError::Overflow),

--- a/bindgen-tests/lib/src/renames.rs
+++ b/bindgen-tests/lib/src/renames.rs
@@ -10,7 +10,7 @@ pub fn function_to_rename(record: RecordToRename) -> EnumToRename {
 #[derive(uniffi::Record)]
 #[uniffi(name = "RenamedRecord")]
 pub struct RecordToRename {
-    item: i32,
+    pub item: i32,
 }
 
 #[derive(uniffi::Enum)]
@@ -88,7 +88,7 @@ pub fn binding_function_to_rename(
 
 #[derive(uniffi::Record)]
 pub struct BindingRecordToRename {
-    item: i32,
+    pub item: i32,
 }
 
 #[derive(uniffi::Enum)]

--- a/bindgen-tests/lib/src/trait_interfaces.rs
+++ b/bindgen-tests/lib/src/trait_interfaces.rs
@@ -33,22 +33,22 @@ pub trait TestTraitInterface: Send + Sync {
 }
 
 #[uniffi::export]
-fn invoke_test_trait_interface_noop(interface: Arc<dyn TestTraitInterface>) {
+pub fn invoke_test_trait_interface_noop(interface: Arc<dyn TestTraitInterface>) {
     interface.noop()
 }
 
 #[uniffi::export]
-fn invoke_test_trait_interface_get_value(interface: Arc<dyn TestTraitInterface>) -> u32 {
+pub fn invoke_test_trait_interface_get_value(interface: Arc<dyn TestTraitInterface>) -> u32 {
     interface.get_value()
 }
 
 #[uniffi::export]
-fn invoke_test_trait_interface_set_value(interface: Arc<dyn TestTraitInterface>, value: u32) {
+pub fn invoke_test_trait_interface_set_value(interface: Arc<dyn TestTraitInterface>, value: u32) {
     interface.set_value(value)
 }
 
 #[uniffi::export]
-fn invoke_test_trait_interface_throw_if_equal(
+pub fn invoke_test_trait_interface_throw_if_equal(
     interface: Arc<dyn TestTraitInterface>,
     numbers: CallbackInterfaceNumbers,
 ) -> Result<CallbackInterfaceNumbers, TestError> {
@@ -57,13 +57,13 @@ fn invoke_test_trait_interface_throw_if_equal(
 
 /// Create an implementation of the interface in Rust
 #[uniffi::export]
-fn create_test_trait_interface(value: u32) -> Arc<dyn TestTraitInterface> {
+pub fn create_test_trait_interface(value: u32) -> Arc<dyn TestTraitInterface> {
     Arc::new(TestTraitInterfaceImpl {
         value: AtomicU32::new(value),
     })
 }
 
-struct TestTraitInterfaceImpl {
+pub struct TestTraitInterfaceImpl {
     value: AtomicU32,
 }
 
@@ -111,26 +111,26 @@ pub trait AsyncTestTraitInterface: Send + Sync {
 }
 
 #[uniffi::export]
-fn create_async_test_trait_interface(value: u32) -> Arc<dyn AsyncTestTraitInterface> {
+pub fn create_async_test_trait_interface(value: u32) -> Arc<dyn AsyncTestTraitInterface> {
     Arc::new(TestTraitInterfaceImpl {
         value: AtomicU32::new(value),
     })
 }
 
 #[uniffi::export]
-async fn invoke_async_test_trait_interface_noop(interface: Arc<dyn AsyncTestTraitInterface>) {
+pub async fn invoke_async_test_trait_interface_noop(interface: Arc<dyn AsyncTestTraitInterface>) {
     interface.noop().await
 }
 
 #[uniffi::export]
-async fn invoke_async_test_trait_interface_get_value(
+pub async fn invoke_async_test_trait_interface_get_value(
     interface: Arc<dyn AsyncTestTraitInterface>,
 ) -> u32 {
     interface.get_value().await
 }
 
 #[uniffi::export]
-async fn invoke_async_test_trait_interface_set_value(
+pub async fn invoke_async_test_trait_interface_set_value(
     interface: Arc<dyn AsyncTestTraitInterface>,
     value: u32,
 ) {
@@ -138,7 +138,7 @@ async fn invoke_async_test_trait_interface_set_value(
 }
 
 #[uniffi::export]
-async fn invoke_async_test_trait_interface_throw_if_equal(
+pub async fn invoke_async_test_trait_interface_throw_if_equal(
     interface: Arc<dyn AsyncTestTraitInterface>,
     numbers: CallbackInterfaceNumbers,
 ) -> Result<CallbackInterfaceNumbers, TestError> {
@@ -175,28 +175,28 @@ impl AsyncTestTraitInterface for TestTraitInterfaceImpl {
 // The list versions are there to test them being passed via a `RustBuffer`.
 
 #[uniffi::export]
-fn roundtrip_test_trait_interface(
+pub fn roundtrip_test_trait_interface(
     interface: Arc<dyn TestTraitInterface>,
 ) -> Arc<dyn TestTraitInterface> {
     interface
 }
 
 #[uniffi::export]
-fn roundtrip_test_trait_interface_list(
+pub fn roundtrip_test_trait_interface_list(
     interfaces: Vec<Arc<dyn TestTraitInterface>>,
 ) -> Vec<Arc<dyn TestTraitInterface>> {
     interfaces
 }
 
 #[uniffi::export]
-fn roundtrip_async_test_trait_interface(
+pub fn roundtrip_async_test_trait_interface(
     interface: Arc<dyn AsyncTestTraitInterface>,
 ) -> Arc<dyn AsyncTestTraitInterface> {
     interface
 }
 
 #[uniffi::export]
-fn roundtrip_async_test_trait_interface_list(
+pub fn roundtrip_async_test_trait_interface_list(
     interfaces: Vec<Arc<dyn AsyncTestTraitInterface>>,
 ) -> Vec<Arc<dyn AsyncTestTraitInterface>> {
     interfaces

--- a/bindgen-tests/swift/src/lib.rs
+++ b/bindgen-tests/swift/src/lib.rs
@@ -123,7 +123,8 @@ mod test {
         ];
         for filename in source_filenames {
             let path = tempdir.join(filename);
-            let contents = fs::read_to_string(path).unwrap();
+            let contents = fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("Error reading modulemap: {path} ({e})"));
             write!(f, "{contents}").unwrap();
         }
     }


### PR DESCRIPTION
* Made export items `pub`.  This is needed for the `uniffi-bindgen-kotlin-jni` code I'm working on. It also seems more correct, since we're calling these functions from across the FFI.
* Order the `futures` tests before `trait_interfaces`.  This is more logical, since `trait_interfaces` depends on the async code.
* Added a `From<uniffi::UnexpectedUniFFICallbackError>` impl to the callback tests.
* Re-export all items in the top-level crate.  This is currently needed to for `uniffi-bindgen-kotlin-jni`.