### PR TITLE
Generate CallableKind::VTableMethod again

### DIFF
--- a/uniffi_bindgen/src/bindings/python/pipeline/nodes.rs
+++ b/uniffi_bindgen/src/bindings/python/pipeline/nodes.rs
@@ -139,7 +139,10 @@ pub enum CallableKind {
     ///
     /// For trait interfaces this only applies to the Callables inside the `vtable.methods` field.
     /// Callables inside `Interface::methods` will still be `Callable::Method`.
-    VTableMethod { self_type: TypeNode },
+    VTableMethod {
+        self_type: TypeNode,
+        for_callback_interface: bool,
+    },
 }
 
 #[derive(Debug, Clone, Node, MapNode, Eq, PartialEq, Hash)]
@@ -520,7 +523,8 @@ impl Callable {
 
     pub fn self_type(&self) -> Option<TypeNode> {
         match &self.kind {
-            CallableKind::Method { self_type, .. } => Some(self_type.clone()),
+            CallableKind::Method { self_type, .. }
+            | CallableKind::VTableMethod { self_type, .. } => Some(self_type.clone()),
             _ => None,
         }
     }

--- a/uniffi_bindgen/src/pipeline/general/callable.rs
+++ b/uniffi_bindgen/src/pipeline/general/callable.rs
@@ -33,12 +33,19 @@ pub fn function_callable(func: &initial::Function, context: &Context) -> Result<
 
 pub fn method_callable(meth: &initial::Method, context: &Context) -> Result<Callable> {
     let self_type = context.self_type()?;
+    method_callable_with_kind(meth, CallableKind::Method { self_type }, context)
+}
+
+pub fn method_callable_with_kind(
+    meth: &initial::Method,
+    kind: CallableKind,
+    context: &Context,
+) -> Result<Callable> {
     let ffi_func = RustFfiFunctionName(uniffi_meta::method_symbol_name(
         &context.crate_name()?,
         &context.current_type_name()?,
         &meth.name,
     ));
-    let kind = CallableKind::Method { self_type };
     let arguments = map_method_args(&meth.inputs, &meth.name, context)?;
     let name = rename::method(meth.name.clone(), context)?;
 

--- a/uniffi_bindgen/src/pipeline/general/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/general/nodes.rs
@@ -121,7 +121,10 @@ pub enum CallableKind {
     ///
     /// For trait interfaces this only applies to the Callables inside the `vtable.methods` field.
     /// Callables inside `Interface::methods` will still be `Callable::Method`.
-    VTableMethod { self_type: TypeNode },
+    VTableMethod {
+        self_type: TypeNode,
+        for_callback_interface: bool,
+    },
 }
 
 #[derive(Debug, Clone, Node, MapNode)]
@@ -296,7 +299,7 @@ pub struct Interface {
     pub docstring: Option<String>,
     #[map_node(objects::constructors(self.constructors, context)?)]
     pub constructors: Vec<Constructor>,
-    #[map_node(objects::methods(self.methods, context)?)]
+    #[map_node(objects::interface_methods(self.methods, self.imp, context)?)]
     pub methods: Vec<Method>,
     pub trait_impls: Vec<ObjectTraitImpl>,
     pub imp: ObjectImpl,
@@ -315,7 +318,7 @@ pub struct CallbackInterface {
     #[map_node(rename::type_(&context.namespace_name()?, self.name, context)?)]
     pub name: String,
     pub docstring: Option<String>,
-    #[map_node(objects::methods(self.methods, context)?)]
+    #[map_node(objects::callback_interface_methods(self.methods, context)?)]
     pub methods: Vec<Method>,
 }
 

--- a/uniffi_bindgen/src/pipeline/general/objects.rs
+++ b/uniffi_bindgen/src/pipeline/general/objects.rs
@@ -100,15 +100,53 @@ pub fn constructors(
         .collect()
 }
 
+pub fn methods_with_kind(
+    methods: Vec<initial::Method>,
+    kind: CallableKind,
+    context: &Context,
+) -> Result<Vec<Method>> {
+    let mut mapped = Vec::with_capacity(methods.len());
+    for meth in methods {
+        if exclude::should_exclude_method(&meth.name, context)? {
+            continue;
+        }
+        mapped.push(Method {
+            callable: callable::method_callable_with_kind(&meth, kind.clone(), context)?,
+            docstring: meth.docstring,
+        })
+    }
+    Ok(mapped)
+}
+
 pub fn methods(methods: Vec<initial::Method>, context: &Context) -> Result<Vec<Method>> {
-    methods
-        .into_iter()
-        .filter_map(
-            |meth| match exclude::should_exclude_method(&meth.name, context) {
-                Err(e) => Some(Err(e)),
-                Ok(true) => None,
-                Ok(false) => Some(meth.map_node(context)),
-            },
-        )
-        .collect()
+    let self_type = context.self_type()?;
+    methods_with_kind(methods, CallableKind::Method { self_type }, context)
+}
+
+pub fn interface_methods(
+    methods: Vec<initial::Method>,
+    imp: ObjectImpl,
+    context: &Context,
+) -> Result<Vec<Method>> {
+    let self_type = context.self_type()?;
+    let kind = match imp {
+        ObjectImpl::Trait | ObjectImpl::CallbackTrait => CallableKind::VTableMethod {
+            self_type,
+            for_callback_interface: false,
+        },
+        ObjectImpl::Struct => CallableKind::Method { self_type },
+    };
+    methods_with_kind(methods, kind, context)
+}
+
+pub fn callback_interface_methods(
+    methods: Vec<initial::Method>,
+    context: &Context,
+) -> Result<Vec<Method>> {
+    let self_type = context.self_type()?;
+    let kind = CallableKind::VTableMethod {
+        self_type,
+        for_callback_interface: true,
+    };
+    methods_with_kind(methods, kind, context)
 }


### PR DESCRIPTION
I noticed that we were no longer using `CallableKind::VTableMethod` for callback interface methods.  The JS code relies on this, so I updated the code to fix that.