### PR TITLE
Re-do the Docker image, now based on the Swift image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - build-api-docs
   Rust and Foreign Language tests:
     docker:
-      - image: janerik/uniffi-ci-test:latest
+      - image: janerik/uniffi-ci-test:2026.05
     resource_class: large
     steps:
       - run: cat ~/.profile >> $BASH_ENV
@@ -105,14 +105,14 @@ jobs:
       - run:
           name: mypy Python typechecks
           command: |
-            pip install mypy
+            uv tool install mypy
             for file in $(find target -name "*.py" ! -name "recursive_types.py"); do
               mypy "$file";
             done
 
   Rust and Foreign Language tests - min supported rust:
     docker:
-      - image: janerik/uniffi-ci-test:latest
+      - image: janerik/uniffi-ci-test:2026.05
     resource_class: large
     steps:
       - run: cat ~/.profile >> $BASH_ENV

--- a/docker/Dockerfile-build
+++ b/docker/Dockerfile-build
@@ -5,53 +5,73 @@
 # This builds a docker image containing all the tools we need to run our
 # test suite in CI, including rust, kotlin, and swift.
 
-FROM cimg/rust:1.69.0
+FROM swift:6.3-noble
 
-MAINTAINER Ryan Kelly "rfkelly@mozilla.com"
+SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
 
-ENV \
-    # Some APT packages like 'tzdata' wait for user input on install by default.
-    # https://stackoverflow.com/questions/44331836/apt-get-install-tzdata-noninteractive
-    DEBIAN_FRONTEND=noninteractive
+# via https://github.com/CircleCI-Public/cimg-base/blob/28e038550d165a5e421a1ffada523ebe11ad525f/24.04/Dockerfile
+ENV DEBIAN_FRONTEND=noninteractive \
+    TERM=dumb \
+    PAGER=cat
 
-SHELL ["/bin/bash", "-c"]
+# Configure environment
+RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
+	echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci && \
+	apt-get update && apt-get install -y \
+		curl \
+		locales \
+		sudo \
+		openjdk-21-jdk-headless \
+		ruby \
+		ruby-dev \
+		unzip \
+		zip \
+		git \
+		build-essential \
+		clang \
+	&& \
+	locale-gen en_US.UTF-8 && \
+	rm -rf /var/lib/apt/lists/* && \
+	\
+	groupadd --gid=1002 circleci && \
+	useradd --uid=1001 --gid=circleci --create-home circleci && \
+	echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci && \
+	echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep && \
+	sudo -u circleci mkdir /home/circleci/project && \
+	sudo -u circleci mkdir /home/circleci/bin && \
+	sudo -u circleci mkdir -p /home/circleci/.local/bin && \
+	\
+	dockerizeArch=arm64 && \
+	if uname -p | grep "x86_64"; then \
+		dockerizeArch=x86_64; \
+	fi && \
+	curl -sSL --fail --retry 3 --output /usr/local/bin/dockerize "https://github.com/powerman/dockerize/releases/download/v0.8.0/dockerize-linux-${dockerizeArch}" && \
+	chmod +x /usr/local/bin/dockerize && \
+	dockerize --version
 
-# already installed in cimg: libcurl4, python3, git, curl, unzip, g++
-RUN sudo apt-get update -qq \
-    && sudo apt-get install -qy --no-install-recommends \
-        clang \
-        openjdk-11-jdk-headless \
-        ruby \
-        ruby-dev \
-        # Swift dependencies
-        libtinfo5 \
-        libncurses5 \
-        python3-pip \
-    && sudo apt-get clean
+ENV PATH=/home/circleci/bin:/home/circleci/.local/bin:$PATH \
+	LANG=en_US.UTF-8 \
+	LANGUAGE=en_US:en \
+	LC_ALL=en_US.UTF-8
 
-# Use Cargo's sparse protocol
-ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+USER circleci
+# opt-out of the new security feature, not needed in a CI environment
+RUN git config --global --add safe.directory '*'
+
+# Match the default CircleCI working directory
+WORKDIR /home/circleci/project
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh -s && \
+  /home/circleci/.local/bin/uv python install 3.14 && \
+  ln -s python3.14 /home/circleci/.local/bin/python3
+RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+ENV PATH="/home/circleci/.cargo/bin:/home/circleci/.local/bin:${PATH}"
+
 # This should automatically install the version specified in rust-toolchain.toml
 ADD rust-toolchain.toml rust-toolchain.toml
-RUN rustup self update \
-  && rustup update \
+RUN rustup update \
   && rustup show \
   && rm rust-toolchain.toml
-
-ARG SWIFT_VERSION=6.0.3
-ARG SWIFT_UBUNTU_VERSION=20.04
-ARG SWIFT_CHECKSUM=012abe32cd1a9251d80ff1eeefcb3ff3fe2c02b569e5c755058b947f7afc9f56
-
-RUN mkdir -p /tmp/setup-swift \
-    && cd /tmp/setup-swift \
-    && curl -o swift.tar.gz https://download.swift.org/swift-${SWIFT_VERSION}-release/ubuntu${SWIFT_UBUNTU_VERSION}/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu${SWIFT_UBUNTU_VERSION}.tar.gz \
-    && echo "${SWIFT_CHECKSUM} swift.tar.gz" | sha256sum -c - \
-    && tar -xzf swift.tar.gz \
-    && sudo mv swift-${SWIFT_VERSION}-RELEASE-ubuntu${SWIFT_UBUNTU_VERSION} /opt/swift \
-    && echo "export PATH=\"\$PATH:/opt/swift/usr/bin\"" >> /home/circleci/.bashrc \
-    && echo "export PATH=\"\$PATH:/opt/swift/usr/bin\"" >> /home/circleci/.profile \
-    && cd ../ \
-    && rm -rf ./setup-swift
 
 RUN mkdir -p /tmp/setup-kotlin \
     && cd /tmp/setup-kotlin \

--- a/docker/Dockerfile-build.checksum
+++ b/docker/Dockerfile-build.checksum
@@ -1,1 +1,0 @@
-df97bf2200a9af87bd773ec620ec7ebd605cf5ef65a9bc3101cbb0b385d02d447584b17e2bc8a3e8601ed3e5dfb00e903286dece6bfa5885f24c9bbfac1663fb  Dockerfile-build

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,9 +4,5 @@ in CI. To build a new version of this docker image, run
 the following from the root of the repository:
 
 ```
-docker build -t rfkelly/uniffi-ci -f docker/Dockerfile-build .
-docker push rfkelly/uniffi-ci
+docker build -t uniffi-ci -f docker/Dockerfile-build .
 ```
-
-That only works if you're `rfkelly`; we need to figure out
-a better strategy for maintainership of said docker image.

--- a/docker/cargo-docker.sh
+++ b/docker/cargo-docker.sh
@@ -5,9 +5,10 @@
 #  * share cargo registry data with the image, so it doesn't have to re-fetch it each run
 #  * mount the current working directory into the image, and run in that directory
 #  * run via bash in interactive mode to get correct $PATH setup from .bashrc
-docker run \
+exec docker run \
     -ti --rm \
     -v $HOME/.cargo/registry:/usr/local/cargo/registry \
     -v $PWD:/mounted_workdir \
     -w /mounted_workdir \
-    rfkelly/uniffi-ci:latest bash -i -c "cargo $*"
+    --platform linux/amd64 \
+    janerik/uniffi-ci-test:2026.05 bash -i -c "cargo $*"

--- a/examples/README.md
+++ b/examples/README.md
@@ -47,7 +47,7 @@ If you want to try them out, you will need:
 * The [Ruby FFI](https://github.com/ffi/ffi#installation)
   * `gem install ffi test-unit rubocop`
 
-We publish a [docker image](https://hub.docker.com/r/rfkelly/uniffi-ci) that has all of this dependencies
+We publish a [docker image](https://hub.docker.com/r/janerik/uniffi-ci-test) that has all of this dependencies
 pre-installed, if you want to get up and running quickly.
 
 With that in place, try the following:

--- a/fixtures/rename/tests/test_rename.kts
+++ b/fixtures/rename/tests/test_rename.kts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import java.net.URL
+import java.net.URI
 import uniffi.uniffi_fixture_rename.*;
 
 // Test renamed types - should be accessible by their custom names
@@ -65,7 +65,7 @@ val ktTraitImpl = createBindingTraitImpl(3)
 assert(ktTraitImpl.kotlinTraitMethod(4) == 12)
 
 // Test renamed custom type that also has binding configuration
-val url = URL("https://example.com/test")
+val url = URI("https://example.com/test")
 assert(roundtripUrl(url) == url)
 
 // We can't test excluded items directly, however the tests will fail if the code is not working

--- a/fixtures/rename/uniffi.toml
+++ b/fixtures/rename/uniffi.toml
@@ -223,9 +223,9 @@ lift = "urllib.parse.urlsplit({})"
 lower = "urllib.parse.urlunsplit({})"
 
 [bindings.kotlin.custom_types.RenamedUrl]
-type_name = "URL"
-imports = [ "java.net.URL" ]
-lift = "URL({})"
+type_name = "URI"
+imports = [ "java.net.URI" ]
+lift = "URI({})"
 lower = "{}.toString()"
 
 [bindings.swift.custom_types.RenamedUrl]


### PR DESCRIPTION
This is now significantly bigger (~~7.6~~ 7.0 GB), but that's unavoidable with
the new way Swift is shipped and all the other tooling we need.

Fixes #2892

---

fwiw I'm trying to figure out if we can push that image to ghcr.io/mozilla/uniffi to make it more "official"