### PR TITLE
Document that constructors on enums and records aren't supported.

### DIFF
--- a/bindgen-tests/kotlin/tests/enums.kts
+++ b/bindgen-tests/kotlin/tests/enums.kts
@@ -31,3 +31,5 @@ assert(ExplicitValuedEnum.THIRTEENTH.value == 13.toUByte())
 assert(GappedEnum.ONE.value == 10.toUByte())
 assert(GappedEnum.TWO.value == 11.toUByte()) // Sequential value after ONE (10+1)
 assert(GappedEnum.THREE.value == 14.toUByte()) // Explicit value again
+// Enum methods
+assert(EnumWithData.A(20.toUByte(), 40.toUShort()).roundtrip() == EnumWithData.A(20.toUByte(), 40.toUShort()))

--- a/bindgen-tests/kotlin/tests/records.kts
+++ b/bindgen-tests/kotlin/tests/records.kts
@@ -33,3 +33,5 @@ assert(
     fieldRec=SimpleRec(a=42.toUByte())
   )
 )
+// methods
+assert(SimpleRec(a=42.toUByte()).roundtrip() == SimpleRec(a=42.toUByte()))

--- a/bindgen-tests/lib/src/enums.rs
+++ b/bindgen-tests/lib/src/enums.rs
@@ -11,11 +11,18 @@ pub enum EnumNoData {
     C,
 }
 
-#[derive(uniffi::Enum)]
+#[derive(uniffi::Enum, Clone)]
 pub enum EnumWithData {
     A { value: u8, value2: u16 },
     B(String, u32),
     C,
+}
+
+#[uniffi::export]
+impl EnumWithData {
+    fn roundtrip(&self) -> Self {
+        self.clone()
+    }
 }
 
 #[derive(uniffi::Enum)]

--- a/bindgen-tests/lib/src/records.rs
+++ b/bindgen-tests/lib/src/records.rs
@@ -7,6 +7,13 @@ pub struct SimpleRec {
     pub a: u8,
 }
 
+#[uniffi::export]
+impl SimpleRec {
+    fn roundtrip(&self) -> Self {
+        SimpleRec { a: self.a }
+    }
+}
+
 #[derive(uniffi::Record)]
 pub struct UnitRec;
 

--- a/bindgen-tests/python/tests/enums.py
+++ b/bindgen-tests/python/tests/enums.py
@@ -49,5 +49,8 @@ class TestEnums(unittest.TestCase):
         self.assertEqual(GappedEnum.TWO.value, 11) # Sequential value after ONE (10+1)
         self.assertEqual(GappedEnum.THREE.value, 14) # Explicit value again
 
+    def test_methods(self):
+        self.assertEqual(EnumWithData.A(1, 0).roundtrip(), EnumWithData.A(1, 0))
+
 if __name__ == '__main__':
     unittest.main()

--- a/bindgen-tests/python/tests/records.py
+++ b/bindgen-tests/python/tests/records.py
@@ -41,5 +41,8 @@ class TestRecords(unittest.TestCase):
           )
         )
 
+    def test_methods(self):
+        self.assertEqual(SimpleRec(a=42).roundtrip(), SimpleRec(a=42))
+
 if __name__ == '__main__':
     unittest.main()

--- a/bindgen-tests/swift/tests/enums.swift
+++ b/bindgen-tests/swift/tests/enums.swift
@@ -38,3 +38,5 @@ assert(ExplicitValuedEnum.thirteenth.rawValue == 13);
 assert(GappedEnum.one.rawValue == 10);
 assert(GappedEnum.two.rawValue == 11); // Sequential value after ONE (10+1)
 assert(GappedEnum.three.rawValue == 14); // Explicit value again
+// Enum methods
+assert(EnumWithData.a(value: 20, value2: 40).roundtrip() == EnumWithData.a(value: 20, value2: 40))

--- a/bindgen-tests/swift/tests/records.swift
+++ b/bindgen-tests/swift/tests/records.swift
@@ -37,3 +37,5 @@ assert(
     fieldRec: SimpleRec(a: 42)
   )
 )
+// methods
+assert(SimpleRec(a: 42).roundtrip() == SimpleRec(a: 42))

--- a/docs/manual/src/types/enumerations.md
+++ b/docs/manual/src/types/enumerations.md
@@ -55,6 +55,8 @@ proc-macros allow you to use `#[uniffi::export]` on an `impl` block for an `enum
 and the bindings will generate a method which calls into the Rust method.
 But take care - every time one of the methods is called, the entire enum will be copied by-value across the FFI.
 
+Constructors are not supported for enums.
+
 ## Recursive enums
 
 Enums that reference themselves are supported. UniFFI automatically detects the cycle and generates appropriate bindings. Use `Box<T>` in variant fields to satisfy Rust's ownership rules:

--- a/docs/manual/src/types/records.md
+++ b/docs/manual/src/types/records.md
@@ -108,6 +108,8 @@ and the bindings will generate a method which calls into the Rust method.
 But take care - every time one of the methods is called, the entire record will be copied by-value across the FFI.
 You probably want to avoid this for large records or in performance sensitive areas.
 
+Constructors are not supported for records.
+
 ## Exposing methods from standard Rust traits
 
 While less useful for Records, there are a number of standard Rust traits (`Debug`, `Eq` etc) you can expose, so, eg, Python

--- a/uniffi_meta/src/reader.rs
+++ b/uniffi_meta/src/reader.rs
@@ -268,14 +268,18 @@ impl<'a> MetadataReader<'a> {
         let (return_type, throws) = self.read_return_type()?;
         let docstring = self.read_optional_long_string()?;
 
-        return_type
-            .filter(|t| {
-                matches!(
-                    t,
-                    Type::Object { name, imp: ObjectImpl::Struct, .. } if name == &self_name
-                )
-            })
-            .context("Constructor return type must be Self or Arc<Self>")?;
+        match return_type {
+            None => bail!("Constructor return type must be Self or Arc<Self>"),
+            Some(t) => match t {
+                Type::Object {
+                    name,
+                    imp: ObjectImpl::Struct,
+                    ..
+                } if name == self_name => {}
+                Type::Object { .. } => bail!("Constructor return type must be Self or Arc<Self>"),
+                _ => bail!("Only interfaces can have constructors"),
+            },
+        };
 
         Ok(ConstructorMetadata {
             module_path,


### PR DESCRIPTION
Also gives a better error message if you try, and adds bindgen tests for regular methods on them.

Fixes #2907

This made me remember why we don't support it - it's tricky because in many languages the normal way to create records and enums is either via a contructor (eg, kotlin), or not compatible with enums (eg, python). This isn't to say we couldn't do something better in the future, but we might as well document the status quo.