### PR TITLE
swift: propagate Task.cancel() to Rust drop

### DIFF
--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -162,7 +162,7 @@ impl Drop for SwiftCancelDropGuard {
     }
 }
 
-#[uniffi::export]
+#[uniffi::export(cancellable)]
 pub async fn swift_cancel_hang() -> Result<(), MyError> {
     let _guard = SwiftCancelDropGuard;
     SWIFT_CANCEL_POLL_COUNT.fetch_add(1, Ordering::SeqCst);
@@ -412,7 +412,7 @@ pub enum AsyncError {
     Timeout,
 }
 
-#[uniffi::export(async_runtime = "tokio")]
+#[uniffi::export(async_runtime = "tokio", cancellable)]
 pub async fn use_shared_resource(options: SharedResourceOptions) -> Result<(), AsyncError> {
     use once_cell::sync::Lazy;
     use tokio::{

--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -5,7 +5,10 @@
 use std::{
     future::Future,
     pin::Pin,
-    sync::{Arc, Mutex, MutexGuard},
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc, Mutex, MutexGuard,
+    },
     task::{Context, Poll, Waker},
     thread,
     time::Duration,
@@ -130,6 +133,57 @@ pub async fn fallible_me(do_fail: bool) -> Result<u8, MyError> {
     } else {
         Ok(42)
     }
+}
+
+// === Swift `Task.cancel()` propagation harness ===
+//
+// `swift_cancel_hang` hangs forever holding a `SwiftCancelDropGuard`. The
+// only way the future ever finishes is by being dropped, which happens
+// when the foreign `Task.cancel()` propagates through the patched
+// `withTaskCancellationHandler` to `ffi_*_rust_future_cancel_*`. Swift
+// tests observe `SWIFT_CANCEL_DROP_COUNT` to verify the drop fired.
+//
+// `SWIFT_CANCEL_POLL_COUNT` is bumped after the guard is in place so the
+// foreign side can synchronize on "body has been polled" (and therefore
+// the scheduler is past `Empty`) instead of sleeping. Without this, a
+// cancel that races the first poll transitions the scheduler straight
+// from `Empty` to `Cancelled` with no callback fired; the next poll
+// short-circuits on `is_cancelled()` before running the body, and
+// `SwiftCancelDropGuard` is never constructed.
+
+static SWIFT_CANCEL_DROP_COUNT: AtomicU32 = AtomicU32::new(0);
+static SWIFT_CANCEL_POLL_COUNT: AtomicU32 = AtomicU32::new(0);
+
+struct SwiftCancelDropGuard;
+
+impl Drop for SwiftCancelDropGuard {
+    fn drop(&mut self) {
+        SWIFT_CANCEL_DROP_COUNT.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[uniffi::export]
+pub async fn swift_cancel_hang() -> Result<(), MyError> {
+    let _guard = SwiftCancelDropGuard;
+    SWIFT_CANCEL_POLL_COUNT.fetch_add(1, Ordering::SeqCst);
+    futures::future::pending::<()>().await;
+    Ok(())
+}
+
+#[uniffi::export]
+pub fn swift_cancel_drop_count() -> u32 {
+    SWIFT_CANCEL_DROP_COUNT.load(Ordering::SeqCst)
+}
+
+#[uniffi::export]
+pub fn swift_cancel_poll_count() -> u32 {
+    SWIFT_CANCEL_POLL_COUNT.load(Ordering::SeqCst)
+}
+
+#[uniffi::export]
+pub fn swift_cancel_reset() {
+    SWIFT_CANCEL_DROP_COUNT.store(0, Ordering::SeqCst);
+    SWIFT_CANCEL_POLL_COUNT.store(0, Ordering::SeqCst);
 }
 
 // An async function returning a struct that can throw.

--- a/fixtures/futures/tests/bindings/test_futures.swift
+++ b/fixtures/futures/tests/bindings/test_futures.swift
@@ -420,15 +420,20 @@ Task {
 counter.enter()
 Task {
 	let task = Task {
-	    try! await useSharedResource(options: SharedResourceOptions(releaseAfterMs: 100, timeoutMs: 1000))
+		do {
+			try await useSharedResource(options: SharedResourceOptions(releaseAfterMs: 100, timeoutMs: 1000))
+		} catch is CancellationError {
+			// Expected: `task.cancel()` below propagates through uniffi
+			// to drop the in-flight Rust future, releasing the lock.
+		} catch {
+			fatalError("unexpected error: \(error)")
+		}
 	}
 
 	// Wait some time to ensure the task has locked the shared resource
 	try await Task.sleep(nanoseconds: 50_000_000)
-	// Cancel the job task the shared resource has been released.
-	//
-	// FIXME: this test currently passes because `test.cancel()` doesn't actually cancel the
-	// operation.  We need to rework the Swift async handling to handle this properly.
+	// Cancel so the shared resource is released before the second
+	// `useSharedResource` below times out.
 	task.cancel()
 
 	// Try accessing the shared resource again.  The initial task should release the shared resource
@@ -442,6 +447,50 @@ counter.enter()
 Task {
 	try! await useSharedResource(options: SharedResourceOptions(releaseAfterMs: 100, timeoutMs: 1000))
 	try! await useSharedResource(options: SharedResourceOptions(releaseAfterMs: 0, timeoutMs: 1000))
+	counter.leave()
+}
+
+// Test that `Task.cancel()` propagates through uniffi to drop the
+// in-flight Rust future.
+//
+// `swiftCancelHang` returns `Result<(), MyError>` so the Swift wrapper is
+// `async throws` and can surface the `CancellationError` thrown out of
+// `uniffiRustCallAsync` when `cancelFunc` fires the scheduler. The
+// hanging Rust future holds a drop guard whose `Drop` impl bumps
+// `swiftCancelDropCount`; we assert it incremented exactly once.
+counter.enter()
+Task {
+	swiftCancelReset()
+	let dropBefore = swiftCancelDropCount()
+
+	let task = Task {
+		try await swiftCancelHang()
+	}
+
+	// Spin until the first poll has run the body and registered a
+	// continuation with the scheduler. Without this, cancel can win the
+	// race and reach the scheduler while it is still `Empty`: the
+	// scheduler transitions Empty → Cancelled with no callback fired,
+	// the next poll short-circuits on `is_cancelled()` before polling
+	// the inner future, and the drop guard is never constructed.
+	while swiftCancelPollCount() == 0 {
+		await Task.yield()
+	}
+
+	task.cancel()
+
+	do {
+		try await task.value
+		fatalError("expected CancellationError, got success")
+	} catch is CancellationError {
+		// Expected.
+	} catch {
+		fatalError("unexpected error: \(error)")
+	}
+
+	let dropAfter = swiftCancelDropCount()
+	assert(dropAfter == dropBefore + 1, "drop count did not increment")
+
 	counter.leave()
 }
 

--- a/fixtures/metadata/src/tests.rs
+++ b/fixtures/metadata/src/tests.rs
@@ -419,6 +419,7 @@ mod test_metadata {
                 name: "state_method_renamed".into(),
                 orig_name: Some("state_method".into()),
                 is_async: false,
+                is_cancellable: false,
                 inputs: vec![],
                 return_type: None,
                 throws: None,
@@ -725,6 +726,7 @@ mod test_function_metadata {
                 name: "test_func_renamed".into(),
                 orig_name: Some("test_func".into()),
                 is_async: false,
+                is_cancellable: false,
                 inputs: vec![
                     FnParamMetadata::simple(
                         "person",
@@ -760,6 +762,7 @@ mod test_function_metadata {
                 name: "test_func_no_return".into(),
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 inputs: vec![],
                 return_type: None,
                 throws: None,
@@ -780,6 +783,7 @@ mod test_function_metadata {
                 name: "test_func_that_throws".into(),
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 inputs: vec![],
                 return_type: Some(Type::Enum {
                     module_path: "uniffi_fixture_metadata::tests::state".into(),
@@ -806,6 +810,7 @@ mod test_function_metadata {
                 name: "test_func_no_return_that_throws".into(),
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 inputs: vec![],
                 return_type: None,
                 throws: Some(Type::Enum {
@@ -831,6 +836,7 @@ mod test_function_metadata {
                 name: "add".into(),
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 inputs: vec![
                     FnParamMetadata::simple("a", Type::UInt8),
                     FnParamMetadata::simple("b", Type::UInt8),
@@ -857,6 +863,7 @@ mod test_function_metadata {
                 name: "new".into(),
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 inputs: vec![],
                 throws: None,
                 checksum: Some(
@@ -874,6 +881,7 @@ mod test_function_metadata {
                 name: "new_renamed".into(),
                 orig_name: Some("new2".into()),
                 is_async: false,
+                is_cancellable: false,
                 inputs: vec![],
                 throws: None,
                 checksum: Some(
@@ -894,6 +902,7 @@ mod test_function_metadata {
                 name: "test_async_func".into(),
                 orig_name: None,
                 is_async: true,
+                is_cancellable: false,
                 inputs: vec![
                     FnParamMetadata::simple(
                         "person",
@@ -929,6 +938,7 @@ mod test_function_metadata {
                 name: "test_async_func_that_throws".into(),
                 orig_name: None,
                 is_async: true,
+                is_cancellable: false,
                 inputs: vec![],
                 return_type: Some(Type::Enum {
                     module_path: "uniffi_fixture_metadata::tests::state".into(),
@@ -957,6 +967,7 @@ mod test_function_metadata {
                 name: "async_sub".into(),
                 orig_name: None,
                 is_async: true,
+                is_cancellable: false,
                 inputs: vec![
                     FnParamMetadata::simple("a", Type::UInt8),
                     FnParamMetadata::simple("b", Type::UInt8),
@@ -1019,6 +1030,7 @@ mod test_function_metadata {
                 name: "get_display".into(),
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 inputs: vec![],
                 throws: None,
                 takes_self_by_arc: false,
@@ -1042,6 +1054,7 @@ mod test_function_metadata {
                 name: "display_result_renamed".into(),
                 orig_name: Some("display_result".into()),
                 is_async: false,
+                is_cancellable: false,
                 inputs: vec![
                     FnParamMetadata::simple("val", Type::String),
                 ],
@@ -1078,6 +1091,7 @@ mod test_function_metadata {
                 name: "input_trait_with_foreign".into(),
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 throws: None,
                 checksum: Some(
                     UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_FUNC_INPUT_TRAIT_WITH_FOREIGN
@@ -1107,6 +1121,7 @@ mod test_function_metadata {
                 name: "log".into(),
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 inputs: vec![FnParamMetadata::simple("message", Type::String)],
                 return_type: None,
                 throws: None,
@@ -1150,6 +1165,7 @@ mod test_function_metadata {
                 name: "input_trait_explicit_rust".into(),
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 throws: None,
                 checksum: Some(
                     UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_FUNC_INPUT_TRAIT_EXPLICIT_RUST
@@ -1191,6 +1207,7 @@ mod test_function_metadata {
                 name: "input_trait_impls_any".into(),
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 throws: None,
                 checksum: Some(
                     UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_FUNC_INPUT_TRAIT_IMPLS_ANY.checksum(),
@@ -1231,6 +1248,7 @@ mod test_function_metadata {
                 name: "input_trait_impls_foreign".into(),
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 throws: None,
                 checksum: Some(
                     UNIFFI_META_CONST_UNIFFI_FIXTURE_METADATA_FUNC_INPUT_TRAIT_IMPLS_FOREIGN

--- a/uniffi_bindgen/src/bindings/swift/templates/Async.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Async.swift
@@ -8,6 +8,7 @@ fileprivate func uniffiRustCallAsync<F, T>(
     pollFunc: (UInt64, @escaping UniffiRustFutureContinuationCallback, UInt64) -> (),
     completeFunc: (UInt64, UnsafeMutablePointer<RustCallStatus>) -> F,
     freeFunc: (UInt64) -> (),
+    cancelFunc: @Sendable @escaping (UInt64) -> (),
     liftFunc: (F) throws -> T,
     errorHandler: ((RustBuffer) throws -> Swift.Error)?
 ) async throws -> T {
@@ -18,19 +19,22 @@ fileprivate func uniffiRustCallAsync<F, T>(
     defer {
         freeFunc(rustFuture)
     }
-    var pollResult: Int8;
-    repeat {
-        pollResult = await withUnsafeContinuation {
-            pollFunc(
-                rustFuture,
-                { handle, pollResult in
-                    uniffiFutureContinuationCallback(handle: handle, pollResult: pollResult)
-                },
-                uniffiContinuationHandleMap.insert(obj: $0)
-            )
-        }
-    } while pollResult != UNIFFI_RUST_FUTURE_POLL_READY
-
+    await withTaskCancellationHandler {
+        var pollResult: Int8 = UNIFFI_RUST_FUTURE_POLL_WAKE
+        repeat {
+            pollResult = await withUnsafeContinuation {
+                pollFunc(
+                    rustFuture,
+                    { handle, pollResult in
+                        uniffiFutureContinuationCallback(handle: handle, pollResult: pollResult)
+                    },
+                    uniffiContinuationHandleMap.insert(obj: $0)
+                )
+            }
+        } while pollResult != UNIFFI_RUST_FUTURE_POLL_READY
+    } onCancel: {
+        cancelFunc(rustFuture)
+    }
     return try liftFunc(makeRustCall(
         { completeFunc(rustFuture, $0) },
         errorHandler: errorHandler

--- a/uniffi_bindgen/src/bindings/swift/templates/Async.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Async.swift
@@ -3,12 +3,24 @@ private let UNIFFI_RUST_FUTURE_POLL_WAKE: Int8 = 1
 
 fileprivate let uniffiContinuationHandleMap = UniffiHandleMap<UnsafeContinuation<Int8, Never>>()
 
+// Holder for a Rust future handle plus its FFI cancel symbol. We capture this
+// in `withTaskCancellationHandler`'s `@Sendable` `onCancel` closure. The cancel
+// function pointer is a plain Swift function type (not `@convention(c)`), so
+// it doesn't satisfy `Sendable` automatically — but the underlying Rust
+// `Scheduler::cancel` is thread-safe by construction. Marking the holder
+// `@unchecked Sendable` matches how `UniffiHandleMap` and generated object
+// types handle the same pattern.
+fileprivate struct UniffiRustFutureCancelHandle: @unchecked Sendable {
+    let handle: UInt64
+    let cancel: (UInt64) -> ()
+}
+
 fileprivate func uniffiRustCallAsync<F, T>(
     rustFutureFunc: () -> UInt64,
     pollFunc: (UInt64, @escaping UniffiRustFutureContinuationCallback, UInt64) -> (),
     completeFunc: (UInt64, UnsafeMutablePointer<RustCallStatus>) -> F,
     freeFunc: (UInt64) -> (),
-    cancelFunc: @Sendable @escaping (UInt64) -> (),
+    cancelFunc: @escaping (UInt64) -> (),
     liftFunc: (F) throws -> T,
     errorHandler: ((RustBuffer) throws -> Swift.Error)?
 ) async throws -> T {
@@ -19,6 +31,7 @@ fileprivate func uniffiRustCallAsync<F, T>(
     defer {
         freeFunc(rustFuture)
     }
+    let cancelHandle = UniffiRustFutureCancelHandle(handle: rustFuture, cancel: cancelFunc)
     await withTaskCancellationHandler {
         var pollResult: Int8 = UNIFFI_RUST_FUTURE_POLL_WAKE
         repeat {
@@ -33,7 +46,7 @@ fileprivate func uniffiRustCallAsync<F, T>(
             }
         } while pollResult != UNIFFI_RUST_FUTURE_POLL_READY
     } onCancel: {
-        cancelFunc(rustFuture)
+        cancelHandle.cancel(cancelHandle.handle)
     }
     return try liftFunc(makeRustCall(
         { completeFunc(rustFuture, $0) },

--- a/uniffi_bindgen/src/bindings/swift/templates/Async.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Async.swift
@@ -3,6 +3,41 @@ private let UNIFFI_RUST_FUTURE_POLL_WAKE: Int8 = 1
 
 fileprivate let uniffiContinuationHandleMap = UniffiHandleMap<UnsafeContinuation<Int8, Never>>()
 
+fileprivate func uniffiRustCallAsync<F, T>(
+    rustFutureFunc: () -> UInt64,
+    pollFunc: (UInt64, @escaping UniffiRustFutureContinuationCallback, UInt64) -> (),
+    completeFunc: (UInt64, UnsafeMutablePointer<RustCallStatus>) -> F,
+    freeFunc: (UInt64) -> (),
+    liftFunc: (F) throws -> T,
+    errorHandler: ((RustBuffer) throws -> Swift.Error)?
+) async throws -> T {
+    // Make sure to call the ensure init function since future creation doesn't have a
+    // RustCallStatus param, so doesn't use makeRustCall()
+    {{ ensure_init_fn_name }}()
+    let rustFuture = rustFutureFunc()
+    defer {
+        freeFunc(rustFuture)
+    }
+    var pollResult: Int8 = UNIFFI_RUST_FUTURE_POLL_WAKE
+    repeat {
+        pollResult = await withUnsafeContinuation {
+            pollFunc(
+                rustFuture,
+                { handle, pollResult in
+                    uniffiFutureContinuationCallback(handle: handle, pollResult: pollResult)
+                },
+                uniffiContinuationHandleMap.insert(obj: $0)
+            )
+        }
+    } while pollResult != UNIFFI_RUST_FUTURE_POLL_READY
+
+    return try liftFunc(makeRustCall(
+        { completeFunc(rustFuture, $0) },
+        errorHandler: errorHandler
+    ))
+}
+
+{%- if ci.has_cancellable_fns() %}
 // Holder for a Rust future handle plus its FFI cancel symbol. We capture this
 // in `withTaskCancellationHandler`'s `@Sendable` `onCancel` closure. The cancel
 // function pointer is a plain Swift function type (not `@convention(c)`), so
@@ -15,7 +50,7 @@ fileprivate struct UniffiRustFutureCancelHandle: @unchecked Sendable {
     let cancel: (UInt64) -> ()
 }
 
-fileprivate func uniffiRustCallAsync<F, T>(
+fileprivate func uniffiRustCallAsyncCancellable<F, T>(
     rustFutureFunc: () -> UInt64,
     pollFunc: (UInt64, @escaping UniffiRustFutureContinuationCallback, UInt64) -> (),
     completeFunc: (UInt64, UnsafeMutablePointer<RustCallStatus>) -> F,
@@ -24,8 +59,6 @@ fileprivate func uniffiRustCallAsync<F, T>(
     liftFunc: (F) throws -> T,
     errorHandler: ((RustBuffer) throws -> Swift.Error)?
 ) async throws -> T {
-    // Make sure to call the ensure init function since future creation doesn't have a
-    // RustCallStatus param, so doesn't use makeRustCall()
     {{ ensure_init_fn_name }}()
     let rustFuture = rustFutureFunc()
     defer {
@@ -53,6 +86,7 @@ fileprivate func uniffiRustCallAsync<F, T>(
         errorHandler: errorHandler
     ))
 }
+{%- endif %}
 
 // Callback handlers for an async calls.  These are invoked by Rust when the future is ready.  They
 // lift the return value or error and resume the suspended function.

--- a/uniffi_bindgen/src/bindings/swift/templates/Helpers.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Helpers.swift
@@ -102,7 +102,8 @@ private func uniffiCheckCallStatus<E: Swift.Error>(
             }
 
         case CALL_CANCELLED:
-            fatalError("Cancellation not supported yet")
+            callStatus.errorBuf.deallocate()
+            throw CancellationError()
 
         default:
             throw UniffiInternalError.unexpectedRustCallStatusCode

--- a/uniffi_bindgen/src/bindings/swift/templates/macros.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/macros.swift
@@ -91,7 +91,7 @@ public convenience init(
 {%- endmacro %}
 
 {%- macro call_async(callable) %}
-        {% call is_try(callable) %}{% endcall %} await uniffiRustCallAsync(
+        {% call is_try(callable) %}{% endcall %} await {% if callable.is_cancellable() %}uniffiRustCallAsyncCancellable{% else %}uniffiRustCallAsync{% endif %}(
             rustFutureFunc: {
                 {{ callable.ffi_func().name() }}(
                     {%- match callable.self_type() %}
@@ -109,7 +109,9 @@ public convenience init(
             pollFunc: {{ callable.ffi_rust_future_poll(ci) }},
             completeFunc: {{ callable.ffi_rust_future_complete(ci) }},
             freeFunc: {{ callable.ffi_rust_future_free(ci) }},
+            {%- if callable.is_cancellable() %}
             cancelFunc: {{ callable.ffi_rust_future_cancel(ci) }},
+            {%- endif %}
             {%- match callable.return_type() %}
             {%- when Some(return_type) %}
             liftFunc: {{ return_type|lift_fn }},
@@ -188,11 +190,11 @@ v{{- field_num -}}
 {%- endmacro -%}
 
 {%- macro throws(func) %}
-{%- if func.throws() %}throws {% endif %}
+{%- if func.throws() || func.is_cancellable() %}throws {% endif %}
 {%- endmacro -%}
 
 {%- macro is_try(func) %}
-{%- if func.throws() %}try {% else %}try! {% endif %}
+{%- if func.throws() || func.is_cancellable() %}try {% else %}try! {% endif %}
 {%- endmacro -%}
 
 {%- macro docstring_value(maybe_docstring, indent_spaces) %}

--- a/uniffi_bindgen/src/bindings/swift/templates/macros.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/macros.swift
@@ -109,6 +109,7 @@ public convenience init(
             pollFunc: {{ callable.ffi_rust_future_poll(ci) }},
             completeFunc: {{ callable.ffi_rust_future_complete(ci) }},
             freeFunc: {{ callable.ffi_rust_future_free(ci) }},
+            cancelFunc: {{ callable.ffi_rust_future_cancel(ci) }},
             {%- match callable.return_type() %}
             {%- when Some(return_type) %}
             liftFunc: {{ return_type|lift_fn }},

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -49,6 +49,7 @@ pub struct Function {
     pub(super) name: String,
     pub(super) module_path: String,
     pub(super) is_async: bool,
+    pub(super) is_cancellable: bool,
     pub(super) arguments: Vec<Argument>,
     pub(super) return_type: Option<Type>,
     // We don't include the FFIFunc in the hash calculation, because:
@@ -81,6 +82,10 @@ impl Function {
 
     pub fn is_async(&self) -> bool {
         self.is_async
+    }
+
+    pub fn is_cancellable(&self) -> bool {
+        self.is_cancellable
     }
 
     pub fn arguments(&self) -> Vec<&Argument> {
@@ -154,6 +159,7 @@ impl From<uniffi_meta::FnMetadata> for Function {
         let ffi_name = meta.ffi_symbol_name();
         let checksum_fn_name = meta.checksum_symbol_name();
         let is_async = meta.is_async;
+        let is_cancellable = meta.is_cancellable;
         let return_type = meta.return_type;
         let arguments = meta.inputs.into_iter().map(Into::into).collect();
 
@@ -167,6 +173,7 @@ impl From<uniffi_meta::FnMetadata> for Function {
             name: meta.name,
             module_path: meta.module_path,
             is_async,
+            is_cancellable,
             arguments,
             return_type,
             ffi_func,
@@ -261,6 +268,12 @@ pub trait Callable {
     fn return_type(&self) -> Option<&Type>;
     fn throws_type(&self) -> Option<&Type>;
     fn is_async(&self) -> bool;
+    /// True if the foreign binding should propagate cancellation to the
+    /// underlying Rust future via drop. Author opt-in: only set when the
+    /// future is drop-safe.
+    fn is_cancellable(&self) -> bool {
+        false
+    }
     fn docstring(&self) -> Option<&str>;
 
     fn self_type(&self) -> Option<Type> {
@@ -336,6 +349,10 @@ impl Callable for Function {
         self.is_async
     }
 
+    fn is_cancellable(&self) -> bool {
+        self.is_cancellable
+    }
+
     fn ffi_func(&self) -> &FfiFunction {
         &self.ffi_func
     }
@@ -357,6 +374,10 @@ impl<T: Callable> Callable for &T {
 
     fn is_async(&self) -> bool {
         (*self).is_async()
+    }
+
+    fn is_cancellable(&self) -> bool {
+        (*self).is_cancellable()
     }
 
     fn docstring(&self) -> Option<&str> {
@@ -474,6 +495,7 @@ mod test {
             name: "fn".to_string(),
             module_path: "fn".to_string(),
             is_async: false,
+            is_cancellable: false,
             arguments: vec![Argument {
                 name: "a".to_string(),
                 type_: Type::Int32,

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -655,6 +655,11 @@ impl ComponentInterface {
                 .any(CallbackInterface::has_async_method)
     }
 
+    /// Does this interface contain any callables marked cancellable?
+    pub fn has_cancellable_fns(&self) -> bool {
+        self.iter_callables().any(|c| c.is_cancellable())
+    }
+
     /// Iterate over `T` parameters of the `FutureCallback<T>` callbacks in this interface
     pub fn iter_future_callback_params(&self) -> impl Iterator<Item = FfiType> {
         let unique_results = self

--- a/uniffi_bindgen/src/interface/object.rs
+++ b/uniffi_bindgen/src/interface/object.rs
@@ -364,6 +364,7 @@ pub struct Constructor {
     pub(super) object_name: String,
     pub(super) object_module_path: String,
     pub(super) is_async: bool,
+    pub(super) is_cancellable: bool,
     pub(super) arguments: Vec<Argument>,
     // We don't include the FFIFunc in the hash calculation, because:
     //  - it is entirely determined by the other fields,
@@ -395,6 +396,10 @@ impl Constructor {
 
     pub fn is_async(&self) -> bool {
         self.is_async
+    }
+
+    pub fn is_cancellable(&self) -> bool {
+        self.is_cancellable
     }
 
     pub fn object_name(&self) -> &str {
@@ -472,6 +477,7 @@ impl From<uniffi_meta::ConstructorMetadata> for Constructor {
             name: meta.name,
             object_name: meta.self_name,
             is_async: meta.is_async,
+            is_cancellable: meta.is_cancellable,
             object_module_path: meta.module_path,
             arguments,
             ffi_func,
@@ -492,6 +498,7 @@ impl From<uniffi_meta::ConstructorMetadata> for Constructor {
 pub struct Method {
     pub(super) name: String,
     pub(super) is_async: bool,
+    pub(super) is_cancellable: bool,
     // Ignore `self_type` for the checksum, we never compare the method checksums for methods from
     // different objects.
     #[checksum_ignore]
@@ -527,6 +534,10 @@ impl Method {
 
     pub fn is_async(&self) -> bool {
         self.is_async
+    }
+
+    pub fn is_cancellable(&self) -> bool {
+        self.is_cancellable
     }
 
     pub fn object_name(&self) -> &str {
@@ -618,6 +629,7 @@ impl Method {
             name: meta.name,
             self_type: receiver,
             is_async: meta.is_async,
+            is_cancellable: meta.is_cancellable,
             arguments,
             return_type: meta.return_type,
             ffi_func,
@@ -751,6 +763,10 @@ impl Callable for Constructor {
         self.is_async
     }
 
+    fn is_cancellable(&self) -> bool {
+        self.is_cancellable
+    }
+
     fn ffi_func(&self) -> &FfiFunction {
         &self.ffi_func
     }
@@ -775,6 +791,10 @@ impl Callable for Method {
 
     fn is_async(&self) -> bool {
         self.is_async
+    }
+
+    fn is_cancellable(&self) -> bool {
+        self.is_cancellable
     }
 
     fn ffi_func(&self) -> &FfiFunction {

--- a/uniffi_bindgen/src/interface/rename.rs
+++ b/uniffi_bindgen/src/interface/rename.rs
@@ -235,6 +235,7 @@ mod tests {
             name: "old_function".to_string(),
             orig_name: None,
             is_async: false,
+            is_cancellable: false,
             inputs: vec![FnParamMetadata {
                 name: "arg".to_string(),
                 ty: Type::Optional {

--- a/uniffi_core/src/ffi/rustfuture/tests.rs
+++ b/uniffi_core/src/ffi/rustfuture/tests.rs
@@ -1,11 +1,17 @@
 use once_cell::sync::OnceCell;
 use std::{
+    cell::Cell,
     future::Future,
     mem::ManuallyDrop,
     panic,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        mpsc, Arc, Mutex,
+    },
     task::{Context, Poll, Waker},
+    thread,
+    time::Duration,
 };
 
 use super::*;
@@ -264,5 +270,220 @@ fn test_wake_during_poll() {
     assert_eq!(
         <String as Lift<crate::UniFfiTag>>::try_lift(return_buf).unwrap(),
         "All done"
+    );
+}
+
+// === Lock discipline: continuations are never invoked while the scheduler is locked ===
+//
+// A continuation callback is foreign code that takes foreign locks.  Swift is the worst case:
+// resuming a continuation from another thread takes the awaiting task's status-record lock, and
+// Swift calls `rust_future_cancel` from a `withTaskCancellationHandler` handler that already holds
+// that same lock.  So if the scheduler invoked callbacks with its own lock held, a completing
+// future and a cancelling foreign thread would deadlock against each other:
+//
+//   waker thread:   Scheduler::wake [scheduler lock] -> continuation -> [foreign lock] BLOCKED
+//   foreign thread: cancel handler  [foreign lock]   -> cancel       -> [scheduler lock] BLOCKED
+//
+// `Scheduler` avoids this by taking the callback out of its state under the lock, releasing the
+// lock, and only then calling foreign code.  These tests drive that interleaving so the property
+// stays true.
+
+thread_local! {
+    /// Whether this thread is inside [ForeignTask::with_lock_held].
+    static HOLDS_FOREIGN_LOCK: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Stands in for the foreign task awaiting a `RustFuture`.
+struct ForeignTask {
+    /// The foreign runtime lock that resuming the continuation needs (Swift's per-task
+    /// status-record lock, Ruby's GVL, ...).
+    ///
+    /// Modelled as re-entrant, because Swift's is: `withStatusRecordLock` detects that the current
+    /// thread already holds the lock and proceeds, which is what lets a cancellation handler
+    /// resume its own task's continuation inline.  Another thread blocks.
+    lock: Mutex<()>,
+    /// Set from inside the continuation, just before it tries to take `lock`.
+    in_callback: AtomicBool,
+    /// How many times the continuation was invoked.  Must always end up at exactly 1.
+    invocations: AtomicUsize,
+    /// The poll result the continuation was invoked with.
+    result: OnceCell<RustFuturePoll>,
+    /// If set, the continuation re-enters the scheduler by cancelling this future.
+    reenter: Mutex<Option<Arc<RustFuture<RustBuffer>>>>,
+}
+
+impl ForeignTask {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            lock: Mutex::new(()),
+            in_callback: AtomicBool::new(false),
+            invocations: AtomicUsize::new(0),
+            result: OnceCell::new(),
+            reenter: Mutex::new(None),
+        })
+    }
+
+    /// Poll `rust_future`, registering this task's continuation.
+    fn poll(self: &Arc<Self>, rust_future: &Arc<RustFuture<RustBuffer>>) {
+        let data = Arc::into_raw(Arc::clone(self)) as u64;
+        Arc::clone(rust_future).poll(RustFutureContinuationBoundCallback {
+            callback: foreign_continuation,
+            data,
+        });
+    }
+
+    fn spin_until_in_callback(&self) {
+        while !self.in_callback.load(Ordering::SeqCst) {
+            std::hint::spin_loop();
+        }
+    }
+
+    /// Run `f` holding the foreign runtime lock, the way Swift runs a cancellation handler.
+    fn with_lock_held<R>(&self, f: impl FnOnce() -> R) -> R {
+        let guard = self.lock.lock().unwrap();
+        HOLDS_FOREIGN_LOCK.with(|held| held.set(true));
+        let result = f();
+        HOLDS_FOREIGN_LOCK.with(|held| held.set(false));
+        drop(guard);
+        result
+    }
+}
+
+extern "C" fn foreign_continuation(data: u64, code: RustFuturePoll) {
+    let task = unsafe { Arc::from_raw(data as *const ForeignTask) };
+    task.invocations.fetch_add(1, Ordering::SeqCst);
+    if let Some(rust_future) = task.reenter.lock().unwrap().take() {
+        // Re-entering the scheduler from inside a continuation only works if the scheduler
+        // released its lock before calling us.
+        rust_future.cancel();
+    }
+    task.in_callback.store(true, Ordering::SeqCst);
+    // Resuming the continuation takes the foreign runtime lock -- unless this thread already holds
+    // it, which is the re-entrant case Swift allows.
+    let _guard = (!HOLDS_FOREIGN_LOCK.with(Cell::get)).then(|| task.lock.lock().unwrap());
+    task.result.set(code).expect("continuation invoked twice");
+}
+
+/// Run `body` on its own thread and fail if it doesn't finish in time, so that a lock-discipline
+/// regression reports as a failure instead of hanging the test run forever.
+fn run_with_watchdog(name: &str, timeout: Duration, body: impl FnOnce() + Send + 'static) {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        body();
+        // Ignore send errors: the receiver is gone if we already timed out.
+        let _ = tx.send(());
+    });
+    if rx.recv_timeout(timeout).is_err() {
+        panic!("{name} deadlocked (no completion within {timeout:?})");
+    }
+}
+
+// The future completes on a worker thread while the foreign side cancels from a thread that holds
+// the lock the continuation needs.  The handshake makes the interleaving deterministic rather than
+// hoping to hit it.
+#[test]
+fn test_cancel_while_waking_does_not_deadlock() {
+    run_with_watchdog(
+        "test_cancel_while_waking_does_not_deadlock",
+        Duration::from_secs(10),
+        || {
+            let (sender, rust_future) = channel();
+            let task = ForeignTask::new();
+            task.poll(&rust_future);
+
+            // Hold the foreign lock, as Swift does across a whole `swift_task_cancel`, and cancel
+            // from inside it.
+            let waker_thread = task.with_lock_held(|| {
+                // Complete the future from a worker thread.  This wakes the RustFuture, which
+                // invokes the continuation, which blocks on the foreign lock we hold.
+                let waker_thread = thread::spawn(move || sender.send(Ok("All done".into())));
+                task.spin_until_in_callback();
+
+                // The continuation is now blocked on us.  Cancelling must not need anything the
+                // blocked continuation is holding.
+                rust_future.cancel();
+                waker_thread
+            });
+            waker_thread.join().unwrap();
+
+            // The wake won the race, so the continuation was resumed exactly once, with `Wake`.
+            assert_eq!(task.invocations.load(Ordering::SeqCst), 1);
+            assert_eq!(task.result.get(), Some(&RustFuturePoll::Wake));
+            assert!(rust_future.is_cancelled());
+
+            // The foreign side polls again after a `Wake`, and now sees the cancellation.
+            let task2 = ForeignTask::new();
+            task2.poll(&rust_future);
+            assert_eq!(task2.invocations.load(Ordering::SeqCst), 1);
+            assert_eq!(task2.result.get(), Some(&RustFuturePoll::Ready));
+            let (_, call_status) = complete(rust_future);
+            assert_eq!(call_status.code, RustCallStatusCode::Cancelled);
+        },
+    );
+}
+
+// Same AB-BA, run unsynchronized many times over: completion and cancellation race freely, and
+// half the iterations use a future that is already complete before the first poll (the "instant
+// local read" shape that makes the window easy to hit).  Whichever side wins, the continuation is
+// resumed exactly once.
+#[test]
+fn test_cancel_racing_completion_stress() {
+    const ITERATIONS: usize = 5_000;
+    run_with_watchdog(
+        "test_cancel_racing_completion_stress",
+        Duration::from_secs(120),
+        || {
+            for i in 0..ITERATIONS {
+                let (sender, rust_future) = channel();
+                let task = ForeignTask::new();
+                let completes_immediately = i % 2 == 0;
+                if completes_immediately {
+                    sender.send(Ok("All done".into()));
+                }
+
+                let canceller = {
+                    let rust_future = Arc::clone(&rust_future);
+                    let task = Arc::clone(&task);
+                    thread::spawn(move || task.with_lock_held(|| rust_future.cancel()))
+                };
+                task.poll(&rust_future);
+                let waker_thread = (!completes_immediately)
+                    .then(|| thread::spawn(move || sender.send(Ok("All done".into()))));
+
+                canceller.join().unwrap();
+                if let Some(waker_thread) = waker_thread {
+                    waker_thread.join().unwrap();
+                }
+
+                assert_eq!(
+                    task.invocations.load(Ordering::SeqCst),
+                    1,
+                    "iteration {i}: continuation not resumed exactly once"
+                );
+                assert!(task.result.get().is_some(), "iteration {i}");
+                assert!(rust_future.is_cancelled(), "iteration {i}");
+            }
+        },
+    );
+}
+
+// A continuation is free to call back into the scheduler -- Swift's continuation resumption can
+// synchronously run the awaiting task, which may cancel or free the future.
+#[test]
+fn test_continuation_can_reenter_scheduler() {
+    run_with_watchdog(
+        "test_continuation_can_reenter_scheduler",
+        Duration::from_secs(10),
+        || {
+            let (sender, rust_future) = channel();
+            let task = ForeignTask::new();
+            *task.reenter.lock().unwrap() = Some(Arc::clone(&rust_future));
+            task.poll(&rust_future);
+            // Wake the future: the continuation runs and cancels from inside the callback.
+            sender.wake();
+            assert_eq!(task.invocations.load(Ordering::SeqCst), 1);
+            assert_eq!(task.result.get(), Some(&RustFuturePoll::Wake));
+            assert!(rust_future.is_cancelled());
+        },
     );
 }

--- a/uniffi_macros/src/export/attributes.rs
+++ b/uniffi_macros/src/export/attributes.rs
@@ -29,6 +29,7 @@ use uniffi_meta::UniffiTraitDiscriminants;
 #[derive(Default)]
 pub struct ExportTraitArgs {
     pub(crate) async_runtime: Option<AsyncRuntime>,
+    pub(crate) cancellable: Option<kw::cancellable>,
     /// Deprecated: use `foreign` (or probably `rust, foreign`) instead.
     pub(crate) callback_interface: Option<kw::callback_interface>,
     /// Deprecated: use `rust, foreign` instead.
@@ -53,6 +54,11 @@ impl UniffiAttributeArgs for ExportTraitArgs {
             let _: Token![=] = input.parse()?;
             Ok(Self {
                 async_runtime: Some(input.parse()?),
+                ..Self::default()
+            })
+        } else if lookahead.peek(kw::cancellable) {
+            Ok(Self {
+                cancellable: input.parse()?,
                 ..Self::default()
             })
         } else if lookahead.peek(kw::callback_interface) {
@@ -83,6 +89,7 @@ impl UniffiAttributeArgs for ExportTraitArgs {
     fn merge(self, other: Self) -> syn::Result<Self> {
         let merged = Self {
             async_runtime: either_attribute_arg(self.async_runtime, other.async_runtime)?,
+            cancellable: either_attribute_arg(self.cancellable, other.cancellable)?,
             callback_interface: either_attribute_arg(
                 self.callback_interface,
                 other.callback_interface,
@@ -115,6 +122,7 @@ impl UniffiAttributeArgs for ExportTraitArgs {
 #[derive(Clone, Default)]
 pub struct ExportFnArgs {
     pub(crate) async_runtime: Option<AsyncRuntime>,
+    pub(crate) cancellable: Option<kw::cancellable>,
     pub(crate) name: Option<String>,
     pub(crate) defaults: DefaultMap,
 }
@@ -133,6 +141,11 @@ impl UniffiAttributeArgs for ExportFnArgs {
             let _: Token![=] = input.parse()?;
             Ok(Self {
                 async_runtime: Some(input.parse()?),
+                ..Self::default()
+            })
+        } else if lookahead.peek(kw::cancellable) {
+            Ok(Self {
+                cancellable: input.parse()?,
                 ..Self::default()
             })
         } else if lookahead.peek(kw::name) {
@@ -159,6 +172,7 @@ impl UniffiAttributeArgs for ExportFnArgs {
     fn merge(self, other: Self) -> syn::Result<Self> {
         Ok(Self {
             async_runtime: either_attribute_arg(self.async_runtime, other.async_runtime)?,
+            cancellable: either_attribute_arg(self.cancellable, other.cancellable)?,
             name: either_attribute_arg(self.name, other.name)?,
             defaults: self.defaults.merge(other.defaults),
         })
@@ -168,6 +182,7 @@ impl UniffiAttributeArgs for ExportFnArgs {
 #[derive(Default)]
 pub struct ExportImplArgs {
     pub(crate) async_runtime: Option<AsyncRuntime>,
+    pub(crate) cancellable: Option<kw::cancellable>,
     pub(crate) name: Option<String>,
 }
 
@@ -185,6 +200,11 @@ impl UniffiAttributeArgs for ExportImplArgs {
             let _: Token![=] = input.parse()?;
             Ok(Self {
                 async_runtime: Some(input.parse()?),
+                ..Self::default()
+            })
+        } else if lookahead.peek(kw::cancellable) {
+            Ok(Self {
+                cancellable: input.parse()?,
                 ..Self::default()
             })
         } else if lookahead.peek(kw::name) {
@@ -206,6 +226,7 @@ impl UniffiAttributeArgs for ExportImplArgs {
     fn merge(self, other: Self) -> syn::Result<Self> {
         Ok(Self {
             async_runtime: either_attribute_arg(self.async_runtime, other.async_runtime)?,
+            cancellable: either_attribute_arg(self.cancellable, other.cancellable)?,
             name: either_attribute_arg(self.name, other.name)?,
         })
     }

--- a/uniffi_macros/src/export/item.rs
+++ b/uniffi_macros/src/export/item.rs
@@ -114,7 +114,13 @@ impl ExportItem {
                 };
 
                 let docstring = extract_docstring(&impl_fn.attrs)?;
-                let attrs = ExportedImplFnAttributes::new(&impl_fn.attrs)?;
+                let mut attrs = ExportedImplFnAttributes::new(&impl_fn.attrs)?;
+
+                // impl-level `cancellable` applies to every async fn in the block.  Sync fns are
+                // skipped rather than rejected, so a block can mix the two.
+                if attrs.args.cancellable.is_none() && impl_fn.sig.asyncness.is_some() {
+                    attrs.args.cancellable = args.cancellable;
+                }
 
                 let foreign_self_ident = if let Some(name) = &args.name {
                     Ident::new(name, self_ident.span())
@@ -207,6 +213,7 @@ impl ExportItem {
 
                 let docstring = extract_docstring(&tim.attrs)?;
                 let attrs = ExportedImplFnAttributes::new(&tim.attrs)?;
+
                 let item = if attrs.constructor {
                     return Err(syn::Error::new_spanned(
                         tim,

--- a/uniffi_macros/src/export/trait_interface.rs
+++ b/uniffi_macros/src/export/trait_interface.rs
@@ -26,6 +26,13 @@ pub(super) fn gen_trait_scaffolding(
     trait_kind: TraitKind,
     docstring: String,
 ) -> syn::Result<TokenStream> {
+    if let Some(c) = args.cancellable {
+        return Err(syn::Error::new_spanned(
+            c,
+            "`cancellable` is not supported for traits; this opt-in only applies to Rust async futures \
+             cancelled from the foreign side, not foreign callback futures awaited by Rust",
+        ));
+    }
     let trait_name = ident_to_string(&self_ident);
     let trait_impl = trait_kind.has_foreign().then(|| {
         callback_interface::trait_impl(mod_path, &self_ident, &items, true)

--- a/uniffi_macros/src/fnsig.rs
+++ b/uniffi_macros/src/fnsig.rs
@@ -39,6 +39,10 @@ pub(crate) struct FnSignature {
     // Did `self.name` come from an attribute
     pub name_from_attrs: bool,
     pub is_async: bool,
+    /// Author opt-in: this future is drop-safe, so foreign-language
+    /// cancellation should propagate by dropping it. Foreign bindings that
+    /// support cancellation surface it (e.g. Swift throws CancellationError).
+    pub is_cancellable: bool,
     pub async_runtime: Option<AsyncRuntime>,
     pub receiver: Option<ReceiverArg>,
     pub args: Vec<NamedArg>,
@@ -165,6 +169,13 @@ impl FnSignature {
             ));
         }
 
+        if !is_async && export_fn_args.cancellable.is_some() {
+            return Err(syn::Error::new(
+                export_fn_args.cancellable.span(),
+                "`cancellable` only applies to async functions".to_string(),
+            ));
+        }
+
         Ok(Self {
             kind,
             span,
@@ -175,6 +186,7 @@ impl FnSignature {
                 .unwrap_or_else(|| ident_to_string(&ident)),
             ident,
             is_async,
+            is_cancellable: export_fn_args.cancellable.is_some(),
             async_runtime: export_fn_args.async_runtime,
             receiver,
             args,
@@ -284,6 +296,7 @@ impl FnSignature {
             name_from_attrs,
             return_ty,
             is_async,
+            is_cancellable,
             docstring,
             ..
         } = &self;
@@ -309,6 +322,7 @@ impl FnSignature {
                     .concat_str(#name)
                     #orig_name
                     .concat_bool(#is_async)
+                    .concat_bool(#is_cancellable)
                     .concat_value(#args_len)
                     #(#arg_metadata_calls)*
                     .concat(#type_id_meta)
@@ -326,6 +340,7 @@ impl FnSignature {
                         .concat_str(#name)
                         #orig_name
                         .concat_bool(#is_async)
+                        .concat_bool(#is_cancellable)
                         .concat_value(#args_len)
                         #(#arg_metadata_calls)*
                         .concat(#type_id_meta)
@@ -343,6 +358,7 @@ impl FnSignature {
                         .concat_str(#name)
                         #orig_name
                         .concat_bool(#is_async)
+                        .concat_bool(#is_cancellable)
                         .concat_value(#args_len)
                         #(#arg_metadata_calls)*
                         .concat(#type_id_meta)
@@ -361,6 +377,7 @@ impl FnSignature {
                         .concat_str(#name)
                         #orig_name
                         .concat_bool(#is_async)
+                        .concat_bool(#is_cancellable)
                         .concat_value(#args_len)
                         #(#arg_metadata_calls)*
                         .concat(#type_id_meta)

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -259,6 +259,7 @@ pub(crate) fn derive_ffi_traits(
 /// Custom keywords
 pub mod kw {
     syn::custom_keyword!(async_runtime);
+    syn::custom_keyword!(cancellable);
     syn::custom_keyword!(callback_interface);
     syn::custom_keyword!(with_foreign);
     syn::custom_keyword!(rust);

--- a/uniffi_meta/src/lib.rs
+++ b/uniffi_meta/src/lib.rs
@@ -25,7 +25,7 @@ pub use metadata::codes;
 // `docs/uniffi-versioning.md` for details.
 //
 // Once we get to 1.0, then we'll need to update the scheme to something like 100 + major_version
-pub const UNIFFI_CONTRACT_VERSION: u32 = 30;
+pub const UNIFFI_CONTRACT_VERSION: u32 = 31;
 
 /// Similar to std::hash::Hash.
 ///
@@ -143,6 +143,7 @@ pub struct FnMetadata {
     // Original name, if this was renamed
     pub orig_name: Option<String>,
     pub is_async: bool,
+    pub is_cancellable: bool,
     pub inputs: Vec<FnParamMetadata>,
     pub return_type: Option<Type>,
     pub throws: Option<Type>,
@@ -168,6 +169,7 @@ pub struct ConstructorMetadata {
     // Original name, if this was renamed
     pub orig_name: Option<String>,
     pub is_async: bool,
+    pub is_cancellable: bool,
     pub inputs: Vec<FnParamMetadata>,
     pub throws: Option<Type>,
     pub checksum: Option<u16>,
@@ -196,6 +198,7 @@ pub struct MethodMetadata {
     // Original name, if this was renamed
     pub orig_name: Option<String>,
     pub is_async: bool,
+    pub is_cancellable: bool,
     pub inputs: Vec<FnParamMetadata>,
     pub return_type: Option<Type>,
     pub throws: Option<Type>,
@@ -225,6 +228,7 @@ pub struct TraitMethodMetadata {
     // Original name, if this was renamed
     pub orig_name: Option<String>,
     pub is_async: bool,
+    pub is_cancellable: bool,
     pub inputs: Vec<FnParamMetadata>,
     pub return_type: Option<Type>,
     pub throws: Option<Type>,
@@ -251,6 +255,7 @@ impl From<TraitMethodMetadata> for MethodMetadata {
             name: meta.name,
             orig_name: meta.orig_name,
             is_async: meta.is_async,
+            is_cancellable: meta.is_cancellable,
             inputs: meta.inputs,
             return_type: meta.return_type,
             throws: meta.throws,

--- a/uniffi_meta/src/reader.rs
+++ b/uniffi_meta/src/reader.rs
@@ -245,6 +245,7 @@ impl<'a> MetadataReader<'a> {
         let name = self.read_string()?;
         let orig_name = self.read_optional_string()?;
         let is_async = self.read_bool()?;
+        let is_cancellable = self.read_bool()?;
         let inputs = self.read_inputs()?;
         let (return_type, throws) = self.read_return_type()?;
         let docstring = self.read_optional_long_string()?;
@@ -253,6 +254,7 @@ impl<'a> MetadataReader<'a> {
             name,
             orig_name,
             is_async,
+            is_cancellable,
             inputs,
             return_type,
             throws,
@@ -267,6 +269,7 @@ impl<'a> MetadataReader<'a> {
         let name = self.read_string()?;
         let orig_name = self.read_optional_string()?;
         let is_async = self.read_bool()?;
+        let is_cancellable = self.read_bool()?;
         let inputs = self.read_inputs()?;
         let (return_type, throws) = self.read_return_type()?;
         let docstring = self.read_optional_long_string()?;
@@ -288,6 +291,7 @@ impl<'a> MetadataReader<'a> {
             module_path,
             self_name,
             is_async,
+            is_cancellable,
             name,
             orig_name,
             inputs,
@@ -303,6 +307,7 @@ impl<'a> MetadataReader<'a> {
         let name = self.read_string()?;
         let orig_name = self.read_optional_string()?;
         let is_async = self.read_bool()?;
+        let is_cancellable = self.read_bool()?;
         let inputs = self.read_inputs()?;
         let (return_type, throws) = self.read_return_type()?;
         let docstring = self.read_optional_long_string()?;
@@ -312,6 +317,7 @@ impl<'a> MetadataReader<'a> {
             name,
             orig_name,
             is_async,
+            is_cancellable,
             inputs,
             return_type,
             throws,
@@ -435,6 +441,7 @@ impl<'a> MetadataReader<'a> {
         let name = self.read_string()?;
         let orig_name = self.read_optional_string()?;
         let is_async = self.read_bool()?;
+        let is_cancellable = self.read_bool()?;
         let inputs = self.read_inputs()?;
         let (return_type, throws) = self.read_return_type()?;
         let docstring = self.read_optional_long_string()?;
@@ -445,6 +452,7 @@ impl<'a> MetadataReader<'a> {
             name,
             orig_name,
             is_async,
+            is_cancellable,
             inputs,
             return_type,
             throws,

--- a/uniffi_parse_rs/src/attrs/callables.rs
+++ b/uniffi_parse_rs/src/attrs/callables.rs
@@ -16,6 +16,9 @@ pub struct FunctionAttributes {
     pub name: Option<String>,
     pub docstring: Option<String>,
     pub async_runtime: Option<LitStr>,
+    /// Author opt-in: this future is drop-safe, so foreign-language cancellation should
+    /// propagate by dropping it.
+    pub cancellable: bool,
 }
 
 impl FunctionAttributes {
@@ -51,6 +54,9 @@ impl FunctionAttributes {
                             meta.value()?;
                             parsed.async_runtime = meta.input.parse()?;
                             Ok(())
+                        } else if meta.path.is_ident("cancellable") {
+                            parsed.cancellable = true;
+                            Ok(())
                         } else {
                             Err(meta.error("Invalid attribute"))
                         }
@@ -70,6 +76,9 @@ pub struct MethodAttributes {
     pub name: Option<String>,
     pub docstring: Option<String>,
     pub async_runtime: Option<LitStr>,
+    /// Author opt-in: this future is drop-safe, so foreign-language cancellation should
+    /// propagate by dropping it.
+    pub cancellable: bool,
 }
 
 impl MethodAttributes {
@@ -93,6 +102,9 @@ impl MethodAttributes {
                             meta.value()?;
                             parsed.async_runtime = meta.input.parse()?;
                             Ok(())
+                        } else if meta.path.is_ident("cancellable") {
+                            parsed.cancellable = true;
+                            Ok(())
                         } else {
                             Err(meta.error("Invalid attribute"))
                         }
@@ -114,6 +126,9 @@ pub struct ConstructorAttributes {
     pub name: Option<String>,
     pub docstring: Option<String>,
     pub async_runtime: Option<LitStr>,
+    /// Author opt-in: this future is drop-safe, so foreign-language cancellation should
+    /// propagate by dropping it.
+    pub cancellable: bool,
 }
 
 impl ConstructorAttributes {
@@ -142,6 +157,9 @@ impl ConstructorAttributes {
                         } else if meta.path.is_ident("async_runtime") {
                             meta.value()?;
                             parsed.async_runtime = meta.input.parse()?;
+                            Ok(())
+                        } else if meta.path.is_ident("cancellable") {
+                            parsed.cancellable = true;
                             Ok(())
                         } else {
                             Err(meta.error("Invalid attribute"))

--- a/uniffi_parse_rs/src/attrs/objects.rs
+++ b/uniffi_parse_rs/src/attrs/objects.rs
@@ -66,6 +66,8 @@ impl ObjectAttributes {
 pub struct ImplAttributes {
     pub name: Option<String>,
     pub async_runtime: Option<LitStr>,
+    /// Applies to every async fn in the block.
+    pub cancellable: bool,
 }
 
 impl ImplAttributes {
@@ -99,6 +101,9 @@ impl ImplAttributes {
                         } else if meta.path.is_ident("async_runtime") {
                             meta.value()?;
                             parsed.async_runtime = Some(meta.input.parse()?);
+                            Ok(())
+                        } else if meta.path.is_ident("cancellable") {
+                            parsed.cancellable = true;
                             Ok(())
                         } else {
                             Err(meta.error("Invalid attribute"))

--- a/uniffi_parse_rs/src/attrs/utraits.rs
+++ b/uniffi_parse_rs/src/attrs/utraits.rs
@@ -70,6 +70,7 @@ impl UniffiTraitAttrs {
                     name: "uniffi_trait_debug".into(),
                     orig_name: None,
                     is_async: false,
+                is_cancellable: false,
                     inputs: vec![],
                     return_type: Some(uniffi_meta::Type::String),
                     throws: None,
@@ -87,6 +88,7 @@ impl UniffiTraitAttrs {
                     name: "uniffi_trait_display".into(),
                     orig_name: None,
                     is_async: false,
+                is_cancellable: false,
                     inputs: vec![],
                     return_type: Some(uniffi_meta::Type::String),
                     throws: None,
@@ -104,6 +106,7 @@ impl UniffiTraitAttrs {
                     name: "uniffi_trait_eq_eq".into(),
                     orig_name: None,
                     is_async: false,
+                is_cancellable: false,
                     inputs: vec![uniffi_meta::FnParamMetadata {
                         name: "other".into(),
                         ty: self_ty.clone(),
@@ -123,6 +126,7 @@ impl UniffiTraitAttrs {
                     name: "uniffi_trait_eq_ne".into(),
                     orig_name: None,
                     is_async: false,
+                is_cancellable: false,
                     inputs: vec![uniffi_meta::FnParamMetadata {
                         name: "other".into(),
                         ty: self_ty.clone(),
@@ -146,6 +150,7 @@ impl UniffiTraitAttrs {
                     name: "uniffi_trait_hash".into(),
                     orig_name: None,
                     is_async: false,
+                is_cancellable: false,
                     inputs: vec![],
                     return_type: Some(uniffi_meta::Type::UInt64),
                     throws: None,
@@ -163,6 +168,7 @@ impl UniffiTraitAttrs {
                     name: "uniffi_trait_ord_cmp".into(),
                     orig_name: None,
                     is_async: false,
+                is_cancellable: false,
                     inputs: vec![uniffi_meta::FnParamMetadata {
                         name: "other".into(),
                         ty: self_ty.clone(),

--- a/uniffi_parse_rs/src/expect/full_interface.txt
+++ b/uniffi_parse_rs/src/expect/full_interface.txt
@@ -5,6 +5,7 @@
             name: "bytes_fn",
             orig_name: None,
             is_async: false,
+            is_cancellable: false,
             inputs: [
                 FnParamMetadata {
                     name: "a",
@@ -35,6 +36,7 @@
                 "func",
             ),
             is_async: false,
+            is_cancellable: false,
             inputs: [
                 FnParamMetadata {
                     name: "a",
@@ -93,6 +95,7 @@
             name: "trait_fn",
             orig_name: None,
             is_async: false,
+            is_cancellable: false,
             inputs: [
                 FnParamMetadata {
                     name: "a",
@@ -470,6 +473,7 @@
                 "constructor_with_default",
             ),
             is_async: false,
+            is_cancellable: false,
             inputs: [
                 FnParamMetadata {
                     name: "a",
@@ -502,6 +506,7 @@
             name: "failible_constructor",
             orig_name: None,
             is_async: false,
+            is_cancellable: false,
             inputs: [
                 FnParamMetadata {
                     name: "a",
@@ -528,6 +533,7 @@
             name: "new",
             orig_name: None,
             is_async: false,
+            is_cancellable: false,
             inputs: [],
             throws: None,
             checksum: None,
@@ -543,6 +549,7 @@
             name: "meth1",
             orig_name: None,
             is_async: false,
+            is_cancellable: false,
             inputs: [],
             return_type: Some(
                 String,
@@ -569,6 +576,7 @@
                 "meth2",
             ),
             is_async: false,
+            is_cancellable: false,
             inputs: [
                 FnParamMetadata {
                     name: "a",
@@ -607,6 +615,7 @@
             name: "meth3",
             orig_name: None,
             is_async: false,
+            is_cancellable: false,
             inputs: [
                 FnParamMetadata {
                     name: "s",
@@ -638,6 +647,7 @@
             name: "method",
             orig_name: None,
             is_async: false,
+            is_cancellable: false,
             inputs: [
                 FnParamMetadata {
                     name: "a",
@@ -673,6 +683,7 @@
             name: "method",
             orig_name: None,
             is_async: false,
+            is_cancellable: false,
             inputs: [],
             return_type: Some(
                 UInt8,
@@ -696,6 +707,7 @@
             name: "method",
             orig_name: None,
             is_async: false,
+            is_cancellable: false,
             inputs: [
                 FnParamMetadata {
                     name: "a",
@@ -738,6 +750,7 @@
                 name: "uniffi_trait_debug",
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 inputs: [],
                 return_type: Some(
                     String,
@@ -757,6 +770,7 @@
                 name: "uniffi_trait_display",
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 inputs: [],
                 return_type: Some(
                     String,
@@ -776,6 +790,7 @@
                 name: "uniffi_trait_eq_eq",
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 inputs: [
                     FnParamMetadata {
                         name: "other",
@@ -803,6 +818,7 @@
                 name: "uniffi_trait_eq_ne",
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 inputs: [
                     FnParamMetadata {
                         name: "other",
@@ -834,6 +850,7 @@
                 name: "uniffi_trait_hash",
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 inputs: [],
                 return_type: Some(
                     UInt64,
@@ -853,6 +870,7 @@
                 name: "uniffi_trait_ord_cmp",
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 inputs: [
                     FnParamMetadata {
                         name: "other",

--- a/uniffi_parse_rs/src/functions.rs
+++ b/uniffi_parse_rs/src/functions.rs
@@ -66,6 +66,7 @@ impl Function {
             name: names.name,
             orig_name: names.orig_name,
             is_async: self.is_async,
+            is_cancellable: self.attrs.cancellable,
             docstring: self.attrs.docstring.clone(),
             checksum: None,
             inputs: self

--- a/uniffi_parse_rs/src/impls.rs
+++ b/uniffi_parse_rs/src/impls.rs
@@ -25,10 +25,15 @@ impl Impl {
         let mut methods = vec![];
         for item in imp.items {
             if let ImplItem::Fn(f) = item {
-                if let Some(attrs) = ConstructorAttributes::parse(env, &f.attrs)? {
-                    constructors.push(Constructor::parse(attrs, f)?);
-                } else if let Some(attrs) = MethodAttributes::parse(env, &f.attrs)? {
-                    methods.push(Method::parse(attrs, f)?);
+                // impl-level `cancellable` applies to every async fn in the block.  Sync fns are
+                // skipped rather than rejected, so a block can mix the two.
+                let inherits_cancellable = attrs.cancellable && f.sig.asyncness.is_some();
+                if let Some(mut a) = ConstructorAttributes::parse(env, &f.attrs)? {
+                    a.cancellable |= inherits_cancellable;
+                    constructors.push(Constructor::parse(a, f)?);
+                } else if let Some(mut a) = MethodAttributes::parse(env, &f.attrs)? {
+                    a.cancellable |= inherits_cancellable;
+                    methods.push(Method::parse(a, f)?);
                 }
             }
         }

--- a/uniffi_parse_rs/src/objects.rs
+++ b/uniffi_parse_rs/src/objects.rs
@@ -119,6 +119,7 @@ impl Constructor {
             orig_name,
             docstring: self.attrs.docstring.clone(),
             is_async: self.is_async,
+            is_cancellable: self.attrs.cancellable,
             inputs: self
                 .args
                 .iter()
@@ -173,6 +174,7 @@ impl Method {
             orig_name,
             docstring: self.attrs.docstring.clone(),
             is_async: self.is_async,
+            is_cancellable: self.attrs.cancellable,
             takes_self_by_arc: self.self_arg.takes_self_by_arc(ir, cache, module_path)?,
             inputs: self
                 .args

--- a/uniffi_parse_rs/src/traits.rs
+++ b/uniffi_parse_rs/src/traits.rs
@@ -162,6 +162,9 @@ impl TraitMethod {
             orig_name,
             docstring: self.attrs.docstring.clone(),
             is_async: self.is_async,
+            // `cancellable` is rejected on traits: it applies to Rust futures cancelled from the
+            // foreign side, not to foreign callback futures awaited by Rust.
+            is_cancellable: false,
             takes_self_by_arc: self.self_arg.takes_self_by_arc(ir, cache, module_path)?,
             inputs: self
                 .args

--- a/uniffi_udl/src/attributes.rs
+++ b/uniffi_udl/src/attributes.rs
@@ -41,6 +41,7 @@ pub(super) enum Attribute {
     // Modifies `Trait` to enable foreign implementations (callback interfaces)
     WithForeign,
     Async,
+    Cancellable,
     NonExhaustive,
 }
 
@@ -70,6 +71,7 @@ impl TryFrom<&weedle::attribute::ExtendedAttribute<'_>> for Attribute {
                 "Trait" => Ok(Attribute::Trait),
                 "WithForeign" => Ok(Attribute::WithForeign),
                 "Async" => Ok(Attribute::Async),
+                "Cancellable" => Ok(Attribute::Cancellable),
                 "NonExhaustive" => Ok(Attribute::NonExhaustive),
                 "Remote" => Ok(Attribute::Remote),
                 _ => anyhow::bail!("ExtendedAttributeNoArgs not supported: {:?}", (attr.0).0),
@@ -277,6 +279,12 @@ impl FunctionAttributes {
     pub(super) fn is_async(&self) -> bool {
         self.0.iter().any(|attr| matches!(attr, Attribute::Async))
     }
+
+    pub(super) fn is_cancellable(&self) -> bool {
+        self.0
+            .iter()
+            .any(|attr| matches!(attr, Attribute::Cancellable))
+    }
 }
 
 impl FromIterator<Attribute> for FunctionAttributes {
@@ -291,10 +299,14 @@ impl TryFrom<&weedle::attribute::ExtendedAttributeList<'_>> for FunctionAttribut
         weedle_attributes: &weedle::attribute::ExtendedAttributeList<'_>,
     ) -> Result<Self, Self::Error> {
         let attrs = parse_attributes(weedle_attributes, |attr| match attr {
-            Attribute::Throws(_) | Attribute::Async => Ok(()),
+            Attribute::Throws(_) | Attribute::Async | Attribute::Cancellable => Ok(()),
             _ => bail!(format!("{attr:?} not supported for functions")),
         })?;
-        Ok(Self(attrs))
+        let result = Self(attrs);
+        if result.is_cancellable() && !result.is_async() {
+            bail!("[Cancellable] only applies to [Async] functions");
+        }
+        Ok(result)
     }
 }
 
@@ -465,6 +477,12 @@ impl ConstructorAttributes {
     pub(super) fn is_async(&self) -> bool {
         self.0.iter().any(|attr| matches!(attr, Attribute::Async))
     }
+
+    pub(super) fn is_cancellable(&self) -> bool {
+        self.0
+            .iter()
+            .any(|attr| matches!(attr, Attribute::Cancellable))
+    }
 }
 
 impl TryFrom<&weedle::attribute::ExtendedAttributeList<'_>> for ConstructorAttributes {
@@ -476,9 +494,14 @@ impl TryFrom<&weedle::attribute::ExtendedAttributeList<'_>> for ConstructorAttri
             Attribute::Throws(_) => Ok(()),
             Attribute::Name(_) => Ok(()),
             Attribute::Async => Ok(()),
+            Attribute::Cancellable => Ok(()),
             _ => bail!(format!("{attr:?} not supported for constructors")),
         })?;
-        Ok(Self(attrs))
+        let result = Self(attrs);
+        if result.is_cancellable() && !result.is_async() {
+            bail!("[Cancellable] only applies to [Async] constructors");
+        }
+        Ok(result)
     }
 }
 
@@ -503,6 +526,12 @@ impl MethodAttributes {
         self.0.iter().any(|attr| matches!(attr, Attribute::Async))
     }
 
+    pub(super) fn is_cancellable(&self) -> bool {
+        self.0
+            .iter()
+            .any(|attr| matches!(attr, Attribute::Cancellable))
+    }
+
     pub(super) fn get_self_by_arc(&self) -> bool {
         self.0
             .iter()
@@ -522,10 +551,17 @@ impl TryFrom<&weedle::attribute::ExtendedAttributeList<'_>> for MethodAttributes
         weedle_attributes: &weedle::attribute::ExtendedAttributeList<'_>,
     ) -> Result<Self, Self::Error> {
         let attrs = parse_attributes(weedle_attributes, |attr| match attr {
-            Attribute::SelfType(_) | Attribute::Throws(_) | Attribute::Async => Ok(()),
+            Attribute::SelfType(_)
+            | Attribute::Throws(_)
+            | Attribute::Async
+            | Attribute::Cancellable => Ok(()),
             _ => bail!(format!("{attr:?} not supported for methods")),
         })?;
-        Ok(Self(attrs))
+        let result = Self(attrs);
+        if result.is_cancellable() && !result.is_async() {
+            bail!("[Cancellable] only applies to [Async] methods");
+        }
+        Ok(result)
     }
 }
 

--- a/uniffi_udl/src/converters/callables.rs
+++ b/uniffi_udl/src/converters/callables.rs
@@ -90,6 +90,7 @@ impl APIConverter<FnMetadata> for weedle::namespace::OperationNamespaceMember<'_
         };
         let attrs = FunctionAttributes::try_from(self.attributes.as_ref())?;
         let is_async = attrs.is_async();
+        let is_cancellable = attrs.is_cancellable();
         let throws = match attrs.get_throws_err() {
             None => None,
             Some(name) => match ci.get_type(name) {
@@ -102,6 +103,7 @@ impl APIConverter<FnMetadata> for weedle::namespace::OperationNamespaceMember<'_
             name,
             orig_name: None,
             is_async,
+            is_cancellable,
             return_type,
             inputs: self.args.body.list.convert(ci)?,
             throws,
@@ -127,6 +129,7 @@ impl APIConverter<ConstructorMetadata> for weedle::interface::ConstructorInterfa
             // We don't know the name of the containing `Object` at this point, fill it in later.
             self_name: Default::default(),
             is_async: attributes.is_async(),
+            is_cancellable: attributes.is_cancellable(),
             // Also fill in checksum_fn_name later, since it depends on object_name
             inputs: self.args.body.list.convert(ci)?,
             throws,
@@ -147,6 +150,7 @@ impl APIConverter<MethodMetadata> for weedle::interface::OperationInterfaceMembe
         let return_type = ci.resolve_return_type_expression(&self.return_type)?;
         let attributes = MethodAttributes::try_from(self.attributes.as_ref())?;
         let is_async = attributes.is_async();
+        let is_cancellable = attributes.is_cancellable();
 
         let throws = match attributes.get_throws_err() {
             Some(name) => match ci.get_type(name) {
@@ -173,6 +177,7 @@ impl APIConverter<MethodMetadata> for weedle::interface::OperationInterfaceMembe
             },
             orig_name: None,
             is_async,
+            is_cancellable,
             inputs: self.args.body.list.convert(ci)?,
             return_type,
             throws,
@@ -194,6 +199,7 @@ impl APIConverter<TraitMethodMetadata> for weedle::interface::OperationInterface
         let return_type = ci.resolve_return_type_expression(&self.return_type)?;
         let attributes = MethodAttributes::try_from(self.attributes.as_ref())?;
         let is_async = attributes.is_async();
+        let is_cancellable = attributes.is_cancellable();
 
         let throws = match attributes.get_throws_err() {
             Some(name) => match ci.get_type(name) {
@@ -220,6 +226,7 @@ impl APIConverter<TraitMethodMetadata> for weedle::interface::OperationInterface
             },
             orig_name: None,
             is_async,
+            is_cancellable,
             inputs: self.args.body.list.convert(ci)?,
             return_type,
             throws,

--- a/uniffi_udl/src/converters/interface.rs
+++ b/uniffi_udl/src/converters/interface.rs
@@ -65,6 +65,7 @@ impl APIConverter<ObjectMetadata> for weedle::InterfaceDefinition<'_> {
                 name: name.to_string(),
                 orig_name: None,
                 is_async: false,
+                is_cancellable: false,
                 inputs,
                 return_type,
                 throws: None,

--- a/uniffi_udl/src/converters/mod.rs
+++ b/uniffi_udl/src/converters/mod.rs
@@ -199,6 +199,7 @@ fn make_uniffi_traits(
             name: name.to_string(),
             orig_name: None,
             is_async: false,
+            is_cancellable: false,
             inputs,
             return_type,
             throws: None,


### PR DESCRIPTION
Wires Swift `Task.cancel()` through `withTaskCancellationHandler` to call the auto-emitted `ffi_*_rust_future_cancel_*` symbols, then throws `CancellationError` on `CALL_CANCELLED`. Gated behind a `cancellable` opt-in so existing async API surfaces don't gain a `throws` clause.

Today, the Swift `uniffiRustCallAsync` template uses plain `withUnsafeContinuation` for its poll loop. When the calling Swift `Task` is cancelled, `Task.isCancelled` becomes true but the await keeps suspending; the Rust future continues being polled and runs to natural completion. Drop-time guards (`AbortOnDrop`, `CancelOnDrop`, sqlx connection release, reqwest abort) on the Rust side never fire on cancel.

## Opt-in

The author of the Rust function attests that the future is drop-safe by adding `cancellable`:

```rust
#[uniffi::export(cancellable)]
pub async fn long_running() -> Foo { ... }

// also valid on an impl block, applies to every async fn in it
#[uniffi::export(cancellable)]
impl SomeObject { ... async fn ... }
```

In UDL: `[Async, Cancellable] void long_running();`

The annotation rides on top of the existing `#[uniffi::export]` surface — same kw-arg style as `async_runtime`. It is rejected on traits (foreign callback futures awaited by Rust use a different `UniffiForeignFutureTask` mechanism, not in scope here).

## Mechanism

Three template-level changes:

- `uniffiRustCallAsync` keeps its existing signature (no `cancelFunc`, no cancel-handler wrap). A new `uniffiRustCallAsyncCancellable` is emitted alongside whenever any callable in the namespace opts in — same body but with `cancelFunc` and the poll loop wrapped in `withTaskCancellationHandler { … } onCancel: { cancelHandle.cancel(cancelHandle.handle) }`. The cancel function pointer + handle are captured in a small `@unchecked Sendable` holder so the `onCancel` closure satisfies the `@Sendable` requirement.
- `Helpers.swift`'s `case CALL_CANCELLED: fatalError(...)` becomes `throw CancellationError()` (deallocating the error buffer first). This is strictly more correct and only fires on cancellable async paths; sync paths and non-cancellable async paths can never reach it.
- `call_async` macro picks `uniffiRustCallAsyncCancellable` and emits `cancelFunc: <ffi_rust_future_cancel symbol>` only at cancellable callsites. The `throws` / `is_try` macros add `throws` / `try` when the callable is cancellable, the same way they already do when it `throws` a Rust-side error.

After this, when a Swift Task running a cancellable callable is cancelled the Rust scheduler synchronously fires the registered continuation with `Ready`, the poll loop exits, `complete()` runs and drops the inner Rust future (firing all the Drop guards), and Swift sees `CALL_CANCELLED` and throws `CancellationError`. Non-cancellable callables behave exactly like before this PR.

The `is_cancellable` bit flows through metadata: `FnMetadata` / `MethodMetadata` / `ConstructorMetadata` / `TraitMethodMetadata` each grow a bool, contract version bumped 30 → 31, readers and writers updated. UDL parses `[Cancellable]` and rejects it without `[Async]`.

## Tests

`fixtures/futures` gains a `swift_cancel_hang` async function (`#[uniffi::export(cancellable)]`) that hangs forever holding a drop guard, plus drop and poll counters. The Swift test cancels a Task running it, asserts `CancellationError` is thrown, and asserts the drop counter incremented exactly once. The test spins on the poll counter to wait for the first poll deterministically rather than sleeping (otherwise cancel can race the first poll, the scheduler goes Empty → Cancelled with no callback fired, the next poll short-circuits on `is_cancelled()` before running the body, and the drop guard is never constructed).

Also fixes the existing `useSharedResource` cancel test that previously had a `FIXME` saying cancel didn't actually cancel — `use_shared_resource` is now `cancellable`, and the test does a `do/catch` for `CancellationError`.

## Notes

Tracks #2771. Closed PR #1768 from 2023 carried roughly the same approach (plus opt-in plumbing) and was closed for lack of energy, not technical reasons.

All commits in this PR were authored with [Claude Code](https://claude.com/claude-code) (Opus 4.7) — `Co-Authored-By` trailer on each commit.