### PR TITLE
Swift: Preserve leading U+FEFF byte order mark in `FfiConverterString`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed bug that sometimes prevented renaming items inside a submodule [#2792](https://github.com/mozilla/uniffi-rs/pull/2792)
 - Exempted `UniFfiTag` from `clippy::exhaustive_structs` since downstream projects may depend on it [#2809](https://github.com/mozilla/uniffi-rs/pull/2809)
 - Ruby: Code for all kinds of enums and custom types is now correctly generated #2880 and #2891
+- Swift: Fixed `FfiConverterString` silently stripping a leading U+FEFF byte order mark from Rust strings.
 
 ### ⚠️ Breaking Changes for external bindings authors ⚠️
 

--- a/bindgen-tests/lib/src/primitive_types.rs
+++ b/bindgen-tests/lib/src/primitive_types.rs
@@ -196,3 +196,17 @@ pub fn sum_with_many_types(
 pub fn func_with_multi_word_arg(the_argument: i32) -> i32 {
     the_argument
 }
+
+// Round-trip strings prefixed with U+FEFF (byte order mark) so the bindings
+// can assert string converters preserve the BOM rather than treating it as
+// encoding metadata. The two functions cover both converter paths: `lift`
+// for top-level returns and `read` for elements inside a serialized buffer.
+#[uniffi::export]
+pub fn string_with_bom() -> String {
+    "\u{feff}hello".to_string()
+}
+
+#[uniffi::export]
+pub fn strings_with_bom() -> Vec<String> {
+    vec!["\u{feff}first".to_string(), "\u{feff}second".to_string()]
+}

--- a/bindgen-tests/swift/tests/primitive_types.swift
+++ b/bindgen-tests/swift/tests/primitive_types.swift
@@ -50,3 +50,8 @@ assert(sumWithManyTypes(a: 1, b: -2, c: 3, d: -4, e: 5, f: -6, g: 7, h: -8, i: 9
 // Test that the argument names get mapped to camelCase
 let _ = funcWithMultiWordArg(theArgument: 16)
 
+// `String(bytes:encoding:.utf8)` strips a leading U+FEFF via Foundation's
+// NSString decoder; assert the lift/read paths preserve it instead.
+assert(stringWithBom() == "\u{feff}hello")
+assert(stringsWithBom() == ["\u{feff}first", "\u{feff}second"])
+

--- a/uniffi_bindgen/src/bindings/swift/templates/StringHelper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/StringHelper.swift
@@ -13,7 +13,11 @@ fileprivate struct FfiConverterString: FfiConverter {
             return String()
         }
         let bytes = UnsafeBufferPointer<UInt8>(start: value.data!, count: Int(value.len))
-        return String(bytes: bytes, encoding: String.Encoding.utf8)!
+        // Use Swift's native UTF-8 decoder; `String(bytes:encoding:.utf8)` goes
+        // through Foundation's NSString and silently strips a leading U+FEFF BOM.
+        // Invalid UTF-8 substitutes U+FFFD instead of trapping (unreachable
+        // given Rust's `String` invariant).
+        return String(decoding: bytes, as: UTF8.self)
     }
 
     public static func lower(_ value: String) -> RustBuffer {
@@ -29,7 +33,8 @@ fileprivate struct FfiConverterString: FfiConverter {
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> String {
         let len: Int32 = try readInt(&buf)
-        return String(bytes: try readBytes(&buf, count: Int(len)), encoding: String.Encoding.utf8)!
+        // See `lift` above for why we avoid Foundation's NSString-backed decoder here.
+        return String(decoding: try readBytes(&buf, count: Int(len)), as: UTF8.self)
     }
 
     public static func write(_ value: String, into buf: inout [UInt8]) {


### PR DESCRIPTION
`FfiConverterString.lift` and `read` use `String(bytes: bytes, encoding: String.Encoding.utf8)!`. That initializer routes through Foundation's NSString decoder, which silently strips a leading U+FEFF byte order mark when decoding UTF-8, even though the caller explicitly asked for UTF-8 and U+FEFF is a valid Unicode code point. A Rust `String` containing `"\u{feff}#"` (4 bytes on the wire) lifts to `"#"` (1 byte) on the Swift side. There is no error and no warning.

## The fix

Switch both call sites to `String(decoding: bytes, as: UTF8.self)`, which uses Swift's standard library UTF-8 decoder and treats U+FEFF as a regular code point.

## Behavioral changes

| Input | Old (`String(bytes:encoding:)!`) | New (`String(decoding:as:UTF8.self)`) |
|---|---|---|
| Valid UTF-8 with leading BOM | Strips BOM (incorrect) | Preserves BOM (correct) |
| Valid UTF-8 without BOM | Identity | Identity |
| Invalid UTF-8 | Returns `nil` → force-unwrap traps | Substitutes U+FFFD per scalar |

By Rust's `String` invariant the third row is unreachable in correct code, so the only observable change is the BOM fix.

## Scope

- `lift` and `read` are the only changed call sites. `lower` and `write` were already correct – they go through `value.utf8`, which doesn't filter scalars.
- Other language backends are unaffected: `Charsets.UTF_8` (Kotlin), `bytes.decode("utf-8")` (Python), and `force_encoding("UTF-8")` (Ruby) all preserve a leading U+FEFF.

## Tests

Added `string_with_bom()` and `strings_with_bom()` to `fixtures/coverall` covering both converter paths (`lift` for top-level returns, `read` for elements inside a serialized `Vec<String>`), with matching assertions in `test_coverall.swift`.