### PR TITLE
Rust: Don't specify the targets

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,12 +6,4 @@
 
 [toolchain]
 channel = "1.90.0"
-targets = [
-    "aarch64-linux-android",
-    "armv7-linux-androideabi",
-    "i686-linux-android",
-    "x86_64-linux-android",
-    "aarch64-apple-ios",
-    "x86_64-apple-ios"
-]
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Specifying the targets causes rustup to install them. We never actually build against all of them and are thus just wasting disk space and download time for devs and on CI.