### PR TITLE
swift: nonisolated(unsafe) on callback vtablePtr for Swift 6 strict concurrency

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceImpl.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceImpl.swift
@@ -113,17 +113,9 @@ fileprivate struct {{ trait_impl }} {
         {%- endfor %}
     )
 
-    // Rust stores this pointer for future callback invocations, so it must live
-    // for the process lifetime (not just for the init function call).
-    //
-    // `nonisolated(unsafe)` is needed under Swift 6 strict concurrency: a
-    // non-isolated `static let` of a non-Sendable type is rejected, and the
-    // FFI-imported pointee struct can't be auto-derived `Sendable`. The
-    // pointee is initialized once during static init and never mutated; its
-    // fields are C function pointers (addresses, atomic reads) whose targets
-    // are uniffi-generated trampolines designed for concurrent invocation.
-    // Same escape hatch the adjacent `UniffiHandleMap`/generated object
-    // templates already use.
+    // `nonisolated(unsafe)` is needed under Swift 6 strict concurrency.
+    // This is safe because the pointee is initialized once during static init
+    // and never mutated by either side of the FFI.  Its fields are C function pointers.
     nonisolated(unsafe) static let vtablePtr: UnsafePointer<{{ vtable|ffi_type_name }}> = {
         let ptr = UnsafeMutablePointer<{{ vtable|ffi_type_name }}>.allocate(capacity: 1)
         ptr.initialize(to: vtable)

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceImpl.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceImpl.swift
@@ -115,11 +115,33 @@ fileprivate struct {{ trait_impl }} {
 
     // Rust stores this pointer for future callback invocations, so it must live
     // for the process lifetime (not just for the init function call).
+    //
+    // `nonisolated(unsafe)` is needed under Swift 6 strict concurrency: a
+    // non-isolated `static let` of a non-Sendable type is rejected, and the
+    // FFI-imported pointee struct can't be auto-derived `Sendable`. The
+    // pointee is initialized once during static init and never mutated; its
+    // fields are C function pointers (addresses, atomic reads) whose targets
+    // are uniffi-generated trampolines designed for concurrent invocation.
+    // Same escape hatch the adjacent `UniffiHandleMap`/generated object
+    // templates already use.
+    //
+    // The annotation requires Swift 6 language mode. In Swift 5 mode the
+    // parser rejects `nonisolated(unsafe)` on stored properties, but the
+    // strict-concurrency check that needs the annotation isn't enforced
+    // there either, so the unannotated form compiles cleanly.
+#if swift(>=6)
+    nonisolated(unsafe) static let vtablePtr: UnsafePointer<{{ vtable|ffi_type_name }}> = {
+        let ptr = UnsafeMutablePointer<{{ vtable|ffi_type_name }}>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
+#else
     static let vtablePtr: UnsafePointer<{{ vtable|ffi_type_name }}> = {
         let ptr = UnsafeMutablePointer<{{ vtable|ffi_type_name }}>.allocate(capacity: 1)
         ptr.initialize(to: vtable)
         return UnsafePointer(ptr)
     }()
+#endif
 }
 
 private func {{ callback_init }}() {

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceImpl.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceImpl.swift
@@ -124,24 +124,11 @@ fileprivate struct {{ trait_impl }} {
     // are uniffi-generated trampolines designed for concurrent invocation.
     // Same escape hatch the adjacent `UniffiHandleMap`/generated object
     // templates already use.
-    //
-    // The annotation requires Swift 6 language mode. In Swift 5 mode the
-    // parser rejects `nonisolated(unsafe)` on stored properties, but the
-    // strict-concurrency check that needs the annotation isn't enforced
-    // there either, so the unannotated form compiles cleanly.
-#if swift(>=6)
     nonisolated(unsafe) static let vtablePtr: UnsafePointer<{{ vtable|ffi_type_name }}> = {
         let ptr = UnsafeMutablePointer<{{ vtable|ffi_type_name }}>.allocate(capacity: 1)
         ptr.initialize(to: vtable)
         return UnsafePointer(ptr)
     }()
-#else
-    static let vtablePtr: UnsafePointer<{{ vtable|ffi_type_name }}> = {
-        let ptr = UnsafeMutablePointer<{{ vtable|ffi_type_name }}>.allocate(capacity: 1)
-        ptr.initialize(to: vtable)
-        return UnsafePointer(ptr)
-    }()
-#endif
 }
 
 private func {{ callback_init }}() {

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceImpl.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceImpl.swift
@@ -113,6 +113,9 @@ fileprivate struct {{ trait_impl }} {
         {%- endfor %}
     )
 
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    //
     // `nonisolated(unsafe)` is needed under Swift 6 strict concurrency.
     // This is safe because the pointee is initialized once during static init
     // and never mutated by either side of the FFI.  Its fields are C function pointers.


### PR DESCRIPTION
Under Swift 6 strict concurrency (`SWIFT_VERSION = "6"` or higher), the generated `vtablePtr` static in `CallbackInterfaceImpl.swift` fails to compile:

```
error: static property 'vtablePtr' is not concurrency-safe because non-'Sendable' type
'UnsafePointer<UniffiVTableCallbackInterface…>' may have shared mutable state
```

A non-isolated `static let` whose type isn't `Sendable` is rejected because static storage is reachable from any thread. `UnsafePointer<UniffiVTableCallbackInterface…>` doesn't satisfy `Sendable` automatically: the pointee is the FFI-imported callback vtable struct, and Swift can't auto-derive `Sendable` for it.

The access pattern is genuinely safe:

- The pointer is initialized exactly once during static init and never mutated.
- The pointee struct's fields are C function pointers — their addresses don't change, and pointer-sized reads are atomic on every platform Swift targets.
- Those function pointers reach uniffi-generated trampolines that lock `UniffiHandleMap`'s internal `NSLock` before any mutation. Designed for concurrent invocation.

`nonisolated(unsafe)` is the standard escape hatch for that case — same pattern uniffi already uses adjacent to this code: `UniffiHandleMap` is `@unchecked Sendable` ("All mutation happens with this lock held, which is why we implement @unchecked Sendable"), generated object classes are `@unchecked Sendable`. The new `vtablePtr` static is the same kind of value — write-once shared storage, thread-safe by construction — and was missed when the 0.31 template restructured the vtable from a 1-element array literal to an explicit heap allocation. The array form happened to be strict-concurrency-clean because each subscript access produced a value-copy; the pointer form announces the shared storage to the type checker.

The annotation is wrapped in `#if swift(>=6)` because the Swift 5 language-mode parser rejects `nonisolated(unsafe)` on stored properties (it was added in SE-0420 for Swift 5.10+ and is gated to Swift 6 mode). Under Swift 5 the strict-concurrency check that needs the annotation isn't enforced anyway, so the unannotated form compiles cleanly there.

Surfaces under the existing Swift-6-tracking issues: #2448 (umbrella), #2046, #2458.

### Note on CI coverage

I tried adding a `UNIFFI_TEST_SWIFT_VERSION=6 cargo test -p uniffi-bindgen-tests-swift` step to `.circleci/config.yml` to lock in the `vtablePtr` fix, but it surfaces other pre-existing Swift 6 errors that aren't in scope for this PR. Specifically, `uniffiTraitInterfaceCallAsync` / `uniffiTraitInterfaceCallAsyncWithError` in `Async.swift` fail with:

```
uniffi_bindgen_tests.swift: error: passing closure as a 'sending' parameter risks
causing data races between code in the current task and concurrent execution of
the closure
   |
   |     let task = Task {
   |                `- error: ...
```

— the `Task { ... }` closure in those helpers captures non-`Sendable` callback parameters (`makeCall`, `handleSuccess`, `handleError`). Independent template fix; ideally a follow-up against #2448. Once that lands, adding the Swift 6 CI step makes sense as a separate PR.