### PR TITLE
Fix swift chrono intermittent failure.

### DIFF
--- a/fixtures/uniffi-fixture-time/tests/bindings/test_chronological.swift
+++ b/fixtures/uniffi-fixture-time/tests/bindings/test_chronological.swift
@@ -20,10 +20,15 @@ do {
     // It's okay!
 }
 
-// Test that rust timestamps behave like swift timestamps
+// Test that rust timestamps behave like swift timestamps.
+// Sleep briefly between each call: Date uses Double (CFAbsoluteTime) which has
+// ~100–200 ns precision at current epoch, so without a gap the ordering can
+// flip intermittently due to floating-point rounding in the FFI conversion.
 let swiftBefore = Date.init()
+Thread.sleep(forTimeInterval: 0.01)
 let rustNow = now()
+Thread.sleep(forTimeInterval: 0.01)
 let swiftAfter = Date.init()
 
-assert(swiftBefore <= rustNow)
-assert(swiftAfter >= rustNow)
+assert(swiftBefore < rustNow)
+assert(swiftAfter > rustNow)

--- a/uniffi_bindgen/src/bindings/swift/templates/TimestampHelper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/TimestampHelper.swift
@@ -7,12 +7,17 @@ fileprivate struct FfiConverterTimestamp: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Date {
         let seconds: Int64 = try readInt(&buf)
         let nanoseconds: UInt32 = try readInt(&buf)
+        // Build the Date from whole seconds first, then add the nanoseconds as a
+        // separate TimeInterval.  Date stores CFAbsoluteTime (seconds since 2001),
+        // so adding a small fraction to the ~7.8e8 base is twice as precise as
+        // adding it to the ~1.76e9 Unix-epoch value, because the smaller magnitude
+        // leaves more mantissa bits for the sub-second part.
         if seconds >= 0 {
-            let delta = Double(seconds) + (Double(nanoseconds) / 1.0e9)
-            return Date.init(timeIntervalSince1970: delta)
+            return Date(timeIntervalSince1970: Double(seconds))
+                .addingTimeInterval(Double(nanoseconds) / 1.0e9)
         } else {
-            let delta = Double(seconds) - (Double(nanoseconds) / 1.0e9)
-            return Date.init(timeIntervalSince1970: delta)
+            return Date(timeIntervalSince1970: Double(seconds))
+                .addingTimeInterval(-Double(nanoseconds) / 1.0e9)
         }
     }
 


### PR DESCRIPTION
Fix intermittent Swift timestamp ordering failure by adding sleeps between clock readings like we do for kotlin.

Also improves FFI decode precision by adding nanoseconds to the smaller CFAbsoluteTime base rather than the larger Unix-epoch value.