### PR TITLE
Callback interfaces test updates

### DIFF
--- a/bindgen-tests/kotlin/tests/callback_interfaces.kts
+++ b/bindgen-tests/kotlin/tests/callback_interfaces.kts
@@ -13,11 +13,17 @@ class CallbackImpl(var value: UInt) : TestCallbackInterface {
     }
 
     override fun throwIfEqual(numbers: CallbackInterfaceNumbers): CallbackInterfaceNumbers {
-        if (numbers.a == numbers.b) {
+        if (numbers.a == 6u && numbers.b == 7u) {
+            throw RuntimeException("unexpected failure")
+        } else if (numbers.a == numbers.b) {
             throw TestException.Failure1()
         } else {
             return numbers
         }
+    }
+
+    override fun echo(s: String): String {
+        return s
     }
 }
 
@@ -29,3 +35,21 @@ invokeTestCallbackInterfaceNoop(cbi)
 assert(invokeTestCallbackInterfaceGetValue(cbi) == 42u)
 invokeTestCallbackInterfaceSetValue(cbi, 43u)
 assert(invokeTestCallbackInterfaceGetValue(cbi) == 43u)
+assert(invokeTestCallbackInterfaceEcho(cbi, "test-string") == "test-string")
+
+
+assert(invokeTestCallbackInterfaceThrowIfEqual(cbi, CallbackInterfaceNumbers(1u, 2u)) == CallbackInterfaceNumbers(1u, 2u))
+try {
+    invokeTestCallbackInterfaceThrowIfEqual(cbi, CallbackInterfaceNumbers(1u, 1u))
+    throw RuntimeException("Expected TestException.Failure1 to be thrown")
+} catch(e: TestException.Failure1) {
+    // Expected
+}
+
+// Test unexpected errors
+try {
+    invokeTestCallbackInterfaceThrowIfEqual(cbi, CallbackInterfaceNumbers(6u, 7u))
+    throw RuntimeException("Expected RuntimeException to be caught, converted to TestException.Failure2, and thrown")
+} catch(e: TestException.Failure2) {
+    assert(e.data.contains("unexpected failure"))
+}

--- a/bindgen-tests/lib/src/callback_interfaces.rs
+++ b/bindgen-tests/lib/src/callback_interfaces.rs
@@ -20,6 +20,8 @@ pub trait TestCallbackInterface {
         &self,
         numbers: CallbackInterfaceNumbers,
     ) -> Result<CallbackInterfaceNumbers, TestError>;
+    /// Test passing a string using a callback interface
+    fn echo(&self, s: String) -> String;
 }
 
 #[derive(uniffi::Record)]
@@ -49,6 +51,14 @@ pub fn invoke_test_callback_interface_throw_if_equal(
     numbers: CallbackInterfaceNumbers,
 ) -> Result<CallbackInterfaceNumbers, TestError> {
     cbi.throw_if_equal(numbers)
+}
+
+#[uniffi::export]
+pub fn invoke_test_callback_interface_echo(
+    cbi: Box<dyn TestCallbackInterface>,
+    s: String,
+) -> String {
+    cbi.echo(s)
 }
 
 impl From<uniffi::UnexpectedUniFFICallbackError> for TestError {

--- a/bindgen-tests/python/tests/callback_interfaces.py
+++ b/bindgen-tests/python/tests/callback_interfaces.py
@@ -25,6 +25,9 @@ class CallbackImpl(TestCallbackInterface):
             raise TestError.Failure1()
         return numbers
 
+    def echo(self, s):
+        return s
+
 class TestCallbackInterfaces(unittest.TestCase):
     def test_callback_interfaces(self):
         # Construct a callback interface to pass to rust
@@ -35,6 +38,7 @@ class TestCallbackInterfaces(unittest.TestCase):
         assert(invoke_test_callback_interface_get_value(cbi) == 42)
         invoke_test_callback_interface_set_value(cbi, 43)
         assert(invoke_test_callback_interface_get_value(cbi) == 43)
+        assert(invoke_test_callback_interface_echo(cbi, "test-string") == "test-string")
 
         # The previous calls created a bunch of callback interface references.  Make sure they've been cleaned
         # up and the only remaining reference is for our `cbi` variable.

--- a/bindgen-tests/swift/tests/callback_interfaces.swift
+++ b/bindgen-tests/swift/tests/callback_interfaces.swift
@@ -34,6 +34,10 @@ final class Callback: TestCallbackInterface, @unchecked Sendable {
         }
         return numbers
     }
+
+    func echo(s: String) -> String {
+        return s
+    }
 }
 
 // Construct a callback interface to pass to rust
@@ -44,6 +48,7 @@ invokeTestCallbackInterfaceNoop(cbi: cbi);
 assert(invokeTestCallbackInterfaceGetValue(cbi: cbi) == 42);
 invokeTestCallbackInterfaceSetValue(cbi: cbi, value: 43);
 assert(invokeTestCallbackInterfaceGetValue(cbi: cbi) == 43);
+assert(invokeTestCallbackInterfaceEcho(cbi: cbi, s: "test-string") == "test-string");
 
 // The previcalls created a bunch of callback interface references.  Make sure they've been cleaned
 // up and the only remaining reference is for our `cbi` variable.


### PR DESCRIPTION
Small update that I've been wanting for the kotlin-bindgen-gecko-js work.

* Added a method that passes a string, this gives us some more variety in what we're passing across the FFI (primitives, strings, records).
* Added Kotlin tests for callback errors.