### PR TITLE
More Rust Future updates

### DIFF
--- a/uniffi_core/src/ffi/rustfuture/future.rs
+++ b/uniffi_core/src/ffi/rustfuture/future.rs
@@ -76,7 +76,7 @@
 //! [`RawWaker`]: https://doc.rust-lang.org/std/task/struct.RawWaker.html
 
 use super::{
-    FutureLowerReturn, RustFutureCallback, RustFutureContinuationCallback, RustFuturePoll,
+    FutureLowerReturn, RustFutureCallback, RustFutureContinuationBoundCallback, RustFuturePoll,
     Scheduler, UniffiCompatibleFuture,
 };
 use crate::{try_rust_call, FfiDefault, LiftArgsError, RustCallResult, RustCallStatus};
@@ -180,7 +180,7 @@ impl<FfiType> WrappedFuture<FfiType> {
 }
 
 /// Future that the foreign code is awaiting
-pub struct RustFuture<FfiType, Callback = RustFutureContinuationCallback> {
+pub struct RustFuture<FfiType, Callback = RustFutureContinuationBoundCallback> {
     // This Mutex should never block if our code is working correctly, since there should not be
     // multiple threads calling [Self::poll] and/or [Self::complete] at the same time.
     future: Mutex<WrappedFuture<FfiType>>,
@@ -202,7 +202,7 @@ where
         }
     }
 
-    pub fn poll(self: Arc<Self>, callback: Callback, data: u64) {
+    pub fn poll(self: Arc<Self>, callback: Callback) {
         let cancelled = self.is_cancelled();
         let ready = cancelled || {
             let mut locked = self.future.lock().unwrap();
@@ -211,9 +211,9 @@ where
         };
         if ready {
             trace!("RustFuture::poll is ready (cancelled: {cancelled})");
-            callback.invoke(data, RustFuturePoll::Ready)
+            callback.invoke(RustFuturePoll::Ready)
         } else {
-            self.scheduler.lock().unwrap().store(callback, data);
+            self.scheduler.lock().unwrap().store(callback);
         }
     }
 

--- a/uniffi_core/src/ffi/rustfuture/mod.rs
+++ b/uniffi_core/src/ffi/rustfuture/mod.rs
@@ -6,14 +6,13 @@ use std::{future::Future, sync::Arc};
 
 mod future;
 mod scheduler;
-use scheduler::*;
 
 #[cfg(test)]
 mod tests;
 
 use crate::{FfiDefault, Handle, LiftArgsError, LowerReturn, RustCallStatus};
 pub(crate) use future::RustFuture;
-pub(crate) use scheduler::RustFutureCallback;
+pub use scheduler::{RustFutureCallback, Scheduler};
 
 /// Result code for [rust_future_poll].  This is passed to the continuation function.
 #[repr(i8)]
@@ -30,6 +29,12 @@ pub enum RustFuturePoll {
 /// The Rust side of things calls this when the foreign side should call [rust_future_poll] again
 /// to continue progress on the future.
 pub type RustFutureContinuationCallback = extern "C" fn(callback_data: u64, RustFuturePoll);
+
+/// RustFutureContinuationCallback and data bound together
+pub struct RustFutureContinuationBoundCallback {
+    callback: RustFutureContinuationCallback,
+    data: u64,
+}
 
 /// This marker trait allows us to put different bounds on the `Future`s we
 /// support, based on `#[cfg(..)]` configuration.
@@ -111,7 +116,7 @@ where
     F: UniffiCompatibleFuture<Result<T, LiftArgsError>> + 'static,
     T: FutureLowerReturn<UT> + 'static,
 {
-    let rust_future = Arc::new(RustFuture::<_, RustFutureContinuationCallback>::new(
+    let rust_future = Arc::new(RustFuture::<_, RustFutureContinuationBoundCallback>::new(
         future, tag,
     ));
     let handle = Handle::from_arc(rust_future);
@@ -129,13 +134,14 @@ where
 /// The [Handle] must not previously have been passed to [rust_future_free]
 pub unsafe fn rust_future_poll<FfiType>(
     handle: Handle,
-    callback: RustFutureContinuationCallback,
+    callback: extern "C" fn(callback_data: u64, RustFuturePoll),
     data: u64,
 ) {
     #[cfg(feature = "ffi-trace")]
     let raw_handle = handle.as_raw();
     trace!("rust_future_poll: {raw_handle:x}");
-    Handle::into_arc_borrowed::<RustFuture<FfiType>>(handle).poll(callback, data);
+    Handle::into_arc_borrowed::<RustFuture<FfiType>>(handle)
+        .poll(RustFutureContinuationBoundCallback { callback, data });
     trace!("rust_future_poll returning: {raw_handle:x}");
 }
 

--- a/uniffi_core/src/ffi/rustfuture/scheduler.rs
+++ b/uniffi_core/src/ffi/rustfuture/scheduler.rs
@@ -4,7 +4,7 @@
 
 use std::mem;
 
-use crate::{RustFutureContinuationCallback, RustFuturePoll};
+use crate::{RustFutureContinuationBoundCallback, RustFuturePoll};
 
 /// Schedules a [crate::RustFuture] by managing the continuation data
 ///
@@ -20,7 +20,7 @@ use crate::{RustFutureContinuationCallback, RustFuturePoll};
 ///   state, invoking any future callbacks as soon as they're stored.
 
 #[derive(Debug)]
-pub(crate) enum Scheduler<Callback = RustFutureContinuationCallback> {
+pub enum Scheduler<Callback = RustFutureContinuationBoundCallback> {
     /// No continuations set, neither wake() nor cancel() called.
     Empty,
     /// `wake()` was called when there was no continuation set.  The next time `store` is called,
@@ -30,59 +30,63 @@ pub(crate) enum Scheduler<Callback = RustFutureContinuationCallback> {
     /// continuation being called with `RustFuturePoll::Ready`.
     Cancelled,
     /// Continuation set, the next time `wake()`  is called is called, we should invoke it.
-    Set(Callback, u64),
+    Set(Callback),
 }
 
 /// Callback function that the scheduler stores
 pub trait RustFutureCallback {
-    fn invoke(self, data: u64, poll: RustFuturePoll);
+    fn invoke(self, poll: RustFuturePoll);
 }
 
-impl RustFutureCallback for RustFutureContinuationCallback {
-    fn invoke(self, data: u64, poll: RustFuturePoll) {
-        self(data, poll)
+impl RustFutureCallback for RustFutureContinuationBoundCallback {
+    fn invoke(self, poll: RustFuturePoll) {
+        (self.callback)(self.data, poll)
+    }
+}
+
+impl<Callback: RustFutureCallback> Default for Scheduler<Callback> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
 impl<Callback: RustFutureCallback> Scheduler<Callback> {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self::Empty
     }
 
     /// Store new continuation data if we are in the `Empty` state.  If we are in the `Waked` or
     /// `Cancelled` state, call the continuation immediately with the data.
-    pub(crate) fn store(&mut self, callback: Callback, data: u64) {
+    pub fn store(&mut self, callback: Callback) {
         match self {
-            Self::Empty => *self = Self::Set(callback, data),
-            Self::Set(_, _) => {
+            Self::Empty => *self = Self::Set(callback),
+            Self::Set(_) => {
                 trace!(
                     "store: observed `Self::Set` state.  Is poll() being called from multiple threads at once?"
                 );
-                let Self::Set(old_callback, old_data) =
-                    mem::replace(self, Self::Set(callback, data))
-                else {
+                let Self::Set(old_callback) = mem::replace(self, Self::Set(callback)) else {
                     unreachable!();
                 };
-                old_callback.invoke(old_data, RustFuturePoll::Ready);
+                old_callback.invoke(RustFuturePoll::Wake);
             }
             Self::Waked => {
                 *self = Self::Empty;
-                callback.invoke(data, RustFuturePoll::Wake);
+                callback.invoke(RustFuturePoll::Wake);
             }
             Self::Cancelled => {
-                callback.invoke(data, RustFuturePoll::Ready);
+                callback.invoke(RustFuturePoll::Ready);
             }
         }
     }
 
-    pub(crate) fn wake(&mut self) {
+    pub fn wake(&mut self) {
         match self {
             // If we had a continuation set, then call it and transition to the `Empty` state.
-            Self::Set(_, _) => {
-                let Self::Set(callback, old_data) = mem::replace(self, Self::Empty) else {
+            Self::Set(_) => {
+                let Self::Set(callback) = mem::replace(self, Self::Empty) else {
                     unreachable!();
                 };
-                callback.invoke(old_data, RustFuturePoll::Wake);
+                callback.invoke(RustFuturePoll::Wake);
             }
             // If we were in the `Empty` state, then transition to `Waked`.  The next time `store`
             // is called, we will immediately call the continuation.
@@ -92,20 +96,13 @@ impl<Callback: RustFutureCallback> Scheduler<Callback> {
         }
     }
 
-    pub(crate) fn cancel(&mut self) {
-        if let Self::Set(callback, old_data) = mem::replace(self, Self::Cancelled) {
-            callback.invoke(old_data, RustFuturePoll::Ready);
+    pub fn cancel(&mut self) {
+        if let Self::Set(callback) = mem::replace(self, Self::Cancelled) {
+            callback.invoke(RustFuturePoll::Ready);
         }
     }
 
-    pub(crate) fn is_cancelled(&self) -> bool {
+    pub fn is_cancelled(&self) -> bool {
         matches!(self, Self::Cancelled)
     }
 }
-
-// The `*const ()` data pointer references an object on the foreign side.
-// This object must be `Sync` in Rust terminology -- it must be safe for us to pass the pointer to the continuation callback from any thread.
-// If the foreign side upholds their side of the contract, then `Scheduler` is Send + Sync.
-
-unsafe impl Send for Scheduler {}
-unsafe impl Sync for Scheduler {}

--- a/uniffi_core/src/ffi/rustfuture/tests.rs
+++ b/uniffi_core/src/ffi/rustfuture/tests.rs
@@ -86,7 +86,12 @@ fn channel() -> (Sender, Arc<RustFuture<RustBuffer>>) {
 fn poll(rust_future: &Arc<RustFuture<RustBuffer>>) -> Arc<OnceCell<RustFuturePoll>> {
     let cell = Arc::new(OnceCell::new());
     let handle = Arc::into_raw(cell.clone()) as u64;
-    rust_future.clone().poll(poll_continuation, handle);
+    rust_future
+        .clone()
+        .poll(RustFutureContinuationBoundCallback {
+            callback: poll_continuation,
+            data: handle,
+        });
     cell
 }
 


### PR DESCRIPTION
Further generalized the continuation callback.  Instead of storing a `u64` handle in the scheduler, we let the callback type store whatever data it wants.  This is prep work for `uniffi-bindgen-kotlin-jni`, where I want to store a JNI object for the callback.

Don't implement `Send` + `Sync` for `Scheduler`.  Rust automatically implements it for the default case, since it only stores a `u64` value. Also, the impls were only for the default callback type, which prevented auto-implementations for other callback types.

Made some more functions `pub` so that they can be used by external bindings generators.