### PR TITLE
Fix ruby enums and make custom types work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@
 - Kotlin and Python now fail to generate bindings when there are async primary constructors.
   Previously these languages skipped the constructor in this case or generated a constructor that always threw.
   You can get similar behavior by adding the primary constructor to the uniffi.toml excludes list in uniffi.toml (e.g. `excludes = ["MyObject.new"])
+- Ruby: Force named parameters for enum constructors (#2880)
 
 ### What's Fixed
 
 - Fixed bug that sometimes prevented renaming items inside a submodule [#2792](https://github.com/mozilla/uniffi-rs/pull/2792)
 - Exempted `UniFfiTag` from `clippy::exhaustive_structs` since downstream projects may depend on it [#2809](https://github.com/mozilla/uniffi-rs/pull/2809)
+- Ruby: Code for all kinds of enums and custom types is now correctly generated (#2880)
 
 ### What's New?
 

--- a/examples/custom-types/tests/bindings/test_custom_types.rb
+++ b/examples/custom-types/tests/bindings/test_custom_types.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require 'test/unit'
+require 'uri'
+require 'custom_types'
+
+class TestCustomTypes < Test::Unit::TestCase
+  def test_get_custom_types_demo_defaults
+    demo = CustomTypes.get_custom_types_demo(nil)
+
+    assert_kind_of URI, demo.url
+    assert_equal 'http://example.com/', demo.url.to_s
+    assert_equal 123, demo.handle
+    assert_equal 456_000, demo.time_interval_ms
+    assert_equal 456.0, demo.time_interval_sec_dbl, 0.001
+    assert_equal 777.0, demo.time_interval_sec_flt, 0.001
+  end
+
+  def test_roundtrip
+    val = CustomTypes.get_custom_types_demo nil
+    val2 = CustomTypes.get_custom_types_demo val
+
+    assert_equal val.url, val2.url
+    assert_equal val.handle, val2.handle
+    assert_equal val.time_interval_ms, val2.time_interval_ms
+  end
+
+  def test_roundtrip_with_modified_url
+    val = CustomTypes.get_custom_types_demo nil
+
+    modified = CustomTypes::CustomTypesDemo.new(
+      url: URI.parse('https://mozilla.org/'),
+      handle: 465,
+      time_interval_ms: val.time_interval_ms,
+      time_interval_sec_dbl: val.time_interval_sec_dbl,
+      time_interval_sec_flt: val.time_interval_sec_flt
+    )
+
+    result = CustomTypes.get_custom_types_demo modified
+
+    assert_kind_of URI, result.url
+    assert_equal 'https://mozilla.org/', result.url.to_s
+    assert_equal 465, result.handle
+  end
+
+  def test_type_validation_wrong_type
+    val = CustomTypes.get_custom_types_demo nil
+
+    wrong = CustomTypes::CustomTypesDemo.new(
+      url: "not a URI",
+      handle: val.handle,
+      time_interval_ms: val.time_interval_ms,
+      time_interval_sec_dbl: val.time_interval_sec_dbl,
+      time_interval_sec_flt: val.time_interval_sec_flt
+    )
+
+    assert_raise TypeError do
+      CustomTypes.get_custom_types_demo wrong
+    end
+  end
+end

--- a/examples/custom-types/tests/test_generated_bindings.rs
+++ b/examples/custom-types/tests/test_generated_bindings.rs
@@ -2,4 +2,5 @@ uniffi::build_foreign_language_testcases!(
     "tests/bindings/test_custom_types.kts",
     "tests/bindings/test_custom_types.py",
     "tests/bindings/test_custom_types.swift",
+    "tests/bindings/test_custom_types.rb",
 );

--- a/examples/custom-types/uniffi.toml
+++ b/examples/custom-types/uniffi.toml
@@ -35,6 +35,15 @@ imports = ["Foundation"]
 into_custom = "Date(timeIntervalSince1970: TimeInterval({}))"
 from_custom = "Float({}.timeIntervalSince1970)"
 
+[bindings.ruby.custom_types.Url]
+# Ruby's builtin URI class acts as the native URI type.
+type_name = "URI"
+imports = ["uri"]
+# Lift a string from Rust into a Ruby URI.
+lift = "URI.parse({})"
+# Lower a Ruby URI into a Rust string.
+lower = "{}.to_s"
+
 [bindings.kotlin]
 package_name = "customtypes"
 

--- a/examples/rondpoint/tests/bindings/test_rondpoint.rb
+++ b/examples/rondpoint/tests/bindings/test_rondpoint.rb
@@ -3,145 +3,156 @@
 require 'test/unit'
 require 'rondpoint'
 
-include Test::Unit::Assertions
-include Rondpoint
+class TestRondpoint < Test::Unit::TestCase
+  include Rondpoint
 
-dico = Dictionnaire.new(
-  un: Enumeration::DEUX,
-  deux: true,
-  petit_nombre: 0,
-  gros_nombre: 123_456_789
-)
+  MIN_I8 = -1 * 2**7
+  MAX_I8 = 2**7 - 1
+  MIN_I16 = -1 * 2**15
+  MAX_I16 = 2**15 - 1
+  MIN_I32 = -1 * 2**31
+  MAX_I32 = 2**31 - 1
+  MIN_I64 = -1 * 2**31
+  MAX_I64 = 2**31 - 1
 
-assert_equal dico, Rondpoint.copie_dictionnaire(dico)
+  # Ruby floats are always doubles, so won't round-trip through f32 correctly.
+  # This truncates them appropriately.
+  F32_ONE_THIRD = [1.0 / 3].pack('f').unpack('f')[0]
 
-assert_equal Rondpoint.copie_enumeration(Enumeration::DEUX), Enumeration::DEUX
+  ST = Stringifier.new
 
-assert_equal Rondpoint.copie_enumerations([
-                                            Enumeration::UN,
-                                            Enumeration::DEUX
-                                          ]), [Enumeration::UN, Enumeration::DEUX]
+  def test_enums
+    dico = Dictionnaire.new(
+      un: Enumeration::DEUX,
+      deux: true,
+      petit_nombre: 0,
+      gros_nombre: 123_456_789
+    )
 
-assert_equal Rondpoint.copie_carte({
-                                     '0' => EnumerationAvecDonnees::ZERO.new,
-                                     '1' => EnumerationAvecDonnees::UN.new(1),
-                                     '2' => EnumerationAvecDonnees::DEUX.new(2, 'deux')
-                                   }), {
-                                     '0' => EnumerationAvecDonnees::ZERO.new,
-                                     '1' => EnumerationAvecDonnees::UN.new(1),
-                                     '2' => EnumerationAvecDonnees::DEUX.new(2, 'deux')
-                                   }
+    assert_equal dico, Rondpoint.copie_dictionnaire(dico)
 
-assert Rondpoint.switcheroo(false)
+    assert_equal Rondpoint.copie_enumeration(Enumeration::DEUX), Enumeration::DEUX
 
-assert_not_equal EnumerationAvecDonnees::ZERO.new, EnumerationAvecDonnees::UN.new(1)
-assert_equal EnumerationAvecDonnees::UN.new(1), EnumerationAvecDonnees::UN.new(1)
-assert_not_equal EnumerationAvecDonnees::UN.new(1), EnumerationAvecDonnees::UN.new(2)
+    assert_equal(
+      Rondpoint.copie_enumerations([Enumeration::UN,Enumeration::DEUX ]), 
+      [Enumeration::UN, Enumeration::DEUX]
+    )
 
-# Test the roundtrip across the FFI.
-# This shows that the values we send come back in exactly the same state as we sent them.
-# i.e. it shows that lowering from ruby and lifting into rust is symmetrical with
-#      lowering from rust and lifting into ruby.
-RT = Retourneur.new
+    zero1 = EnumerationAvecDonnees::ZERO.new
+    un1 = EnumerationAvecDonnees::UN.new(premier: 1)
+    deux1 = EnumerationAvecDonnees::DEUX.new(premier: 2, second: 'deux')
+    map1 = Rondpoint.copie_carte({ '0' => zero1, '1' => un1, '2' => deux1 })
 
-def affirm_aller_retour(vals, fn_name)
-  vals.each do |v|
-    id_v = RT.public_send fn_name, v
+    map2 = {
+      '0' => EnumerationAvecDonnees::ZERO.new,
+      '1' => EnumerationAvecDonnees::UN.new(premier: 1),
+      '2' => EnumerationAvecDonnees::DEUX.new(premier: 2, second: 'deux')
+    }
 
-    assert_equal id_v, v, "Round-trip failure: #{v} => #{id_v}"
+    assert_equal map1, map2
+
+    assert Rondpoint.switcheroo(false)
+
+    assert_not_equal EnumerationAvecDonnees::ZERO.new, EnumerationAvecDonnees::UN.new(premier: 1)
+    assert_equal EnumerationAvecDonnees::UN.new(premier: 1), EnumerationAvecDonnees::UN.new(premier: 1)
+    assert_not_equal EnumerationAvecDonnees::UN.new(premier: 1), EnumerationAvecDonnees::UN.new(premier: 2)
+  end
+
+  # Test the roundtrip across the FFI.
+  # This shows that the values we send come back in exactly the same state as we sent them.
+  # i.e. it shows that lowering from ruby and lifting into rust is symmetrical with
+  #      lowering from rust and lifting into ruby.
+  def test_roundtrip
+    # Booleans
+    affirm_aller_retour([true, false], :identique_boolean)
+
+    # Bytes.
+    affirm_aller_retour([MIN_I8, -1, 0, 1, MAX_I8], :identique_i8)
+    affirm_aller_retour([0x00, 0x12, 0xFF], :identique_u8)
+
+    # Shorts
+    affirm_aller_retour([MIN_I16, -1, 0, 1, MAX_I16], :identique_i16)
+    affirm_aller_retour([0x0000, 0x1234, 0xFFFF], :identique_u16)
+
+    # Ints
+    affirm_aller_retour([MIN_I32, -1, 0, 1, MAX_I32], :identique_i32)
+    affirm_aller_retour([0x00000000, 0x12345678, 0xFFFFFFFF], :identique_u32)
+
+    # Longs
+    affirm_aller_retour([MIN_I64, -1, 0, 1, MAX_I64], :identique_i64)
+    affirm_aller_retour([0x0000000000000000, 0x1234567890ABCDEF, 0xFFFFFFFFFFFFFFFF], :identique_u64)
+
+    # Floats
+    affirm_aller_retour([0.0, 0.5, 0.25, 1.0, F32_ONE_THIRD], :identique_float)
+
+    # Doubles
+    affirm_aller_retour(
+      [0.0, 0.5, 0.25, 1.0, 1.0 / 3, Float::MAX, Float::MIN],
+      :identique_double
+    )
+
+    # Strings
+    affirm_aller_retour(
+      ['', 'abc', 'été', 'ښي لاس ته لوستلو لوستل',
+       '😻emoji 👨‍👧‍👦multi-emoji, 🇨🇭a flag, a canal, panama'],
+       :identique_string
+    )
+
+  end
+
+  # Test one way across the FFI.
+  #
+  # We send one representation of a value to lib.rs, and it transforms it into another, a string.
+  # lib.rs sends the string back, and then we compare here in ruby.
+  #
+  # This shows that the values are transformed into strings the same way in both ruby and rust.
+  # i.e. if we assume that the string return works (we test this assumption elsewhere)
+  #      we show that lowering from ruby and lifting into rust has values that both ruby and rust
+  #      both stringify in the same way. i.e. the same values.
+  #
+  # If we roundtripping proves the symmetry of our lowering/lifting from here to rust, and lowering/lifting from rust to here,
+  # and this convinces us that lowering/lifting from here to rust is correct, then
+  # together, we've shown the correctness of the return leg.
+  def test_string_transport
+    # Test the efficacy of the string transport from rust. If this fails, but everything else
+    # works, then things are very weird.
+    assert_equal ST.well_known_string('ruby'), 'uniffi 💚 ruby!'
+
+    # Booleans
+    affirm_enchaine([true, false], :to_string_boolean)
+
+    # Bytes.
+    affirm_enchaine([MIN_I8, -1, 0, 1, MAX_I8], :to_string_i8)
+    affirm_enchaine([0x00, 0x12, 0xFF], :to_string_u8)
+
+    # Shorts
+    affirm_enchaine([MIN_I16, -1, 0, 1, MAX_I16], :to_string_i16)
+    affirm_enchaine([0x0000, 0x1234, 0xFFFF], :to_string_u16)
+
+    # Ints
+    affirm_enchaine([MIN_I32, -1, 0, 1, MAX_I32], :to_string_i32)
+    affirm_enchaine([0x00000000, 0x12345678, 0xFFFFFFFF], :to_string_u32)
+
+    # Longs
+    affirm_enchaine([MIN_I64, -1, 0, 1, MAX_I64], :to_string_i64)
+    affirm_enchaine([0x0000000000000000, 0x1234567890ABCDEF, 0xFFFFFFFFFFFFFFFF], :to_string_u64)
+  end
+
+  # -- helpers --
+
+  def affirm_aller_retour(vals, fn_name)
+    vals.each do |v|
+      id_v = Rondpoint::Retourneur.new.public_send fn_name, v
+
+      assert_equal id_v, v, "Round-trip failure: #{v} => #{id_v}"
+    end
+  end
+
+  def affirm_enchaine(vals, fn_name)
+    vals.each do |v|
+      str_v = ST.public_send fn_name, v
+
+      assert_equal v.to_s, str_v, "String compare error #{v} => #{str_v}"
+    end
   end
 end
-
-MIN_I8 = -1 * 2**7
-MAX_I8 = 2**7 - 1
-MIN_I16 = -1 * 2**15
-MAX_I16 = 2**15 - 1
-MIN_I32 = -1 * 2**31
-MAX_I32 = 2**31 - 1
-MIN_I64 = -1 * 2**31
-MAX_I64 = 2**31 - 1
-
-# Ruby floats are always doubles, so won't round-trip through f32 correctly.
-# This truncates them appropriately.
-F32_ONE_THIRD = [1.0 / 3].pack('f').unpack('f')[0]
-
-# Booleans
-affirm_aller_retour([true, false], :identique_boolean)
-
-# Bytes.
-affirm_aller_retour([MIN_I8, -1, 0, 1, MAX_I8], :identique_i8)
-affirm_aller_retour([0x00, 0x12, 0xFF], :identique_u8)
-
-# Shorts
-affirm_aller_retour([MIN_I16, -1, 0, 1, MAX_I16], :identique_i16)
-affirm_aller_retour([0x0000, 0x1234, 0xFFFF], :identique_u16)
-
-# Ints
-affirm_aller_retour([MIN_I32, -1, 0, 1, MAX_I32], :identique_i32)
-affirm_aller_retour([0x00000000, 0x12345678, 0xFFFFFFFF], :identique_u32)
-
-# Longs
-affirm_aller_retour([MIN_I64, -1, 0, 1, MAX_I64], :identique_i64)
-affirm_aller_retour([0x0000000000000000, 0x1234567890ABCDEF, 0xFFFFFFFFFFFFFFFF], :identique_u64)
-
-# Floats
-affirm_aller_retour([0.0, 0.5, 0.25, 1.0, F32_ONE_THIRD], :identique_float)
-
-# Doubles
-affirm_aller_retour(
-  [0.0, 0.5, 0.25, 1.0, 1.0 / 3, Float::MAX, Float::MIN],
-  :identique_double
-)
-
-# Strings
-affirm_aller_retour(
-  ['', 'abc', 'été', 'ښي لاس ته لوستلو لوستل',
-   '😻emoji 👨‍👧‍👦multi-emoji, 🇨🇭a flag, a canal, panama'],
-  :identique_string
-)
-
-# Test one way across the FFI.
-#
-# We send one representation of a value to lib.rs, and it transforms it into another, a string.
-# lib.rs sends the string back, and then we compare here in ruby.
-#
-# This shows that the values are transformed into strings the same way in both ruby and rust.
-# i.e. if we assume that the string return works (we test this assumption elsewhere)
-#      we show that lowering from ruby and lifting into rust has values that both ruby and rust
-#      both stringify in the same way. i.e. the same values.
-#
-# If we roundtripping proves the symmetry of our lowering/lifting from here to rust, and lowering/lifting from rust to here,
-# and this convinces us that lowering/lifting from here to rust is correct, then
-# together, we've shown the correctness of the return leg.
-ST = Stringifier.new
-
-def affirm_enchaine(vals, fn_name)
-  vals.each do |v|
-    str_v = ST.public_send fn_name, v
-
-    assert_equal v.to_s, str_v, "String compare error #{v} => #{str_v}"
-  end
-end
-
-# Test the efficacy of the string transport from rust. If this fails, but everything else
-# works, then things are very weird.
-assert_equal ST.well_known_string('ruby'), 'uniffi 💚 ruby!'
-
-# Booleans
-affirm_enchaine([true, false], :to_string_boolean)
-
-# Bytes.
-affirm_enchaine([MIN_I8, -1, 0, 1, MAX_I8], :to_string_i8)
-affirm_enchaine([0x00, 0x12, 0xFF], :to_string_u8)
-
-# Shorts
-affirm_enchaine([MIN_I16, -1, 0, 1, MAX_I16], :to_string_i16)
-affirm_enchaine([0x0000, 0x1234, 0xFFFF], :to_string_u16)
-
-# Ints
-affirm_enchaine([MIN_I32, -1, 0, 1, MAX_I32], :to_string_i32)
-affirm_enchaine([0x00000000, 0x12345678, 0xFFFFFFFF], :to_string_u32)
-
-# Longs
-affirm_enchaine([MIN_I64, -1, 0, 1, MAX_I64], :to_string_i64)
-affirm_enchaine([0x0000000000000000, 0x1234567890ABCDEF, 0xFFFFFFFFFFFFFFFF], :to_string_u64)

--- a/fixtures/enum-types/tests/bindings/test_enum_types.rb
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'enum_types'
+
+class TestEnumTypes < Test::Unit::TestCase
+
+  def test_animals
+    # Plain enum: Doc=0, Cat=1 (sequential, starting at 0)
+    assert_equal 0, EnumTypes::Animal::DOG
+    assert_equal 1, EnumTypes::Animal::CAT
+
+    assert_equal EnumTypes::Animal::DOG, EnumTypes.get_animal(nil)
+
+    # In Ruby flat enums are integers; Animal::CAT == 1, so get_animal(1) succeeds.
+    assert_equal EnumTypes::Animal::CAT, EnumTypes.get_animal(1)
+
+    # AnimalNoReprInt
+    assert_equal 3, EnumTypes::AnimalNoReprInt::DOG
+    assert_equal 4, EnumTypes::AnimalNoReprInt::CAT
+
+    # AnimalUInt: repr u8
+    assert_equal 3, EnumTypes::AnimalUInt::DOG
+    assert_equal 4, EnumTypes::AnimalUInt::CAT
+
+    # AnimalLargeUInt: repr u64, Dog=u32::MAX+3, Cat=u32::MAX+4
+    assert_equal 4294967295 + 3, EnumTypes::AnimalLargeUInt::DOG
+    assert_equal 4294967295 + 4, EnumTypes::AnimalLargeUInt::CAT
+
+    # AnimalSignedInt: repr i8, Dog=-3, Cat=-2, Koala=-1, Wallaby=0, Wombat=1
+    assert_equal -3, EnumTypes::AnimalSignedInt::DOG
+    assert_equal -2, EnumTypes::AnimalSignedInt::CAT
+    assert_equal -1, EnumTypes::AnimalSignedInt::KOALA
+    assert_equal 0, EnumTypes::AnimalSignedInt::WALLABY
+    assert_equal 1, EnumTypes::AnimalSignedInt::WOMBAT
+  end
+
+  def test_containers
+    dog_enum = EnumTypes.get_animal_enum(EnumTypes::Animal::DOG)
+    assert dog_enum.dog?
+    assert_equal 'dog', dog_enum[0].get_record.name
+
+    cat_enum = EnumTypes.get_animal_enum(EnumTypes::Animal::CAT)
+    assert cat_enum.cat?
+    assert_equal 'cat', cat_enum[0].name
+
+    # Equality: Ruby doesn't support equality for enums, so we can't test that dog_enum ==
+    # EnumTypes.get_animal_enum(EnumTypes::Animal::DOG).
+    #
+    # assert dog_enum == EnumTypes.get_animal_enum(EnumTypes::Animal::DOG)
+    # assert cat_enum == EnumTypes.get_animal_enum(EnumTypes::Animal::CAT)
+
+    # Different variants are not equal.
+    assert_not_equal dog_enum, cat_enum
+  end
+
+  def test_defaults
+    e = EnumTypes::NamedEnumWithDefaults::I.new
+    assert_equal 0, e.d
+    assert_equal 1, e.e
+
+    e2 = EnumTypes::NamedEnumWithDefaults::I.new(e: 2)
+    assert_equal 0, e2.d
+    assert_equal 2, e2.e
+  end
+
+  def test_boxed_types
+    boxed_enum = EnumTypes.create_boxed_enum('hello')
+    assert boxed_enum.boxed?
+    assert_equal 'hello', EnumTypes.get_boxed_enum_value(boxed_enum)
+
+    empty_enum = EnumTypes::EnumWithBoxedVariant::EMPTY.new
+    assert empty_enum.empty?
+    assert_equal 'empty', EnumTypes.get_boxed_enum_value(empty_enum)
+
+    content = EnumTypes::BoxedContent.new(value: 'world')
+    result = EnumTypes.roundtrip_boxed_record(content)
+    assert_equal 'world', result.value
+  end
+end

--- a/fixtures/enum-types/tests/test_generated_bindings.rs
+++ b/fixtures/enum-types/tests/test_generated_bindings.rs
@@ -1,5 +1,6 @@
 uniffi::build_foreign_language_testcases!(
     "tests/bindings/test_enum_types.kts",
     "tests/bindings/test_enum_types.py",
-    "tests/bindings/test_enum_types.swift"
+    "tests/bindings/test_enum_types.swift",
+    "tests/bindings/test_enum_types.rb",
 );

--- a/fixtures/error-types/tests/bindings/test.rb
+++ b/fixtures/error-types/tests/bindings/test.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require 'test/unit'
+require 'error_types'
+
+class TestErrorTypes < Test::Unit::TestCase
+  def test_oops_raises_error_interface
+    e = assert_raises(ErrorTypes::ErrorInterface) { ErrorTypes.oops }
+
+    assert_equal ['because uniffi told me so', 'oops'], e.chain
+    assert_equal 'because uniffi told me so', e.link(0)
+    assert_nil e.link(99)
+  end
+
+  def test_error_interface_is_standard_error
+    e = assert_raise_kind_of(StandardError) { ErrorTypes.oops }
+
+    assert_kind_of ErrorTypes::ErrorInterface, e
+  end
+
+  def test_oops_nowrap_raises_error_interface
+    e = assert_raises(ErrorTypes::ErrorInterface) { ErrorTypes.oops_nowrap }
+
+    assert_equal ['because uniffi told me so', 'oops'], e.chain
+    assert_equal 'because uniffi told me so', e.link(0)
+  end
+
+  def test_get_error_returns_without_raising
+    e = ErrorTypes.get_error 'the error'
+
+    assert_equal ['the error'], e.chain
+    assert_equal 'the error', e.link(0)
+    assert_nil e.link(99)
+  end
+
+  def test_throw_rich_raises_rich_error
+    e = assert_raises(ErrorTypes::RichError) { ErrorTypes.throw_rich 'oh no' }
+
+    assert_kind_of StandardError, e
+  end
+
+  def test_toops_raises_error_trait
+    e = assert_raises(ErrorTypes::ErrorTrait) { ErrorTypes.toops }
+
+    assert_equal 'trait-oops', e.msg
+  end
+
+  def test_test_interface_constructor
+    ti = ErrorTypes::TestInterface.new
+
+    assert_not_nil ti
+  end
+
+  def test_test_interface_fallible_new
+    e = assert_raises(ErrorTypes::ErrorInterface) { ErrorTypes::TestInterface.fallible_new }
+
+    assert_equal ['fallible_new'], e.chain
+  end
+
+  def test_test_interface_oops
+    ti = ErrorTypes::TestInterface.new
+    e = assert_raises(ErrorTypes::ErrorInterface) { ti.oops }
+
+    assert_equal ['because the interface told me so', 'oops'], e.chain
+  end
+
+  def test_throw_proc_error
+    e = assert_raises(ErrorTypes::ProcErrorInterface) { ErrorTypes.throw_proc_error 'eek' }
+
+    assert_equal 'eek', e.message
+  end
+
+  def test_return_proc_error
+    e = ErrorTypes.return_proc_error 'hello'
+
+    assert_equal 'hello', e.message
+  end
+
+  def test_oops_enum_oops
+    assert_raises(ErrorTypes::Error::Oops) { ErrorTypes.oops_enum 0 }
+  end
+
+  def test_oops_enum_value
+    e = assert_raises(ErrorTypes::Error::Value) { ErrorTypes.oops_enum 1 }
+
+    assert_equal 'value', e.value
+  end
+
+  def test_oops_enum_int_value
+    e = assert_raises(ErrorTypes::Error::IntValue) { ErrorTypes.oops_enum 2 }
+
+    assert_equal 2, e.value
+  end
+
+  def test_oops_enum_int_case_a
+    e = assert_raises(ErrorTypes::Error::FlatInnerError) { ErrorTypes.oops_enum 3 }
+
+    assert_kind_of ErrorTypes::FlatInner::CaseA, e.error
+  end
+
+  def test_oops_enum_int_case_b
+    e = assert_raises(ErrorTypes::Error::FlatInnerError) { ErrorTypes.oops_enum 4 }
+
+    assert_kind_of ErrorTypes::FlatInner::CaseB, e.error
+  end
+
+  def test_oops_enum_inner_error
+    e = assert_raises(ErrorTypes::Error::InnerError) { ErrorTypes.oops_enum 5 }
+
+    assert_kind_of ErrorTypes::Inner::CaseA, e.error
+    assert_equal 'inner', e.error[0]
+  end
+
+  def test_oops_tuple_oops
+    e = assert_raises(ErrorTypes::TupleError::Oops) { ErrorTypes.oops_tuple 0 }
+
+    assert_equal 'oops', e[0]
+  end
+
+  def test_oops_tuple_value
+    e = assert_raises(ErrorTypes::TupleError::Value) { ErrorTypes.oops_tuple 1 }
+
+    assert_equal 1, e[0]
+  end
+
+  def test_oops_custom
+    # CustomError is lowered as its builtin TupleError - identical behaviour to oops_tuple
+    e = assert_raises(ErrorTypes::TupleError::Value) { ErrorTypes.oops_custom 1 }
+
+    assert_equal 1, e[0]
+  end
+
+  def test_get_tuple_default
+    t = ErrorTypes.get_tuple
+
+    assert_kind_of ErrorTypes::TupleError::Oops, t
+    assert_equal 'oops', t[0]
+  end
+end

--- a/fixtures/error-types/tests/test_generated_bindings.rs
+++ b/fixtures/error-types/tests/test_generated_bindings.rs
@@ -1,5 +1,6 @@
 uniffi::build_foreign_language_testcases!(
     "tests/bindings/test.py",
     "tests/bindings/test.kts",
-    "tests/bindings/test.swift"
+    "tests/bindings/test.swift",
+    "tests/bindings/test.rb",
 );

--- a/fixtures/ext-types/custom-types/tests/bindings/test_custom_types.rb
+++ b/fixtures/ext-types/custom-types/tests/bindings/test_custom_types.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require 'test/unit'
+require 'ext_types_custom'
+
+class TestCustomTypes < Test::Unit::TestCase
+
+  # -- Basic lift/lower --
+  
+  def test_get_guid
+    assert_equal 'NewGuid', ExtTypesCustom.get_guid(nil)
+    assert_equal 'SomeGuid', ExtTypesCustom.get_guid('SomeGuid')
+    assert_equal 'Ouid', ExtTypesCustom.get_ouid(nil)
+  end
+  
+  # -- Custom types inside a Record and a Sequence --
+
+  def test_guid_helper
+    helper = ExtTypesCustom.get_guid_helper(nil)
+    assert_equal 'first-guid', helper.guid
+    assert_equal ['second-guid', 'third-guid'], helper.guids
+    assert_nil helper.maybe_guid
+
+    # Round-trip: pass the same record back in
+    helper2 = ExtTypesCustom.get_guid_helper(helper)
+    assert_equal helper.guid, helper2.guid
+    assert_equal helper.guids, helper2.guids
+    assert_equal helper.maybe_guid, helper2.maybe_guid
+  end
+
+  # -- Error when lifting fails (no Result return type -> InternalError panic) --
+
+  def test_get_guid_errors
+    assert_raise(ExtTypesCustom::InternalError) { ExtTypesCustom.get_guid('') }
+    assert_raise(ExtTypesCustom::InternalError) { ExtTypesCustom.get_guid('unexpected') }
+    assert_raise(ExtTypesCustom::InternalError) { ExtTypesCustom.get_guid('panic') }
+  end
+
+  # -- Error when lifting fails and function returns Result --
+
+  def test_try_get_guid_errors
+    # Empty string -> declared Error (GuidError::TooShort)
+    assert_raise(ExtTypesCustom::GuidError::TooShort) { ExtTypesCustom.try_get_guid('') }
+
+    # "unexpected" triggers an InternalError (not declared in the throws clause)
+    assert_raise(ExtTypesCustom::InternalError) { ExtTypesCustom.try_get_guid('unexpected') }
+
+    # "panic" triggers a Rust panic -> InternalError
+    assert_raise(ExtTypesCustom::InternalError) { ExtTypesCustom.try_get_guid('panic') }
+  end
+
+  # -- Nested custom types (ANestedGuid wraps Guid wraps String) --
+  
+  def test_nested_custom_type
+    result = ExtTypesCustom.get_nested_guid nil
+    assert_equal 'ANestedGuid', result
+
+    result2 = ExtTypesCustom.get_nested_guid result
+    assert_equal result, result2
+  end
+
+  # -- HandleU8 (custom_newtype over u8 = Integer --
+
+  def test_handle_u8
+    assert_equal 2, ExtTypesCustom.get_handle_u8(nil)
+    assert_equal 42, ExtTypesCustom.get_handle_u8(42)
+  end
+end

--- a/fixtures/ext-types/custom-types/tests/test_generated_bindings.rs
+++ b/fixtures/ext-types/custom-types/tests/test_generated_bindings.rs
@@ -1,1 +1,4 @@
-uniffi::build_foreign_language_testcases!("tests/bindings/test_custom_types.py",);
+uniffi::build_foreign_language_testcases!(
+    "tests/bindings/test_custom_types.py",
+    "tests/bindings/test_custom_types.rb",
+);

--- a/fixtures/proc-macro/tests/bindings/test_proc_macro.rb
+++ b/fixtures/proc-macro/tests/bindings/test_proc_macro.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'proc_macro'
+
+include ProcMacro
+
+class TestProcMacroDefaults < Test::Unit::TestCase
+  def test_record_with_explicit_defaults
+    r = RecordWithDefaults.new no_default_string: 'Test'
+
+    assert_equal 'Test', r.no_default_string
+    assert r.boolean
+    assert_equal 42, r.integer
+    assert_in_delta 4.2, r.float_var, 0.001
+    assert_equal [], r.vec
+    assert_nil r.opt_vec
+    assert_equal 42, r.opt_integer
+    assert_equal 42, r.custom_integer
+    assert !r.boolean_default
+    assert_equal '', r.string_default
+    assert_nil r.opt_default
+  end
+
+  def test_record_with_implicit_defaults
+    r = RecordWithImplicitDefaults.new
+
+    assert !r.boolean
+    assert_equal 0, r.int8
+    assert_equal 0, r.uint8
+    assert_equal 0, r.int16
+    assert_equal 0, r.uint16
+    assert_equal 0, r.int32
+    assert_equal 0, r.uint32
+    assert_equal 0, r.int64
+    assert_equal 0, r.uint64
+    assert_equal 0.0, r.afloat
+    assert_equal 0.0, r.adouble
+    assert_equal [], r.vec
+    assert_equal({}, r.map)
+    assert_equal ''.b, r.some_bytes
+    assert_nil r.opt_int32
+    assert_equal 0, r.custom_integer
+  end
+
+  def test_function_defaults
+    assert_equal 42, ProcMacro.double_with_default
+    assert_equal 1, ProcMacro.sum_with_default(1)
+    assert_equal 3, ProcMacro.sum_with_default(1, 2)
+  end
+
+  def test_object_defaults
+    obj = ObjectWithDefaults.new
+
+    assert_equal 42, obj.add_to_num
+    assert_equal 30, obj.add_to_implicit_num
+    assert_equal 31, obj.add_to_implicit_num(1)
+  end
+end

--- a/fixtures/proc-macro/tests/test_generated_bindings.rs
+++ b/fixtures/proc-macro/tests/test_generated_bindings.rs
@@ -2,4 +2,5 @@ uniffi::build_foreign_language_testcases!(
     "tests/bindings/test_proc_macro.kts",
     "tests/bindings/test_proc_macro.swift",
     "tests/bindings/test_proc_macro.py",
+    "tests/bindings/test_proc_macro.rb",
 );

--- a/fixtures/rename/tests/test_generated_bindings.rs
+++ b/fixtures/rename/tests/test_generated_bindings.rs
@@ -2,4 +2,5 @@ uniffi::build_foreign_language_testcases!(
     "tests/test_rename.kts",
     "tests/test_rename.py",
     "tests/test_rename.swift",
+    "tests/test_rename.rb",
 );

--- a/fixtures/rename/tests/test_rename.rb
+++ b/fixtures/rename/tests/test_rename.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uri'
+require 'uniffi_fixture_rename'
+
+class TestRename < Test::Unit::TestCase
+  def test_rename_record
+    record = UniffiFixtureRename::RenamedRecord.new renamed_field: 42
+    assert_equal 42, record.renamed_field
+  end
+
+  def test_renamed_enum
+    variant_a = UniffiFixtureRename::RenamedEnum::RENAMED_VARIANT.new
+    assert variant_a.renamed_variant?
+    assert !variant_a.record?
+
+    record = UniffiFixtureRename::RenamedRecord.new renamed_field: 42
+    variant_record = UniffiFixtureRename::RenamedEnum::RECORD.new record
+    assert !variant_record.renamed_variant?
+    assert variant_record.record?
+    assert_equal 42, variant_record[0].renamed_field
+  end
+
+  def test_renamed_enum_with_fields
+    variant = UniffiFixtureRename::RenamedEnumWithFields::RENAMED_VARIANT_WITH_FIELDS.new(
+      renamed_variant_field: 42
+    )
+
+    assert variant.renamed_variant_with_fields?
+    assert_equal 42, variant.renamed_variant_field
+  end
+
+  def test_renamed_function
+    record = UniffiFixtureRename::RenamedRecord.new renamed_field: 42
+    result = UniffiFixtureRename.renamed_function record
+
+    assert_instance_of UniffiFixtureRename::RenamedEnum::RECORD, result
+    assert_equal 42, result[0].renamed_field
+  end
+
+  def test_renamed_object
+    renamed_object = UniffiFixtureRename::RenamedObject.renamed_constructor 42
+
+    assert_instance_of UniffiFixtureRename::RenamedObject, renamed_object
+    assert_equal 42, renamed_object.renamed_method
+  end
+
+  def test_renamed_error
+    assert UniffiFixtureRename::RenamedError::RenamedErrorVariant < StandardError
+  end
+
+  def test_renamed_trait_method
+    impl = UniffiFixtureRename.create_trait_impl 5
+
+    assert_equal 50, impl.renamed_trait_method(10)
+  end
+
+  def test_roundtrip_url
+    url = URI.parse 'https://example.com/test'
+    result = UniffiFixtureRename.roundtrip_url url
+
+    assert_instance_of URI::HTTPS, result
+    assert_equal url, result
+  end
+end
+
+class TestBindingRenames < Test::Unit::TestCase
+  def test_rb_record
+    record = UniffiFixtureRename::RbRecord.new rb_item: 42
+
+    assert_equal 42, record.rb_item
+  end
+
+  def test_rb_enum
+    record = UniffiFixtureRename::RbRecord.new rb_item: 42
+
+    variant_a = UniffiFixtureRename::RbEnum::RB_VARIANT_A.new
+    assert variant_a.rb_variant_a?
+
+    variant_record = UniffiFixtureRename::RbEnum::RB_RECORD.new record
+    assert variant_record.rb_record?
+    assert_equal 42, variant_record[0].rb_item
+  end
+
+  def test_rb_enum_with_fields
+    variant_a = UniffiFixtureRename::RbEnumWithFields::RB_VARIANT_A.new rb_int: 42
+    assert variant_a.rb_variant_a?
+    assert_equal 42, variant_a.rb_int
+
+    inner = UniffiFixtureRename::RbRecord.new rb_item: 7
+    variant_rec = UniffiFixtureRename::RbEnumWithFields::RB_RECORD.new rb_record: inner, rb_int: 3
+    
+    assert variant_rec.rb_record?
+    assert_equal inner, variant_rec.rb_record
+    assert_equal 3, variant_rec.rb_int
+  end
+
+  def test_rb_function_with_record
+    record = UniffiFixtureRename::RbRecord.new rb_item: 99
+    result = UniffiFixtureRename.rb_function record
+
+    assert_instance_of UniffiFixtureRename::RbEnum::RB_RECORD, result
+    assert_equal 99, result[0].rb_item
+  end
+
+  def test_rb_function_with_nil_raises
+    assert_raise(UniffiFixtureRename::RbError::RbSimple) { UniffiFixtureRename.rb_function nil }
+  end
+
+  def test_rb_object
+    obj = UniffiFixtureRename::RbObject.new 7
+
+    assert_equal 17, obj.rb_method(10)
+  end
+
+  def test_rb_trait
+    impl = UniffiFixtureRename.create_binding_trait_impl 3
+
+    assert_equal 30, impl.rb_trait_method(10)
+  end
+
+  def test_exclusions
+    assert !UniffiFixtureRename.respond_to?(:function_to_exclude)
+    assert !defined?(UniffiFixtureRename::RecordToExclude)
+
+    obj = UniffiFixtureRename::RenamedObject.renamed_constructor 42
+    assert !obj.respond_to?(:method_to_exclude)
+  end
+end

--- a/fixtures/rename/uniffi.toml
+++ b/fixtures/rename/uniffi.toml
@@ -56,6 +56,53 @@ exclude = [
 ]
 
 #
+# Ruby
+#
+[bindings.ruby.rename]
+binding_function = "rb_function"
+"binding_function.record" = "rb_record"
+
+BindingRecord = "RbRecord"
+"BindingRecord.item" = "rb_item"
+
+BindingEnum = "RbEnum"
+"BindingEnum.VariantA" = "RbVariantA"
+"BindingEnum.Record" = "RbRecord"
+
+BindingEnumWithFields = "RbEnumWithFields"
+"BindingEnumWithFields.VariantA" = "RbVariantA"
+"BindingEnumWithFields.VariantA.binding_int" = "rb_int"
+"BindingEnumWithFields.Record" = "RbRecord"
+"BindingEnumWithFields.Record.binding_record" = "rb_record"
+"BindingEnumWithFields.Record.binding_int" = "rb_int"
+
+BindingError = "RbError"
+"BindingError.Simple" = "RbSimple"
+
+BindingTrait = "RbTrait"
+"BindingTrait.trait_method" = "rb_trait_method"
+
+BindingObject = "RbObject"
+"BindingObject.method" = "rb_method"
+"BindingObject.method.arg" = "rb_arg"
+
+Url = "RenamedUrl"
+
+# Item exclusions.
+function_to_exclude = ""
+"RenamedObject.new" = ""
+"RenamedObject.method_to_exclude" = ""
+RecordToExclude = ""
+
+[bindings.ruby]
+exclude = [
+    "function_to_exclude",
+    "RenamedObject.new",
+    "RenamedObject.method_to_exclude",
+    "RecordToExclude",
+]
+
+#
 # Python
 #
 [bindings.python.rename]
@@ -185,3 +232,9 @@ lower = "{}.toString()"
 type_name = "URL"
 lift = "URL(string: {})!"
 lower = "{}.absoluteString"
+
+[bindings.ruby.custom_types.RenamedUrl]
+type_name = "URI"
+imports = [ "uri" ]
+lift = "URI.parse({})"
+lower = "{}.to_s"

--- a/fixtures/simple-fns/tests/bindings/test_simple_fns.rb
+++ b/fixtures/simple-fns/tests/bindings/test_simple_fns.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_simple_fns'
+
+class TestSimpleFns < Test::Unit::TestCase
+  def test_simple_fns
+    assert_equal 'String created by Rust', UniffiSimpleFns.get_string
+    assert_equal 1289, UniffiSimpleFns.get_int
+    assert_equal 'String created by Ruby', UniffiSimpleFns.string_identity('String created by Ruby')
+    assert_equal 255, UniffiSimpleFns.byte_to_u32(255)
+
+    a_set = UniffiSimpleFns.new_set
+    UniffiSimpleFns.add_to_set a_set, 'foo'
+    UniffiSimpleFns.add_to_set a_set, 'bar'
+
+    assert UniffiSimpleFns.set_contains(a_set, 'foo')
+    assert UniffiSimpleFns.set_contains(a_set, 'bar')
+    assert !UniffiSimpleFns.set_contains(a_set, 'baz')
+
+    assert_equal({'a' => 'b'}, UniffiSimpleFns.hash_map_identity({'a' => 'b'}))
+  end
+end

--- a/fixtures/simple-fns/tests/test_generated_bindings.rs
+++ b/fixtures/simple-fns/tests/test_generated_bindings.rs
@@ -2,4 +2,5 @@ uniffi::build_foreign_language_testcases!(
     "tests/bindings/test_simple_fns.kts",
     "tests/bindings/test_simple_fns.swift",
     "tests/bindings/test_simple_fns.py",
+    "tests/bindings/test_simple_fns.rb",
 );

--- a/fixtures/simple-iface/tests/bindings/test_simple_iface.rb
+++ b/fixtures/simple-iface/tests/bindings/test_simple_iface.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_simple_iface'
+
+class TestSimpleIface < Test::Unit::TestCase
+  def test_simple_iface
+    obj = UniffiSimpleIface.make_object 9000
+
+    assert_equal 9000, obj.get_inner()
+
+    obj.some_method()
+  end
+end

--- a/fixtures/simple-iface/tests/test_generated_bindings.rs
+++ b/fixtures/simple-iface/tests/test_generated_bindings.rs
@@ -2,4 +2,5 @@ uniffi::build_foreign_language_testcases!(
     "tests/bindings/test_simple_iface.kts",
     "tests/bindings/test_simple_iface.swift",
     "tests/bindings/test_simple_iface.py",
+    "tests/bindings/test_simple_iface.rb",
 );

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -8,8 +8,9 @@ use askama::Template;
 use heck::{ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
+use std::collections::HashMap;
 
-use crate::interface::*;
+use crate::interface::{Enum, *};
 
 const RESERVED_WORDS: &[&str] = &[
     "alias", "and", "BEGIN", "begin", "break", "case", "class", "def", "defined?", "do", "else",
@@ -76,6 +77,44 @@ pub fn canonical_name(t: &Type) -> String {
     }
 }
 
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CustomTypeConfig {
+    type_name: Option<String>,
+    imports: Option<Vec<String>>,
+    into_custom: String, // b/w compat alias for lift
+    lift: String,
+    from_custom: String, // b/w compat alias for lower
+    lower: String,
+}
+
+impl CustomTypeConfig {
+    /// Produce a Ruby expression that lifts a raw-builtin value `nm` into the custom type.
+    fn lift(&self, name: &str) -> String {
+        let converter = if self.lift.is_empty() {
+            &self.into_custom
+        } else {
+            &self.lift
+        };
+        converter.replace("{}", name)
+    }
+
+    /// Produce a Ruby expression that lowers a value `nm` to its raw builtin.
+    fn lower(&self, name: &str) -> String {
+        let converter = if self.lower.is_empty() {
+            &self.from_custom
+        } else {
+            &self.lower
+        };
+        converter.replace("{}", name)
+    }
+
+    /// True if this config actually specifies conversion expressions.
+    pub fn has_conversion(&self) -> bool {
+        !self.lift.is_empty() || !self.into_custom.is_empty()
+    }
+}
+
 // Some config options for it the caller wants to customize the generated ruby.
 // Note that this can only be used to control details of the ruby *that do not affect the underlying component*,
 // since the details of the underlying component are entirely determined by the `ComponentInterface`.
@@ -83,6 +122,12 @@ pub fn canonical_name(t: &Type) -> String {
 pub struct Config {
     pub(super) cdylib_name: Option<String>,
     cdylib_path: Option<String>,
+    #[serde(default)]
+    custom_types: HashMap<String, CustomTypeConfig>,
+    #[serde(default)]
+    pub(super) exclude: Vec<String>,
+    #[serde(default)]
+    pub(super) rename: toml::Table,
 }
 
 impl Config {
@@ -146,18 +191,14 @@ mod filters {
         })
     }
 
-    #[askama::filter_fn]
-    pub fn default_rb(
-        default: &DefaultValue,
-        _: &dyn askama::Values,
-    ) -> Result<String, askama::Error> {
-        default_rb_inner(default)
-    }
-
     fn default_rb_inner(default: &DefaultValue) -> Result<String, askama::Error> {
         let DefaultValue::Literal(literal) = default else {
             unimplemented!("not supported.");
         };
+        literal_rb_inner(literal)
+    }
+
+    fn literal_rb_inner(literal: &Literal) -> Result<String, askama::Error> {
         Ok(match literal {
             Literal::Boolean(v) => {
                 if *v {
@@ -191,6 +232,68 @@ mod filters {
             },
             Literal::Float(string, _type_) => string.clone(),
         })
+    }
+
+    /// Return the Ruby zero/default value for a type (used for `#[uniffi::default]`).
+    fn type_zero_value_rb(ty: &Type) -> Result<String, askama::Error> {
+        Ok(match ty {
+            Type::Int8
+            | Type::UInt8
+            | Type::Int16
+            | Type::UInt16
+            | Type::Int32
+            | Type::UInt32
+            | Type::Int64
+            | Type::UInt64 => "0".to_string(),
+            Type::Float32 | Type::Float64 => "0.0".to_string(),
+            Type::Boolean => "false".to_string(),
+            Type::String => "\"\"".to_string(),
+            Type::Optional { .. } => "nil".to_string(),
+            Type::Sequence { .. } => "[]".to_string(),
+            Type::Bytes => "\"\".b".to_string(),
+            Type::Map { .. } => "{}".to_string(),
+            // Named types with no-arg constructors
+            Type::Record { name, .. } | Type::Object { name, .. } => {
+                format!("{}.new", class_name_rb_inner(name)?)
+            }
+            // Custom types delegate to their underlying builtin
+            Type::Custom { builtin, .. } => type_zero_value_rb(builtin)?,
+            _ => {
+                return Err(askama::Error::Custom(
+                    anyhow::anyhow!("No zero value for type {ty:?}").into(),
+                ))
+            }
+        })
+    }
+
+    /// Render the Ruby default value for a field, handling both `Default` and `Literal` variants.
+    #[askama::filter_fn]
+    pub fn field_default_rb(
+        field: &Field,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
+        match field.default_value() {
+            Some(DefaultValue::Default) => {
+                let ty = field.as_type();
+                type_zero_value_rb(&ty)
+            }
+            Some(DefaultValue::Literal(lit)) => literal_rb_inner(lit),
+            None => Err(askama::Error::Custom(
+                anyhow::anyhow!("field_default_rb called on field with no default value").into(),
+            )),
+        }
+    }
+
+    /// Render the Ruby default value for a function/method argument.
+    #[askama::filter_fn]
+    pub fn arg_default_rb(arg: &Argument, _: &dyn askama::Values) -> Result<String, askama::Error> {
+        match arg.default_value() {
+            Some(DefaultValue::Default) => type_zero_value_rb(&arg.as_type()),
+            Some(DefaultValue::Literal(lit)) => literal_rb_inner(lit),
+            None => Err(askama::Error::Custom(
+                anyhow::anyhow!("arg_default_rb called on arg with no default value").into(),
+            )),
+        }
     }
 
     #[askama::filter_fn]
@@ -230,14 +333,16 @@ mod filters {
         _: &dyn askama::Values,
         ns: S2,
         type_: &Type,
+        config: &Config,
     ) -> Result<String, askama::Error> {
-        coerce_rb_inner(nm, ns, type_)
+        coerce_rb_inner(nm, ns, type_, &config.custom_types)
     }
 
     pub fn coerce_rb_inner<S1: AsRef<str>, S2: AsRef<str>>(
         nm: S1,
         ns: S2,
         type_: &Type,
+        custom_types: &HashMap<String, CustomTypeConfig>,
     ) -> Result<String, askama::Error> {
         let nm = nm.as_ref();
         let ns = ns.as_ref();
@@ -256,14 +361,19 @@ mod filters {
             Type::String => format!("{ns}::uniffi_utf8({nm})"),
             Type::Bytes => format!("{ns}::uniffi_bytes({nm})"),
             Type::Timestamp | Type::Duration => nm.to_string(),
-            Type::CallbackInterface { .. } => {
-                panic!("No support for coercing callback interfaces yet")
+            Type::CallbackInterface { name, .. } => {
+                // Callback interfaces are not yet supported; emit a Ruby runtime error so that
+                // code generation succeeds but calling such functions raises clearly.
+                format!("raise NotImplementedError, \"Callback interface {name} is not yet supported in the Ruby bindings\"")
             }
             Type::Optional { inner_type: t } => {
-                format!("({nm} ? {} : nil)", coerce_rb_inner(nm, ns, t)?)
+                format!(
+                    "({nm} ? {} : nil)",
+                    coerce_rb_inner(nm, ns, t, custom_types)?
+                )
             }
             Type::Sequence { inner_type: t } => {
-                let coerce_code = coerce_rb_inner("v", ns, t)?;
+                let coerce_code = coerce_rb_inner("v", ns, t, custom_types)?;
                 if coerce_code == "v" {
                     nm.to_string()
                 } else {
@@ -271,8 +381,8 @@ mod filters {
                 }
             }
             Type::Map { value_type: t, .. } => {
-                let k_coerce_code = coerce_rb_inner("k", ns, &Type::String)?;
-                let v_coerce_code = coerce_rb_inner("v", ns, t)?;
+                let k_coerce_code = coerce_rb_inner("k", ns, &Type::String, custom_types)?;
+                let v_coerce_code = coerce_rb_inner("v", ns, t, custom_types)?;
 
                 if k_coerce_code == "k" && v_coerce_code == "v" {
                     nm.to_string()
@@ -282,8 +392,16 @@ mod filters {
                     )
                 }
             }
-            Type::Box { inner_type } => coerce_rb_inner(nm, ns, inner_type)?,
-            Type::Custom { .. } => panic!("No support for custom types, yet"),
+            Type::Box { inner_type } => coerce_rb_inner(nm, ns, inner_type, custom_types)?,
+            Type::Custom { name, builtin, .. } => {
+                // For config-backed custom types, the user passes a custom-typed values;
+                // skip builtin coercion (the lower expression handles conversion).
+                if custom_types.contains_key(name) {
+                    nm.to_string()
+                } else {
+                    coerce_rb_inner(nm, ns, builtin, custom_types)?
+                }
+            }
         })
     }
 
@@ -292,6 +410,7 @@ mod filters {
         nm: S,
         _: &dyn askama::Values,
         type_: &Type,
+        config: &Config,
     ) -> Result<String, askama::Error> {
         let nm = nm.as_ref();
         Ok(match type_ {
@@ -307,19 +426,57 @@ mod filters {
                 class_name_rb_inner(&canonical_name(type_))?,
                 nm
             ),
+            Type::Custom { name, .. } => {
+                if let Some(cfg) = config.custom_types.get(name) {
+                    if let Some(type_name) = &cfg.type_name {
+                        // Emit: rause TypeError, "Expected URI, got #{nm.class}" unless nm.is_a?(URI)
+                        format!(
+                            "raise TypeError, \"Expected {type_name}, got {{#{nm}.class}}\" unless {nm}.is_a?({type_name})"
+                        )
+                    } else {
+                        "".to_string()
+                    }
+                } else {
+                    "".to_string()
+                }
+            }
             _ => "".to_owned(),
         })
     }
 
-    #[askama::filter_fn]
-    pub fn lower_rb(
+    pub fn lower_rb_inner(
         nm: &str,
-        _: &dyn askama::Values,
-        mut type_: &Type,
+        type_: &Type,
+        custom_types: &HashMap<String, CustomTypeConfig>,
     ) -> Result<String, askama::Error> {
+        let mut type_ = type_;
         while let Type::Box { inner_type } = type_ {
             type_ = &**inner_type;
         }
+        lower_rb_inner_no_box(nm, type_, custom_types)
+    }
+
+    fn lower_rb_inner_no_box(
+        nm: &str,
+        type_: &Type,
+        custom_types: &HashMap<String, CustomTypeConfig>,
+    ) -> Result<String, askama::Error> {
+        Ok(match type_ {
+            Type::Box { inner_type } => lower_rb_inner(nm, inner_type, custom_types)?,
+            Type::Custom { name, builtin, .. } => {
+                if let Some(cfg) = custom_types.get(name) {
+                    // Apply the configured `lower` expression, then lower the resulting builtin.
+                    let lowered_nm = cfg.lower(nm);
+                    lower_rb_inner(&lowered_nm, builtin, custom_types)?
+                } else {
+                    lower_rb_inner(nm, builtin, custom_types)?
+                }
+            }
+            type_ => return lower_rb_inner_dispatch(nm, type_),
+        })
+    }
+
+    pub fn lower_rb_inner_dispatch(nm: &str, type_: &Type) -> Result<String, askama::Error> {
         Ok(match type_ {
             Type::Int8
             | Type::UInt8
@@ -337,8 +494,10 @@ mod filters {
             Type::Object { name, .. } => {
                 format!("({}.uniffi_lower {nm})", class_name_rb_inner(name)?)
             }
-            Type::CallbackInterface { .. } => {
-                panic!("No support for lowering callback interfaces yet")
+            Type::CallbackInterface { name, .. } => {
+                format!(
+                    "raise(NotImplementedError, \"Callback interface {name} is not yet supported in the Ruby bindings\")"
+                )
             }
             Type::Enum { .. }
             | Type::Record { .. }
@@ -352,19 +511,57 @@ mod filters {
                 nm
             ),
             Type::Box { .. } => unreachable!(),
-            Type::Custom { .. } => panic!("No support for lowering custom types, yet"),
+            Type::Custom { .. } => unreachable!("Custom types should be handled before dispatch"),
         })
     }
 
     #[askama::filter_fn]
-    pub fn lift_rb(
+    pub fn lower_rb(
         nm: &str,
         _: &dyn askama::Values,
-        mut type_: &Type,
+        type_: &Type,
+        config: &Config,
     ) -> Result<String, askama::Error> {
+        lower_rb_inner(nm, type_, &config.custom_types)
+    }
+
+    fn lift_rb_inner(
+        nm: &str,
+        type_: &Type,
+        custom_types: &HashMap<String, CustomTypeConfig>,
+    ) -> Result<String, askama::Error> {
+        let mut type_ = type_;
         while let Type::Box { inner_type } = type_ {
             type_ = &**inner_type;
         }
+        lift_rb_inner_no_box(nm, type_, custom_types)
+    }
+
+    fn lift_rb_inner_no_box(
+        nm: &str,
+        type_: &Type,
+        custom_types: &HashMap<String, CustomTypeConfig>,
+    ) -> Result<String, askama::Error> {
+        Ok(match type_ {
+            Type::Box { inner_type } => lift_rb_inner(nm, inner_type, custom_types)?,
+            Type::Custom { name, builtin, .. } => {
+                // First lift the raw builtin value, then apply the configured lift expression.
+                let lifted = lift_rb_inner(nm, builtin, custom_types)?;
+                if let Some(cfg) = custom_types.get(name) {
+                    cfg.lift(&lifted)
+                } else {
+                    lifted
+                }
+            }
+            type_ => return lift_rb_inner_dispatch(nm, type_, custom_types),
+        })
+    }
+
+    pub fn lift_rb_inner_dispatch(
+        nm: &str,
+        type_: &Type,
+        custom_types: &HashMap<String, CustomTypeConfig>,
+    ) -> Result<String, askama::Error> {
         Ok(match type_ {
             Type::Int8
             | Type::UInt8
@@ -381,8 +578,10 @@ mod filters {
             Type::Object { name, .. } => {
                 format!("{}.uniffi_allocate({nm})", class_name_rb_inner(name)?)
             }
-            Type::CallbackInterface { .. } => {
-                panic!("No support for lifting callback interfaces, yet")
+            Type::CallbackInterface { name, .. } => {
+                format!(
+                    "raise(NotImplementedError, \"Callback interface {name} is not yet supported in the Ruby bindings\")"
+                )
             }
             Type::Enum { .. } => {
                 format!(
@@ -402,8 +601,45 @@ mod filters {
                 class_name_rb_inner(&canonical_name(type_))?
             ),
             Type::Box { .. } => unreachable!(),
-            Type::Custom { .. } => panic!("No support for lifting custom types, yet"),
+            Type::Custom { name, builtin, .. } => {
+                let lifted = lift_rb_inner(nm, builtin, custom_types)?;
+                if let Some(cfg) = custom_types.get(name) {
+                    cfg.lift(&lifted)
+                } else {
+                    lifted
+                }
+            }
         })
+    }
+
+    #[askama::filter_fn]
+    pub fn lift_rb(
+        nm: &str,
+        _: &dyn askama::Values,
+        type_: &Type,
+        config: &Config,
+    ) -> Result<String, askama::Error> {
+        lift_rb_inner(nm, type_, &config.custom_types)
+    }
+
+    /// Render a Ruby integer literal for the discriminant of the variant at `index` in enum `e`.
+    #[askama::filter_fn]
+    pub fn variant_discr_literal(
+        e: &Enum,
+        _: &dyn askama::Values,
+        index: &usize,
+    ) -> Result<String, askama::Error> {
+        let literal = e
+            .variant_discr(*index)
+            .map_err(|err| askama::Error::Custom(err.into()))?;
+
+        match literal {
+            Literal::UInt(v, _, _) => Ok(v.to_string()),
+            Literal::Int(v, _, _) => Ok(v.to_string()),
+            _ => Err(askama::Error::Custom(
+                anyhow::anyhow!("Only integer discriminants are supported").into(),
+            )),
+        }
     }
 }
 

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/tests.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/tests.rs
@@ -12,16 +12,13 @@ fn when_not_reserved_word() {
 
 #[test]
 fn cdylib_name() {
-    let config = Config {
-        cdylib_name: None,
-        cdylib_path: None,
-    };
+    let config = Config::default();
 
     assert_eq!("uniffi", config.cdylib_name());
 
     let config = Config {
         cdylib_name: Some("todolist".to_string()),
-        cdylib_path: None,
+        ..Default::default()
     };
 
     assert_eq!("todolist", config.cdylib_name());
@@ -29,17 +26,14 @@ fn cdylib_name() {
 
 #[test]
 fn cdylib_path() {
-    let config = Config {
-        cdylib_name: None,
-        cdylib_path: None,
-    };
+    let config = Config::default();
 
     assert_eq!("", config.cdylib_path());
     assert!(!config.custom_cdylib_path());
 
     let config = Config {
-        cdylib_name: None,
         cdylib_path: Some("/foo/bar".to_string()),
+        ..Default::default()
     };
 
     assert_eq!("/foo/bar", config.cdylib_path());

--- a/uniffi_bindgen/src/bindings/ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/mod.rs
@@ -2,8 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::collections::HashMap;
 use std::process::Command;
 
+use crate::interface::{apply_exclusions, rename};
 use crate::{bindings::GenerateOptions, BindgenLoader, Component, ComponentInterface};
 use anyhow::{bail, Context, Result};
 use fs_err as fs;
@@ -24,6 +26,7 @@ pub fn generate(loader: &BindgenLoader, options: GenerateOptions) -> Result<()> 
     let cdylib = loader.library_name(&options.source).map(|l| l.to_string());
     let mut components =
         loader.load_components(cis, |ci, toml| parse_config(ci, toml, cdylib.clone()))?;
+    apply_renames(&mut components);
     for c in components.iter_mut() {
         c.ci.derive_ffi_funcs()?;
     }
@@ -71,4 +74,25 @@ fn parse_config(
             .unwrap_or_else(|| format!("uniffi_{}", ci.namespace()))
     });
     Ok(config)
+}
+
+fn apply_renames(components: &mut Vec<Component<Config>>) {
+    // Remove excluded items, this happens before renaming
+    for c in components.iter_mut() {
+        apply_exclusions(&mut c.ci, &c.config.exclude);
+    }
+
+    let mut module_renames = HashMap::new();
+    for c in components.iter() {
+        if !c.config.rename.is_empty() {
+            let module_path = c.ci.crate_name().to_string();
+            module_renames.insert(module_path, c.config.rename.clone());
+        }
+    }
+
+    if !module_renames.is_empty() {
+        for c in &mut *components {
+            rename(&mut c.ci, &module_renames);
+        }
+    }
 }

--- a/uniffi_bindgen/src/bindings/ruby/templates/CustomTypeTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/CustomTypeTemplate.rb
@@ -1,0 +1,19 @@
+{%- match config.custom_types.get(name.as_str()) %}
+{%- when None %}
+# Custom type `{{ name }}` - no binding config, backed by builtin `{{ self::canonical_name(builtin) }}`.
+# Values crosss the FFI as the builtin type unchanged.
+
+{%- when Some(cfg) %}
+# Custom type `{{ name }}` - binding config supplied, backed by builtin `{{ self::canonical_name(builtin) }}`.
+{%- if cfg.has_conversion() %}
+#   lift expression: {{ cfg.lift("raw_value") }}
+#   lower expression: {{ cfg.lower("custom_value") }}
+{%- endif %}
+{%- match cfg.imports %}
+{%- when Some(imports) %}
+{%- for import_name in imports %}
+require '{{ import_name }}'
+{%- endfor %}
+{%- when None %}
+{%- endmatch %}
+{%- endmatch %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/EnumTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/EnumTemplate.rb
@@ -2,7 +2,7 @@
 
 class {{ e.name()|class_name_rb }}
   {% for variant in e.variants() -%}
-  {{ variant.name()|enum_name_rb }} = {{ loop.index }}
+  {{ variant.name()|enum_name_rb }} = {{ e|variant_discr_literal(loop.index0) }}
   {% endfor %}
 end
 
@@ -16,32 +16,54 @@ class {{ e.name()|class_name_rb }}
   # Each enum variant is a nested class of the enum itself.
   {% for variant in e.variants() -%}
   class {{ variant.name()|enum_name_rb }}
+    {%- let named_fields = variant.has_fields() && !variant.fields()[0].name().is_empty() %}
     {% if variant.has_fields() %}
-    attr_reader {% for field in variant.fields() %}:{{ field.name()|var_name_rb }}{% if loop.last %}{% else %}, {% endif %}{%- endfor %}
+    {%- if named_fields %}
+      attr_reader {% for field in variant.fields() %}:{{ field.name()|var_name_rb }}{% if loop.last %}{% else %}, {% endif %}{%- endfor %}
+    {%- else %}
+      attr_reader :values
+    {%- endif %}
     {% endif %}
-    def initialize({% for field in variant.fields() %}{{ field.name()|var_name_rb }}{% if loop.last %}{% else %}, {% endif %}{% endfor %})
+    {%- if named_fields %}
+    def initialize({% for field in variant.fields() %}{{ field.name()|var_name_rb -}}:
+      {%- match field.default_value() %}
+      {%- when Some(default) %} {{ field|field_default_rb }}
+      {%- else %}
+      {% endmatch %}
+      {%- if loop.last %}{% else %}, {% endif -%}{% endfor %})
+        {%- for field in variant.fields() %}
+        @{{ field.name()|var_name_rb }} = {{ field.name()|var_name_rb }}
+        {%- endfor %}
+    end
+    {%- else %}
+    def initialize({% for field in variant.fields() %}v{{ loop.index }}{% if loop.last %}{% else %}, {% endif %}{% endfor %})
       {% if variant.has_fields() %}
-      {%- for field in variant.fields() %}
-      @{{ field.name()|var_name_rb }} = {{ field.name()|var_name_rb }}
-      {%- endfor %}
+        @values = [{% for field in variant.fields() %}v{{ loop.index }}{% if loop.last %}{% else %}, {% endif %}{% endfor %}]
       {% else %}
       {% endif %}
     end
 
+    def [](index)
+      @values[index]
+    end
+    {% endif %}
+
     def to_s
-      "{{ e.name()|class_name_rb }}::{{ variant.name()|enum_name_rb }}({% for field in variant.fields() %}{{ field.name() }}=#{@{{ field.name() }}}{% if loop.last %}{% else %}, {% endif %}{% endfor %})"
+      "{{ e.name()|class_name_rb }}::{{ variant.name()|enum_name_rb }}"
     end
 
     def ==(other)
-      if !other.{{ variant.name()|var_name_rb }}?
-        return false
-      end
+      return false unless other.respond_to?(:{{variant.name()|var_name_rb}}?)
+      return false unless other.{{ variant.name()|var_name_rb }}?
+      {%- if named_fields %}
       {%- for field in variant.fields() %}
-      if @{{ field.name()|var_name_rb }} != other.{{ field.name()|var_name_rb }}
-        return false
-      end
+        return false if @{{ field.name()|var_name_rb }} != other.{{ field.name()|var_name_rb }}
       {%- endfor %}
-
+      {%- else %}
+      {%- if variant.has_fields() %}
+        return false if @values != other.values
+      {% endif %}
+      {% endif %}
       true
     end
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/ErrorTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/ErrorTemplate.rb
@@ -30,19 +30,48 @@ class {{ e.name()|class_name_rb }}
 module {{ e.name()|class_name_rb }}
   {%- for variant in e.variants() %}
   class {{ variant.name()|class_name_rb }} < StandardError
-    def initialize({% for field in variant.fields() %}{{ field.name()|var_name_rb }}{% if !loop.last %}, {% endif %}{% endfor %})
-        {%- for field in variant.fields() %}
+    {%- let named_fields = variant.has_fields() && !variant.fields()[0].name().is_empty() %}
+    {%- if named_fields %}
+    def initialize({% for field in variant.fields() %}{{ field.name()|var_name_rb }}:{% if !loop.last %}, {% endif %}{% endfor %})
+        {% for field in variant.fields() %}
         @{{ field.name()|var_name_rb }} = {{ field.name()|var_name_rb }}
-        {%- endfor %}
+        {% endfor %}
         super()
-      end
+    end
+    {% else %}
+    def initialize({% for field in variant.fields() %}v{{ loop.index }}{% if !loop.last %}, {% endif %}{% endfor %})
+        {% if variant.has_fields() %}
+        @values = [{% for field in variant.fields() %}v{{ loop.index }}{% if !loop.last %}, {% endif %}{% endfor %}]
+        {% endif %}
+        super()
+    end
+    {% endif %}
     {%- if variant.has_fields() %}
+    {%- if named_fields %}
 
     attr_reader {% for field in variant.fields() %}:{{ field.name()|var_name_rb }}{% if !loop.last %}, {% endif %}{% endfor %}
+    {%- else %}
+
+    attr_reader :values
+
+    def [](index)
+        @values[index]
+    end
+    {%- endif %}
     {% endif %}
 
     def to_s
-     "#{self.class.name}({% for field in variant.fields() %}{{ field.name()|var_name_rb }}=#{@{{ field.name()|var_name_rb }}.inspect}{% if !loop.last %}, {% endif %}{% endfor %})"
+      {%- if named_fields %}
+        "#{self.class.name}({% for field in variant.fields() %}{{ field.name()|var_name_rb }}=#{@{{ field.name()|var_name_rb }}.inspect}{% if !loop.last %}, {% endif %}{% endfor %})"
+
+      {%- else %}
+      {%- if variant.has_fields() %}
+        "#{self.class.name}(#{@values.inspect})"
+      {%- else %}
+        "#{self.class.name}()"
+      {%- endif %}
+      {%- endif %}
+
     end
   end
   {%- endfor %}
@@ -55,9 +84,12 @@ end
 ERROR_MODULE_TO_READER_METHOD = {
 {%- for e in ci.enum_definitions() %}
 {% if ci.is_name_used_as_error(e.name()) %}
-{%- let typ=ci.get_type(e.name()).unwrap() %}
-{%- let canonical_type_name = self::canonical_name(typ.borrow()).borrow()|class_name_rb %}
-  {{ e.name()|class_name_rb }} => :read{{ canonical_type_name }},
+     {{ e.name()|class_name_rb }} => :readType{{ e.name()|class_name_rb }},
+{% endif %}
+{%- endfor %}
+{% for obj in ci.object_definitions() %}
+{% if ci.is_name_used_as_error(obj.name()) %}
+     '{{ obj.name()|class_name_rb }}' => :readType{{ obj.name()|class_name_rb }},
 {% endif %}
 {%- endfor %}
 }
@@ -67,7 +99,8 @@ private_constant :ERROR_MODULE_TO_READER_METHOD, :CALL_SUCCESS, :CALL_ERROR, :CA
 
 def self.consume_buffer_into_error(error_module, rust_buffer)
   rust_buffer.consumeWithStream do |stream|
-    reader_method = ERROR_MODULE_TO_READER_METHOD[error_module]
+    reader_method = ERROR_MODULE_TO_READER_METHOD[error_module] ||
+                    ERROR_MODULE_TO_READER_METHOD[error_module.name&.split('::')&.last]
     return stream.send(reader_method)
   end
 end

--- a/uniffi_bindgen/src/bindings/ruby/templates/ObjectTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/ObjectTemplate.rb
@@ -1,4 +1,4 @@
-class {{ obj.name()|class_name_rb }}
+class {{ obj.name()|class_name_rb }}{% if ci.is_name_used_as_error(obj.name()) %} < StandardError{% endif %}
 
   # A private helper for initializing instances of the class from a raw handle,
   # bypassing any initialization logic and ensuring they are GC'd properly.
@@ -69,7 +69,7 @@ class {{ obj.name()|class_name_rb }}
   def {{ meth.name()|fn_name_rb }}({% call rb::arg_list_decl(meth) %}{% endcall %})
     {%- call rb::setup_args_extra_indent(meth) %}{% endcall %}
     result = {% call rb::to_ffi_call_with_prefix("uniffi_clone_handle()", meth) %}{% endcall %}
-    return {{ "result"|lift_rb(return_type) }}
+    return {{ "result"|lift_rb(return_type, config) }}
   end
 
   {%- when None -%}

--- a/uniffi_bindgen/src/bindings/ruby/templates/RecordTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RecordTemplate.rb
@@ -4,7 +4,7 @@ class {{ rec.name()|class_name_rb }}
 
   def initialize({% for field in rec.fields() %}{{ field.name()|var_name_rb -}}:
         {%- match field.default_value() %}
-        {%- when Some(default) %} {{ default|default_rb }}
+        {%- when Some(_) %} {{ field|field_default_rb }}
         {%- else %}
         {%- endmatch %}
   {%- if loop.last %}{% else %}, {% endif -%}{% endfor %})

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -174,13 +174,17 @@ class RustBufferBuilder
 
   def write_{{ canonical_type_name }}(v)
     {%- if e.is_flat() %}
-    pack_into(4, 'l>', v)
+    {%- for variant in e.variants() %}
+    if v == {{ enum_name|class_name_rb }}::{{ variant.name()|enum_name_rb }}
+      pack_into(4, 'l>', {{ loop.index }})
+    end
+    {%- endfor %}
     {%- else -%}
     {%- for variant in e.variants() %}
     if v.{{ variant.name()|var_name_rb }}?
       pack_into(4, 'l>', {{ loop.index }})
       {%- for field in variant.fields() %}
-      self.write_{{ self::canonical_name(field.as_type().borrow()).borrow()|class_name_rb }}(v.{{ field.name() }})
+        self.write_{{ self::canonical_name(field.as_type().borrow()).borrow()|class_name_rb }}(v.{% call rb::field_name(field, loop.index) %}{% endcall %})
       {%- endfor %}
     end
     {%- endfor %}
@@ -232,6 +236,26 @@ class RustBufferBuilder
       self.write_{{ self::canonical_name(inner_type).borrow()|class_name_rb }}(v)
     end
   end
+
+  {% when Type::Custom { name, builtin, .. } -%}
+  {%- match config.custom_types.get(name.as_str()) %}
+  {%- when Some(cfg) %}{%- if cfg.has_conversion() %}
+  # Custom type {{ name }}: applies lower, then writes builtin `{{ self::canonical_name(builtin) }}`
+  def write_{{ canonical_type_name }}(v)
+    write_{{ self::canonical_name(builtin).borrow()|class_name_rb }}({{ cfg.lower("v") }})
+  end
+  {%- else %}
+  # The Custom type {{ name }} delegates serialization to its builtin type.
+  def write_{{ canonical_type_name }}(v)
+    write_{{ self::canonical_name(builtin).borrow()|class_name_rb }}(v)
+  end
+  {%- endif %}
+  {%- when None %}
+  # The Custom type {{ name }} delegates serialization to its builtin type.
+  def write_{{ canonical_type_name }}(v)
+    write_{{ self::canonical_name(builtin).borrow()|class_name_rb }}(v)
+  end
+  {%- endmatch %}
 
   {%- else -%}
   # This type is not yet supported in the Ruby backend.

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
@@ -178,9 +178,10 @@ class RustBufferStream
     {%- for variant in e.variants() %}
     if variant == {{ loop.index }}
         {%- if variant.has_fields() %}
+        {%- let named_fields = !variant.fields()[0].name().is_empty() %}
         return {{ enum_name|class_name_rb }}::{{ variant.name()|enum_name_rb }}.new(
             {%- for field in variant.fields() %}
-            self.read{{ self::canonical_name(field.as_type().borrow()).borrow()|class_name_rb }}(){% if loop.last %}{% else %},{% endif %}
+            {% if named_fields %}{{ field.name()|var_name_rb }}: {% endif %}self.read{{ self::canonical_name(field.as_type().borrow()).borrow()|class_name_rb }}(){% if loop.last %}{% else %},{% endif %}
             {%- endfor %}
         )
         {%- else %}
@@ -214,9 +215,10 @@ class RustBufferStream
     {%- for variant in e.variants() %}
     if variant == {{ loop.index }}
         {%- if variant.has_fields() %}
+        {%- let named_fields = !variant.fields()[0].name().is_empty() %}
         return {{ error_name|class_name_rb }}::{{ variant.name()|class_name_rb }}.new(
             {%- for field in variant.fields() %}
-            read{{ self::canonical_name(field.as_type().borrow()).borrow()|class_name_rb }}(){% if loop.last %}{% else %},{% endif %}
+            {% if named_fields %}{{ field.name()|var_name_rb }}: {% endif %}read{{ self::canonical_name(field.as_type().borrow()).borrow()|class_name_rb }}(){% if loop.last %}{% else %},{% endif %}
             {%- endfor %}
         )
         {%- else %}
@@ -289,6 +291,28 @@ class RustBufferStream
 
     items
   end
+
+  {% when Type::Custom { name, builtin, .. } -%}
+  {%- match config.custom_types.get(name.as_str()) %}
+  {%- when Some(cfg) %}{%- if cfg.has_conversion() %}
+  # Custom type {{ name }}: reads builtin `{{ self::canonical_name(builtin) }}`, then applies lift.
+  def read{{ canonical_type_name }}
+    raw = read{{ self::canonical_name(builtin).borrow()|class_name_rb }}
+    {{ cfg.lift("raw") }}
+  end
+  {%- else %}
+  # The Custom type {{ name }} delegates deserialization to its builtin type.
+  def read{{ canonical_type_name }}
+    read{{ self::canonical_name(builtin).borrow()|class_name_rb }}
+  end
+  {%- endif %}
+  {%- when None %}
+  # The Custom type {{ name }} delegates deserialization to its builtin type.
+  def read{{ canonical_type_name }}
+    read{{ self::canonical_name(builtin).borrow()|class_name_rb }}
+  end
+  {%- endmatch %}
+
   {%- else -%}
   # This type is not yet supported in the Ruby backend.
   def read{{ canonical_type_name }}

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
@@ -130,7 +130,7 @@ class RustBuffer < FFI::Struct
 
   def self.check_lower_{{ canonical_type_name }}(v)
     {%- for field in rec.fields() %}
-    {{ "v.{}"|format(field.name()|var_name_rb)|check_lower_rb(field.as_type().borrow()) }}
+    {{ "v.{}"|format(field.name()|var_name_rb)|check_lower_rb(field.as_type().borrow(), config) }}
     {%- endfor %}
   end
 
@@ -157,7 +157,11 @@ class RustBuffer < FFI::Struct
     {%- for variant in e.variants() %}
     if v.{{ variant.name()|var_name_rb }}?
       {%- for field in variant.fields() %}
-        {{ "v.{}"|format(field.name())|check_lower_rb(field.as_type().borrow()) }}
+      {%- if field.name().is_empty() %}
+        {{ "v.v{}"|format(loop.index)|check_lower_rb(field.as_type().borrow(), config) }}
+      {%- else %}
+        {{ "v.{}"|format(field.name())|check_lower_rb(field.as_type().borrow(), config) }}
+      {%- endif %}
       {%- endfor %}
       return
     end
@@ -177,6 +181,13 @@ class RustBuffer < FFI::Struct
       return stream.read{{ canonical_type_name }}
     end
   end
+  {% else %}
+  # Enum used as error - generate consumeInto for use as a return value
+  def consumeInto{{ canonical_type_name }}
+    consumeWithStream do |stream|
+      return stream.read{{ canonical_type_name }}
+    end
+  end
   {% endif %}
 
   {% when Type::Optional { inner_type } -%}
@@ -184,7 +195,7 @@ class RustBuffer < FFI::Struct
 
   def self.check_lower_{{ canonical_type_name }}(v)
     if not v.nil?
-      {{ "v"|check_lower_rb(inner_type.borrow()) }}
+      {{ "v"|check_lower_rb(inner_type.borrow(), config) }}
     end
   end
 
@@ -206,7 +217,7 @@ class RustBuffer < FFI::Struct
 
   def self.check_lower_{{ canonical_type_name }}(v)
     v.each do |item|
-      {{ "item"|check_lower_rb(inner_type.borrow()) }}
+      {{ "item"|check_lower_rb(inner_type.borrow(), config) }}
     end
   end
 
@@ -228,8 +239,8 @@ class RustBuffer < FFI::Struct
 
   def self.check_lower_{{ canonical_type_name }}(v)
     v.each do |k, v|
-      {{ "k"|check_lower_rb(k.borrow()) }}
-      {{ "v"|check_lower_rb(inner_type.borrow()) }}
+      {{ "k"|check_lower_rb(k.borrow(), config) }}
+      {{ "v"|check_lower_rb(inner_type.borrow(), config) }}
     end
   end
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/TopLevelFunctionTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/TopLevelFunctionTemplate.rb
@@ -4,7 +4,7 @@
 def self.{{ func.name()|fn_name_rb }}({%- call rb::arg_list_decl(func) %}{% endcall -%})
   {%- call rb::setup_args(func) %}{% endcall %}
   result = {% call rb::to_ffi_call(func) %}{% endcall %}
-  return {{ "result"|lift_rb(return_type) }}
+  return {{ "result"|lift_rb(return_type, config) }}
 end
 
 {% when None %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
@@ -4,10 +4,34 @@
 // passed to rust via `_arg_list_ffi_call` (we use  `var_name_rb` in `lower_rb`)
 #}
 
+{#
+// Returns the Ruby name for an enum variant field.
+// For tuple-style fields (empty name is uniffi metadata) we generate a 
+// positional name like v1, v2, ... using the 1-based loop index.
+#}
+{%- macro field_name(field, field_num) -%}
+{%- if field.name().is_empty() -%}
+values[{{- field_num - 1 -}}]
+{%- else -%}
+{{ field.name()|var_name_rb }}
+{%- endif -%}
+{%- endmacro -%}
+  
 {%- macro to_ffi_call(func) -%}
-    {%- match func.throws_name() -%}
-    {%- when Some with (e) -%}
-      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ e|class_name_rb }},
+    {%- match func.throws_type() -%}
+    {%- when Some(Type::Custom { builtin, .. }) -%}
+      {%- match builtin.borrow() -%}
+      {%- when Type::Enum { name, .. } -%}
+      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+      {%- when Type::Object { name, .. } -%}
+      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+      {%- else -%}
+      {{ ci.namespace()|class_name_rb }}.rust_call
+      {%- endmatch -%}
+    {%- when Some(Type::Enum { name, .. }) -%}
+      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+    {%- when Some(Type::Object { name, .. }) -%}
+      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
     {%- else -%}
       {{ ci.namespace()|class_name_rb }}.rust_call(
     {%- endmatch -%}
@@ -17,9 +41,20 @@
 {%- endmacro -%}
 
 {%- macro to_ffi_call_with_prefix(prefix, func) -%}
-    {%- match func.throws_name() -%}
-    {%- when Some with (e) -%}
-      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ e|class_name_rb }},
+    {%- match func.throws_type() -%}
+    {%- when Some(Type::Custom { builtin, .. }) -%}
+      {%- match builtin.borrow() -%}
+      {%- when Type::Enum { name, .. } -%}
+      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+      {%- when Type::Object { name, .. } -%}
+      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+      {%- else -%}
+      {{ ci.namespace()|class_name_rb }}.rust_call
+      {%- endmatch -%}
+    {%- when Some(Type::Enum { name, .. }) -%}
+      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+    {%- when Some(Type::Object { name, .. }) -%}
+      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
     {%- else -%}
       {{ ci.namespace()|class_name_rb }}.rust_call(
     {%- endmatch -%}
@@ -31,7 +66,7 @@
 
 {%- macro _arg_list_ffi_call(func) %}
     {%- for arg in func.arguments() %}
-        {{- arg.name()|lower_rb(arg.as_type().borrow()) }}
+        {{- arg.name()|lower_rb(arg.as_type().borrow(), config) }}
         {%- if !loop.last %},{% endif %}
     {%- endfor %}
 {%- endmacro -%}
@@ -45,7 +80,7 @@
     {%- for arg in func.arguments() -%}
         {{ arg.name()|var_name_rb }}
         {%- match arg.default_value() %}
-        {%- when Some(default) %} = {{ default|default_rb }}
+        {%- when Some(_) %} = {{ arg|arg_default_rb }}
         {%- else %}
         {%- endmatch %}
         {%- if !loop.last %}, {% endif -%}
@@ -62,14 +97,14 @@
 
 {%- macro setup_args(func) %}
     {%- for arg in func.arguments() %}
-    {{ arg.name() }} = {{ arg.name()|coerce_rb(ci.namespace()|class_name_rb, arg.as_type().borrow()) }}
-    {{ arg.name()|check_lower_rb(arg.as_type().borrow()) }}
+    {{ arg.name() }} = {{ arg.name()|coerce_rb(ci.namespace()|class_name_rb, arg.as_type().borrow(), config) }}
+    {{ arg.name()|check_lower_rb(arg.as_type().borrow(), config) }}
     {% endfor -%}
 {%- endmacro -%}
 
 {%- macro setup_args_extra_indent(meth) %}
         {%- for arg in meth.arguments() %}
-        {{ arg.name() }} = {{ arg.name()|coerce_rb(ci.namespace()|class_name_rb, arg.as_type().borrow()) }}
-        {{ arg.name()|check_lower_rb(arg.as_type().borrow()) }}
+        {{ arg.name() }} = {{ arg.name()|coerce_rb(ci.namespace()|class_name_rb, arg.as_type().borrow(), config) }}
+        {{ arg.name()|check_lower_rb(arg.as_type().borrow(), config) }}
         {%- endfor %}
 {%- endmacro -%}

--- a/uniffi_bindgen/src/bindings/ruby/templates/wrapper.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/wrapper.rb
@@ -28,6 +28,31 @@ module {{ ci.namespace()|class_name_rb }}
 
   {% include "NamespaceLibraryTemplate.rb" %}
 
+  # Custom type definitions.
+
+  {%- for type_ in ci.iter_local_types() -%}
+  {%- match type_ -%}
+  {%- when Type::Custom { name, builtin, .. } -%}
+  {%- if !ci.is_external(type_) %}
+  {% include "CustomTypeTemplate.rb" %}
+  {%- else -%}
+  {%- match config.custom_types.get(name.as_str()) %}
+  {%- when Some(cfg) %}
+  {%- match cfg.imports %}
+  {%- when Some(imports) %}
+  # External custom type `{{ name }}`: importing configured dependencies.
+  {%- for import_name in imports %}
+  require '{{ import_name }}'
+  {%- endfor %}
+  {%- when None %}
+  {%- endmatch %}
+  {%- when None %}
+  {%- endmatch %}
+  {%- endif %}
+  {%- else -%}
+  {%- endmatch %}
+  {%- endfor %}
+
   # Public interface members begin here.
 
   {% for e in ci.enum_definitions() %}


### PR DESCRIPTION
This PR significantly improves the Ruby bindings by addressing several long-standing limitations:

- Enums were quite limited (this also impacted error handling)
- No support for custom types
- Limited support for default values

I've added a comprehensive set of tests to cover the new functionality.

### Breaking Change
The only breaking change is in **named parameters for enum constructors**. This is largely a continuation and refinement of the work started in #1840. The changelog has been updated accordingly.

### Why it's large
Apologies for the size of the PR. I tried to split the changes into smaller, independent PRs, but the features have strong interdependencies, making clean separation difficult. This foundational work should enable much more focused and smaller PRs in the future.

I'm happy to explain any design decisions or adjust things based on feedback.

Thank you for reviewing!