### PR TITLE
Implement bindgen tests for ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 - Fixed bug that sometimes prevented renaming items inside a submodule [#2792](https://github.com/mozilla/uniffi-rs/pull/2792)
 - Exempted `UniFfiTag` from `clippy::exhaustive_structs` since downstream projects may depend on it [#2809](https://github.com/mozilla/uniffi-rs/pull/2809)
-- Ruby: Code for all kinds of enums and custom types is now correctly generated (#2880)
+- Ruby: Code for all kinds of enums and custom types is now correctly generated #2880 and #2891
 
 ### ⚠️ Breaking Changes for external bindings authors ⚠️
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,6 +1744,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-bindgen-tests-ruby"
+version = "0.31.0"
+dependencies = [
+ "camino",
+ "glob",
+ "uniffi",
+ "uniffi-bindgen-tests",
+]
+
+[[package]]
 name = "uniffi-bindgen-tests-swift"
 version = "0.31.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
   "bindgen-tests/kotlin/enum-payload-clash",
   "bindgen-tests/kotlin/keywords",
   "bindgen-tests/python",
+  "bindgen-tests/ruby",
   "bindgen-tests/swift",
   "bindgen-tests/swift/keywords",
   "bindgen-tests/swift/callbacks-omit-labels",

--- a/bindgen-tests/lib/uniffi.toml
+++ b/bindgen-tests/lib/uniffi.toml
@@ -20,6 +20,12 @@ type_name = "Dictionary<String, UInt64>"
 lift = "[\"value\": {}]"
 lower = "{}[\"value\"]!"
 
+[bindings.ruby.custom_types.CustomType2]
+# Use `Hash` as our custom type wrapper, since we can use it without having to import any types
+type_name = "Hash"
+lift = "{\"value\" => {}}"
+lower = "{}[\"value\"]"
+
 #
 # Rename configuration
 #
@@ -113,3 +119,32 @@ BindingObjectToRename = "SwiftObject"
 # Swift method and arg renaming
 "BindingObjectToRename.method" = "swift_method"
 "BindingObjectToRename.method.arg" = "swiftArg"
+
+[bindings.ruby.rename]
+binding_function_to_rename = "rb_function"
+"binding_function_to_rename.record" = "rb_record"
+
+BindingRecordToRename = "RbRecord"
+"BindingRecordToRename.item" = "rb_item"
+
+BindingEnumToRename = "RbEnum"
+"BindingEnumToRename.VariantA" = "RbVariantA"
+"BindingEnumToRename.Record" = "RbRecord"
+
+BindingEnumWithFieldsToRename = "RbEnumWithFields"
+"BindingEnumWithFieldsToRename.VariantA" = "RbVariantA"
+"BindingEnumWithFieldsToRename.VariantA.binding_int" = "rb_int"
+"BindingEnumWithFieldsToRename.Record" = "RbRecord"
+"BindingEnumWithFieldsToRename.Record.binding_record" = "rb_record"
+"BindingEnumWithFieldsToRename.Record.binding_int" = "rb_int"
+
+BindingErrorToRename = "RbError"
+"BindingErrorToRename.Simple" = "RbSimple"
+
+BindingTraitToRename = "RbTrait"
+"BindingTraitToRename.trait_method" = "rb_trait_method"
+
+BindingObjectToRename = "RbObject"
+"BindingObjectToRename.new.value" = "rb_value"
+"BindingObjectToRename.method" = "rb_method"
+"BindingObjectToRename.method.arg" = "rb_arg"

--- a/bindgen-tests/ruby/Cargo.toml
+++ b/bindgen-tests/ruby/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "uniffi-bindgen-tests-ruby"
+version = "0.31.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+camino = "1"
+glob = "0.3"
+uniffi = { path = "../../uniffi", features = ["bindgen"] }
+uniffi-bindgen-tests = { path = "../lib" }

--- a/bindgen-tests/ruby/src/lib.rs
+++ b/bindgen-tests/ruby/src/lib.rs
@@ -1,0 +1,133 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate uniffi_bindgen_tests;
+
+#[cfg(test)]
+mod test {
+    use std::{
+        env::{self},
+        ffi::OsString,
+        fs,
+        process::Command,
+        sync::OnceLock,
+    };
+
+    use camino::{Utf8Path, Utf8PathBuf};
+
+    use uniffi::TargetLanguage;
+    use uniffi_bindgen_tests::test_util;
+
+    #[test]
+    fn test_simple_fns() {
+        run_tests(test_dir(), "tests/simple_fns.rb");
+    }
+
+    #[test]
+    fn test_primitive_types() {
+        run_tests(test_dir(), "tests/primitive_types.rb");
+    }
+
+    #[test]
+    fn test_records() {
+        run_tests(test_dir(), "tests/records.rb");
+    }
+
+    #[test]
+    fn test_enums() {
+        run_tests(test_dir(), "tests/enums.rb");
+    }
+
+    #[test]
+    fn test_compound_types() {
+        run_tests(test_dir(), "tests/compound_types.rb");
+    }
+
+    #[test]
+    fn test_interfaces() {
+        run_tests(test_dir(), "tests/interfaces.rb");
+    }
+
+    #[test]
+    fn test_errors() {
+        run_tests(test_dir(), "tests/errors.rb");
+    }
+
+    #[test]
+    fn test_defaults() {
+        run_tests(test_dir(), "tests/defaults.rb");
+    }
+
+    #[test]
+    fn test_custom_types() {
+        run_tests(test_dir(), "tests/custom_types.rb");
+    }
+
+    #[test]
+    fn test_bytes() {
+        run_tests(test_dir(), "tests/bytes.rb");
+    }
+
+    #[test]
+    fn test_recursive_types() {
+        run_tests(test_dir(), "tests/recursive_types.rb");
+    }
+
+    #[test]
+    fn test_renames() {
+        run_tests(test_dir(), "tests/renames.rb");
+    }
+
+    #[test]
+    fn test_time() {
+        run_tests(test_dir(), "tests/time.rb");
+    }
+
+    #[test]
+    fn test_rust_traits() {
+        run_tests(test_dir(), "tests/rust_traits.rb");
+    }
+
+    fn test_dir() -> &'static Utf8Path {
+        static TEST_TEMPDIR: OnceLock<Utf8PathBuf> = OnceLock::new();
+        TEST_TEMPDIR.get_or_init(|| {
+            let temp_dir = test_util::setup_test_dir("ruby");
+            let lib_dir = temp_dir.join("lib");
+            fs::create_dir_all(&lib_dir).unwrap();
+            test_util::build_library(&lib_dir);
+            test_util::generate_sources(&lib_dir, TargetLanguage::Ruby);
+            test_util::copy_test_sources(&temp_dir, "tests/*.rb");
+            temp_dir
+        })
+    }
+
+    fn run_tests(tempdir: &Utf8Path, script_filename: &str) {
+        let lib_dir = tempdir.join("lib");
+        let script_path = tempdir.join(script_filename);
+        let rubypath = env::var_os("RUBYLIB").unwrap_or_else(|| OsString::from(""));
+        let rubypath = env::join_paths(
+            env::split_paths(&rubypath).chain(vec![lib_dir.to_path_buf().into_std_path_buf()]),
+        )
+        .unwrap();
+
+        let mut command = Command::new("ruby");
+        command
+            // Run from lib_dir so FFI finds the dylib in the current directory
+            .current_dir(lib_dir)
+            .env("RUBYLIB", rubypath)
+            .arg(script_path);
+
+        let output = command
+            .output()
+            .expect("Failed to spawn `ruby` when running test script");
+        print!("{}", String::from_utf8_lossy(&output.stdout));
+
+        if !output.status.success() {
+            println!("---------------------------------------- STDERR ----------------------------------------");
+            print!("{}", String::from_utf8_lossy(&output.stderr));
+            println!("----------------------------------------------------------------------------------------");
+            panic!("running `ruby` to run test script failed ({:?})", command);
+        }
+    }
+}

--- a/bindgen-tests/ruby/tests/bytes.rb
+++ b/bindgen-tests/ruby/tests/bytes.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_bindgen_tests'
+
+class TestBytes < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  def test_roundtrip_bytes
+    data = 'test-data'.b
+
+    assert_equal data, UniffiBindgenTests.roundtrip_bytes(data)
+  end
+
+  def test_roundtrip_empty_bytes
+    assert_equal ''.b, UniffiBindgenTests.roundtrip_bytes(''.b)
+  end
+
+  def test_roundtrip_binary_bytes
+    data = "\x00\x01\x02\xFF".b
+
+    assert_equal data, UniffiBindgenTests.roundtrip_bytes(data)
+  end
+
+  def test_bytes_encoding
+    result = UniffiBindgenTests.roundtrip_bytes('hello'.b)
+
+    assert_equal Encoding::BINARY, result.encoding
+  end
+end

--- a/bindgen-tests/ruby/tests/compound_types.rb
+++ b/bindgen-tests/ruby/tests/compound_types.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_bindgen_tests'
+
+class TestCompoundTypes < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  def test_option_name
+    assert_equal 42, UniffiBindgenTests.roundtrip_option(42)
+  end
+
+  def test_option_none
+    assert_nil UniffiBindgenTests.roundtrip_option(nil)
+  end
+
+  def test_vec
+    assert_equal [1, 2, 3], UniffiBindgenTests.roundtrip_vec([1, 2, 3])
+    assert_equal [], UniffiBindgenTests.roundtrip_vec([])
+  end
+
+  def test_hash_map
+    map = { 'a' => 1, 'b' => 2 }
+
+    assert_equal map, UniffiBindgenTests.roundtrip_hash_map(map)
+    assert_equal({}, UniffiBindgenTests.roundtrip_hash_map({}))
+  end
+
+  def test_complex_compound_some
+    inner = [{ 'x' => 10, 'y' => 20 }]
+
+    assert_equal inner, UniffiBindgenTests.roundtrip_complex_compound(inner)
+  end
+
+  def test_complex_compound_none
+    assert_nil UniffiBindgenTests.roundtrip_complex_compound(nil)
+  end
+end

--- a/bindgen-tests/ruby/tests/custom_types.rb
+++ b/bindgen-tests/ruby/tests/custom_types.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_bindgen_tests'
+
+class TestEnums < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  # CustomType1 has no foreign-side config: treat as raw u64
+  def test_custom_type1
+    assert_equal 100, UniffiBindgenTests.roundtrip_custom_type1(100)
+  end
+
+  # CustomType2 is lifted/lowered via a Ruby Hash per uniffi.toml Ruby config
+  def test_custom_type2
+    assert_equal({ 'value' => 200 }, UniffiBindgenTests.roundtrip_custom_type2({ 'value' => 200 }))
+  end
+end

--- a/bindgen-tests/ruby/tests/defaults.rb
+++ b/bindgen-tests/ruby/tests/defaults.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_bindgen_tests'
+
+class TestDefaults < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  def test_record_with_defaults
+    rec = RecWithDefault.new
+
+    assert_equal 42, rec.n
+    assert_equal [], rec.v
+  end
+
+  def test_record_override_defaults
+    rec = RecWithDefault.new(n: 123, v: [1, 2, 3])
+
+    assert_equal 123, rec.n
+    assert_equal [1, 2, 3], rec.v
+  end
+
+  def test_enum_other_variant_default_fields
+    en = EnumWithDefault::OTHER_VARIANT.new
+
+    assert_equal 'default', en.a
+  end
+
+  def test_enum_other_variant_override
+    en = EnumWithDefault::OTHER_VARIANT.new(a: 'override')
+
+    assert_equal 'override', en.a
+  end
+
+  def test_func_with_default
+    assert_equal 'DEFAULT', UniffiBindgenTests.func_with_default
+  end
+
+  def test_func_with_default_override
+    assert_equal 'NON-DEFAULT', UniffiBindgenTests.func_with_default('NON-DEFAULT')
+  end
+
+  def test_interface_method_with_default
+    iface = InterfaceWithDefaults.new
+
+    assert_equal 'DEFAULT', iface.method_with_default
+  end
+
+  def test_interface_method_with_default_override
+    iface = InterfaceWithDefaults.new
+
+    assert_equal 'NON-DEFAULT', iface.method_with_default('NON-DEFAULT')
+  end
+end

--- a/bindgen-tests/ruby/tests/enums.rb
+++ b/bindgen-tests/ruby/tests/enums.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_bindgen_tests'
+
+class TestEnums < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  # --- EnumWithData (flat enum) ---
+
+  def test_enum_no_data_roundtrip
+    assert_equal EnumNoData::A, UniffiBindgenTests.roundtrip_enum_no_data(EnumNoData::A)
+    assert_equal EnumNoData::B, UniffiBindgenTests.roundtrip_enum_no_data(EnumNoData::B)
+    assert_equal EnumNoData::C, UniffiBindgenTests.roundtrip_enum_no_data(EnumNoData::C)
+  end
+
+  def test_enum_no_data_distinct
+    assert_not_equal EnumNoData::A, EnumNoData::B
+    assert_not_equal EnumNoData::A, EnumNoData::C
+  end
+
+  # --- EnumWithData (non-flat enum) ---
+  def test_enum_with_data_named_variant
+    em = EnumWithData::A.new value: 10, value2: 20
+    result = UniffiBindgenTests.roundtrip_enum_with_data(em)
+
+    assert_kind_of EnumWithData::A, result
+    assert_equal 10, result.value
+    assert_equal 20, result.value2
+  end
+
+  def test_enum_with_data_tuple_variant
+    en = EnumWithData::B.new 'hello', 42
+    result = UniffiBindgenTests.roundtrip_enum_with_data(en)
+
+    assert_kind_of EnumWithData::B, result
+    assert_equal 'hello', result[0]
+    assert_equal 42, result[1]
+  end
+
+  def test_enum_with_data_empty_variant
+    # C has no data but lives is a non-flat enum - still a class
+    en = EnumWithData::C.new
+    result = UniffiBindgenTests.roundtrip_enum_with_data(en)
+
+    assert_kind_of EnumWithData::C, result
+  end
+
+  # --- ComplexEnum ---
+
+  def test_complex_enum_a
+    inner = EnumNoData::B
+    en = ComplexEnum::A.new value: inner
+    result = UniffiBindgenTests.roundtrip_complex_enum(en)
+
+    assert_kind_of ComplexEnum::A, result
+    assert_equal EnumNoData::B, result.value
+  end
+
+  def test_complex_enum_b
+    inner = EnumWithData::A.new value: 5, value2: 6
+    en = ComplexEnum::B.new value: inner
+    result = UniffiBindgenTests.roundtrip_complex_enum(en)
+
+    assert_kind_of ComplexEnum::B, result
+    assert_kind_of EnumWithData::A, result.value
+    assert_equal 5, result.value.value
+    assert_equal 6, result.value.value2
+  end
+
+  def test_complex_enum_c
+    inner = SimpleRec.new a: 77
+    en = ComplexEnum::C.new value: inner
+    result = UniffiBindgenTests.roundtrip_complex_enum(en)
+
+    assert_kind_of ComplexEnum::C, result
+    assert_kind_of SimpleRec, result.value
+    assert_equal 77, result.value.a
+  end
+
+  # --- ExplicitValuedEnum ---
+
+  # ExplicitValuedEnum is a separate type from EnumNoData - just verify constants exists and differ
+  def test_explicit_valued_enum_roundtrip
+    assert_not_nil ExplicitValuedEnum::FIRST
+    assert_not_nil ExplicitValuedEnum::SECOND
+    assert_not_nil ExplicitValuedEnum::FOURTH
+    assert_not_nil ExplicitValuedEnum::TENTH
+    assert_not_nil ExplicitValuedEnum::ELEVENTH
+    assert_not_nil ExplicitValuedEnum::THIRTEENTH
+  end
+
+  def test_explicit_valued_enum_distinct
+    assert_not_equal ExplicitValuedEnum::FIRST, ExplicitValuedEnum::SECOND
+    assert_not_equal ExplicitValuedEnum::SECOND, ExplicitValuedEnum::FOURTH
+    assert_not_equal ExplicitValuedEnum::THIRTEENTH, ExplicitValuedEnum::TENTH
+  end
+
+  # --- GappedEnum (flat) ---
+
+  # GappedEnum is a separate type - just verify constants exists
+  def test_gapped_enum_roundtrip
+    assert_not_nil GappedEnum::ONE
+    assert_not_nil GappedEnum::TWO
+    assert_not_nil GappedEnum::THREE
+  end
+
+  def test_gapped_enum_distinct
+    assert_not_equal GappedEnum::ONE, GappedEnum::TWO
+    assert_not_equal GappedEnum::TWO, GappedEnum::THREE
+  end
+end

--- a/bindgen-tests/ruby/tests/errors.rb
+++ b/bindgen-tests/ruby/tests/errors.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_bindgen_tests'
+
+class TestErrors < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  def test_failure1
+    err = assert_raises(TestError::Failure1) { UniffiBindgenTests.func_with_error(0) }
+
+    assert_kind_of TestError::Failure1, err
+  end
+
+  def test_failure2
+    err = assert_raises(TestError::Failure2) { UniffiBindgenTests.func_with_error(1) }
+
+    assert_kind_of TestError::Failure2, err
+    assert_equal 'DATA', err.data
+  end
+
+  def test_failure3
+    err = assert_raises(TestError::Failure3) { UniffiBindgenTests.func_with_error(50) }
+
+    assert_kind_of TestError::Failure3, err
+    assert_equal 50, err[0]
+  end
+
+  def test_flat_error
+    assert_raises(TestFlatError::IoError) { UniffiBindgenTests.func_with_flat_error(0) }
+  end
+
+  # Should not raise
+  def test_success
+    UniffiBindgenTests.func_with_error 100
+    UniffiBindgenTests.func_with_flat_error 1
+  end
+
+  # All variants are subclasses of StandardError
+  def test_error_hierarchy
+    assert TestError::Failure1 < StandardError
+    assert TestError::Failure2 < StandardError
+    assert TestError::Failure3 < StandardError
+    assert TestFlatError::IoError < StandardError
+  end
+
+  def test_rescue_by_base_class
+    rescued = false
+
+    begin
+      UniffiBindgenTests.func_with_error(0)
+    rescue StandardError
+      rescued = true
+    end
+
+    assert rescued
+  end
+end

--- a/bindgen-tests/ruby/tests/interfaces.rb
+++ b/bindgen-tests/ruby/tests/interfaces.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_bindgen_tests'
+
+class TestInterfaces < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  def test_basic_interface
+    iface = TestInterface.new 20
+
+    assert_equal 20, iface.get_value
+  end
+
+  def test_clone_interface
+    iface = TestInterface.new 20
+    cloned = UniffiBindgenTests.clone_interface iface
+
+    assert_equal 20, cloned.get_value
+  end
+
+  def test_secondary_constructor
+    iface = TestInterface.secondary_constructor 20
+
+    assert_equal 40, iface.get_value
+  end
+
+  def test_records_with_interface_fields
+    two = TwoTestInterfaces.new(
+      first: TestInterface.new(1),
+      second: TestInterface.new(2)
+    )
+    swapped = UniffiBindgenTests.swap_test_interfaces two
+
+    assert_equal 2, swapped.first.get_value
+    assert_equal 1, swapped.second.get_value
+  end
+
+  def test_enums_with_intefaces
+    one = TestInterfaceEnum::ONE.new i: TestInterface.new(1)
+    two = TestInterfaceEnum::TWO.new i: TestInterface.new(2)
+
+    assert_equal 1, one.i.get_value
+    assert_equal 2, two.i.get_value
+  end
+
+  def test_interface_ref_count
+    iface = TestInterface.new 42
+
+    # Single reference
+    assert_equal 1, iface.ref_count
+
+    # After clone there are 2 references: the original and the clone still alive in scope
+    UniffiBindgenTests.clone_interface iface
+    assert_equal 2, iface.ref_count
+
+    # Drop the clone
+    nil
+    GC.start
+
+    # After GC, back to 1 referece held by `iface`
+    assert_equal 1, iface.ref_count
+  end
+
+  def test_multi_word_arg
+    iface = TestInterface.new 0
+
+    assert_equal 'test', iface.method_with_multi_word_arg('test')
+  end
+end

--- a/bindgen-tests/ruby/tests/primitive_types.rb
+++ b/bindgen-tests/ruby/tests/primitive_types.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_bindgen_tests'
+
+class TestPrimitiveTypes < Test::Unit::TestCase
+  def test_input
+    UniffiBindgenTests.input_u8 255
+    UniffiBindgenTests.input_i8(-128)
+    UniffiBindgenTests.input_u16 65_535
+    UniffiBindgenTests.input_i16(-32_768)
+    UniffiBindgenTests.input_u32 4_294_967_295
+    UniffiBindgenTests.input_i32(-2_147_483_648)
+    UniffiBindgenTests.input_u64 18_446_744_073_709_551_615
+    UniffiBindgenTests.input_i64(-9_223_372_036_854_775_808)
+    UniffiBindgenTests.input_f32 3.14
+    UniffiBindgenTests.input_f64 3.141_592_653_589_793
+    UniffiBindgenTests.input_bool true
+    UniffiBindgenTests.input_string 'test-string'
+  end
+
+  def test_output
+    assert_equal 1, UniffiBindgenTests.output_u8
+    assert_equal 1, UniffiBindgenTests.output_i8
+    assert_equal 1, UniffiBindgenTests.output_u16
+    assert_equal 1, UniffiBindgenTests.output_i16
+    assert_equal 1, UniffiBindgenTests.output_u32
+    assert_equal 1, UniffiBindgenTests.output_i32
+    assert_equal 1, UniffiBindgenTests.output_u64
+    assert_equal 1, UniffiBindgenTests.output_i64
+    assert_in_delta 1.0, UniffiBindgenTests.output_f32, 0.0001
+    assert_in_delta 1.0, UniffiBindgenTests.output_f64, 0.0001
+    assert_equal UniffiBindgenTests.output_bool, true
+    assert_equal UniffiBindgenTests.output_string, 'test-string'
+  end
+
+  def test_roundtrip
+    assert_equal 42, UniffiBindgenTests.roundtrip_u8(42)
+    assert_equal(-42, UniffiBindgenTests.roundtrip_i8(-42))
+    assert_equal 1000, UniffiBindgenTests.roundtrip_u16(1000)
+    assert_equal(-1000, UniffiBindgenTests.roundtrip_i16(-1000))
+    assert_equal 1_000_000, UniffiBindgenTests.roundtrip_u32(1_000_000)
+    assert_equal(-1_000_000, UniffiBindgenTests.roundtrip_i32(-1_000_000))
+    assert_equal 1_000_000_000, UniffiBindgenTests.roundtrip_u64(1_000_000_000)
+    assert_equal(-1_000_000_000, UniffiBindgenTests.roundtrip_i64(-1_000_000_000))
+    assert_in_delta 3.14, UniffiBindgenTests.roundtrip_f32(3.14), 0.0001
+    assert_in_delta 3.141_592, UniffiBindgenTests.roundtrip_f64(3.141_592), 0.000_001
+    assert UniffiBindgenTests.roundtrip_bool(true)
+    assert !UniffiBindgenTests.roundtrip_bool(false)
+    assert_equal 'test-string', UniffiBindgenTests.roundtrip_string('test-string')
+  end
+
+  def test_sum_with_many_types
+    result = UniffiBindgenTests.sum_with_many_types 1, -2, 3, -4, 5, -6, 7, -8, 9.5, -10.5, true
+
+    assert_in_delta 5.0, result, 0.0001
+  end
+
+  def test_func_with_multi_word_arg
+    assert_equal 16, UniffiBindgenTests.func_with_multi_word_arg(16)
+  end
+end

--- a/bindgen-tests/ruby/tests/records.rb
+++ b/bindgen-tests/ruby/tests/records.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_bindgen_tests'
+
+class TestRecords < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  def test_simple_rec
+    rec = SimpleRec.new a: 42
+    result = UniffiBindgenTests.roundtrip_simple_rec rec
+
+    assert_equal 42, result.a
+  end
+
+  def test_unit_rec
+    assert_equal UnitRec.new, UnitRec.new
+  end
+
+  def test_complex_rec
+    rec = ComplexRec.new(
+      field_u8: 1,
+      field_i8: -1,
+      field_u16: 1000,
+      field_i16: -1000,
+      field_u32: 100_000,
+      field_i32: -100_000,
+      field_u64: 10_000_000_000,
+      field_i64: -10_000_000_000,
+      field_f32: 1.5,
+      field_f64: 3.141_592_653_589_793,
+      field_string: 'hello world',
+      field_rec: SimpleRec.new(a: 99)
+    )
+
+    result = UniffiBindgenTests.roundtrip_complex_rec rec
+
+    assert_equal 1, result.field_u8
+    assert_equal(-1, result.field_i8)
+    assert_equal 1000, result.field_u16
+    assert_equal(-1000, result.field_i16)
+    assert_equal 100_000, result.field_u32
+    assert_equal(-100_000, result.field_i32)
+    assert_equal 10_000_000_000, result.field_u64
+    assert_equal(-10_000_000_000, result.field_i64)
+    assert_in_delta 1.5, result.field_f32, 0.001
+    assert_in_delta 3.141_592_653_589_793, result.field_f64, 0.000_000_001
+    assert_equal 'hello world', result.field_string
+    assert_equal 99, result.field_rec.a
+  end
+end

--- a/bindgen-tests/ruby/tests/recursive_types.rb
+++ b/bindgen-tests/ruby/tests/recursive_types.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_bindgen_tests'
+
+class TestRecursiveTypes < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  # --- Self-recursive tree ---
+
+  def test_tree_leaf
+    assert_equal 42, UniffiBindgenTests.sum_tree(Tree::LEAF.new(42))
+  end
+
+  def test_tree_node
+    tree = Tree::NODE.new(
+      left: Tree::LEAF.new(1),
+      right: Tree::LEAF.new(2)
+    )
+
+    assert_equal 3, UniffiBindgenTests.sum_tree(tree)
+  end
+
+  def test_tree_nested
+    tree = Tree::NODE.new(
+      left: Tree::NODE.new(
+        left: Tree::LEAF.new(1),
+        right: Tree::LEAF.new(2)
+      ),
+      right: Tree::LEAF.new(3)
+    )
+
+    assert_equal 6, UniffiBindgenTests.sum_tree(tree)
+  end
+
+  # --- Mutally recursive Expr / BoolExpr ---
+
+  def test_expr_lit
+    assert_equal 42, UniffiBindgenTests.eval_expr(Expr::LIT.new(42))
+  end
+
+  def test_expr_if_true
+    expr = Expr::IF.new(
+      cond: BoolExpr::TRUE.new,
+      _then: Expr::LIT.new(1),
+      _else: Expr::LIT.new(0)
+    )
+
+    assert_equal 1, UniffiBindgenTests.eval_expr(expr)
+  end
+
+  def test_expr_if_false
+    expr = Expr::IF.new(
+      cond: BoolExpr::FALSE.new,
+      _then: Expr::LIT.new(1),
+      _else: Expr::LIT.new(0)
+    )
+
+    assert_equal 0, UniffiBindgenTests.eval_expr(expr)
+  end
+
+  def test_bool_not
+    assert UniffiBindgenTests.eval_bool(BoolExpr::NOT.new(BoolExpr::FALSE.new))
+    assert !UniffiBindgenTests.eval_bool(BoolExpr::NOT.new(BoolExpr::TRUE.new))
+  end
+
+  def test_bool_is_zero
+    assert UniffiBindgenTests.eval_bool(BoolExpr::IS_ZERO.new(Expr::LIT.new(0)))
+    assert !UniffiBindgenTests.eval_bool(BoolExpr::IS_ZERO.new(Expr::LIT.new(5)))
+  end
+
+  # --- LinkedList ---
+
+  def test_linked_list_nil
+    assert_equal 0, UniffiBindgenTests.list_sum(LinkedList::NIL.new)
+  end
+
+  def test_linked_list_single
+    list = LinkedList::CONS.new head: 5, tail: nil
+
+    assert_equal 5, UniffiBindgenTests.list_sum(list)
+  end
+
+  def test_linked_list_multiple
+    list = LinkedList::CONS.new(
+      head: 1,
+      tail: LinkedList::CONS.new(
+        head: 2,
+        tail: LinkedList::CONS.new(head: 3, tail: nil)
+      )
+    )
+
+    assert_equal 6, UniffiBindgenTests.list_sum(list)
+  end
+
+  # -- Trie --
+
+  def test_trie_leaf
+    assert_equal 10, UniffiBindgenTests.trie_sum(Trie::LEAF.new(10))
+  end
+
+  def test_trie_branch
+    trie = Trie::BRANCH.new(children: {
+                              'a' => Trie::LEAF.new(1),
+                              'b' => Trie::LEAF.new(2)
+                            })
+
+    assert_equal 3, UniffiBindgenTests.trie_sum(trie)
+  end
+
+  # -- RoseTree --
+
+  def test_rose_tree_leaf
+    assert_equal 5, UniffiBindgenTests.sum_rose_tree(RoseTree::LEAF.new(5))
+  end
+
+  def test_rose_tree_branch
+    tree = RoseTree::BRANCH.new(
+      RoseData.new(
+        value: 1,
+        children: [
+          RoseTree::LEAF.new(2),
+          RoseTree::LEAF.new(3)
+        ]
+      )
+    )
+
+    assert_equal 6, UniffiBindgenTests.sum_rose_tree(tree)
+  end
+
+  # --- Recursive EvalError ---
+
+  def test_maybe_throw_no_error
+    assert_equal 42, UniffiBindgenTests.maybe_throw_error(false)
+  end
+
+  def test_maybe_throw_error
+    assert_raises(EvalError::Nested) { UniffiBindgenTests.maybe_throw_error(true) }
+  end
+end

--- a/bindgen-tests/ruby/tests/renames.rb
+++ b/bindgen-tests/ruby/tests/renames.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_bindgen_tests'
+
+class TestRenames < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  # Rust-side renames via #[uniffi(name = ...)] ---
+
+  def test_rename_record
+    rec = RenamedRecord.new item: 42
+    assert_equal 42, rec.item
+  end
+
+  def test_rename_enum
+    rec = RenamedRecord.new item: 42
+    result = UniffiBindgenTests.renamed_function rec
+
+    assert_kind_of RenamedEnum::RECORD, result
+    assert_equal rec.item, result[0].item
+  end
+
+  def test_renamed_enum_variant
+    variant = RenamedEnum::RENAMED_VARIANT.new
+
+    assert_kind_of RenamedEnum::RENAMED_VARIANT, variant
+  end
+
+  def test_rename_object
+    obj = RenamedObject.renamed_constructor 123
+
+    assert_equal 123, obj.renamed_method
+  end
+
+  def test_rename_trait
+    impl = UniffiBindgenTests.create_trait_impl 5
+
+    assert_equal 50, impl.renamed_trait_method(10)
+  end
+
+  # --- Binding-specific renames via uniffi.toml [bindings.ruby.rename] ---
+
+  def test_rb_record
+    rec = RbRecord.new rb_item: 100
+
+    assert_equal 100, rec.rb_item
+  end
+
+  def test_rb_enum
+    assert_kind_of RbEnum::RB_VARIANT_A, RbEnum::RB_VARIANT_A.new
+
+    rec = RbRecord.new rb_item: 7
+    result = RbEnum::RB_RECORD.new rec
+
+    assert_equal 7, result[0].rb_item
+  end
+
+  def test_rb_enum_with_fields
+    va = RbEnumWithFields::RB_VARIANT_A.new rb_int: 5
+    assert_equal 5, va.rb_int
+
+    rec = RbRecord.new rb_item: 3
+    vr = RbEnumWithFields::RB_RECORD.new rb_record: rec, rb_int: 9
+
+    assert_equal 3, vr.rb_record.rb_item
+    assert_equal 9, vr.rb_int
+  end
+
+  def test_rb_function
+    rec = RbRecord.new rb_item: 100
+    result = UniffiBindgenTests.rb_function rec
+
+    assert_kind_of RbEnum::RB_RECORD, result
+    assert_equal 100, result[0].rb_item
+  end
+
+  def test_rb_function_raises
+    assert_raises(RbError::RbSimple) { UniffiBindgenTests.rb_function nil }
+  end
+
+  def test_rb_object
+    obj = RbObject.new 200
+
+    assert_equal 250, obj.rb_method(50)
+  end
+
+  def test_rb_trait
+    impl = UniffiBindgenTests.create_binding_trait_to_rename_impl 3
+
+    assert_equal 21, impl.rb_trait_method(7)
+  end
+end

--- a/bindgen-tests/ruby/tests/rust_traits.rb
+++ b/bindgen-tests/ruby/tests/rust_traits.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_bindgen_tests'
+
+class TestRustTraits < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  def test_debug
+    trait_test = RustTraitTest.new(a: 1, b: 2)
+    assert_equal 'debug-test-string', trait_test.inspect
+  end
+
+  def test_display
+    trait_test = RustTraitTest.new(a: 1, b: 2)
+    assert_equal 'display-test-string', trait_test.to_s
+  end
+
+  def test_eq
+    # The Rust code only uses `a` for the equality
+    assert_equal RustTraitTest.new(a: 1, b: 2), RustTraitTest.new(a: 1, b: 3)
+    assert_not_equal RustTraitTest.new(a: 2, b: 2), RustTraitTest.new(a: 1, b: 2)
+  end
+
+  def test_ord
+    # The Rust code only uses `a` for the ordering
+    assert RustTraitTest.new(a: 1, b: 2) < RustTraitTest.new(a: 2, b: 3)
+    assert RustTraitTest.new(a: 2, b: 3) > RustTraitTest.new(a: 1, b: 2)
+    assert RustTraitTest.new(a: 1, b: 2) <= RustTraitTest.new(a: 1, b: 2)
+    assert RustTraitTest.new(a: 1, b: 2) >= RustTraitTest.new(a: 1, b: 2)
+  end
+
+  def test_hash
+    # The Rust code only uses `a` for the hash
+    assert_equal RustTraitTest.new(a: 1, b: 2).hash, RustTraitTest.new(a: 1, b: 2).hash
+    assert_not_equal RustTraitTest.new(a: 1, b: 2).hash, RustTraitTest.new(a: 2, b: 2).hash
+  end
+
+  def test_hash_fn
+    # rust_trait_test_hash should match Ruby's hash based on `a` only
+    assert_equal(
+      UniffiBindgenTests.rust_trait_test_hash(RustTraitTest.new(a: 1, b: 2)), 
+      UniffiBindgenTests.rust_trait_test_hash(RustTraitTest.new(a: 1, b: 3))
+    )
+
+    assert_not_equal(
+      UniffiBindgenTests.rust_trait_test_hash(RustTraitTest.new(a: 1, b: 2)), 
+      UniffiBindgenTests.rust_trait_test_hash(RustTraitTest.new(a: 2, b: 2))
+    )
+  end
+end

--- a/bindgen-tests/ruby/tests/simple_fns.rb
+++ b/bindgen-tests/ruby/tests/simple_fns.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_bindgen_tests'
+
+class TestSimpleFns < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  def test_func
+    assert_nothing_raised { UniffiBindgenTests.test_func }
+  end
+
+  def test_unexpected_error_func
+    # Rust panics are wrapped in UniffiBindgenTests::InternalError
+    assert_raise(UniffiBindgenTests::InternalError) do
+      UniffiBindgenTests.test_unexpected_error_func
+    end
+  end
+end

--- a/bindgen-tests/ruby/tests/time.rb
+++ b/bindgen-tests/ruby/tests/time.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_bindgen_tests'
+
+# In Ruby, both Duration and SystemTime are represented as Ruby Time objects.
+# Duration must have a non-negative tv_sec.
+# SystemTime maps to a UTC Time around the Unix epoch.
+
+class TestTime < Test::Unit::TestCase
+  UTC = '+00:00'
+
+  include UniffiBindgenTests
+
+  def test_roundtrip_duration_whole_seconds
+    dur = Time.at(3600, 0, :nanosecond, in: UTC).utc
+
+    result = UniffiBindgenTests.roundtrip_duration dur
+
+    assert_equal dur.tv_sec, result.tv_sec
+    assert_equal dur.tv_nsec, result.tv_nsec
+  end
+
+  def test_roundtrip_duration_with_nanoseconds
+    dur = Time.at(3600, 500_000_000, :nanosecond, in: UTC).utc
+    result = UniffiBindgenTests.roundtrip_duration dur
+
+    assert_equal dur.tv_sec, result.tv_sec
+    assert_equal dur.tv_nsec, result.tv_nsec
+  end
+
+  def test_roundtrip_duration_zero
+    dur = Time.at(0, 0, :nanosecond, in: UTC).utc
+    result = UniffiBindgenTests.roundtrip_duration dur
+
+    assert_equal dur.tv_sec, result.tv_sec
+    assert_equal dur.tv_nsec, result.tv_nsec
+  end
+
+  def test_roundtrip_duration_negative_raises
+    assert_raises(ArgumentError) do
+      UniffiBindgenTests.roundtrip_duration Time.at(-1, 0, :nanosecond, in: UTC).utc
+    end
+  end
+
+  def test_roundtrip_systemtime_epoch
+    t = Time.at(0, 0, :nanosecond, in: UTC).utc
+    result = UniffiBindgenTests.roundtrip_systemtime t
+
+    assert_equal 0, result.tv_sec
+    assert_equal 0, result.tv_nsec
+  end
+
+  def test_roundtrip_systemtime_post_epoch
+    # 2019-01-01 00:00:00 UTC
+    t = Time.at(1_546_340_800, 0, :nanosecond, in: UTC).utc
+    result = UniffiBindgenTests.roundtrip_systemtime t
+
+    assert_equal t.tv_sec, result.tv_sec
+    assert_equal t.tv_nsec, result.tv_nsec
+  end
+
+  def test_roundtrip_systemtime_with_nanoseconds
+    t = Time.at(1_546_340_800, 123_456_789, :nanosecond, in: UTC).utc
+    result = UniffiBindgenTests.roundtrip_systemtime t
+
+    assert_equal t.tv_sec, result.tv_sec
+    assert_equal t.tv_nsec, result.tv_nsec
+  end
+
+  def test_roundtrip_systemtime_pre_epoch
+    # 1 second before the epoch, no subsecond precision
+    t = Time.at(-1, 0, :nanosecond, in: UTC).utc
+    result = UniffiBindgenTests.roundtrip_systemtime t
+
+    assert_equal t.tv_sec, result.tv_sec
+    assert_equal t.tv_nsec, result.tv_nsec
+  end
+
+  def test_roundtrip_systemtime_pre_epoch_with_nanoseconds
+    # 2 second before the epoch, with subsecond precision
+    t = Time.at(-2, 500_000_000, :nanosecond, in: UTC).utc
+    result = UniffiBindgenTests.roundtrip_systemtime t
+
+    assert_equal t.tv_sec, result.tv_sec
+    assert_equal t.tv_nsec, result.tv_nsec
+  end
+end

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -312,10 +312,10 @@ mod filters {
 
     #[askama::filter_fn]
     pub fn var_name_rb(nm: &str, _: &dyn askama::Values) -> Result<String, askama::Error> {
-        let nm = nm.to_string();
-        let prefix = if is_reserved_word(&nm) { "_" } else { "" };
+        let snake = nm.to_string().to_snake_case();
+        let prefix = if is_reserved_word(&snake) { "_" } else { "" };
 
-        Ok(format!("{prefix}{}", nm.to_snake_case()))
+        Ok(format!("{prefix}{snake}"))
     }
 
     #[askama::filter_fn]
@@ -517,12 +517,12 @@ mod filters {
 
     #[askama::filter_fn]
     pub fn lower_rb(
-        nm: &str,
+        nm: impl AsRef<str>,
         _: &dyn askama::Values,
         type_: &Type,
         config: &Config,
     ) -> Result<String, askama::Error> {
-        lower_rb_inner(nm, type_, &config.custom_types)
+        lower_rb_inner(nm.as_ref(), type_, &config.custom_types)
     }
 
     fn lift_rb_inner(

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
@@ -158,7 +158,7 @@ class RustBuffer < FFI::Struct
     if v.{{ variant.name()|var_name_rb }}?
       {%- for field in variant.fields() %}
       {%- if field.name().is_empty() %}
-        {{ "v.v{}"|format(loop.index)|check_lower_rb(field.as_type().borrow(), config) }}
+        {{ "v.values[{}]"|format(loop.index0)|check_lower_rb(field.as_type().borrow(), config) }}
       {%- else %}
         {{ "v.{}"|format(field.name())|check_lower_rb(field.as_type().borrow(), config) }}
       {%- endif %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
@@ -66,7 +66,7 @@ values[{{- field_num - 1 -}}]
 
 {%- macro _arg_list_ffi_call(func) %}
     {%- for arg in func.arguments() %}
-        {{- arg.name()|lower_rb(arg.as_type().borrow(), config) }}
+        {{- arg.name()|var_name_rb|lower_rb(arg.as_type().borrow(), config) }}
         {%- if !loop.last %},{% endif %}
     {%- endfor %}
 {%- endmacro -%}
@@ -97,14 +97,14 @@ values[{{- field_num - 1 -}}]
 
 {%- macro setup_args(func) %}
     {%- for arg in func.arguments() %}
-    {{ arg.name() }} = {{ arg.name()|coerce_rb(ci.namespace()|class_name_rb, arg.as_type().borrow(), config) }}
-    {{ arg.name()|check_lower_rb(arg.as_type().borrow(), config) }}
+    {{ arg.name()|var_name_rb }} = {{ arg.name()|var_name_rb|coerce_rb(ci.namespace()|class_name_rb, arg.as_type().borrow(), config) }}
+    {{ arg.name()|var_name_rb|check_lower_rb(arg.as_type().borrow(), config) }}
     {% endfor -%}
 {%- endmacro -%}
 
 {%- macro setup_args_extra_indent(meth) %}
         {%- for arg in meth.arguments() %}
-        {{ arg.name() }} = {{ arg.name()|coerce_rb(ci.namespace()|class_name_rb, arg.as_type().borrow(), config) }}
-        {{ arg.name()|check_lower_rb(arg.as_type().borrow(), config) }}
+        {{ arg.name()|var_name_rb }} = {{ arg.name()|var_name_rb|coerce_rb(ci.namespace()|class_name_rb, arg.as_type().borrow(), config) }}
+        {{ arg.name()|var_name_rb|check_lower_rb(arg.as_type().borrow(), config) }}
         {%- endfor %}
 {%- endmacro -%}


### PR DESCRIPTION
This PR implements ruby tests for `bindgen-tests` (as @bendk [recommended earlier](https://github.com/mozilla/uniffi-rs/pull/2883#pullrequestreview-4228255236)). New tests have exposed few small bugs in codegen for certain edge cases, I fixed those.

Kudos to the team for implementing `bindgen-tests`, these tests run much faster and are easier to use!

Not all of the features are implemented yet, I'm still working on callbacks. Moving forward I'll be adding `bindgen-tests` for new features.

Thank you!