### PR TITLE
Fix Kotlin async external RustBuffer returns

### DIFF
--- a/fixtures/ext-types/lib/src/lib.rs
+++ b/fixtures/ext-types/lib/src/lib.rs
@@ -143,6 +143,36 @@ fn get_nested_external_ouid(ouid: Option<NestedExternalOuid>) -> NestedExternalO
     ouid.unwrap_or_else(|| NestedExternalOuid(Ouid("nested-external-ouid".to_string())))
 }
 
+#[uniffi::export]
+async fn get_nested_external_ouid_async(ouid: Option<NestedExternalOuid>) -> NestedExternalOuid {
+    get_nested_external_ouid(ouid)
+}
+
+pub struct LocalExternalGuid {
+    pub value: String,
+}
+
+impl From<Guid> for LocalExternalGuid {
+    fn from(value: Guid) -> Self {
+        Self { value: value.0 }
+    }
+}
+
+impl From<LocalExternalGuid> for Guid {
+    fn from(value: LocalExternalGuid) -> Self {
+        Guid(value.value)
+    }
+}
+
+uniffi::custom_type!(LocalExternalGuid, Guid, { remote });
+
+#[uniffi::export]
+async fn get_local_external_guid_async() -> LocalExternalGuid {
+    LocalExternalGuid {
+        value: "local-external-guid".to_string(),
+    }
+}
+
 // A struct
 fn get_uniffi_one_type(t: UniffiOneType) -> UniffiOneType {
     t

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.kts
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.kts
@@ -6,6 +6,8 @@ import uniffi.imported_types_lib.*
 import uniffi.imported_types_sublib.*
 import uniffi.uniffi_one_ns.*
 import uniffi.ext_types_custom.*
+import java.net.URI
+import kotlinx.coroutines.runBlocking
 
 // First step: implement a trait from an external crate in Kotlin and pass it to a function from this
 // crate.  This tests #2343 -- the codegen for this module needs to initialize the vtable from
@@ -20,7 +22,7 @@ assert(invokeUniffiOneTrait(KtUniffiOneImpl()) == "Hello from Kotlin")
 val ct = getCombinedType(null)
 assert(ct.uot.sval == "hello")
 assert(ct.guid ==  "a-guid")
-assert(ct.url ==  java.net.URL("http://example.com/"))
+assert(ct.url ==  URI.create("http://example.com/").toURL())
 
 val ct2 = getCombinedType(ct)
 assert(ct == ct2)
@@ -32,7 +34,7 @@ assert(getUniffiOneTrait(null) == null)
 assert(getSubType(null).maybeInterface == null)
 assert(getTraitImpl().hello() == "sub-lib trait impl says hello")
 
-val url = java.net.URL("http://example.com/")
+val url = URI.create("http://example.com/").toURL()
 assert(getUrl(url) ==  url)
 assert(getMaybeUrl(url)!! ==  url)
 assert(getMaybeUrl(null) ==  null)
@@ -44,6 +46,10 @@ assert(getOuid("ouid") == "ouid")
 //assert(getImportedGuid("guid") == "guid")
 assert(getImportedOuid("ouid") == "ouid")
 assert(getImportedHandleU8(null) == 3u.toUByte())
+runBlocking {
+    assert(getNestedExternalOuidAsync(null) == "nested-external-ouid")
+    assert(getLocalExternalGuidAsync() == "local-external-guid")
+}
 
 val uot = UniffiOneType("hello")
 assert(getUniffiOneType(uot) == uot)

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -984,18 +984,18 @@ mod filters {
     ) -> Result<String, askama::Error> {
         let ffi_func = callable.ffi_rust_future_complete(ci);
         let call = format!("UniffiLib.{ffi_func}(future, continuation)");
-        // May need to convert the RustBuffer from our package to the RustBuffer of the external package
+        // May need to convert the RustBuffer from our package to the RustBuffer of the external package.
         let call = match callable.return_type() {
-            Some(return_type) if ci.is_external(return_type) => {
-                let ffi_type = FfiType::from(return_type);
-                match ffi_type {
-                    FfiType::RustBuffer(Some(ExternalFfiMetadata { name, .. })) => {
-                        let suffix = KotlinCodeOracle.class_name(ci, &name);
-                        format!("{call}.let {{ RustBuffer{suffix}.create(it.capacity.toULong(), it.len.toULong(), it.data) }}")
-                    }
-                    _ => call,
+            Some(return_type) => match FfiType::from(return_type) {
+                FfiType::RustBuffer(Some(external_meta))
+                    if external_meta.crate_name() != ci.crate_name() =>
+                {
+                    let ExternalFfiMetadata { name, .. } = external_meta;
+                    let suffix = KotlinCodeOracle.class_name(ci, &name);
+                    format!("{call}.let {{ RustBuffer{suffix}.create(it.capacity.toULong(), it.len.toULong(), it.data) }}")
                 }
-            }
+                _ => call,
+            },
             _ => call,
         };
         Ok(format!("{{ future, continuation -> {call} }}"))


### PR DESCRIPTION
## Summary

Fix Kotlin bindings for async functions that return custom/external types whose FFI carrier is an external `RustBuffer`.

For these async return values, Kotlin's `rust_future_complete_rust_buffer` helper returns the local package's `RustBuffer.ByValue`, but the return type's lift converter can expect an external package's `RustBuffer.ByValue`. That causes the compile error reported in #2630.

This changes the Kotlin async-complete generation to inspect the return `FfiType`, not only whether the high-level return type is external. If the return carrier is `FfiType::RustBuffer(Some(external_meta))` from another crate, the complete result is converted into that external package's `RustBuffer` before it is passed to the lift converter.

## Tests

- `cargo fmt --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo check -p uniffi_bindgen`
- `JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk/bin:$PATH CLASSPATH=/Users/liaowenzhao/Desktop/UniFFI/test-deps/jna-5.18.1.jar:/opt/homebrew/Cellar/kotlin/2.3.21/libexec/lib/kotlinx-coroutines-core-jvm.jar CARGO_NET_OFFLINE=true CARGO_INCREMENTAL=0 cargo test -p uniffi-fixture-ext-types test_imported_types_kts -- --nocapture`

Generated Kotlin now includes conversions like:

```kotlin
RustBufferGuid.create(it.capacity.toULong(), it.len.toULong(), it.data)
RustBufferOuid.create(it.capacity.toULong(), it.len.toULong(), it.data)
```

before calling the lift converters for the async return values.

Fixes #2630.
Related to #2675.
