### PR TITLE
Benchmark tables

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,3 +16,4 @@ release-backend-crates = [
     "-p", "uniffi_udl",
 ]
 release-uniffi = ["release", "--execute", "--no-publish", "-p", "uniffi"]
+uniffi-bench  = ["bench", "-p", "uniffi-fixture-benchmarks", "--"]

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ xcuserdata
 docs/manual/src/internals/api
 # The old mdbook outdir
 docs/manual/book
+# Outputs from the `perf` command
+perf.data
 
 examples/app/ios/Generated
 examples/app/ios/IOSApp.xcodeproj/project.xcworkspace/xcshareddata/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,9 +1868,13 @@ dependencies = [
 name = "uniffi-fixture-benchmarks"
 version = "0.22.0"
 dependencies = [
+ "anyhow",
+ "camino",
  "clap",
  "criterion",
+ "indexmap",
  "regex",
+ "serde_json",
  "thiserror",
  "uniffi",
  "uniffi_bindgen",

--- a/bindgen-tests/lib/src/enums.rs
+++ b/bindgen-tests/lib/src/enums.rs
@@ -20,7 +20,7 @@ pub enum EnumWithData {
 
 #[uniffi::export]
 impl EnumWithData {
-    fn roundtrip(&self) -> Self {
+    pub fn roundtrip(&self) -> Self {
         self.clone()
     }
 }

--- a/bindgen-tests/lib/src/records.rs
+++ b/bindgen-tests/lib/src/records.rs
@@ -9,7 +9,7 @@ pub struct SimpleRec {
 
 #[uniffi::export]
 impl SimpleRec {
-    fn roundtrip(&self) -> Self {
+    pub fn roundtrip(&self) -> Self {
         SimpleRec { a: self.a }
     }
 }

--- a/fixtures/benchmarks/Cargo.toml
+++ b/fixtures/benchmarks/Cargo.toml
@@ -12,9 +12,13 @@ bench = false
 
 [dependencies]
 uniffi = { workspace = true }
+anyhow = "1"
+camino = "1"
 clap = { version = "4", features = ["cargo", "std", "derive"] }
 criterion = "0.5.1"
+indexmap = "2"
 regex = "1.5.1"
+serde_json = "1"
 thiserror = "2"
 
 [dev-dependencies]

--- a/fixtures/benchmarks/README.md
+++ b/fixtures/benchmarks/README.md
@@ -1,11 +1,43 @@
 This fixture runs a set of benchmark tests, using criterion to test the performance.
 
-Note your cwd must be this crate, not the workspace/repo root!
+- `cargo uniffi-bench` to run all benchmarks.
+- `cargo uniffi-bench [filter-string]` to run a subset of the benchmarks
+- `cargo uniffi-bench --help` for more details on the CLI
 
-- `cargo bench` to run all benchmarks.
-- `cargo bench -- -p` to run all python benchmarks (or -s for swift, -k for kotlin)
-- `cargo bench -- [glob]` to run a subset of the benchmarks
-- `cargo bench -- --help` for more details on the CLI
+## Creating benchmark tables
+
+`cargo uniffi-bench` can create tables to compare multiple branches.
+Use the `--save`/`-s` and `--compare`/`-c` flags to do this.
+For example, to generate a table that compares 3 branches:
+
+- checkout branch1
+- `cargo uniffi-bench [args] --save branch1`
+- checkout branch2
+- `cargo uniffi-bench [args] --save branch2`
+- checkout branch3
+- `cargo uniffi-bench [args] --save branch3 --compare branch1,branch2,branch3`
+
+## Profiling a benchmark using the Firefox profiler
+
+You can use the `perf` command alongside the Firefox profiler to debug benchmark performance:
+
+Run the bechmarks using `perf record` and with the `--profile-time` flag, for example:
+
+```
+perf record -g -F 999 cargo uniffi-bench --profile-time 5 kotlin-rust-call-only
+```
+
+Generate a profile from the raw perf data and copy it to some temporary location:
+
+```
+perf script -F +pid > ~/Downloads/test.perf
+```
+
+Go to https://profiler.firefox.com/ and open the file you just generated.
+Focus on the last 5 seconds or so of data and ignore the begining data
+which is tracks compiling the benchmarks crate.
+
+## Behind the scenes
 
 Benchmarking UniFFI is tricky and involves a bit of ping-pong between Rust and
 the foreign language:

--- a/fixtures/benchmarks/benches/benchmarks.rs
+++ b/fixtures/benchmarks/benches/benchmarks.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use anyhow::{Context, Result};
 use clap::Parser;
 use std::env;
 use uniffi_benchmarks::Args;
@@ -10,17 +11,31 @@ use uniffi_bindgen::bindings::{
     swift_test::run_script as swift_run_script, RunScriptOptions,
 };
 
-fn main() {
+fn main() -> Result<()> {
     let args = Args::parse();
     let script_args: Vec<String> = std::iter::once(String::from("--"))
         .chain(env::args())
         .collect();
 
+    let measurement_tracker = uniffi_benchmarks::CriterionMeasurementTracker::new()?;
+
+    if let Some(delete) = &args.delete_save {
+        measurement_tracker.delete_save(delete)?;
+        return Ok(());
+    }
+
+    if args.has_compare() && !args.has_save_name() {
+        // User is asking to compare, but not save any new args.  We can just print the table
+        // without running any benchmarks
+        measurement_tracker.compare(&args.compare, args.compare_last, None)?;
+        return Ok(());
+    }
+
     let options = RunScriptOptions {
         show_compiler_messages: args.compiler_messages,
     };
 
-    if args.should_run_python() {
+    if args.should_run_foreign_language("python") {
         python_run_script(
             std::env!("CARGO_TARGET_TMPDIR"),
             "uniffi-fixture-benchmarks",
@@ -28,10 +43,10 @@ fn main() {
             script_args.clone(),
             &options,
         )
-        .unwrap()
+        .context("Error runing python benchmark script")?;
     }
 
-    if args.should_run_kotlin() {
+    if args.should_run_foreign_language("kotlin") {
         kotlin_run_script(
             std::env!("CARGO_TARGET_TMPDIR"),
             "uniffi-fixture-benchmarks",
@@ -39,10 +54,10 @@ fn main() {
             script_args.clone(),
             &options,
         )
-        .unwrap()
+        .context("Error running kotlin benchmark script")?;
     }
 
-    if args.should_run_swift() {
+    if args.should_run_foreign_language("swift") {
         swift_run_script(
             std::env!("CARGO_TARGET_TMPDIR"),
             "uniffi-fixture-benchmarks",
@@ -50,6 +65,15 @@ fn main() {
             script_args,
             &options,
         )
-        .unwrap()
+        .context("Error running Swift benchmark script")?;
     }
+
+    if args.has_compare() || args.has_save_name() {
+        let save_name = args
+            .has_save_name()
+            .then(|| args.calculate_save_name())
+            .transpose()?;
+        measurement_tracker.compare(&args.compare, args.compare_last, save_name.as_deref())?;
+    }
+    Ok(())
 }

--- a/fixtures/benchmarks/benches/bindings/run_benchmarks.kts
+++ b/fixtures/benchmarks/benches/bindings/run_benchmarks.kts
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import org.mozilla.uniffi.benchmarks.*
+import kotlin.ByteArray
+import kotlin.experimental.xor
 import kotlin.system.measureNanoTime
 
 // Create objects to use in the tests.  This way the benchmarks don't include the time needed to
@@ -12,6 +14,8 @@ object TestData {
     val testLargeString2 = "b".repeat(1500)
     val testRec1 = TestRecord(a = -1, b = 1.toULong(), c = 1.5)
     val testRec2 = TestRecord(a = -2, b = 2.toULong(), c = 4.5)
+    val testLargeRec1 = TestLargeRecord(a = 1, b = 2, c = 3, d = 4, e = 1.0f, f = 2.0, g = true)
+    val testLargeRec2 = TestLargeRecord(a = -1, b = -2, c = -3, d = -4, e = -1.0f, f = -2.0, g = false)
     val testEnum1 = TestEnum.One(a = -1, b = 0.toULong())
     val testEnum2 = TestEnum.Two(c = 1.5)
     val testVec1 = listOf(0.toUInt(), 1.toUInt())
@@ -22,6 +26,9 @@ object TestData {
     val testInterface2 = TestInterface()
     val testTraitInterface = makeTestTraitInterface()
     val testTraitInterface2 = makeTestTraitInterface()
+    val testBytes = ByteArray(256) { it.toByte() }
+    val testPrimitiveList = (0..1024).map { it.toUInt() }
+    val testRecordList = (0..1024).map { TestRecord(it, it.toULong() * 2uL, it.toDouble() / 2.0) }
     val testNestedData1 = NestedData(
         a = listOf(TestRecord(a = -1, b = 1.toULong(), c = 1.5)),
         b = listOf(listOf("one", "two"), listOf("three")),
@@ -59,6 +66,18 @@ class TestCallbackObj : TestCallbackInterface {
         return TestRecord(a=a.a + b.a, b=a.b + b.b, c=a.c + b.c)
     }
 
+    override fun largeRecords(a: TestLargeRecord, b: TestLargeRecord): TestLargeRecord {
+        return TestLargeRecord(
+            a=(a.a + b.a).toByte(),
+            b=(a.b + b.b).toShort(),
+            c=a.c + b.c,
+            d=a.d + b.d,
+            e=a.e + b.e,
+            f=a.f + b.f,
+            g=a.g && b.g,
+        )
+    }
+
     override fun enums(a: TestEnum, b: TestEnum): TestEnum {
         val aSum = when (a) {
             is TestEnum.One -> a.a.toDouble() + a.b.toDouble()
@@ -69,10 +88,6 @@ class TestCallbackObj : TestCallbackInterface {
             is TestEnum.Two -> b.c
         }
         return TestEnum.Two(aSum + bSum)
-    }
-
-    override fun vecs(a: List<UInt>, b: List<UInt>): List<UInt> {
-        return a + b
     }
 
     override fun hashMaps(
@@ -101,6 +116,36 @@ class TestCallbackObj : TestCallbackInterface {
         } else {
             b
         }
+    }
+
+    override fun optionals(a: UInt?, b: Boolean?, c: String?): UInt {
+        var sum = 0u;
+        if (a != null) {
+            sum += a;
+        }
+        if (b == true) {
+            sum *= 2u;
+        }
+        if (c != null) {
+            sum += c.length.toUInt()
+        }
+        return sum.toUInt()
+    }
+
+    override fun bytes(v: ByteArray): ByteArray {
+        return v
+    }
+
+    override fun vecSmall(a: List<UInt>, b: List<UInt>): List<UInt> {
+        return a + b
+    }
+
+    override fun vecPrimitives(v: List<UInt>): List<UInt> {
+        return v
+    }
+
+    override fun vecRecords(v: List<TestRecord>): List<TestRecord> {
+        return v
     }
 
     override fun nestedData(a: NestedData, b: NestedData): NestedData {
@@ -157,15 +202,15 @@ class TestCallbackObj : TestCallbackInterface {
                 }
             }
 
-            TestCase.ENUMS -> measureNanoTime {
+            TestCase.LARGE_RECORDS -> measureNanoTime {
                 for (i in 0UL..count) {
-                    testCaseEnums(TestData.testEnum1, TestData.testEnum2)
+                    testCaseLargeRecords(TestData.testLargeRec1, TestData.testLargeRec2)
                 }
             }
 
-            TestCase.VECS -> measureNanoTime {
+            TestCase.ENUMS -> measureNanoTime {
                 for (i in 0UL..count) {
-                    testCaseVecs(TestData.testVec1, TestData.testVec2)
+                    testCaseEnums(TestData.testEnum1, TestData.testEnum2)
                 }
             }
 
@@ -184,6 +229,42 @@ class TestCallbackObj : TestCallbackInterface {
             TestCase.TRAIT_INTERFACES -> measureNanoTime {
                 for (i in 0UL..count) {
                     testCaseTraitInterfaces(TestData.testTraitInterface, TestData.testTraitInterface2)
+                }
+            }
+
+            TestCase.OPTIONALS -> measureNanoTime {
+                for (i in 0UL..count) {
+                    testCaseOptionals(10u, null, "testing-123")
+                }
+            }
+
+            TestCase.BYTES -> measureNanoTime {
+                for (i in 0UL..count) {
+                    testCaseBytes(TestData.testBytes)
+                }
+            }
+
+            TestCase.VEC_SMALL -> measureNanoTime {
+                for (i in 0UL..count) {
+                    testCaseVecSmall(TestData.testVec1, TestData.testVec2)
+                }
+            }
+
+            TestCase.VEC_PRIMITIVES -> measureNanoTime {
+                for (i in 0UL..count) {
+                    testCaseVecPrimitives(TestData.testPrimitiveList)
+                }
+            }
+
+            TestCase.VEC_RECORDS -> measureNanoTime {
+                for (i in 0UL..count) {
+                    testCaseVecRecords(TestData.testRecordList)
+                }
+            }
+
+            TestCase.METHODS -> measureNanoTime {
+                for (i in 0UL..count) {
+                    TestData.testInterface.noopMethod()
                 }
             }
 

--- a/fixtures/benchmarks/benches/bindings/run_benchmarks.py
+++ b/fixtures/benchmarks/benches/bindings/run_benchmarks.py
@@ -3,6 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from benchmarks import *
+import functools
+import itertools
 import time
 
 # Create objects to use in the tests.  This way the benchmarks don't include the time needed to
@@ -12,6 +14,8 @@ TEST_LARGE_STRING_1 = "a" * 2048
 TEST_LARGE_STRING_2 = "b" * 1500
 TEST_REC1 = TestRecord(a=-1, b=1, c=1.5)
 TEST_REC2 = TestRecord(a=-2, b=2, c=4.5)
+TEST_LARGE_REC1 = TestLargeRecord(a=1, b=2, c=3, d=4, e=1.0, f=2.0, g=True)
+TEST_LARGE_REC2 = TestLargeRecord(a=-1, b=-2, c=-3, d=-4, e=-1.0, f=-2.0, g=False)
 TEST_ENUM1 = TestEnum.ONE(a=-1, b=0)
 TEST_ENUM2 = TestEnum.TWO(c=1.5)
 TEST_VEC1 = [0, 1]
@@ -22,6 +26,9 @@ TEST_INTERFACE = TestInterface()
 TEST_INTERFACE2 = TestInterface()
 TEST_TRAIT_INTERFACE = make_test_trait_interface()
 TEST_TRAIT_INTERFACE2 = make_test_trait_interface()
+TEST_BYTES = bytes(v for v in range(0, 256))
+TEST_PRIMITIVE_LIST = [v for v in range(0, 1024)]
+TEST_RECORD_LIST = [TestRecord(a=i, b=i * 2, c=float(i) / 2.0) for i in range(0, 1024)]
 TEST_NESTED_DATA1 = NestedData(
     a=[TestRecord(a=-1, b=1, c=1.5)],
     b=[["one", "two"], ["three"]],
@@ -58,6 +65,17 @@ class TestCallbackObj(TestCallbackInterface):
             c=a.c + b.c,
         )
 
+    def large_records(self, a, b):
+        return TestLargeRecord(
+            a=a.a + b.a,
+            b=a.b + b.b,
+            c=a.c + b.c,
+            d=a.d + b.d,
+            e=a.e + b.e,
+            f=a.f + b.f,
+            g=a.g or b.g,
+        )
+
     def enums(self, a, b):
         if isinstance(a, TestEnum.ONE):
             a_sum = a.a + a.b
@@ -68,9 +86,6 @@ class TestCallbackObj(TestCallbackInterface):
         else:
             b_sum = b.c
         return TestEnum.TWO(a_sum + b_sum)
-
-    def vecs(self, a, b):
-        return a + b
 
     def hash_maps(self, a, b):
         return a | b
@@ -88,6 +103,28 @@ class TestCallbackObj(TestCallbackInterface):
             return a
         else:
             return b
+
+    def optionals(self, a, b, c):
+        sum = 0;
+        if a is not None:
+            sum += a
+        if b == True:
+            sum *= 2;
+        if c is not None:
+            sum += len(c)
+        return sum
+
+    def bytes(self, a):
+        return a
+
+    def vec_small(self, a, b):
+        return a + b
+
+    def vec_primitives(self, a):
+        return a
+
+    def vec_records(self, a):
+        return a
 
     def nested_data(self, a, b):
         return NestedData(a=a.a + b.a, b=a.b + b.b, c=a.c | b.c)
@@ -119,14 +156,14 @@ class TestCallbackObj(TestCallbackInterface):
             start = time.perf_counter_ns()
             for _ in range(count):
                 test_case_records(TEST_REC1, TEST_REC2)
+        elif test_case == TestCase.LARGE_RECORDS:
+            start = time.perf_counter_ns()
+            for _ in range(count):
+                test_case_large_records(TEST_LARGE_REC1, TEST_LARGE_REC2)
         elif test_case == TestCase.ENUMS:
             start = time.perf_counter_ns()
             for _ in range(count):
                 test_case_enums(TEST_ENUM1, TEST_ENUM2)
-        elif test_case == TestCase.VECS:
-            start = time.perf_counter_ns()
-            for _ in range(count):
-                test_case_vecs(TEST_VEC1, TEST_VEC2)
         elif test_case == TestCase.HASHMAPS:
             start = time.perf_counter_ns()
             for _ in range(count):
@@ -139,6 +176,30 @@ class TestCallbackObj(TestCallbackInterface):
             start = time.perf_counter_ns()
             for _ in range(count):
                 test_case_trait_interfaces(TEST_TRAIT_INTERFACE, TEST_TRAIT_INTERFACE2)
+        elif test_case == TestCase.OPTIONALS:
+            start = time.perf_counter_ns()
+            for _ in range(count):
+                test_case_optionals(10, None, "testing-123")
+        elif test_case == TestCase.BYTES:
+            start = time.perf_counter_ns()
+            for _ in range(count):
+                test_case_bytes(TEST_BYTES)
+        elif test_case == TestCase.VEC_SMALL:
+            start = time.perf_counter_ns()
+            for _ in range(count):
+                test_case_vec_small(TEST_VEC1, TEST_VEC2)
+        elif test_case == TestCase.VEC_PRIMITIVES:
+            start = time.perf_counter_ns()
+            for _ in range(count):
+                test_case_vec_primitives(TEST_PRIMITIVE_LIST)
+        elif test_case == TestCase.VEC_RECORDS:
+            start = time.perf_counter_ns()
+            for _ in range(count):
+                test_case_vec_records(TEST_RECORD_LIST)
+        elif test_case == TestCase.METHODS:
+            start = time.perf_counter_ns()
+            for _ in range(count):
+                TEST_INTERFACE.noop_method()
         elif test_case == TestCase.NESTED_DATA:
             start = time.perf_counter_ns()
             for _ in range(count):

--- a/fixtures/benchmarks/benches/bindings/run_benchmarks.swift
+++ b/fixtures/benchmarks/benches/bindings/run_benchmarks.swift
@@ -11,6 +11,7 @@
 #else
     import Darwin.C
 #endif
+import Foundation
 
 // Create objects to use in the tests.  This way the benchmarks don't include the time needed to
 // construct these objects.
@@ -19,6 +20,8 @@ let TEST_LARGE_STRING1 = String(repeating: "a", count: 2048)
 let TEST_LARGE_STRING2 = String(repeating: "b", count: 1500)
 let TEST_REC1 = TestRecord(a: -1, b: 1, c: 1.5)
 let TEST_REC2 = TestRecord(a: -2, b: 2, c: 4.5)
+let TEST_LARGE_REC1 = TestLargeRecord(a: 1, b: 2, c: 3, d: 4, e: 1.0, f: 2.0, g: true)
+let TEST_LARGE_REC2 = TestLargeRecord(a: -1, b: -2, c: -3, d: -4, e: -1.0, f: -2.0, g: false)
 let TEST_ENUM1 = TestEnum.one(a: -1, b: 0)
 let TEST_ENUM2 = TestEnum.two(c: 1.5)
 let TEST_VEC1: [UInt32] = [0, 1]
@@ -29,6 +32,9 @@ let TEST_INTERFACE = TestInterface()
 let TEST_INTERFACE2 = TestInterface()
 let TEST_TRAIT_INTERFACE = makeTestTraitInterface()
 let TEST_TRAIT_INTERFACE2 = makeTestTraitInterface()
+let TEST_BYTES = Data(bytes: Array((0...255).map { UInt8($0) }))
+let TEST_PRIMITIVE_LIST = Array((0...1024).map { UInt32($0) })
+let TEST_RECORD_LIST = Array((0...1024).map { TestRecord(a: Int32($0), b: UInt64($0) * 2, c: Float64($0) / 2.0) })
 let TEST_NESTED_DATA1 = NestedData(
     a: [TestRecord(a: -1, b: 1, c: 1.5)],
     b: [["one", "two"], ["three"]],
@@ -69,6 +75,18 @@ final class TestCallbackObj: TestCallbackInterface {
         )
     }
 
+    func largeRecords(a: TestLargeRecord, b: TestLargeRecord) -> TestLargeRecord {
+        return TestLargeRecord(
+            a: a.a + b.a,
+            b: a.b + b.b,
+            c: a.c + b.c,
+            d: a.d + b.d,
+            e: a.e + b.e,
+            f: a.f + b.f,
+            g: a.g && b.g
+        )
+    }
+
     func enums(a: TestEnum, b: TestEnum) -> TestEnum {
         let aSum = switch a {
         case .one(let a, let b): Float64(a) + Float64(b)
@@ -79,10 +97,6 @@ final class TestCallbackObj: TestCallbackInterface {
         case .two(let c): c
         }
         return TestEnum.two(c: aSum + bSum)
-    }
-
-    func vecs(a: [UInt32], b: [UInt32]) -> [UInt32] {
-        return a + b
     }
 
     func hashMaps(
@@ -111,6 +125,36 @@ final class TestCallbackObj: TestCallbackInterface {
         } else {
             return b
         }
+    }
+
+    func optionals(a: UInt32?, b: Bool?, c: String?) -> UInt32 {
+        var sum: UInt32 = 0;
+        if let value = a {
+            sum += value;
+        }
+        if b == true {
+            sum *= 2;
+        }
+        if let string = c {
+            sum += UInt32(string.count)
+        }
+        return sum
+    }
+
+    func bytes(v: Data) -> Data {
+        return v
+    }
+
+    func vecSmall(a: [UInt32], b: [UInt32]) -> [UInt32] {
+        return a + b
+    }
+
+    func vecPrimitives(v: [UInt32]) -> [UInt32] {
+        return v
+    }
+
+    func vecRecords(v: [TestRecord]) -> [TestRecord] {
+        return v
     }
 
     func nestedData(a: NestedData, b: NestedData) -> NestedData {
@@ -158,16 +202,16 @@ final class TestCallbackObj: TestCallbackInterface {
                 let _ = testCaseRecords(a: TEST_REC1, b: TEST_REC2)
             }
 
+        case TestCase.largeRecords:
+            start = clock()
+            for _ in 0...count {
+                let _ = testCaseLargeRecords(a: TEST_LARGE_REC1, b: TEST_LARGE_REC2)
+            }
+
         case TestCase.enums:
             start = clock()
             for _ in 0...count {
                 let _ = testCaseEnums(a: TEST_ENUM1, b: TEST_ENUM2)
-            }
-
-        case TestCase.vecs:
-            start = clock()
-            for _ in 0...count {
-                let _ = testCaseVecs(a: TEST_VEC1, b: TEST_VEC2)
             }
 
         case TestCase.hashmaps:
@@ -186,6 +230,42 @@ final class TestCallbackObj: TestCallbackInterface {
             start = clock()
             for _ in 0...count {
                 let _ = testCaseTraitInterfaces(a: TEST_TRAIT_INTERFACE, b: TEST_TRAIT_INTERFACE2)
+            }
+
+        case TestCase.optionals:
+            start = clock()
+            for _ in 0...count {
+                let _ = testCaseOptionals(a: 10, b: nil, c: "testing-123")
+            }
+
+        case TestCase.bytes:
+            start = clock()
+            for _ in 0...count {
+                let _ = testCaseBytes(v: TEST_BYTES)
+            }
+
+        case TestCase.vecSmall:
+            start = clock()
+            for _ in 0...count {
+                let _ = testCaseVecSmall(a: TEST_VEC1, b: TEST_VEC2)
+            }
+
+        case TestCase.vecPrimitives:
+            start = clock()
+            for _ in 0...count {
+                let _ = testCaseVecPrimitives(v: TEST_PRIMITIVE_LIST)
+            }
+
+        case TestCase.vecRecords:
+            start = clock()
+            for _ in 0...count {
+                let _ = testCaseVecRecords(v: TEST_RECORD_LIST)
+            }
+
+        case TestCase.methods:
+            start = clock()
+            for _ in 0...count {
+                let _ = TEST_INTERFACE.noopMethod()
             }
 
         case TestCase.nestedData:

--- a/fixtures/benchmarks/src/cli.rs
+++ b/fixtures/benchmarks/src/cli.rs
@@ -2,37 +2,62 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::{process::Command, time::Duration};
+
+use anyhow::{bail, Result};
 use clap::Parser;
 use criterion::Criterion;
 
+use crate::TestCase;
+
 #[derive(Parser, Debug)]
 pub struct Args {
-    // Args to select which test scripts run.  These are handled in `benchmarks.rs`.
-    /// Run Python tests
-    #[clap(short, long = "py", display_order = 0)]
-    pub python: bool,
-    /// Run Kotlin tests
-    #[clap(short, long = "kt", display_order = 0)]
-    pub kotlin: bool,
-    /// Run Swift tests
-    #[clap(short, long, display_order = 0)]
-    pub swift: bool,
-
     /// Dump compiler output to the console.  Good for debugging new benchmarks.
-    #[clap(long, display_order = 1)]
+    #[clap(long)]
     pub compiler_messages: bool,
 
-    /// Save benchmark data to new baseline named [baseline]
-    #[clap(long)]
-    pub save_baseline: Option<String>,
+    /// Save benchmark data for later comparisons
+    #[clap(short, long)]
+    pub save: Option<String>,
 
-    /// Load benchmark data from a saved baseline named [baseline]
+    /// Save benchmark data, using the JJ change ID of the parent commit
+    #[clap(long, conflicts_with("save"))]
+    pub save_with_jj_parent: bool,
+
+    /// Save benchmark data, using the JJ change ID of the current commit
+    #[clap(long, conflicts_with("save"), conflicts_with("save_with_jj_parent"))]
+    pub save_with_jj_commit: bool,
+
+    /// Delete benchmark data previously recorded with save
     #[clap(long)]
-    pub load_baseline: Option<String>,
+    pub delete_save: Option<String>,
+
+    /// Create a table comparing previously saved benchmark data
+    ///
+    /// Inputs a list of names previously passed to `--save`.
+    /// Each name will be a column in the table.
+    ///
+    /// If `--save` is also present, then new measurements will be added as a column in the table.
+    /// If not, then this will skip new measurements and only print out a table.
+    #[clap(short, long, use_value_delimiter = true)]
+    pub compare: Vec<String>,
+
+    /// Create a table comparing previously saved benchmark data
+    ///
+    /// This works like `--compare`, instead of inputting save names, this compares against the last
+    /// N save points.
+    #[clap(long)]
+    pub compare_last: Option<usize>,
+
+    /// Run for a fixed number of seconds and skip the analysis.
+    ///
+    /// Use this for hooking up a profile to the benchmark code.
+    #[clap(long)]
+    pub profile_time: Option<u64>,
 
     // Args for running the metrics, these are handled in `lib.rs`
     /// Only run benchmarks whose names contain FILTER
-    /// Multiple filters will be ORed together.
+    /// Multiple arguments are ANDed together
     #[clap()]
     pub filter: Vec<String>,
 
@@ -45,23 +70,14 @@ pub struct Args {
 }
 
 impl Args {
-    /// Should we run the Python tests?
-    pub fn should_run_python(&self) -> bool {
-        self.python || self.no_languages_selected()
+    /// Should we run the tests for a foreign language?
+    pub fn should_run_foreign_language(&self, language: &str) -> bool {
+        TestCase::all_names_for_language(language)
+            .any(|name| self.test_case_name_matches_filter(&name))
     }
 
-    /// Should we run the Kotlin tests?
-    pub fn should_run_kotlin(&self) -> bool {
-        self.kotlin || self.no_languages_selected()
-    }
-
-    /// Should we run the Swift tests?
-    pub fn should_run_swift(&self) -> bool {
-        self.swift || self.no_languages_selected()
-    }
-
-    pub fn no_languages_selected(&self) -> bool {
-        !(self.python || self.kotlin || self.swift)
+    pub fn test_case_name_matches_filter(&self, name: &str) -> bool {
+        self.filter.iter().all(|filter| name.contains(filter))
     }
 
     /// Parse arguments for run_benchmarks()
@@ -87,29 +103,74 @@ impl Args {
     /// Build a Criterion instance from the arguments
     pub fn build_criterion(&self) -> Criterion {
         let mut c = Criterion::default();
-        c = match &self.filter.len() {
-            0 => c,
-            _ => {
-                let re = regex::Regex::new(
-                    &self
-                        .filter
-                        .iter()
-                        .map(|s| format!("({})", regex::escape(s)))
-                        .collect::<Vec<_>>()
-                        .join("|"),
-                )
-                .unwrap();
-                c.with_benchmark_filter(criterion::BenchmarkFilter::Regex(re))
-            }
-        };
-        c = match &self.save_baseline {
-            Some(baseline) => c.save_baseline(baseline.clone()),
-            None => c,
-        };
-        c = match &self.load_baseline {
-            Some(baseline) => c.retain_baseline(baseline.clone(), true),
-            None => c,
-        };
+        if let Some(profile_time) = self.profile_time {
+            c = c.profile_time(Some(Duration::from_secs(profile_time)));
+        }
         c
+    }
+
+    pub fn skip_measurements(&self) -> bool {
+        !self.has_save_name() && !self.has_compare()
+    }
+
+    pub fn has_compare(&self) -> bool {
+        !self.compare.is_empty() || self.compare_last.is_some()
+    }
+
+    pub fn has_save_name(&self) -> bool {
+        self.save.is_some() || self.save_with_jj_parent || self.save_with_jj_commit
+    }
+
+    pub fn calculate_save_name(&self) -> Result<String> {
+        if let Some(name) = &self.save {
+            Ok(name.clone())
+        } else if self.save_with_jj_commit {
+            self.determine_save_name_from_jj_commit()
+        } else if self.save_with_jj_parent {
+            self.determine_save_name_from_jj_parent()
+        } else {
+            bail!("Save name not found")
+        }
+    }
+
+    pub fn determine_save_name_from_jj_commit(&self) -> Result<String> {
+        let output = Command::new("jj")
+            .args(["log", "-r", "@", "-G", "-T", "change_id.short()"])
+            .output()?;
+        if !output.status.success() {
+            bail!(
+                "jj log failed:\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        Ok(str::from_utf8(&output.stdout)?.trim().to_string())
+    }
+
+    pub fn determine_save_name_from_jj_parent(&self) -> Result<String> {
+        let output = Command::new("jj")
+            .args([
+                "log",
+                "-r",
+                "ancestors(@,2)",
+                "-G",
+                "-T",
+                "concat(change_id.short(),'\n')",
+            ])
+            .output()?;
+        if !output.status.success() {
+            bail!(
+                "jj log failed:\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        let lines = str::from_utf8(&output.stdout)?
+            .split('\n')
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<&str>>();
+        match lines.as_slice() {
+            [] | [_] => bail!("No JJ parent commit"),
+            [_, parent_change_id] => Ok(parent_change_id.to_string()),
+            [_, _, ..] => bail!("Multiple JJ parent commits"),
+        }
     }
 }

--- a/fixtures/benchmarks/src/compare.rs
+++ b/fixtures/benchmarks/src/compare.rs
@@ -1,0 +1,275 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+*
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::{
+    collections::{BTreeSet, HashMap},
+    fs::{create_dir_all, read_to_string, remove_file, File},
+    io::Write,
+    time::SystemTime,
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use indexmap::IndexSet;
+use serde_json::Value;
+
+use crate::TestCase;
+
+pub struct CriterionMeasurementTracker {
+    workspace_dir: Utf8PathBuf,
+    initial_mtimes: HashMap<Utf8PathBuf, SystemTime>,
+}
+
+impl CriterionMeasurementTracker {
+    pub fn new() -> Result<Self> {
+        let mut initial_mtimes = HashMap::new();
+        let workspace_dir = find_workspace_root()?;
+        for test_case in test_case_dirs(&workspace_dir)? {
+            let path = estimate_path(&test_case);
+            if path.exists() {
+                let meta = path
+                    .metadata()
+                    .with_context(|| format!("Reading metadata for {path}"))?;
+                initial_mtimes.insert(path, meta.modified()?);
+            }
+        }
+        Ok(Self {
+            workspace_dir,
+            initial_mtimes,
+        })
+    }
+
+    pub fn save(&self, name: &str) -> Result<()> {
+        let uniffi_bench = self.workspace_dir.join("target/uniffi-bench");
+        if !uniffi_bench.exists() {
+            create_dir_all(&uniffi_bench)?;
+        }
+        let path = uniffi_bench.join(format!("{name}.json"));
+        let contents = serde_json::to_string(&self.times_from_last_run()?)?;
+        let mut f = File::create(path)?;
+        write!(f, "{contents}")?;
+        Ok(())
+    }
+
+    pub fn delete_save(&self, name: &str) -> Result<()> {
+        let uniffi_bench = self.workspace_dir.join("target/uniffi-bench");
+        let path = uniffi_bench.join(format!("{name}.json"));
+        if !path.exists() {
+            bail!("Save file {name:?} not found");
+        }
+        remove_file(path)?;
+        Ok(())
+    }
+
+    fn read(&self, name: &str) -> Result<HashMap<String, u64>> {
+        let uniffi_bench = self.workspace_dir.join("target/uniffi-bench");
+        if !uniffi_bench.exists() {
+            create_dir_all(&uniffi_bench)?;
+        }
+        let path = uniffi_bench.join(format!("{name}.json"));
+        if !path.exists() {
+            bail!("No save found for {name}");
+        }
+        let contents = read_to_string(path)?;
+        Ok(serde_json::from_str(&contents)?)
+    }
+
+    fn find_last_compare_names(
+        &self,
+        count: usize,
+        save_name: Option<&str>,
+    ) -> Result<Vec<String>> {
+        let uniffi_bench = self.workspace_dir.join("target/uniffi-bench");
+        if !uniffi_bench.exists() {
+            create_dir_all(&uniffi_bench)?;
+        }
+        let mut entries = vec![];
+        for entry in uniffi_bench.read_dir()? {
+            let entry = entry?;
+            let name = match entry.file_name().to_string_lossy().strip_suffix(".json") {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            if let Some(save_name) = save_name {
+                if save_name == name {
+                    continue;
+                }
+            }
+
+            entries.push((name, entry.metadata()?.modified()?))
+        }
+        entries.sort_by(|a, b| b.1.cmp(&a.1));
+        entries.truncate(count);
+        entries.reverse();
+
+        Ok(entries.into_iter().map(|(name, _)| name).collect())
+    }
+
+    pub fn compare(
+        &self,
+        compare: &[String],
+        compare_last: Option<usize>,
+        save_name: Option<&str>,
+    ) -> Result<()> {
+        let mut all_names = IndexSet::<String>::from_iter(compare.iter().cloned());
+        if let Some(count) = compare_last {
+            all_names.extend(self.find_last_compare_names(count, save_name)?);
+        }
+        if let Some(save_name) = save_name {
+            all_names.insert(save_name.to_string());
+        };
+
+        let all_times = all_names
+            .iter()
+            .map(|name| self.read(name))
+            .collect::<Result<Vec<HashMap<String, u64>>>>()?;
+        let all_cases = match save_name {
+            None => {
+                // No save name specified, print out all cases we have times for
+                BTreeSet::from_iter(all_times.iter().flat_map(|map| map.keys()))
+            }
+            Some(name) => {
+                // Save name specified, only print out cases for that name
+                let idx = all_names.iter().position(|n| n == name).unwrap();
+                BTreeSet::from_iter(all_times[idx].keys())
+            }
+        };
+        let mut sorted_test_cases = Vec::from_iter(all_cases);
+        sorted_test_cases.sort_by_cached_key(|name| {
+            let mut parts = name.splitn(3, "-");
+            // All these unwraps should succeed, but let's use a fallback just in case.
+            let language1 = parts.next().unwrap_or("").to_string();
+            let language2 = parts.next().unwrap_or("").to_string();
+            let test_case_name = parts.next().unwrap_or("");
+            let is_rust = language1 == "rust";
+
+            for (case_index, test_case) in TestCase::iter_all().enumerate() {
+                if test_case.name() == test_case_name {
+                    return (is_rust, language1, language2, case_index);
+                }
+            }
+            (is_rust, language1, language2, usize::MAX)
+        });
+
+        print_col("", &all_names);
+        println!("{}", "-".repeat(35 + 20 * all_names.len()));
+        for case in sorted_test_cases {
+            let mut first_time = None;
+            let times = all_times.iter().map(|map| match map.get(case.as_str()) {
+                Some(nanos) => {
+                    let nanos = *nanos;
+                    let time_str = format_time(nanos);
+                    match first_time {
+                        None => {
+                            first_time = Some(nanos);
+                            time_str
+                        }
+                        Some(first_time) => {
+                            let percent_change =
+                                format!("({:.01}x)", first_time as f64 / nanos as f64);
+                            format!("{time_str} {percent_change:>7}")
+                        }
+                    }
+                }
+                None => "".to_string(),
+            });
+            print_col(case, times);
+        }
+        Ok(())
+    }
+
+    fn times_from_last_run(&self) -> Result<HashMap<String, u64>> {
+        let mut times = HashMap::new();
+        for dir in test_case_dirs(&self.workspace_dir)? {
+            let test_case = dir.file_name().expect("invalid workspace dir");
+            let path = estimate_path(&dir);
+            if path.exists() && self.path_changed(&path)? {
+                times.insert(test_case.to_string(), read_time(&path)?);
+            }
+        }
+        Ok(times)
+    }
+
+    fn path_changed(&self, path: &Utf8Path) -> Result<bool> {
+        let meta = path
+            .metadata()
+            .with_context(|| format!("Reading metadata for {path}"))?;
+        let mtime = meta.modified()?;
+        Ok(match self.initial_mtimes.get(path) {
+            None => true,
+            Some(initial_mtime) => mtime != *initial_mtime,
+        })
+    }
+}
+
+fn test_case_dirs(workspace_dir: &Utf8Path) -> Result<Vec<Utf8PathBuf>> {
+    let criterion_dir = workspace_dir.join("target/criterion");
+    let mut dirs = vec![];
+    if criterion_dir.exists() {
+        for entry in criterion_dir.read_dir()? {
+            dirs.push(utf8_path_buf(entry?.path())?);
+        }
+    }
+
+    Ok(dirs)
+}
+
+fn estimate_path(test_case_dir: &Utf8Path) -> Utf8PathBuf {
+    // Get estimates from the `new` directory, which represents the benchmarks created by
+    // this run.
+    test_case_dir.join("new/estimates.json")
+}
+
+fn find_workspace_root() -> Result<Utf8PathBuf> {
+    let current_dir = utf8_path_buf(std::env::current_dir()?)?;
+
+    let mut dir = current_dir.as_path();
+
+    loop {
+        if dir.join("Cargo.toml").exists()
+            && dir.join("target").exists()
+            && dir.join("LICENSE").exists()
+        {
+            return Ok(dir.to_path_buf());
+        }
+        dir = match dir.parent() {
+            Some(dir) => dir,
+            None => bail!("Can't find workspace root dir"),
+        };
+    }
+}
+
+fn read_time(estimates_json_path: &Utf8Path) -> Result<u64> {
+    let data = read_to_string(estimates_json_path)?;
+    let json: Value = serde_json::from_str(&data)?;
+    match json
+        .pointer("/median/point_estimate")
+        .and_then(Value::as_f64)
+    {
+        None => bail!("Can't find median value in {estimates_json_path}"),
+        Some(v) => Ok(v as u64),
+    }
+}
+
+fn utf8_path_buf(path_buf: std::path::PathBuf) -> Result<Utf8PathBuf> {
+    Utf8PathBuf::from_path_buf(path_buf).map_err(|p| anyhow!("Non-UTF8 path: {p:?}"))
+}
+
+fn print_col(label: &str, columns: impl IntoIterator<Item = impl Into<String>>) {
+    let mut line = format!("{label:<35}");
+    for c in columns {
+        line.push_str(&format!("{:>20}", c.into()));
+    }
+    println!("{line}");
+}
+
+fn format_time(nanoseconds: u64) -> String {
+    match nanoseconds {
+        0..1_000 => format!("{nanoseconds}ns"),
+        1_000..1_000_000 => format!("{:.2}us", nanoseconds as f64 / 1_000.0),
+        1_000_000..1_000_000_000 => format!("{:.2}ms", nanoseconds as f64 / 1_000_000.0),
+        _ => format!("{:.2}s ", nanoseconds as f64 / 1_000_000_000.0),
+    }
+}

--- a/fixtures/benchmarks/src/lib.rs
+++ b/fixtures/benchmarks/src/lib.rs
@@ -5,23 +5,31 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 mod cli;
+mod compare;
 pub use cli::Args;
+pub use compare::CriterionMeasurementTracker;
 
 /// Benchmark test cases
 ///
 /// Each variant represent an FFI call that passes/returns a particular kind of data.
-#[derive(uniffi::Enum, Clone, Copy)]
+#[derive(uniffi::Enum, Clone, Copy, Debug)]
 pub enum TestCase {
     CallOnly,
     Primitives,
     Strings,
     LargeStrings,
     Records,
+    LargeRecords,
     Enums,
-    Vecs,
     Hashmaps,
     Interfaces,
     TraitInterfaces,
+    Optionals,
+    Bytes,
+    VecSmall,
+    VecPrimitives,
+    VecRecords,
+    Methods,
     NestedData,
     Errors,
 }
@@ -34,12 +42,18 @@ impl TestCase {
             Self::Strings,
             Self::LargeStrings,
             Self::Records,
+            Self::LargeRecords,
             Self::Enums,
-            Self::Vecs,
             Self::Hashmaps,
             Self::Interfaces,
             Self::TraitInterfaces,
             Self::NestedData,
+            Self::Optionals,
+            Self::Bytes,
+            Self::VecSmall,
+            Self::VecPrimitives,
+            Self::VecRecords,
+            Self::Methods,
             Self::Errors,
         ]
         .into_iter()
@@ -52,14 +66,44 @@ impl TestCase {
             Self::Strings => "strings",
             Self::LargeStrings => "large-strings",
             Self::Records => "records",
+            Self::LargeRecords => "large-records",
             Self::Enums => "enums",
-            Self::Vecs => "vecs",
             Self::Hashmaps => "hash-maps",
             Self::Interfaces => "interfaces",
             Self::TraitInterfaces => "trait-interfaces",
             Self::NestedData => "nested-data",
+            Self::Optionals => "optionals",
+            Self::Bytes => "bytes",
+            Self::VecSmall => "vecs-small",
+            Self::VecPrimitives => "vec-primitives",
+            Self::VecRecords => "vec-records",
+            Self::Methods => "methods",
             Self::Errors => "errors",
         }
+    }
+
+    fn rust_to_foreign_name(&self, language: &str) -> String {
+        format!("{language}-rust-{}", self.name())
+    }
+
+    fn foreign_to_rust_name(&self, language: &str) -> String {
+        format!("rust-{language}-{}", self.name())
+    }
+
+    fn all_names_for_language(language: &str) -> impl Iterator<Item = String> {
+        let language = language.to_string();
+        Self::iter_all().flat_map(move |test_case| {
+            [
+                test_case.rust_to_foreign_name(&language),
+                test_case.foreign_to_rust_name(&language),
+            ]
+        })
+    }
+
+    pub fn skip_foreign_side(&self) -> bool {
+        // The methods tests only makes sense on Rust.
+        // The equivalent on the foreign side is the `TestCase::CallOnly`.
+        matches!(self, Self::Methods)
     }
 
     fn callback_test_case_fn(&self, cb: Arc<dyn TestCallbackInterface>) -> Box<dyn Fn()> {
@@ -71,9 +115,13 @@ impl TestCase {
             TestCase::Strings => Box::new(move || {
                 cb.strings("a".to_string(), "b".to_string());
             }),
-            TestCase::LargeStrings => Box::new(move || {
-                cb.large_strings("a".repeat(2048), "b".repeat(1500));
-            }),
+            TestCase::LargeStrings => {
+                let large_string1 = "a".repeat(2048);
+                let large_string2 = "b".repeat(1500);
+                Box::new(move || {
+                    cb.large_strings(large_string1.clone(), large_string2.clone());
+                })
+            }
             TestCase::Records => Box::new(move || {
                 cb.records(
                     TestRecord {
@@ -88,11 +136,33 @@ impl TestCase {
                     },
                 );
             }),
+            TestCase::LargeRecords => Box::new(move || {
+                cb.large_records(
+                    TestLargeRecord {
+                        a: 1,
+                        b: 2,
+                        c: 3,
+                        d: 4,
+                        e: 1.0,
+                        f: 2.0,
+                        g: true,
+                    },
+                    TestLargeRecord {
+                        a: 1,
+                        b: 2,
+                        c: 3,
+                        d: 4,
+                        e: 1.0,
+                        f: 2.0,
+                        g: true,
+                    },
+                );
+            }),
             TestCase::Enums => Box::new(move || {
                 cb.enums(TestEnum::One { a: -1, b: 0 }, TestEnum::Two { c: 1.5 });
             }),
-            TestCase::Vecs => Box::new(move || {
-                cb.vecs(vec![0, 1], vec![2, 4, 6]);
+            TestCase::VecSmall => Box::new(move || {
+                cb.vec_small(vec![0, 1], vec![2, 4, 6]);
             }),
             TestCase::Hashmaps => Box::new(move || {
                 cb.hash_maps(HashMap::from([(0, 1), (1, 2)]), HashMap::from([(2, 4)]));
@@ -106,6 +176,36 @@ impl TestCase {
                     Arc::new(TestTraitInterfaceImpl),
                 );
             }),
+            TestCase::Optionals => Box::new(move || {
+                cb.optionals(Some(10), None, Some("testing-123".into()));
+            }),
+            TestCase::Bytes => {
+                let vec: Vec<u8> = (0..=255).collect();
+                Box::new(move || {
+                    cb.bytes(vec.clone());
+                })
+            }
+            TestCase::VecPrimitives => {
+                let vec: Vec<u32> = (0..1024).collect();
+                Box::new(move || {
+                    cb.vec_primitives(vec.clone());
+                })
+            }
+            TestCase::VecRecords => {
+                let vec: Vec<TestRecord> = (0..1024)
+                    .map(|i| TestRecord {
+                        a: i,
+                        b: i as u64 * 2,
+                        c: i as f64 / 2.0,
+                    })
+                    .collect();
+                Box::new(move || {
+                    cb.vec_records(vec.clone());
+                })
+            }
+            TestCase::Methods => {
+                panic!("Attempt to run TestCase::Method from the foreign side");
+            }
             TestCase::NestedData => Box::new(move || {
                 cb.nested_data(
                     NestedData {
@@ -141,11 +241,22 @@ impl TestCase {
     }
 }
 
-#[derive(uniffi::Record)]
+#[derive(uniffi::Record, Clone)]
 pub struct TestRecord {
     a: i32,
     b: u64,
     c: f64,
+}
+
+#[derive(uniffi::Record)]
+pub struct TestLargeRecord {
+    a: i8,
+    b: i16,
+    c: i32,
+    d: i64,
+    e: f32,
+    f: f64,
+    g: bool,
 }
 
 #[derive(uniffi::Enum)]
@@ -228,6 +339,19 @@ pub fn test_case_records(a: TestRecord, b: TestRecord) -> TestRecord {
 }
 
 #[uniffi::export]
+pub fn test_case_large_records(a: TestLargeRecord, b: TestLargeRecord) -> TestLargeRecord {
+    TestLargeRecord {
+        a: a.a + b.a,
+        b: a.b + b.b,
+        c: a.c + b.c,
+        d: a.d + b.d,
+        e: a.e + b.e,
+        f: a.f + b.f,
+        g: a.g || b.g,
+    }
+}
+
+#[uniffi::export]
 pub fn test_case_enums(a: TestEnum, b: TestEnum) -> TestEnum {
     let a_sum = match a {
         TestEnum::One { a, b } => a as f64 + b as f64,
@@ -238,11 +362,6 @@ pub fn test_case_enums(a: TestEnum, b: TestEnum) -> TestEnum {
         TestEnum::Two { c } => c,
     };
     TestEnum::Two { c: a_sum + b_sum }
-}
-
-#[uniffi::export]
-pub fn test_case_vecs(a: Vec<u32>, b: Vec<u32>) -> Vec<u32> {
-    a.into_iter().chain(b).collect()
 }
 
 #[uniffi::export]
@@ -274,6 +393,41 @@ pub fn test_case_trait_interfaces(
 }
 
 #[uniffi::export]
+pub fn test_case_optionals(a: Option<u32>, b: Option<bool>, c: Option<String>) -> u32 {
+    let mut sum = 0;
+    if let Some(value) = a {
+        sum += value;
+    }
+    if let Some(true) = b {
+        sum *= 2;
+    }
+    if let Some(string) = c {
+        sum += string.len() as u32;
+    }
+    sum
+}
+
+#[uniffi::export]
+pub fn test_case_bytes(v: Vec<u8>) -> Vec<u8> {
+    v
+}
+
+#[uniffi::export]
+pub fn test_case_vec_small(a: Vec<u32>, b: Vec<u32>) -> Vec<u32> {
+    a.into_iter().chain(b).collect()
+}
+
+#[uniffi::export]
+pub fn test_case_vec_primitives(v: Vec<u32>) -> Vec<u32> {
+    v
+}
+
+#[uniffi::export]
+pub fn test_case_vec_records(v: Vec<TestRecord>) -> Vec<TestRecord> {
+    v
+}
+
+#[uniffi::export]
 pub fn test_case_nested_data(a: NestedData, b: NestedData) -> NestedData {
     NestedData {
         a: a.a.into_iter().chain(b.a).collect(),
@@ -287,6 +441,11 @@ pub fn test_case_errors() -> Result<u32, TestError> {
     Err(TestError::Two)
 }
 
+#[uniffi::export]
+impl TestInterface {
+    pub fn noop_method(&self) {}
+}
+
 /// Benchmarks callback interface
 ///
 /// This contains a method for each [TestCase] variant.  To test callback methods, the Rust code
@@ -298,8 +457,8 @@ pub trait TestCallbackInterface: Send + Sync {
     fn strings(&self, a: String, b: String) -> String;
     fn large_strings(&self, a: String, b: String) -> String;
     fn records(&self, a: TestRecord, b: TestRecord) -> TestRecord;
+    fn large_records(&self, a: TestLargeRecord, b: TestLargeRecord) -> TestLargeRecord;
     fn enums(&self, a: TestEnum, b: TestEnum) -> TestEnum;
-    fn vecs(&self, a: Vec<u32>, b: Vec<u32>) -> Vec<u32>;
     fn hash_maps(&self, a: HashMap<u32, u32>, b: HashMap<u32, u32>) -> HashMap<u32, u32>;
     fn interfaces(&self, a: Arc<TestInterface>, b: Arc<TestInterface>) -> Arc<TestInterface>;
     fn trait_interfaces(
@@ -307,6 +466,11 @@ pub trait TestCallbackInterface: Send + Sync {
         a: Arc<dyn TestTraitInterface>,
         b: Arc<dyn TestTraitInterface>,
     ) -> Arc<dyn TestTraitInterface>;
+    fn optionals(&self, a: Option<u32>, b: Option<bool>, c: Option<String>) -> u32;
+    fn bytes(&self, v: Vec<u8>) -> Vec<u8>;
+    fn vec_small(&self, a: Vec<u32>, b: Vec<u32>) -> Vec<u32>;
+    fn vec_primitives(&self, v: Vec<u32>) -> Vec<u32>;
+    fn vec_records(&self, v: Vec<TestRecord>) -> Vec<TestRecord>;
     fn nested_data(&self, a: NestedData, b: NestedData) -> NestedData;
     fn errors(&self) -> Result<u32, TestError>;
 
@@ -335,27 +499,38 @@ pub fn run_callback_test(cb: Arc<dyn TestCallbackInterface>, test_case: TestCase
 #[uniffi::export]
 pub fn run_benchmarks(language: String, cb: Arc<dyn TestCallbackInterface>) {
     let args = Args::parse_for_run_benchmarks();
+
+    let measurement_tracker =
+        CriterionMeasurementTracker::new().expect("Error creating CriterionMeasurementTracker");
+
     let mut c = args.build_criterion();
 
-    {
-        let mut function_calls = c.benchmark_group("function-calls");
-        for test_case in TestCase::iter_all() {
-            function_calls.bench_function(format!("{language}-{}", test_case.name()), |b| {
+    for test_case in TestCase::iter_all() {
+        let rust_to_foreign_name = test_case.rust_to_foreign_name(&language);
+        let foreign_to_rust_name = test_case.foreign_to_rust_name(&language);
+
+        if args.test_case_name_matches_filter(&rust_to_foreign_name) {
+            c.bench_function(&rust_to_foreign_name, |b| {
                 b.iter_custom(|count| Duration::from_nanos(cb.run_test(test_case, count)))
             });
         }
-    }
-    {
-        let mut callbacks = c.benchmark_group("callbacks");
-        for test_case in TestCase::iter_all() {
-            let test_case_fn = test_case.callback_test_case_fn(cb.clone());
-            callbacks.bench_function(format!("{language}-{}", test_case.name()), move |b| {
-                b.iter(&test_case_fn);
+
+        if !test_case.skip_foreign_side()
+            && args.test_case_name_matches_filter(&foreign_to_rust_name)
+        {
+            let callback_fn = test_case.callback_test_case_fn(cb.clone());
+            c.bench_function(&foreign_to_rust_name, move |b| {
+                b.iter(&callback_fn);
             });
         }
     }
 
     c.final_summary();
+
+    if args.has_save_name() {
+        let name = args.calculate_save_name().expect("Error saving times");
+        measurement_tracker.save(&name).expect("Error saving times");
+    }
 }
 
 uniffi::setup_scaffolding!("benchmarks");

--- a/uniffi_testing/src/lib.rs
+++ b/uniffi_testing/src/lib.rs
@@ -170,6 +170,7 @@ fn get_cargo_build_messages() -> Vec<Message> {
 
     let mut child = Command::new(env!("CARGO"))
         .arg("test")
+        .arg("--release")
         .arg(features_arg)
         .arg("--no-run")
         .arg("--message-format=json")


### PR DESCRIPTION
Added flags to the benchmarks fixture to create tables for benchmarks. The tables look like the ones in #2845, but without dropping Criterion. It works by inspecting the JSON files that Criterion leaves around and uses that to build the tables.

* Removed the test case groups. This allows the filter strings to also match against what would have been in the group name.
* Removed filters like `--python'.  You can just use "python" as a filter to do that.
* Only allow one filter at a time.  ORing them together isn't intuitive.
* Removed the `--save-baseline` and `--load-baseline` args. The new `--save` and `--compare` args serve the same purpose, but work better IMO.