### PR TITLE
Allow async_runtime on trait exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Custom Types can have docstrings in some languages ([#2853](https://github.com/mozilla/uniffi-rs/pull/2853))
 - Ruby: Expose standard Rust traits for generated ruby code (#2883)
 - Added zero-copy transfer of `&[u8]` / `[ByRef] bytes` arguments from foreign code to Rust. Kotlin (`java.nio.ByteBuffer`, must be direct), Swift (`Data`), and Python (`bytes`-like, buffer protocol) pass byte buffers as pointer + length (`ForeignBytes`) rather than copying through `RustBuffer`. Not yet supported on Ruby, and not yet supported in async functions on any language ([#2878](https://github.com/mozilla/uniffi-rs/pull/2878)).
+- `#[uniffi::export(async_runtime = "tokio")]` can now be applied to trait exports, wrapping each method's FFI scaffolding future in `async_compat::Compat` the same way it does for inherent impls and free functions ([#2899](https://github.com/mozilla/uniffi-rs/pull/2899)).
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.31.1...HEAD).
 

--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -432,6 +432,32 @@ fn get_say_after_udl_traits() -> Vec<Arc<dyn SayAfterUdlTrait>> {
     vec![Arc::new(SayAfterImpl1), Arc::new(SayAfterImpl2)]
 }
 
+// Example of an async trait whose Rust implementation uses tokio resources.
+#[uniffi::export(with_foreign, async_runtime = "tokio")]
+#[async_trait::async_trait]
+pub trait SayAfterTraitTokio: Send + Sync {
+    async fn say_after(&self, ms: u16, who: String) -> String;
+}
+
+#[async_trait::async_trait]
+impl SayAfterTraitTokio for SayAfterImpl1 {
+    async fn say_after(&self, ms: u16, who: String) -> String {
+        say_after_with_tokio(ms, who).await
+    }
+}
+
+#[async_trait::async_trait]
+impl SayAfterTraitTokio for SayAfterImpl2 {
+    async fn say_after(&self, ms: u16, who: String) -> String {
+        say_after_with_tokio(ms, who).await
+    }
+}
+
+#[uniffi::export]
+fn get_say_after_tokio_traits() -> Vec<Arc<dyn SayAfterTraitTokio>> {
+    vec![Arc::new(SayAfterImpl1), Arc::new(SayAfterImpl2)]
+}
+
 // Async callback interface implemented in foreign code
 #[uniffi::export(with_foreign)]
 #[async_trait::async_trait]

--- a/fixtures/futures/tests/bindings/test_futures.kts
+++ b/fixtures/futures/tests/bindings/test_futures.kts
@@ -146,6 +146,20 @@ runBlocking {
     assertApproximateTime(time, 200, "async methods")
 }
 
+// Test async trait methods backed by a tokio-using Rust impl
+runBlocking {
+    val traits = getSayAfterTokioTraits()
+    val time = measureTimeMillis {
+        val result1 = traits[0].sayAfter(100U, "Alice")
+        val result2 = traits[1].sayAfter(100U, "Bob")
+
+        assert(result1 == "Hello, Alice (with Tokio)!")
+        assert(result2 == "Hello, Bob (with Tokio)!")
+    }
+
+    assertApproximateTime(time, 200, "async tokio trait methods")
+}
+
 // Test foreign implemented async trait methods
 class KotlinAsyncParser: AsyncParser {
     var completedDelays: Int = 0

--- a/fixtures/futures/tests/bindings/test_futures.py
+++ b/fixtures/futures/tests/bindings/test_futures.py
@@ -117,6 +117,21 @@ class TestFutures(unittest.TestCase):
 
         asyncio.run(test())
 
+    def test_tokio_async_trait_interface_methods(self):
+        async def test():
+            traits = get_say_after_tokio_traits()
+            t0 = now()
+            result1 = await traits[0].say_after(100, 'Alice')
+            result2 = await traits[1].say_after(100, 'Bob')
+            t1 = now()
+
+            self.assertEqual(result1, 'Hello, Alice (with Tokio)!')
+            self.assertEqual(result2, 'Hello, Bob (with Tokio)!')
+            t_delta = (t1 - t0).total_seconds()
+            self.assertGreater(t_delta, 0.2)
+
+        asyncio.run(test())
+
     def test_foreign_async_trait_interface_methods(self):
         class PyAsyncParser(AsyncParser):
             def __init__(self):

--- a/fixtures/futures/tests/bindings/test_futures.swift
+++ b/fixtures/futures/tests/bindings/test_futures.swift
@@ -150,6 +150,25 @@ Task {
 	counter.leave()
 }
 
+// Test async trait methods backed by a tokio-using Rust impl
+counter.enter()
+
+Task {
+	let traits = getSayAfterTokioTraits()
+
+	let t0 = Date()
+	let result1 = await traits[0].sayAfter(ms: 1000, who: "Alice")
+	let result2 = await traits[1].sayAfter(ms: 1000, who: "Bob")
+	let t1 = Date()
+
+	assert(result1 == "Hello, Alice (with Tokio)!")
+	assert(result2 == "Hello, Bob (with Tokio)!")
+	let tDelta = DateInterval(start: t0, end: t1)
+	assert(tDelta.duration > 2 && tDelta.duration < 2.1)
+
+	counter.leave()
+}
+
 // Test object with a fallible async ctor.
 counter.enter()
 

--- a/uniffi_macros/src/export/trait_interface.rs
+++ b/uniffi_macros/src/export/trait_interface.rs
@@ -26,9 +26,6 @@ pub(super) fn gen_trait_scaffolding(
     with_foreign: bool,
     docstring: String,
 ) -> syn::Result<TokenStream> {
-    if let Some(rt) = args.async_runtime {
-        return Err(syn::Error::new_spanned(rt, "not supported for traits"));
-    }
     let trait_name = ident_to_string(&self_ident);
     let trait_impl = with_foreign.then(|| {
         callback_interface::trait_impl(mod_path, &self_ident, &items, true)
@@ -91,7 +88,9 @@ pub(super) fn gen_trait_scaffolding(
     let impl_tokens: TokenStream = items
         .into_iter()
         .map(|item| match item {
-            ImplItem::Method(sig) => gen_method_scaffolding(sig, None, udl_mode, None),
+            ImplItem::Method(sig) => {
+                gen_method_scaffolding(sig, args.async_runtime.as_ref(), udl_mode, None)
+            }
             _ => unreachable!("traits have no constructors"),
         })
         .collect::<syn::Result<_>>()?;


### PR DESCRIPTION
Accept #[uniffi::export(async_runtime = "tokio")] on trait exports. Trait method futures now get the same async_compat::Compat wrap that inherent impls and free functions already use to enter a tokio runtime context on every poll.