### PR TITLE
Pipeline IDs

### DIFF
--- a/uniffi_bindgen/src/pipeline/general/callable.rs
+++ b/uniffi_bindgen/src/pipeline/general/callable.rs
@@ -13,6 +13,7 @@ pub fn function_callable(func: &initial::Function, context: &Context) -> Result<
     let name = rename::func(func.name.clone(), context)?;
 
     Ok(Callable {
+        id: func.id,
         name,
         orig_name: func.orig_name.clone(),
         async_data: function_async_data(func, context)?,
@@ -51,6 +52,7 @@ pub fn method_callable_with_kind(
     let name = rename::method(meth.name.clone(), context)?;
 
     Ok(Callable {
+        id: meth.id,
         name,
         orig_name: meth.orig_name.clone(),
         arguments,
@@ -86,6 +88,7 @@ pub fn constructor_callable(cons: &initial::Constructor, context: &Context) -> R
     let name = rename::method(cons.name.clone(), context)?;
 
     Ok(Callable {
+        id: cons.id,
         name,
         orig_name: cons.orig_name.clone(),
         async_data: constructor_async_data(cons, interface_name, imp, context)?,

--- a/uniffi_bindgen/src/pipeline/general/context.rs
+++ b/uniffi_bindgen/src/pipeline/general/context.rs
@@ -20,6 +20,7 @@ pub struct Context {
     pub rename_tables: HashMap<String, toml::Table>,
     // Maps namespaces to exclude tables from the TOML config
     pub exclude_sets: HashMap<String, HashSet<String>>,
+    pub type_id_map: HashMap<Type, u64>,
 }
 
 impl Context {
@@ -34,6 +35,7 @@ impl Context {
             names_used_as_error: HashSet::default(),
             rename_tables: HashMap::default(),
             exclude_sets: HashMap::default(),
+            type_id_map: HashMap::default(),
         }
     }
 
@@ -103,6 +105,7 @@ impl Context {
             self.exclude_sets
                 .insert(namespace.name.clone(), exclude_set);
         }
+        self.populate_type_id_map(root)?;
         Ok(())
     }
 
@@ -145,20 +148,12 @@ impl Context {
     }
 
     pub fn update_from_record(&mut self, rec: &initial::Record) -> Result<()> {
-        self.current_type = Some(Type::Record {
-            namespace: self.namespace_name()?,
-            name: rec.name.clone(),
-            orig_name: rec.orig_name.clone(),
-        });
+        self.current_type = Some(types::type_for_record(rec, self)?);
         Ok(())
     }
 
     pub fn update_from_enum(&mut self, en: &initial::Enum) -> Result<()> {
-        self.current_type = Some(Type::Enum {
-            namespace: self.namespace_name()?,
-            name: en.name.clone(),
-            orig_name: en.orig_name.clone(),
-        });
+        self.current_type = Some(types::type_for_enum(en, self)?);
         Ok(())
     }
 
@@ -174,12 +169,7 @@ impl Context {
     }
 
     pub fn update_from_interface(&mut self, int: &initial::Interface) -> Result<()> {
-        self.current_type = Some(Type::Interface {
-            namespace: self.namespace_name()?,
-            name: int.name.clone(),
-            orig_name: int.orig_name.clone(),
-            imp: int.imp,
-        });
+        self.current_type = Some(types::type_for_interface(int, self)?);
         Ok(())
     }
 
@@ -187,21 +177,12 @@ impl Context {
         &mut self,
         cbi: &initial::CallbackInterface,
     ) -> Result<()> {
-        self.current_type = Some(Type::CallbackInterface {
-            namespace: self.namespace_name()?,
-            name: cbi.name.clone(),
-            orig_name: cbi.orig_name.clone(),
-        });
+        self.current_type = Some(types::type_for_callback_interface(cbi, self)?);
         Ok(())
     }
 
     pub fn update_from_custom_type(&mut self, custom: &initial::CustomType) -> Result<()> {
-        self.current_type = Some(Type::Custom {
-            namespace: self.namespace_name()?,
-            name: custom.name.clone(),
-            orig_name: custom.orig_name.clone(),
-            builtin: Box::new(custom.builtin.clone()),
-        });
+        self.current_type = Some(types::type_for_custom_type(custom, self)?);
         Ok(())
     }
 
@@ -224,5 +205,69 @@ impl Context {
             | Type::Custom { name, .. } => self.names_used_as_error.contains(name),
             _ => false,
         }
+    }
+
+    fn populate_type_id_map(&mut self, root: &initial::Root) -> Result<()> {
+        let mut type_id_counter = 0..;
+        let mut type_id_map = HashMap::new();
+        let mut add_type = |ty: Type| {
+            if !type_id_map.contains_key(&ty) {
+                type_id_map.insert(ty, type_id_counter.next().unwrap());
+            }
+        };
+
+        // Add builtin types to `type_id_map`
+        //
+        // This is needed to handle types that we use in the interface that may not appear in
+        // `initial::Root`.  For example `Type::String` is needed to handle exceptions and the integer
+        // types are used for enum discriminants.  If we didn't add them to `type_id_map`, and they
+        // didn't appear in the exported interface, then get key errors in `get_type_id`.
+        add_type(Type::UInt8);
+        add_type(Type::Int8);
+        add_type(Type::UInt16);
+        add_type(Type::Int16);
+        add_type(Type::UInt32);
+        add_type(Type::Int32);
+        add_type(Type::UInt64);
+        add_type(Type::Int64);
+        add_type(Type::Float32);
+        add_type(Type::Float64);
+        add_type(Type::String);
+        // Add types from the interface
+        root.visit(|ty: &Type| add_type(ty.clone()));
+        root.try_visit(|namespace: &initial::Namespace| {
+            self.current_namespace_name = Some(namespace.name.clone());
+            root.try_visit(|rec: &initial::Record| {
+                add_type(types::type_for_record(rec, self)?);
+                Ok(())
+            })?;
+            root.try_visit(|en: &initial::Enum| {
+                add_type(types::type_for_enum(en, self)?);
+                Ok(())
+            })?;
+            root.try_visit(|int: &initial::Interface| {
+                add_type(types::type_for_interface(int, self)?);
+                Ok(())
+            })?;
+            root.try_visit(|cbi: &initial::CallbackInterface| {
+                add_type(types::type_for_callback_interface(cbi, self)?);
+                Ok(())
+            })?;
+            root.try_visit(|custom: &initial::CustomType| {
+                add_type(types::type_for_custom_type(custom, self)?);
+                Ok(())
+            })?;
+            Ok(())
+        })?;
+        self.current_namespace_name = None;
+        self.type_id_map = type_id_map;
+        Ok(())
+    }
+
+    pub fn get_type_id(&self, ty: &Type) -> Result<u64> {
+        self.type_id_map
+            .get(ty)
+            .cloned()
+            .ok_or_else(|| anyhow!("Type not in type_id_map: {ty:?} {:#?}", self.type_id_map))
     }
 }

--- a/uniffi_bindgen/src/pipeline/general/infer_recursive_enums.rs
+++ b/uniffi_bindgen/src/pipeline/general/infer_recursive_enums.rs
@@ -202,6 +202,7 @@ mod tests {
 
     fn make_type_node(ty: Type) -> TypeNode {
         TypeNode {
+            id: 0, // not used for these tests
             canonical_name: "Test".to_string(),
             is_used_as_error: false,
             ffi_type: FfiType::RustBuffer(None),

--- a/uniffi_bindgen/src/pipeline/general/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/general/nodes.rs
@@ -102,6 +102,7 @@ pub struct Method {
 /// Common data from Function/Method/Constructor
 #[derive(Debug, Clone, Node, MapNode)]
 pub struct Callable {
+    pub id: u64,
     pub name: String,
     pub orig_name: String,
     pub async_data: Option<AsyncData>,
@@ -429,6 +430,7 @@ pub struct TypeNode {
     ///     Many bindings will create a `UniffiConverter[canonical_name]` class.
     ///   - Creating a unique key for a type
     pub canonical_name: String,
+    pub id: u64,
     pub is_used_as_error: bool,
     pub ffi_type: FfiType,
     pub ty: Type,

--- a/uniffi_bindgen/src/pipeline/general/types.rs
+++ b/uniffi_bindgen/src/pipeline/general/types.rs
@@ -6,6 +6,7 @@ use super::*;
 
 pub fn map_type_node(ty: Type, context: &Context) -> Result<TypeNode> {
     Ok(TypeNode {
+        id: context.get_type_id(&ty)?,
         canonical_name: canonical_name(&ty),
         is_used_as_error: context.type_is_used_as_error(&ty),
         ffi_type: ffi_types::ffi_type(&ty, context)?,
@@ -109,5 +110,50 @@ pub fn map_type(mut ty: Type, context: &Context) -> Result<Type> {
         },
         // All other types can be returned unchanged
         _ => ty,
+    })
+}
+
+pub fn type_for_record(rec: &initial::Record, context: &Context) -> Result<Type> {
+    Ok(Type::Record {
+        namespace: context.namespace_name()?,
+        name: rec.name.clone(),
+        orig_name: rec.orig_name.clone(),
+    })
+}
+
+pub fn type_for_enum(en: &initial::Enum, context: &Context) -> Result<Type> {
+    Ok(Type::Enum {
+        namespace: context.namespace_name()?,
+        name: en.name.clone(),
+        orig_name: en.orig_name.clone(),
+    })
+}
+
+pub fn type_for_interface(int: &initial::Interface, context: &Context) -> Result<Type> {
+    Ok(Type::Interface {
+        namespace: context.namespace_name()?,
+        name: int.name.clone(),
+        orig_name: int.orig_name.clone(),
+        imp: int.imp,
+    })
+}
+
+pub fn type_for_callback_interface(
+    cbi: &initial::CallbackInterface,
+    context: &Context,
+) -> Result<Type> {
+    Ok(Type::CallbackInterface {
+        namespace: context.namespace_name()?,
+        name: cbi.name.clone(),
+        orig_name: cbi.orig_name.clone(),
+    })
+}
+
+pub fn type_for_custom_type(custom: &initial::CustomType, context: &Context) -> Result<Type> {
+    Ok(Type::Custom {
+        namespace: context.namespace_name()?,
+        name: custom.name.clone(),
+        orig_name: custom.orig_name.clone(),
+        builtin: Box::new(custom.builtin.clone()),
     })
 }

--- a/uniffi_bindgen/src/pipeline/initial/context.rs
+++ b/uniffi_bindgen/src/pipeline/initial/context.rs
@@ -2,10 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
 
 use super::*;
 
+#[derive(Default)]
 pub struct Context {
     // Map crate names to namespace names
     //
@@ -27,6 +34,8 @@ pub struct Context {
         BTreeMap<uniffi_meta::Type, uniffi_meta::ObjectTraitImplMetadata>,
     >,
     pub orig_names: BTreeMap<(String, String), String>,
+    // Uses an arc so we get a shared counter even if the context is cloned.
+    pub callable_id_counter: Arc<AtomicU64>,
 }
 
 impl Context {
@@ -44,6 +53,10 @@ impl Context {
             Some(orig_name) => orig_name.to_string(),
             None => type_name.to_string(),
         }
+    }
+
+    pub fn new_callable_id(&self) -> u64 {
+        self.callable_id_counter.fetch_add(1, Ordering::Relaxed)
     }
 
     pub fn methods_for_type(&self, module_path: &str, type_name: &str) -> Result<Vec<Method>> {

--- a/uniffi_bindgen/src/pipeline/initial/from_uniffi_meta.rs
+++ b/uniffi_bindgen/src/pipeline/initial/from_uniffi_meta.rs
@@ -264,6 +264,7 @@ impl UniffiMetaConverter {
             uniffi_traits: self.uniffi_traits,
             trait_impls: self.trait_impls,
             orig_names: self.orig_names,
+            ..Context::default()
         };
 
         let mut root = Root {

--- a/uniffi_bindgen/src/pipeline/initial/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/initial/nodes.rs
@@ -35,6 +35,8 @@ pub struct Namespace {
 pub struct Function {
     #[map_node(self.orig_name.unwrap_or_else(|| self.name.clone()))]
     pub orig_name: String,
+    #[map_node(context.new_callable_id())]
+    pub id: u64,
     pub name: String,
     pub is_async: bool,
     pub inputs: Vec<Argument>,
@@ -58,6 +60,8 @@ pub enum TypeDefinition {
 pub struct Constructor {
     #[map_node(self.orig_name.unwrap_or_else(|| self.name.clone()))]
     pub orig_name: String,
+    #[map_node(context.new_callable_id())]
+    pub id: u64,
     pub name: String,
     pub is_async: bool,
     pub inputs: Vec<Argument>,
@@ -72,6 +76,8 @@ pub struct Constructor {
 pub struct Method {
     #[map_node(self.orig_name.unwrap_or_else(|| self.name.clone()))]
     pub orig_name: String,
+    #[map_node(context.new_callable_id())]
+    pub id: u64,
     pub name: String,
     pub is_async: bool,
     pub inputs: Vec<Argument>,


### PR DESCRIPTION
Add `Callable.id` and `Type.id`.  These are useful when you need a unique ID for one of these, for example because you want to populate a hash map or generate a unique function name.

I prefer using a unique ID over canonical_name for that because it avoids name collisions in weird corner cases.  For example `HashMap<Foo, TypeBar>` and `HashMap<FooType, Bar>` both map to the same canonical name.  Also, the ID is unique over all crates.  `canonical_name` would also need to incorporate the namespace to make that true, which would increase the number of corner cases.

We're generating these in the Gecko JS pipeline and I also used them for uniffi-bindgen-kotlin-jni and I think other languages will want them as well.