### PR TITLE
Expose standard Rust traits for ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Kotlin objects now have an `uniffiIsDestroyed` property that returns `true` if the Rust reference no longer exists ([#2825](https://github.com/mozilla/uniffi-rs/pull/2825))
 - Updated `askama` version to `0.15.6`
 - Custom Types can have docstrings in some languages ([#2853](https://github.com/mozilla/uniffi-rs/pull/2853))
+- Ruby: Expose standard Rust traits for generated ruby code (#2883)
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.31.1...HEAD).
 

--- a/fixtures/trait-methods/tests/bindings/test.rb
+++ b/fixtures/trait-methods/tests/bindings/test.rb
@@ -1,0 +1,229 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require 'test/unit'
+require 'trait_methods'
+
+# Keep module-qualified names to avoid ambiguity with the TraitMethods class which has the same
+# name as the module.
+Tm = TraitMethods
+
+class TestTraitMethodsObject < Test::Unit::TestCase
+  def test_to_s
+    m = Tm::TraitMethods.new 'yo'
+
+    assert_equal 'TraitMethods(yo)', m.to_s
+  end
+
+  def test_inspect
+    m = Tm::TraitMethods.new 'yo'
+
+    assert_equal 'TraitMethods { val: "yo" }', m.inspect
+  end
+
+  def test_eq
+    m = Tm::TraitMethods.new 'yo'
+
+    assert_equal m, Tm::TraitMethods.new('yo')
+    assert_not_equal m, Tm::TraitMethods.new('yoyo')
+  end
+
+  def test_eq_wrong_type
+    m = Tm::TraitMethods.new 'yo'
+
+    assert_not_equal m, 17
+  end
+
+  def test_hash
+    m = Tm::TraitMethods.new 'm'
+    h = {}
+    h[m] = 'm'
+
+    assert h.key?(m)
+    assert_equal 'm', h[Tm::TraitMethods.new('m')]
+  end
+
+  def test_ord
+    a = Tm::TraitMethods.new 'a'
+    b = Tm::TraitMethods.new 'b'
+
+    assert a < b
+    assert a <= b
+    assert a <= Tm::TraitMethods.new('a')
+    assert b > a
+    assert b >= a
+    assert b >= Tm::TraitMethods.new('b')
+  end
+end
+
+class TestProcTraitMethodsObject < Test::Unit::TestCase
+  def test_to_s
+    m = Tm::ProcTraitMethods.new 'yo'
+
+    assert_equal 'ProcTraitMethods(yo)', m.to_s
+  end
+
+  def test_inspect
+    m = Tm::ProcTraitMethods.new 'yo'
+
+    assert_equal 'ProcTraitMethods { val: "yo" }', m.inspect
+  end
+
+  def test_eq
+    m = Tm::ProcTraitMethods.new 'yo'
+
+    assert_equal m, Tm::ProcTraitMethods.new('yo')
+    assert_not_equal m, Tm::ProcTraitMethods.new('yoyo')
+  end
+
+  def test_eq_wrong_type
+    m = Tm::ProcTraitMethods.new 'yo'
+
+    assert_not_equal m, 17
+  end
+
+  def test_hash
+    m = Tm::ProcTraitMethods.new 'm'
+    h = {}
+    h[m] = 'm'
+
+    assert h.key?(m)
+  end
+
+  def test_ord
+    a = Tm::ProcTraitMethods.new 'a'
+    b = Tm::ProcTraitMethods.new 'b'
+
+    assert a < b
+    assert a <= b
+    assert b > a
+    assert b >= a
+  end
+end
+
+class TestTraitRecord < Test::Unit::TestCase
+  def test_inspect
+    r = Tm::TraitRecord.new s: 'yo', i: 2
+
+    assert_equal 'TraitRecord { s: "yo", i: 2 }', r.inspect
+  end
+
+  def test_eq
+    # eq compares only `s`, not `i`
+    assert_equal Tm::TraitRecord.new(s: 'yo', i: 2), Tm::TraitRecord.new(s: 'yo', i: 3)
+    assert_not_equal Tm::TraitRecord.new(s: 'yo', i: 2), Tm::TraitRecord.new(s: 'hi', i: 2)
+  end
+
+  def test_hash
+    r1 = Tm::TraitRecord.new(s: 'yo', i: 2)
+    r2 = Tm::TraitRecord.new(s: 'yo', i: 3)
+    h = {}
+    h[r1] = 'r1'
+
+    # same hash since hash is based on `s` only
+    assert h.key?(r2)
+  end
+
+  def test_ord
+    r1 = Tm::TraitRecord.new(s: 'a', i: 0)
+    r2 = Tm::TraitRecord.new(s: 'b', i: 0)
+
+    assert r1 < r2
+  end
+end
+
+class TestUdlRecord < Test::Unit::TestCase
+  def test_inspect
+    r = Tm::UdlRecord.new s: 'yo', i: 2
+
+    assert_equal 'UdlRecord { s: "yo", i: 2 }', r.inspect
+  end
+
+  def test_eq
+    # eq compares only `s`, not `i`
+    assert_equal Tm::UdlRecord.new(s: 'yo', i: 2), Tm::UdlRecord.new(s: 'yo', i: 2)
+    assert_not_equal Tm::UdlRecord.new(s: 'yo', i: 2), Tm::UdlRecord.new(s: 'hi', i: 3)
+  end
+
+  def test_hash
+    r1 = Tm::UdlRecord.new(s: 'yo', i: 2)
+    r2 = Tm::UdlRecord.new(s: 'yo', i: 3)
+    h = {}
+    h[r1] = 'r1'
+
+    # same hash since hash is based on `s` only
+    assert h.key?(r2)
+  end
+
+  def test_ord
+    assert Tm::UdlRecord.new(s: 'a', i: 0) < Tm::UdlRecord.new(s: 'b', i: 0)
+  end
+end
+
+class TestTraitEnum < Test::Unit::TestCase
+  def test_to_s
+    m = Tm::TraitEnum::S.new 'yo'
+
+    assert_equal 'TraitEnum::S("yo")', m.to_s
+  end
+
+  def test_inspect
+    m = Tm::TraitEnum::S.new 'yo'
+
+    assert_equal 'S("yo")', m.inspect
+  end
+
+  def test_eq
+    assert_equal Tm::TraitEnum::S.new('1'), Tm::TraitEnum::S.new('1')
+
+    # eq is descriminant-only: S("1") == S("2")
+    assert_equal Tm::TraitEnum::S.new('1'), Tm::TraitEnum::S.new('2')
+    assert_equal Tm::TraitEnum::I.new(1), Tm::TraitEnum::I.new(1)
+
+    # different variants are never equal
+    assert_not_equal Tm::TraitEnum::S.new('1'), Tm::TraitEnum::I.new(1)
+  end
+
+  def test_eq_wrong_type
+    assert_not_equal Tm::TraitEnum::S.new('1'), 17
+  end
+
+  def test_hash
+    m = Tm::TraitEnum::S.new('m')
+    h = {}
+    h[m] = 'm'
+
+    assert h.key?(m)
+  end
+
+  def test_ord
+    s = Tm::TraitEnum::S.new('1')
+    i = Tm::TraitEnum::I.new(1)
+
+    assert s < i
+    assert s <= i
+  end
+end
+
+class TestUdlEnum < Test::Unit::TestCase
+  def test_inspect
+    m = Tm::UdlEnum::S.new s: 'yo'
+
+    assert_equal 'S { s: "yo" }', m.inspect
+  end
+
+  def test_eq
+    assert_equal Tm::UdlEnum::S.new(s: 'yo'), Tm::UdlEnum::S.new(s: 'yo')
+
+    # eq is descriminant-only
+    assert_equal Tm::UdlEnum::S.new(s: '1'), Tm::UdlEnum::S.new(s: '2')
+    assert_not_equal Tm::UdlEnum::S.new(s: '1'), Tm::UdlEnum::I.new(i: 1)
+  end
+
+  def test_ord
+    assert Tm::UdlEnum::S.new(s: '1') < Tm::UdlEnum::I.new(i: 1)
+  end
+end

--- a/fixtures/trait-methods/tests/test_generated_bindings.rs
+++ b/fixtures/trait-methods/tests/test_generated_bindings.rs
@@ -1,5 +1,6 @@
 uniffi::build_foreign_language_testcases!(
     "tests/bindings/test.py",
     "tests/bindings/test.kts",
-    "tests/bindings/test.swift"
+    "tests/bindings/test.swift",
+    "tests/bindings/test.rb",
 );

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -347,19 +347,19 @@ mod filters {
         let nm = nm.as_ref();
         let ns = ns.as_ref();
         Ok(match type_ {
-            Type::Int8 => format!("{ns}::uniffi_in_range({nm}, \"i8\", -2**7, 2**7)"),
-            Type::Int16 => format!("{ns}::uniffi_in_range({nm}, \"i16\", -2**15, 2**15)"),
-            Type::Int32 => format!("{ns}::uniffi_in_range({nm}, \"i32\", -2**31, 2**31)"),
-            Type::Int64 => format!("{ns}::uniffi_in_range({nm}, \"i64\", -2**63, 2**63)"),
-            Type::UInt8 => format!("{ns}::uniffi_in_range({nm}, \"u8\", 0, 2**8)"),
-            Type::UInt16 => format!("{ns}::uniffi_in_range({nm}, \"u16\", 0, 2**16)"),
-            Type::UInt32 => format!("{ns}::uniffi_in_range({nm}, \"u32\", 0, 2**32)"),
-            Type::UInt64 => format!("{ns}::uniffi_in_range({nm}, \"u64\", 0, 2**64)"),
+            Type::Int8 => format!("::{ns}::uniffi_in_range({nm}, \"i8\", -2**7, 2**7)"),
+            Type::Int16 => format!("::{ns}::uniffi_in_range({nm}, \"i16\", -2**15, 2**15)"),
+            Type::Int32 => format!("::{ns}::uniffi_in_range({nm}, \"i32\", -2**31, 2**31)"),
+            Type::Int64 => format!("::{ns}::uniffi_in_range({nm}, \"i64\", -2**63, 2**63)"),
+            Type::UInt8 => format!("::{ns}::uniffi_in_range({nm}, \"u8\", 0, 2**8)"),
+            Type::UInt16 => format!("::{ns}::uniffi_in_range({nm}, \"u16\", 0, 2**16)"),
+            Type::UInt32 => format!("::{ns}::uniffi_in_range({nm}, \"u32\", 0, 2**32)"),
+            Type::UInt64 => format!("::{ns}::uniffi_in_range({nm}, \"u64\", 0, 2**64)"),
             Type::Float32 | Type::Float64 => nm.to_string(),
             Type::Boolean => format!("{nm} ? true : false"),
             Type::Object { .. } | Type::Enum { .. } | Type::Record { .. } => nm.to_string(),
-            Type::String => format!("{ns}::uniffi_utf8({nm})"),
-            Type::Bytes => format!("{ns}::uniffi_bytes({nm})"),
+            Type::String => format!("::{ns}::uniffi_utf8({nm})"),
+            Type::Bytes => format!("::{ns}::uniffi_bytes({nm})"),
             Type::Timestamp | Type::Duration => nm.to_string(),
             Type::CallbackInterface { name, .. } => {
                 // Callback interfaces are not yet supported; emit a Ruby runtime error so that
@@ -620,6 +620,22 @@ mod filters {
         config: &Config,
     ) -> Result<String, askama::Error> {
         lift_rb_inner(nm, type_, &config.custom_types)
+    }
+
+    /// Render the Ruby expression that lowers the `self` value of a trait method.
+    /// For Object types, this is `(ClassName.uniffi_lower self)`.
+    /// For Record/Enum types, this serializes `self` into a RustBuffer.
+    #[askama::filter_fn]
+    pub fn lower_method_self_rb(
+        meth: &Method,
+        _: &dyn askama::Values,
+        config: &Config,
+    ) -> Result<String, askama::Error> {
+        let self_type = meth
+            .self_type()
+            .expect("Trait method must have a self type");
+
+        lower_rb_inner("self", &self_type, &config.custom_types)
     }
 
     /// Render a Ruby integer literal for the discriminant of the variant at `index` in enum `e`.

--- a/uniffi_bindgen/src/bindings/ruby/templates/EnumTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/EnumTemplate.rb
@@ -48,10 +48,15 @@ class {{ e.name()|class_name_rb }}
     end
     {% endif %}
 
+    {%- let trait_methods = e.uniffi_trait_methods() %}
+    {%- if trait_methods.display_fmt.is_none() %}
     def to_s
       "{{ e.name()|class_name_rb }}::{{ variant.name()|enum_name_rb }}"
     end
+    {%- endif %}
+    {%- include "UniffiTraitImpls.rb" %}
 
+    {%- if trait_methods.eq_eq.is_none() %}
     def ==(other)
       return false unless other.respond_to?(:{{variant.name()|var_name_rb}}?)
       return false unless other.{{ variant.name()|var_name_rb }}?
@@ -66,6 +71,7 @@ class {{ e.name()|class_name_rb }}
       {% endif %}
       true
     end
+    {%- endif %}
 
     # For each variant, we have an `NAME?` method for easily checking
     # whether an instance is that variant.

--- a/uniffi_bindgen/src/bindings/ruby/templates/ObjectTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/ObjectTemplate.rb
@@ -14,7 +14,7 @@ class {{ obj.name()|class_name_rb }}{% if ci.is_name_used_as_error(obj.name()) %
   # to the actual instance, only its underlying handle.
   def self.uniffi_define_finalizer_by_handle(handle, object_id)
     Proc.new do |_id|
-      {{ ci.namespace()|class_name_rb }}.rust_call(
+      ::{{ ci.namespace()|class_name_rb }}.rust_call(
         :{{ obj.ffi_object_free().name() }},
         handle
       )
@@ -31,7 +31,7 @@ class {{ obj.name()|class_name_rb }}{% if ci.is_name_used_as_error(obj.name()) %
   end
 
   def uniffi_clone_handle()
-    return {{ ci.namespace()|class_name_rb }}.rust_call(
+    return ::{{ ci.namespace()|class_name_rb }}.rust_call(
       :{{ obj.ffi_object_clone().name() }},
       @handle
     )
@@ -79,4 +79,6 @@ class {{ obj.name()|class_name_rb }}{% if ci.is_name_used_as_error(obj.name()) %
   end
   {% endmatch %}
   {% endfor %}
+  {%- let trait_methods = obj.uniffi_trait_methods() %}
+  {%- include "UniffiTraitImpls.rb" %}
 end

--- a/uniffi_bindgen/src/bindings/ruby/templates/RecordTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RecordTemplate.rb
@@ -13,6 +13,8 @@ class {{ rec.name()|class_name_rb }}
     {%- endfor %}
   end
 
+  {%- let trait_methods = rec.uniffi_trait_methods() %}
+  {%- if trait_methods.eq_eq.is_none() %}
   def ==(other)
     {%- for field in rec.fields() %}
     if @{{ field.name()|var_name_rb }} != other.{{ field.name()|var_name_rb }}
@@ -22,4 +24,6 @@ class {{ rec.name()|class_name_rb }}
 
     true
   end
+  {% endif %}
+  {%- include "UniffiTraitImpls.rb" %}
 end

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -34,56 +34,56 @@ class RustBufferBuilder
   {% when Type::Int8 -%}
 
   def write_I8(v)
-    v = {{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i8", -2**7, 2**7)
+    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i8", -2**7, 2**7)
     pack_into(1, 'c', v)
   end
 
   {% when Type::UInt8 -%}
 
   def write_U8(v)
-    v = {{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u8", 0, 2**8)
+    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u8", 0, 2**8)
     pack_into(1, 'c', v)
   end
 
   {% when Type::Int16 -%}
 
   def write_I16(v)
-    v = {{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i16", -2**15, 2**15)
+    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i16", -2**15, 2**15)
     pack_into(2, 's>', v)
   end
 
   {% when Type::UInt16 -%}
 
   def write_U16(v)
-    v = {{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u16", 0, 2**16)
+    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u16", 0, 2**16)
     pack_into(2, 'S>', v)
   end
 
   {% when Type::Int32 -%}
 
   def write_I32(v)
-    v = {{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i32", -2**31, 2**31)
+    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i32", -2**31, 2**31)
     pack_into(4, 'l>', v)
   end
 
   {% when Type::UInt32 -%}
 
   def write_U32(v)
-    v = {{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u32", 0, 2**32)
+    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u32", 0, 2**32)
     pack_into(4, 'L>', v)
   end
 
   {% when Type::Int64 -%}
 
   def write_I64(v)
-    v = {{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i64", -2**63, 2**63)
+    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i64", -2**63, 2**63)
     pack_into(8, 'q>', v)
   end
 
   {% when Type::UInt64 -%}
 
   def write_U64(v)
-    v = {{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u64", 0, 2**64)
+    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u64", 0, 2**64)
     pack_into(8, 'Q>', v)
   end
 
@@ -108,7 +108,7 @@ class RustBufferBuilder
   {% when Type::String -%}
 
   def write_String(v)
-    v = {{ ci.namespace()|class_name_rb }}::uniffi_utf8(v)
+    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_utf8(v)
     pack_into 4, 'l>', v.bytes.size
     write v
   end
@@ -116,7 +116,7 @@ class RustBufferBuilder
   {% when Type::Bytes -%}
 
   def write_Bytes(v)
-    v = {{ ci.namespace()|class_name_rb }}::uniffi_bytes(v)
+    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_bytes(v)
     pack_into 4, 'l>', v.bytes.size
     write v
   end

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
@@ -4,15 +4,15 @@ class RustBuffer < FFI::Struct
          :data,     :pointer
 
   def self.alloc(size)
-    return {{ ci.namespace()|class_name_rb }}.rust_call(:{{ ci.ffi_rustbuffer_alloc().name() }}, size)
+    return ::{{ ci.namespace()|class_name_rb }}.rust_call(:{{ ci.ffi_rustbuffer_alloc().name() }}, size)
   end
 
   def self.reserve(rbuf, additional)
-    return {{ ci.namespace()|class_name_rb }}.rust_call(:{{ ci.ffi_rustbuffer_reserve().name() }}, rbuf, additional)
+    return ::{{ ci.namespace()|class_name_rb }}.rust_call(:{{ ci.ffi_rustbuffer_reserve().name() }}, rbuf, additional)
   end
 
   def free
-    {{ ci.namespace()|class_name_rb }}.rust_call(:{{ ci.ffi_rustbuffer_free().name() }}, self)
+    ::{{ ci.namespace()|class_name_rb }}.rust_call(:{{ ci.ffi_rustbuffer_free().name() }}, self)
   end
 
   def capacity

--- a/uniffi_bindgen/src/bindings/ruby/templates/UniffiTraitImpls.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/UniffiTraitImpls.rb
@@ -1,0 +1,72 @@
+{# Template to generate standard Rust trait method implementations for a Ruby classes.
+# Expects `trait_methods` to be a bound in the including template's scope.
+# (e.g. `{%- let trait_methods = obj.uniffi_trait_methods() %}`)
+#}
+
+{%- if let Some(display_fmt) = trait_methods.display_fmt %}
+# The Rust `Display::fmt` implementation.
+def to_s
+  result = ::{{ ci.namespace()|class_name_rb }}.rust_call(
+    :{{ display_fmt.ffi_func().name() }},
+    {{ display_fmt|lower_method_self_rb(config) }}
+  )
+  {{ "result"|lift_rb(display_fmt.return_type().unwrap(), config) }}
+end
+{%- endif %}
+
+{%- if let Some(debug_fmt) = trait_methods.debug_fmt %}
+# The Rust `Debug::fmt` implementation.
+def inspect
+  result = ::{{ ci.namespace()|class_name_rb }}.rust_call(
+    :{{ debug_fmt.ffi_func().name() }},
+    {{ debug_fmt|lower_method_self_rb(config) }}
+  )
+  {{ "result"|lift_rb(debug_fmt.return_type().unwrap(), config) }}
+end
+{%- endif %}
+
+{%- if let Some(eq) = trait_methods.eq_eq %}
+# The Rust `Eq::eq` implementation.
+def ==(other)
+  return false unless other.is_a?(self.class)
+  result = ::{{ ci.namespace()|class_name_rb }}.rust_call(
+    :{{ eq.ffi_func().name() }},
+    {{ eq|lower_method_self_rb(config) }},
+    {{ "other"|lower_rb(eq.arguments()[0].as_type().borrow(), config) }}
+  )
+  {{ "result"|lift_rb(eq.return_type().unwrap(), config) }}
+end
+{%- endif %}
+
+{%- if let Some(hash) = trait_methods.hash_hash %}
+# The Rust `Hash::hash` implementation.
+def hash
+  result = ::{{ ci.namespace()|class_name_rb }}.rust_call(
+    :{{ hash.ffi_func().name() }},
+    {{ hash|lower_method_self_rb(config) }}
+  )
+  {{ "result"|lift_rb(hash.return_type().unwrap(), config) }}
+end
+
+def eql?(other)
+  self == other
+end
+{%- endif %}
+
+{%- if let Some(cmp) = trait_methods.ord_cmp %}
+# The Rust `Ord::cmp` implementation.
+include Comparable
+
+def <=>(other)
+  # do we need this?
+  # return nil unless other.is_a?(self.class)
+  result = ::{{ ci.namespace()|class_name_rb }}.rust_call(
+    :{{ cmp.ffi_func().name() }},
+    {{ cmp|lower_method_self_rb(config) }},
+    {{ "other"|lower_rb(cmp.arguments()[0].as_type().borrow(), config) }}
+  )
+  {{ "result"|lift_rb(cmp.return_type().unwrap(), config) }}
+rescue
+  nil
+end
+{%- endif %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
@@ -22,18 +22,18 @@ values[{{- field_num - 1 -}}]
     {%- when Some(Type::Custom { builtin, .. }) -%}
       {%- match builtin.borrow() -%}
       {%- when Type::Enum { name, .. } -%}
-      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
       {%- when Type::Object { name, .. } -%}
-      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
       {%- else -%}
-      {{ ci.namespace()|class_name_rb }}.rust_call
+      ::{{ ci.namespace()|class_name_rb }}.rust_call
       {%- endmatch -%}
     {%- when Some(Type::Enum { name, .. }) -%}
-      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
     {%- when Some(Type::Object { name, .. }) -%}
-      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
     {%- else -%}
-      {{ ci.namespace()|class_name_rb }}.rust_call(
+      ::{{ ci.namespace()|class_name_rb }}.rust_call(
     {%- endmatch -%}
     :{{ func.ffi_func().name() }},
     {%- call _arg_list_ffi_call(func) %}{% endcall -%}
@@ -45,18 +45,18 @@ values[{{- field_num - 1 -}}]
     {%- when Some(Type::Custom { builtin, .. }) -%}
       {%- match builtin.borrow() -%}
       {%- when Type::Enum { name, .. } -%}
-      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
       {%- when Type::Object { name, .. } -%}
-      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
       {%- else -%}
-      {{ ci.namespace()|class_name_rb }}.rust_call
+      ::{{ ci.namespace()|class_name_rb }}.rust_call
       {%- endmatch -%}
     {%- when Some(Type::Enum { name, .. }) -%}
-      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
     {%- when Some(Type::Object { name, .. }) -%}
-      {{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
     {%- else -%}
-      {{ ci.namespace()|class_name_rb }}.rust_call(
+      ::{{ ci.namespace()|class_name_rb }}.rust_call(
     {%- endmatch -%}
     :{{ func.ffi_func().name() }},
     {{- prefix }},


### PR DESCRIPTION
**This PR implements standard Rust traits for the Ruby bindings.**

It adds idiomatic Ruby support for common Rust traits by mapping them to their natural Ruby equivalents:

- `std::fmt::Debug` → `#inspect` 
- `std::fmt::Display` → `#to_s`
- `PartialEq` / `Eq` → `#==` and `#eql?`
- `PartialOrd` / `Ord` → `#<=>`, `#<`, `#<=`, `#>`, `#>=`
- `Hash` → `#hash`

### Key Benefits
- More idiomatic and Ruby-like API
- Better interoperability with Ruby's standard library and ecosystem
- Enables use of common Ruby idioms (e.g. `pp`, `Set`, `Hash` keys, sorting, etc.)

**No breaking changes** — all existing functionality continues to work as before.