### PR TITLE
Add sync callbacks support for Ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Updated `askama` version to `0.15.6`
 - Custom Types can have docstrings in some languages ([#2853](https://github.com/mozilla/uniffi-rs/pull/2853))
 - Ruby: Expose standard Rust traits for generated ruby code (#2883)
+- Ruby: Add support for sync foreign traits ([#2916](https://github.com/mozilla/uniffi-rs/pull/2916))
 - Added zero-copy transfer of `&[u8]` / `[ByRef] bytes` arguments from foreign code to Rust. Kotlin (`java.nio.ByteBuffer`, must be direct), Swift (`Data`), and Python (`bytes`-like, buffer protocol) pass byte buffers as pointer + length (`ForeignBytes`) rather than copying through `RustBuffer`. Not yet supported on Ruby, and not yet supported in async functions on any language ([#2878](https://github.com/mozilla/uniffi-rs/pull/2878)).
 - `#[uniffi::export(async_runtime = "tokio")]` can now be applied to trait exports, wrapping each method's FFI scaffolding future in `async_compat::Compat` the same way it does for inherent impls and free functions ([#2899](https://github.com/mozilla/uniffi-rs/pull/2899)).
 - Added support for using `HashSet` with proc-macros

--- a/bindgen-tests/ruby/src/lib.rs
+++ b/bindgen-tests/ruby/src/lib.rs
@@ -60,6 +60,16 @@ mod test {
     }
 
     #[test]
+    fn test_callback_interfaces() {
+        run_tests(test_dir(), "tests/callback_interfaces.rb");
+    }
+
+    #[test]
+    fn test_trait_interfaces() {
+        run_tests(test_dir(), "tests/trait_interfaces.rb");
+    }
+
+    #[test]
     fn test_defaults() {
         run_tests(test_dir(), "tests/defaults.rb");
     }

--- a/bindgen-tests/ruby/tests/bytes.rb
+++ b/bindgen-tests/ruby/tests/bytes.rb
@@ -31,4 +31,12 @@ class TestBytes < Test::Unit::TestCase
 
     assert_equal Encoding::BINARY, result.encoding
   end
+
+  # Zero-copy &[u8] — proc-macro path
+  def zero_copy_bytes
+    assert_equal 0, sum_bytes_procmacro(''.b)
+    assert_equal 6, sum_bytes_procmacro("\x01\x02\x03".b)
+    assert_nil first_byte_procmacro(''.b)
+    assert_equal 42, first_byte_procmacro("\x2a".b)
+  end
 end

--- a/bindgen-tests/ruby/tests/callback_interfaces.rb
+++ b/bindgen-tests/ruby/tests/callback_interfaces.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_bindgen_tests'
+
+class CallbackImpl
+  attr_accessor :value
+
+  @@callback_ref_count = 0
+
+  def self.callback_ref_count
+    @@callback_ref_count
+  end
+
+  def self.reset_callback_ref_count
+    @@callback_ref_count = 0
+  end
+
+  def self.finalizer
+    proc { @@callback_ref_count -= 1 }
+  end
+
+  def initialize(value)
+    @value = value
+    @@callback_ref_count += 1
+    ObjectSpace.define_finalizer(self, self.class.finalizer)
+  end
+
+  def noop; end
+
+  def get_value
+    value
+  end
+
+  def set_value(value)
+    self.value = value
+  end
+
+  def throw_if_equal(numbers)
+    if numbers.a == 6 && numbers.b == 7
+      raise 'unexpected failure'
+    elsif numbers.a == numbers.b
+      raise UniffiBindgenTests::TestError::Failure1
+    end
+
+    numbers
+  end
+
+  def echo(s)
+    s
+  end
+end
+
+class TestCallbackInterfaces < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  def test_callback_interface
+    # Construct a callback interface to pass to rust
+    CallbackImpl.reset_callback_ref_count
+    cbi = CallbackImpl.new 42
+
+    # Test calling callback interface methods, which we can only do indirectly.
+    # Each of these Rust functions inputs a callback interface, calls a method on it, then returns the result.
+    UniffiBindgenTests.invoke_test_callback_interface_noop cbi
+    assert_equal 42, UniffiBindgenTests.invoke_test_callback_interface_get_value(cbi)
+    UniffiBindgenTests.invoke_test_callback_interface_set_value cbi, 43
+    assert_equal 43, UniffiBindgenTests.invoke_test_callback_interface_get_value(cbi)
+    assert_equal 'test-string', UniffiBindgenTests.invoke_test_callback_interface_echo(cbi, 'test-string')
+
+    # The previous calls created a bunch of callback interface references.  Make sure they've been cleaned
+    # up and the only remaining reference is for our `cbi` variable.
+    assert_equal 1, CallbackImpl.callback_ref_count
+  end
+
+  def test_echo
+    cbi = CallbackImpl.new 0
+
+    assert_equal 'test-string', UniffiBindgenTests.invoke_test_callback_interface_echo(cbi, 'test-string')
+    assert_equal '', UniffiBindgenTests.invoke_test_callback_interface_echo(cbi, '')
+    assert_equal '*' * 1000, UniffiBindgenTests.invoke_test_callback_interface_echo(cbi, '*' * 1000)
+  end
+
+  def test_throw
+    cbi = CallbackImpl.new 0
+
+    result = UniffiBindgenTests.invoke_test_callback_interface_throw_if_equal(
+      cbi, CallbackInterfaceNumbers.new(a: 1, b: 2)
+    )
+
+    assert_equal 1, result.a
+    assert_equal 2, result.b
+  end
+
+  def test_raises_unexpected_error
+    cbi = CallbackImpl.new 0
+    numbers = CallbackInterfaceNumbers.new a: 1, b: 1
+
+    assert_raises(TestError::Failure1) do
+      UniffiBindgenTests.invoke_test_callback_interface_throw_if_equal cbi, numbers
+    end
+  end
+
+  def test_raises_unexpected_error_converted
+    cbi = CallbackImpl.new 0
+    numbers = CallbackInterfaceNumbers.new a: 6, b: 7
+
+    err = assert_raises(TestError::Failure2) do
+      UniffiBindgenTests.invoke_test_callback_interface_throw_if_equal cbi, numbers
+    end
+
+    assert_kind_of String, err.data
+    assert_match(/unexpected failure/, err.data)
+  end
+
+  def test_callback_interface_calls_and_errors
+    CallbackImpl.reset_callback_ref_count
+    cbi = CallbackImpl.new(42)
+
+    # Only our local Ruby reference should remain alive.
+    assert_equal 1, CallbackImpl.callback_ref_count
+  end
+end

--- a/bindgen-tests/ruby/tests/collections.rb
+++ b/bindgen-tests/ruby/tests/collections.rb
@@ -18,11 +18,13 @@ class TestCollections < Test::Unit::TestCase
     assert_equal [1, 2, 3], UniffiBindgenTests.roundtrip_vec_i32([1, 2, 3])
     assert_equal [1, 2, 3], UniffiBindgenTests.roundtrip_vec_u64([1, 2, 3])
     assert_equal [1, 2, 3], UniffiBindgenTests.roundtrip_vec_i64([1, 2, 3])
-    assert_equal ["test-string"], UniffiBindgenTests.roundtrip_vec_string(["test-string"])
+    assert_equal ['test-string'], UniffiBindgenTests.roundtrip_vec_string(['test-string'])
     assert_equal [true, false], UniffiBindgenTests.roundtrip_vec_bool([true, false])
 
-    rec = CollectionsRec.new(a: 42)
-    assert_equal [rec], UniffiBindgenTests.roundtrip_vec_rec([rec])
+    assert_equal(
+      [CollectionsRec.new(a: 42)],
+      UniffiBindgenTests.roundtrip_vec_rec([CollectionsRec.new(a: 42)])
+    )
   end
 
   def test_hash_map
@@ -30,25 +32,52 @@ class TestCollections < Test::Unit::TestCase
 
     assert_equal map, UniffiBindgenTests.roundtrip_hash_map(map)
     assert_equal({}, UniffiBindgenTests.roundtrip_hash_map({}))
+
+    assert_equal(
+      { 1 => 2, 2 => 4 },
+      UniffiBindgenTests.roundtrip_hash_map_u32_key({ 1 => 2, 2 => 4 })
+    )
+  end
+
+  def test_hash_set
+    set = Set.new(%w[a b c])
+
+    assert_equal set, UniffiBindgenTests.roundtrip_hash_set(set)
+    assert_equal(Set.new([]), UniffiBindgenTests.roundtrip_hash_set(Set.new([])))
+
+    assert_equal [Set.new(%w[a b c])], UniffiBindgenTests.roundtrip_vec_hash_set([set])
+    assert_equal nil, UniffiBindgenTests.roundtrip_vec_hash_set(nil)
   end
 
   def test_rec_with_collections
-    rec = RecWithCollections.new(
-      a: EnumWithCollections::A.new(nil),
-      b: nil,
-      c: [true, false],
-      d: { 'a' => 1, 'b' => 2 },
+    assert_equal(
+      record_with_collection,
+      UniffiBindgenTests.roundtrip_rec_with_collections(record_with_collection)
     )
-
-    assert_equal rec, UniffiBindgenTests.roundtrip_rec_with_collections(rec)
   end
 
   def test_complex_collection_type
-    inner = [{
-      'a' => CollectionsComplexRec.new(a: 10, b: "test", c: CollectionsEnum::A.new(100)),
-      'b' => CollectionsComplexRec.new(a: 20, b: "test2", c: CollectionsEnum::B.new(a: 1.0, b: true)),
-    }]
-    assert_equal inner, UniffiBindgenTests.roundtrip_complex_collection_type(inner)
+    assert_equal(
+      complex_collection_type,
+      UniffiBindgenTests.roundtrip_complex_collection_type(complex_collection_type)
+    )
+
     assert_nil UniffiBindgenTests.roundtrip_complex_collection_type(nil)
+  end
+
+  def record_with_collection
+    RecWithCollections.new(
+      a: EnumWithCollections::A.new(nil),
+      b: nil,
+      c: [true, false],
+      d: { 'a' => 1, 'b' => 2 }
+    )
+  end
+
+  def complex_collection_type
+    [{
+      'a' => CollectionsComplexRec.new(a: 10, b: 'test', c: CollectionsEnum::A.new(100)),
+      'b' => CollectionsComplexRec.new(a: 20, b: 'test2', c: CollectionsEnum::B.new(a: 1.0, b: true))
+    }]
   end
 end

--- a/bindgen-tests/ruby/tests/enums.rb
+++ b/bindgen-tests/ruby/tests/enums.rb
@@ -24,47 +24,57 @@ class TestEnums < Test::Unit::TestCase
   end
 
   # --- EnumWithData (non-flat enum) ---
-  def test_enum_with_data_named_variant
-    em = EnumWithData::A.new value: 10, value2: 20
-    result = UniffiBindgenTests.roundtrip_enum_with_data(em)
+  def test_enums_with_data
+    assert_equal(
+      UniffiBindgenTests.roundtrip_complex_enum(ComplexEnum::A.new(value: EnumNoData::C)),
+      ComplexEnum::A.new(value: EnumNoData::C)
+    )
 
-    assert_kind_of EnumWithData::A, result
-    assert_equal 10, result.value
-    assert_equal 20, result.value2
+    assert_equal(
+      UniffiBindgenTests.roundtrip_complex_enum(
+        ComplexEnum::B.new(value: EnumWithData::A.new(value: 20, value2: 40))
+      ),
+      ComplexEnum::B.new(value: EnumWithData::A.new(value: 20, value2: 40))
+    )
+
+    assert_equal(
+      UniffiBindgenTests.roundtrip_complex_enum(ComplexEnum::C.new(value: SimpleRec.new(a: 30))),
+      ComplexEnum::C.new(value: SimpleRec.new(a: 30))
+    )
   end
 
-  def test_enum_with_data_tuple_variant
-    en = EnumWithData::B.new 'hello', 42
-    result = UniffiBindgenTests.roundtrip_enum_with_data(en)
+  def test_methods
+    assert_equal(
+      EnumWithData::A.new(value: 1, value2: 0),
+      EnumWithData::A.new(value: 1, value2: 0).roundtrip
+    )
+
+    result = EnumWithData::B.new('hello', 42).roundtrip
 
     assert_kind_of EnumWithData::B, result
     assert_equal 'hello', result[0]
     assert_equal 42, result[1]
   end
 
-  def test_enum_with_data_empty_variant
-    # C has no data but lives is a non-flat enum - still a class
-    en = EnumWithData::C.new
-    result = UniffiBindgenTests.roundtrip_enum_with_data(en)
-
-    assert_kind_of EnumWithData::C, result
-  end
-
   # --- ComplexEnum ---
 
   def test_complex_enum_a
-    inner = EnumNoData::B
+    inner = EnumNoData::C
     en = ComplexEnum::A.new value: inner
     result = UniffiBindgenTests.roundtrip_complex_enum(en)
 
+    assert_equal en, result
+
     assert_kind_of ComplexEnum::A, result
-    assert_equal EnumNoData::B, result.value
+    assert_equal EnumNoData::C, result.value
   end
 
   def test_complex_enum_b
     inner = EnumWithData::A.new value: 5, value2: 6
     en = ComplexEnum::B.new value: inner
     result = UniffiBindgenTests.roundtrip_complex_enum(en)
+
+    assert_equal en, result
 
     assert_kind_of ComplexEnum::B, result
     assert_kind_of EnumWithData::A, result.value
@@ -77,6 +87,8 @@ class TestEnums < Test::Unit::TestCase
     en = ComplexEnum::C.new value: inner
     result = UniffiBindgenTests.roundtrip_complex_enum(en)
 
+    assert_equal en, result
+
     assert_kind_of ComplexEnum::C, result
     assert_kind_of SimpleRec, result.value
     assert_equal 77, result.value.a
@@ -84,14 +96,18 @@ class TestEnums < Test::Unit::TestCase
 
   # --- ExplicitValuedEnum ---
 
-  # ExplicitValuedEnum is a separate type from EnumNoData - just verify constants exists and differ
-  def test_explicit_valued_enum_roundtrip
-    assert_not_nil ExplicitValuedEnum::FIRST
-    assert_not_nil ExplicitValuedEnum::SECOND
-    assert_not_nil ExplicitValuedEnum::FOURTH
-    assert_not_nil ExplicitValuedEnum::TENTH
-    assert_not_nil ExplicitValuedEnum::ELEVENTH
-    assert_not_nil ExplicitValuedEnum::THIRTEENTH
+  def test_discriminents
+    assert_equal 1, ExplicitValuedEnum::FIRST
+    assert_equal 2, ExplicitValuedEnum::SECOND
+    assert_equal 4, ExplicitValuedEnum::FOURTH
+    assert_equal 10, ExplicitValuedEnum::TENTH
+    assert_equal 11, ExplicitValuedEnum::ELEVENTH
+    assert_equal 13, ExplicitValuedEnum::THIRTEENTH
+
+    # Some discriminants specified, increment by one for any unspecified variants
+    assert_equal 10, GappedEnum::ONE
+    assert_equal 11, GappedEnum::TWO # Sequential value after ONE (10+1)
+    assert_equal 14, GappedEnum::THREE # Explicit value
   end
 
   def test_explicit_valued_enum_distinct

--- a/bindgen-tests/ruby/tests/options.rb
+++ b/bindgen-tests/ruby/tests/options.rb
@@ -21,7 +21,7 @@ class TestOptions < Test::Unit::TestCase
     assert_equal 42, UniffiBindgenTests.roundtrip_option_i64(42)
     assert_equal 42, UniffiBindgenTests.roundtrip_option_f32(42.0)
     assert_equal 42, UniffiBindgenTests.roundtrip_option_f64(42.0)
-    assert_equal "test-string", UniffiBindgenTests.roundtrip_option_string("test-string")
+    assert_equal 'test-string', UniffiBindgenTests.roundtrip_option_string('test-string')
     assert_equal true, UniffiBindgenTests.roundtrip_option_bool(true)
 
     rec = OptionsRec.new(a: 42)
@@ -42,5 +42,6 @@ class TestOptions < Test::Unit::TestCase
     assert_nil UniffiBindgenTests.roundtrip_option_string(nil)
     assert_nil UniffiBindgenTests.roundtrip_option_string(nil)
     assert_nil UniffiBindgenTests.roundtrip_option_rec(nil)
+    assert_nil UniffiBindgenTests.roundtrip_option_bool(nil)
   end
 end

--- a/bindgen-tests/ruby/tests/records.rb
+++ b/bindgen-tests/ruby/tests/records.rb
@@ -52,4 +52,8 @@ class TestRecords < Test::Unit::TestCase
     assert_equal 'hello world', result.field_string
     assert_equal 99, result.field_rec.a
   end
+
+  def test_methods
+    assert_equal SimpleRec.new(a: 42), SimpleRec.new(a: 42).roundtrip
+  end
 end

--- a/bindgen-tests/ruby/tests/recursive_types.rb
+++ b/bindgen-tests/ruby/tests/recursive_types.rb
@@ -104,32 +104,61 @@ class TestRecursiveTypes < Test::Unit::TestCase
   end
 
   def test_trie_branch
-    trie = Trie::BRANCH.new(children: {
-                              'a' => Trie::LEAF.new(1),
-                              'b' => Trie::LEAF.new(2)
-                            })
+    assert_equal 0, UniffiBindgenTests.trie_sum(Trie::BRANCH.new(children: {}))
+
+    assert_equal(
+      7,
+      UniffiBindgenTests.trie_sum(
+        Trie::BRANCH.new(children: { 'x' => Trie::BRANCH.new(children: { 'y' => Trie::LEAF.new(7) }) })
+      )
+    )
+
+    trie = Trie::BRANCH.new(children: { 'a' => Trie::LEAF.new(1), 'b' => Trie::LEAF.new(2) })
 
     assert_equal 3, UniffiBindgenTests.trie_sum(trie)
   end
 
-  # -- RoseTree --
+  # -- RoseTree (cycle through a record: RoseTree → RoseData → Vec<RoseTree>) --
 
   def test_rose_tree_leaf
     assert_equal 5, UniffiBindgenTests.sum_rose_tree(RoseTree::LEAF.new(5))
   end
 
   def test_rose_tree_branch
-    tree = RoseTree::BRANCH.new(
-      RoseData.new(
-        value: 1,
-        children: [
-          RoseTree::LEAF.new(2),
-          RoseTree::LEAF.new(3)
-        ]
+    assert_equal 10, UniffiBindgenTests.sum_rose_tree(
+      RoseTree::BRANCH.new(
+        RoseData.new(value: 10, children: [])
       )
     )
 
-    assert_equal 6, UniffiBindgenTests.sum_rose_tree(tree)
+    assert_equal 6, UniffiBindgenTests.sum_rose_tree(
+      RoseTree::BRANCH.new(
+        RoseData.new(
+          value: 1,
+          children: [
+            RoseTree::LEAF.new(2),
+            RoseTree::LEAF.new(3),
+          ]
+        )
+      )
+    )
+
+    assert_equal 10, UniffiBindgenTests.sum_rose_tree(
+      RoseTree::BRANCH.new(
+        RoseData.new(
+          value: 1,
+          children: [
+            RoseTree::BRANCH.new(
+              RoseData.new(
+                value: 2,
+                children: [RoseTree::LEAF.new(3)]
+              )
+            ),
+            RoseTree::LEAF.new(4),
+          ]
+        )
+      )
+    )
   end
 
   # --- Recursive EvalError ---

--- a/bindgen-tests/ruby/tests/references.rb
+++ b/bindgen-tests/ruby/tests/references.rb
@@ -7,15 +7,8 @@
 require 'test/unit'
 require 'uniffi_bindgen_tests'
 
-class TestRecords < Test::Unit::TestCase
+class TestReferences < Test::Unit::TestCase
   include UniffiBindgenTests
-
-  def test_simple_rec
-    rec = SimpleRec.new a: 42
-    result = UniffiBindgenTests.roundtrip_simple_rec rec
-
-    assert_equal 42, result.a
-  end
 
   def test_value_ref
     result = UniffiBindgenTests.roundtrip_u8_ref 2

--- a/bindgen-tests/ruby/tests/renames.rb
+++ b/bindgen-tests/ruby/tests/renames.rb
@@ -19,6 +19,8 @@ class TestRenames < Test::Unit::TestCase
 
   def test_rename_enum
     rec = RenamedRecord.new item: 42
+    _enum1 = RenamedEnum::RENAMED_VARIANT.new
+    _enum2 = RenamedEnum::RECORD.new rec
     result = UniffiBindgenTests.renamed_function rec
 
     assert_kind_of RenamedEnum::RECORD, result

--- a/bindgen-tests/ruby/tests/rust_traits.rb
+++ b/bindgen-tests/ruby/tests/rust_traits.rb
@@ -30,13 +30,13 @@ class TestRustTraits < Test::Unit::TestCase
     # The Rust code only uses `a` for the ordering
     assert RustTraitTest.new(a: 1, b: 2) < RustTraitTest.new(a: 2, b: 3)
     assert RustTraitTest.new(a: 2, b: 3) > RustTraitTest.new(a: 1, b: 2)
-    assert RustTraitTest.new(a: 1, b: 2) <= RustTraitTest.new(a: 1, b: 2)
-    assert RustTraitTest.new(a: 1, b: 2) >= RustTraitTest.new(a: 1, b: 2)
+    assert RustTraitTest.new(a: 1, b: 2) <= RustTraitTest.new(a: 1, b: 3)
+    assert RustTraitTest.new(a: 1, b: 2) >= RustTraitTest.new(a: 1, b: 3)
   end
 
   def test_hash
     # The Rust code only uses `a` for the hash
-    assert_equal RustTraitTest.new(a: 1, b: 2).hash, RustTraitTest.new(a: 1, b: 2).hash
+    assert_equal RustTraitTest.new(a: 1, b: 2).hash, RustTraitTest.new(a: 1, b: 3).hash
     assert_not_equal RustTraitTest.new(a: 1, b: 2).hash, RustTraitTest.new(a: 2, b: 2).hash
   end
 

--- a/bindgen-tests/ruby/tests/trait_interfaces.rb
+++ b/bindgen-tests/ruby/tests/trait_interfaces.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_bindgen_tests'
+
+class TraitImpl
+  attr_accessor :value
+
+  @@ref_count = 0
+
+  def self.ref_count
+    @@ref_count
+  end
+
+  def self.finalizer
+    proc { @@ref_count -= 1 }
+  end
+
+  def initialize(value)
+    @value = value
+    @@ref_count += 1
+    ObjectSpace.define_finalizer(self, self.class.finalizer)
+  end
+
+  def noop; end
+
+  def get_value
+    value
+  end
+
+  def set_value(value)
+    self.value = value
+  end
+
+  def roundtrip_record(value)
+    value
+  end
+
+  def roundtrip_enum(value)
+    value
+  end
+
+  def roundtrip_interface(value)
+    value
+  end
+
+  def throw_if_equal(numbers)
+    raise UniffiBindgenTests::TestError::Failure1 if numbers.a == numbers.b
+
+    numbers
+  end
+end
+
+class TestTraitInterfaces < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  def check_rust_impl(trait_impl)
+    trait_impl.noop
+    assert_equal 42, trait_impl.get_value
+    trait_impl.set_value(43)
+    assert_equal 43, trait_impl.get_value
+    assert_raises(TestError::Failure1) do
+      trait_impl.throw_if_equal(CallbackInterfaceNumbers.new(a: 10, b: 10))
+    end
+    numbers = CallbackInterfaceNumbers.new(a: 10, b: 11)
+    assert_equal numbers, trait_impl.throw_if_equal(numbers)
+
+    assert_equal trait_impl.roundtrip_record(SimpleRec.new(a: 10)), SimpleRec.new(a: 10)
+    assert_equal(
+      trait_impl.roundtrip_enum(EnumWithData::A.new(value: 10, value2: 20)),
+      EnumWithData::A.new(value: 10, value2: 20)
+    )
+    assert_equal trait_impl.roundtrip_interface(TestInterface.new(20)).get_value, 20
+  end
+
+  def check_rb_impl(trait_impl)
+    UniffiBindgenTests.invoke_test_trait_interface_noop(trait_impl)
+    assert_equal 42, UniffiBindgenTests.invoke_test_trait_interface_get_value(trait_impl)
+    UniffiBindgenTests.invoke_test_trait_interface_set_value(trait_impl, 43)
+    assert_equal 43, UniffiBindgenTests.invoke_test_trait_interface_get_value(trait_impl)
+    assert_raises(TestError::Failure1) do
+      UniffiBindgenTests.invoke_test_trait_interface_throw_if_equal(
+        trait_impl,
+        CallbackInterfaceNumbers.new(a: 10, b: 10)
+      )
+    end
+    numbers = CallbackInterfaceNumbers.new(a: 10, b: 11)
+    assert_equal numbers, UniffiBindgenTests.invoke_test_trait_interface_throw_if_equal(trait_impl, numbers)
+
+    assert_equal(
+      UniffiBindgenTests.invoke_test_trait_interface_roundtrip_record(trait_impl, SimpleRec.new(a: 10)),
+      SimpleRec.new(a: 10)
+    )
+    assert_equal(
+      UniffiBindgenTests.invoke_test_trait_interface_roundtrip_enum(trait_impl,
+                                                                    EnumWithData::A.new(value: 10, value2: 20)),
+      EnumWithData::A.new(value: 10, value2: 20)
+    )
+
+    assert_equal(
+      UniffiBindgenTests.invoke_test_trait_interface_roundtrip_interface(trait_impl, TestInterface.new(20)).get_value,
+      20
+    )
+  end
+
+  def test_rust_impl
+    check_rust_impl(UniffiBindgenTests.create_test_trait_interface(42))
+  end
+
+  def test_rust_impl_roundtripped
+    check_rust_impl(
+      UniffiBindgenTests.roundtrip_test_trait_interface(
+        UniffiBindgenTests.create_test_trait_interface(42)
+      )
+    )
+  end
+
+  def test_rust_impl_roundtripped_list
+    check_rust_impl(
+      UniffiBindgenTests.roundtrip_test_trait_interface_list(
+        [UniffiBindgenTests.create_test_trait_interface(42)]
+      )[0]
+    )
+  end
+
+  def test_rb_impl
+    check_rb_impl(TraitImpl.new(42))
+    GC.start
+
+    assert_equal 0, TraitImpl.ref_count
+  end
+
+  def test_rb_impl_roundtripped_list
+    impl = UniffiBindgenTests.roundtrip_test_trait_interface_list([TraitImpl.new(42)])[0]
+    check_rb_impl(impl)
+    # rubocop:disable Lint/UselessAssignment
+    impl = nil
+    # rubocop:enable Lint/UselessAssignment
+    GC.start
+
+    assert_equal 0, TraitImpl.ref_count
+  end
+
+  def test_rb_impl_roundtripped
+    impl = UniffiBindgenTests.roundtrip_test_trait_interface(TraitImpl.new(42))
+    check_rb_impl(impl)
+    # rubocop:disable Lint/UselessAssignment
+    impl = nil
+    # rubocop:enable Lint/UselessAssignment
+    GC.start
+
+    assert_equal 0, TraitImpl.ref_count
+  end
+end
+
+class TestRustOnlyTraitInterfaces < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  def check_rust_only_impl(impl)
+    assert_raises(TestError::Failure1) do
+      impl.throw_if_equal(CallbackInterfaceNumbers.new(a: 10, b: 10))
+    end
+
+    assert_equal(
+      impl.throw_if_equal(CallbackInterfaceNumbers.new(a: 10, b: 11)),
+      CallbackInterfaceNumbers.new(a: 10, b: 11)
+    )
+  end
+
+  def test_rust_only_impl
+    check_rust_only_impl UniffiBindgenTests.create_rust_only_test_trait_interface
+  end
+end
+
+class TestFireignOnlyTraitInterfaces < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  class ForeignOnlyImpl < TestForeignOnlyTraitInterface
+    include UniffiBindgenTests
+
+    def throw_if_equal(numbers)
+      raise TestError::Failure1 if numbers.a == numbers.b
+
+      numbers
+    end
+  end
+
+  def check_foreign_only_impl(impl)
+    assert_raises(TestError::Failure1) do
+      UniffiBindgenTests.invoke_test_foreign_only_trait_throw_if_equal(
+        impl,
+        CallbackInterfaceNumbers.new(a: 10, b: 10)
+      )
+    end
+
+    assert_equal(
+      UniffiBindgenTests.invoke_test_foreign_only_trait_throw_if_equal(
+        impl,
+        CallbackInterfaceNumbers.new(a: 10, b: 11)
+      ),
+      CallbackInterfaceNumbers.new(a: 10, b: 11)
+    )
+  end
+
+  def test_foreign_only_impl
+    check_foreign_only_impl ForeignOnlyImpl.new
+  end
+
+  def test_foreign_only_impl_roundtripped
+    check_foreign_only_impl UniffiBindgenTests.roundtrip_test_foreign_only_trait(ForeignOnlyImpl.new)
+  end
+end

--- a/examples/callbacks/tests/bindings/test_callbacks.rb
+++ b/examples/callbacks/tests/bindings/test_callbacks.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require 'test/unit'
+require 'callbacks'
+
+# This is defined in UDL as a "callback". It's not possible to have a Rust
+# implementation of a callback, they only exist on the foreign side.
+class CallAnswererImpl < Callbacks::CallAnswerer
+  def initialize(mode)
+    @mode = mode
+  end
+
+  def answer
+    if @mode == 'ready'
+      'Bonjour'
+    elsif @mode == 'busy'
+      raise Callbacks::TelephoneError::Busy
+    else
+      raise ValueError, 'Testing an unexpected error'
+    end
+  end
+end
+
+# This is a normal Rust trait - very much like a callback but can be implemented
+# in Rust or in foreign code and is generally more consistent with the uniffi
+# Arc<>-based object model.
+class DiscountSim < Callbacks::SimCard
+  def name
+    'ruby'
+  end
+end
+
+class TestCallbacks < Test::Unit::TestCase
+  TelephoneImpl = Callbacks::Telephone
+
+  def test_answer
+    cb_object = CallAnswererImpl.new 'ready'
+
+    assert_equal 'Bonjour', telephone.call(sim, cb_object)
+  end
+
+  def test_busy
+    cb_object = CallAnswererImpl.new 'busy'
+
+    assert_raise(Callbacks::TelephoneError::Busy) do
+      telephone.call sim, cb_object
+    end
+  end
+
+  def test_unexpected_error
+    cb_object = CallAnswererImpl.new 'something-else'
+
+    assert_raise(Callbacks::TelephoneError::InternalTelephoneError) do
+      telephone.call sim, cb_object
+    end
+  end
+
+  def test_sims
+    cb_object = CallAnswererImpl.new 'ready'
+    sim = DiscountSim.new
+
+    assert_equal 'ruby est bon marché', telephone.call(sim, cb_object)
+  end
+
+  def sim
+    Callbacks.get_sim_cards[0]
+  end
+
+  def telephone
+    self.class::TelephoneImpl.new
+  end
+end
+
+class FancyTestCallbacks < TestCallbacks
+  TelephoneImpl = Callbacks::FancyTelephone
+
+  def test_answer
+    super
+  end
+
+  def test_busy
+    super
+  end
+
+  def test_unexpected_error
+    super
+  end
+
+  def test_sims
+    super
+  end
+end

--- a/examples/callbacks/tests/test_generated_bindings.rs
+++ b/examples/callbacks/tests/test_generated_bindings.rs
@@ -2,4 +2,5 @@ uniffi::build_foreign_language_testcases!(
     "tests/bindings/test_callbacks.kts",
     "tests/bindings/test_callbacks.swift",
     "tests/bindings/test_callbacks.py",
+    "tests/bindings/test_callbacks.rb",
 );

--- a/examples/traits/tests/bindings/test_traits.rb
+++ b/examples/traits/tests/bindings/test_traits.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require 'test/unit'
+require 'traits'
+
+class RbButton < Traits::Button
+  def name
+    'RbButton'
+  end
+end
+
+class TestTraits < Test::Unit::TestCase
+  def test_first_button
+    buttons = Traits.get_buttons
+
+    assert_equal 'stop', buttons[0].name
+    assert_equal 'stop', Traits.press(buttons[0]).name
+  end
+
+  def test_second_button
+    buttons = Traits.get_buttons
+
+    assert_equal 'go', buttons[1].name
+    assert_equal 'go', Traits.press(buttons[1]).name
+  end
+
+  def test_rb_button
+    assert_equal 'RbButton', Traits.press(RbButton.new).name
+  end
+end

--- a/examples/traits/tests/test_generated_bindings.rs
+++ b/examples/traits/tests/test_generated_bindings.rs
@@ -2,4 +2,5 @@ uniffi::build_foreign_language_testcases!(
     "tests/bindings/test_traits.py",
     "tests/bindings/test_traits.kts",
     "tests/bindings/test_traits.swift",
+    "tests/bindings/test_traits.rb",
 );

--- a/fixtures/callbacks/tests/bindings/test_callbacks.rb
+++ b/fixtures/callbacks/tests/bindings/test_callbacks.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'fixture_callbacks'
+
+class SomeOtherError < StandardError
+end
+
+class RubyGetters
+  def get_bool(v, argument_two)
+    v ^ argument_two
+  end
+
+  def get_string(v, arg2)
+    raise FixtureCallbacks::SimpleError::BadArgument if v == 'bad-argument'
+    raise SomeOtherError, 'unexpected value' if v == 'unexpected-error'
+
+    arg2 ? '1234567890123' : v
+  end
+
+  def get_option(v, arg2)
+    raise FixtureCallbacks::ComplexError::ReallyBadArgument.new(code: 20) if v == 'bad-argument'
+    raise SomeOtherError, 'unexpected value' if v == 'unexpected-error'
+
+    arg2 ? v&.upcase : v
+  end
+
+  def get_list(v, arg2)
+    arg2 ? v : []
+  end
+
+  def get_nothing(v)
+    raise FixtureCallbacks::SimpleError::BadArgument if v == 'bad-argument'
+    raise SomeOtherError, 'unexpected value' if v == 'unexpected-error'
+  end
+end
+
+class StoredRubyStringifier
+  def from_simple_type(value)
+    "ruby: #{value}"
+  end
+
+  # Included to ensure callback argument type collection handles nested optional sequence types.
+  def from_complex_type(values)
+    "ruby: #{values}"
+  end
+end
+
+class TestCallbacks < Test::Unit::TestCase
+  def setup
+    @rust_getters = FixtureCallbacks::RustGetters.new
+    @callback = RubyGetters.new
+  end
+
+  def test_roundtrip_callback_values
+    [true, false].each do |v|
+      flag = true
+      assert_equal @callback.get_bool(v, flag), @rust_getters.get_bool(@callback, v, flag)
+    end
+
+    [[1, 2], [0, 1]].each do |v|
+      flag = true
+      assert_equal @callback.get_list(v, flag), @rust_getters.get_list(@callback, v, flag)
+    end
+
+    %w[Hello world].each do |v|
+      flag = true
+      assert_equal @callback.get_string(v, flag), @rust_getters.get_string(@callback, v, flag)
+    end
+
+    ['Some', nil].each do |v|
+      flag = false
+      assert_equal @callback.get_option(v, flag), @rust_getters.get_option(@callback, v, flag)
+    end
+  end
+
+  def test_optional_callback_argument
+    assert_equal 'TestString', @rust_getters.get_string_optional_callback(@callback, 'TestString', false)
+    assert_nil @rust_getters.get_string_optional_callback(nil, 'TestString', false)
+  end
+
+  def test_void_callback_method
+    assert_nothing_raised do
+      @rust_getters.get_nothing(@callback, 'TestString')
+    end
+  end
+
+  def test_callback_error_mapping
+    assert_raises(FixtureCallbacks::SimpleError::BadArgument) do
+      @rust_getters.get_string(@callback, 'bad-argument', true)
+    end
+
+    assert_raises(FixtureCallbacks::SimpleError::UnexpectedError) do
+      @rust_getters.get_string(@callback, 'unexpected-error', true)
+    end
+
+    e = assert_raises(FixtureCallbacks::ComplexError::ReallyBadArgument) do
+      @rust_getters.get_option(@callback, 'bad-argument', true)
+    end
+    assert_equal 20, e.code
+
+    e = assert_raises(FixtureCallbacks::ComplexError::UnexpectedErrorWithReason) do
+      @rust_getters.get_option(@callback, 'unexpected-error', true)
+    end
+    assert_kind_of String, e.reason
+    assert_match e.reason, SomeOtherError.new('unexpected value').inspect
+
+    assert_raises(FixtureCallbacks::SimpleError::BadArgument) do
+      @rust_getters.get_nothing(@callback, 'bad-argument')
+    end
+
+    assert_raises(FixtureCallbacks::SimpleError::UnexpectedError) do
+      @rust_getters.get_nothing(@callback, 'unexpected-error')
+    end
+  end
+
+  def test_stored_callback_roundtrip
+    ruby_stringifier = StoredRubyStringifier.new
+    rust_stringifier = FixtureCallbacks::RustStringifier.new(ruby_stringifier)
+
+    [1, 2].each do |v|
+      assert_equal ruby_stringifier.from_simple_type(v), rust_stringifier.from_simple_type(v)
+    end
+  end
+
+  def test_stored_callback_lifetime_with_multiple_references
+    stringifier = StoredRubyStringifier.new
+    rust_stringifier1 = FixtureCallbacks::RustStringifier.new(stringifier)
+    rust_stringifier2 = FixtureCallbacks::RustStringifier.new(stringifier)
+
+    assert_equal 'ruby: 123', rust_stringifier2.from_simple_type(123)
+    nil
+    GC.start
+
+    assert_equal 'ruby: 123', rust_stringifier1.from_simple_type(123)
+  end
+end

--- a/fixtures/callbacks/tests/test_generated_bindings.rs
+++ b/fixtures/callbacks/tests/test_generated_bindings.rs
@@ -2,4 +2,5 @@ uniffi::build_foreign_language_testcases!(
     "tests/bindings/test_callbacks.kts",
     "tests/bindings/test_callbacks.swift",
     "tests/bindings/test_callbacks.py",
+    "tests/bindings/test_callbacks.rb",
 );

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -159,6 +159,10 @@ impl<'a> RubyWrapper<'a> {
     }
 }
 
+fn class_name_rb_inner(nm: &str) -> Result<String, askama::Error> {
+    Ok(nm.to_string().to_upper_camel_case())
+}
+
 mod filters {
     use super::*;
 
@@ -179,16 +183,39 @@ mod filters {
             FfiType::RustBuffer(_) => "RustBuffer.by_value".to_string(),
             FfiType::RustCallStatus => "RustCallStatus".to_string(),
             FfiType::ForeignBytes => "ForeignBytes".to_string(),
-            FfiType::Callback(_) => unimplemented!("FFI Callbacks not implemented"),
-            // Note: this can't just be `unimplemented!()` because some of the FFI function
-            // definitions use references.  Those FFI functions aren't actually used, so we just
-            // pick something that runs and makes some sense.  Revisit this once the references
-            // are actually implemented.
-            FfiType::Reference(_) | FfiType::MutReference(_) => ":pointer".to_string(),
+            FfiType::Callback(name) => format!(":{name}"),
+            FfiType::Reference(inner) | FfiType::MutReference(inner) => match inner.as_ref() {
+                FfiType::Struct(name) => format!("{name}.by_ref"),
+                _ => ":pointer".to_string(),
+            },
             FfiType::VoidPointer => ":pointer".to_string(),
-            FfiType::Struct(_) => {
-                unimplemented!("Structs are not implemented")
-            }
+            FfiType::Struct(name) => format!("{name}.by_value"),
+        })
+    }
+
+    /// Generate the Ruby FFI::Pointer write method name for writing a lowered return value.
+    /// For RustBuffer returns, return "rustbuffer" as a sentinel - template handles it specially.
+    #[askama::filter_fn]
+    pub fn ffi_write_return_rb(
+        return_type: &Type,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
+        let ffi_type = FfiType::from(return_type);
+
+        Ok(match &ffi_type {
+            FfiType::Int8 => "write_int8".to_string(),
+            FfiType::UInt8 => "write_uint8".to_string(),
+            FfiType::Int16 => "write_int16".to_string(),
+            FfiType::UInt16 => "write_uint16".to_string(),
+            FfiType::Int32 => "write_int32".to_string(),
+            FfiType::UInt32 => "write_uint32".to_string(),
+            FfiType::Int64 => "write_int64".to_string(),
+            FfiType::UInt64 => "write_uint64".to_string(),
+            FfiType::Float32 => "write_float".to_string(),
+            FfiType::Float64 => "write_double".to_string(),
+            FfiType::Handle => "write_uint64".to_string(),
+            FfiType::RustBuffer(_) => "rustbuffer".to_string(),
+            _ => panic!("Unsupported FFI return type for callback: {ffi_type:?}"),
         })
     }
 
@@ -304,10 +331,6 @@ mod filters {
         class_name_rb_inner(nm)
     }
 
-    fn class_name_rb_inner(nm: &str) -> Result<String, askama::Error> {
-        Ok(nm.to_string().to_upper_camel_case())
-    }
-
     #[askama::filter_fn]
     pub fn fn_name_rb(nm: &str, _: &dyn askama::Values) -> Result<String, askama::Error> {
         Ok(nm.to_string().to_snake_case())
@@ -358,17 +381,17 @@ mod filters {
             Type::UInt16 => format!("::{ns}::uniffi_in_range({nm}, \"u16\", 0, 2**16)"),
             Type::UInt32 => format!("::{ns}::uniffi_in_range({nm}, \"u32\", 0, 2**32)"),
             Type::UInt64 => format!("::{ns}::uniffi_in_range({nm}, \"u64\", 0, 2**64)"),
-            Type::Float32 | Type::Float64 => nm.to_string(),
+            Type::Float32
+            | Type::Float64
+            | Type::Object { .. }
+            | Type::Enum { .. }
+            | Type::Record { .. }
+            | Type::Timestamp
+            | Type::Duration
+            | Type::CallbackInterface { .. } => nm.to_string(),
             Type::Boolean => format!("{nm} ? true : false"),
-            Type::Object { .. } | Type::Enum { .. } | Type::Record { .. } => nm.to_string(),
             Type::String => format!("::{ns}::uniffi_utf8({nm})"),
             Type::Bytes => format!("::{ns}::uniffi_bytes({nm})"),
-            Type::Timestamp | Type::Duration => nm.to_string(),
-            Type::CallbackInterface { name, .. } => {
-                // Callback interfaces are not yet supported; emit a Ruby runtime error so that
-                // code generation succeeds but calling such functions raises clearly.
-                format!("raise NotImplementedError, \"Callback interface {name} is not yet supported in the Ruby bindings\"")
-            }
             Type::Optional { inner_type: t } => {
                 format!(
                     "({nm} ? {} : nil)",
@@ -391,9 +414,12 @@ mod filters {
                     format!("{nm}.map {{ |v| {coerce_code} }}.to_set")
                 }
             }
-            Type::Map { value_type: t, .. } => {
-                let k_coerce_code = coerce_rb_inner("k", ns, &Type::String, custom_types)?;
-                let v_coerce_code = coerce_rb_inner("v", ns, t, custom_types)?;
+            Type::Map {
+                key_type: kt,
+                value_type: vt,
+            } => {
+                let k_coerce_code = coerce_rb_inner("k", ns, kt, custom_types)?;
+                let v_coerce_code = coerce_rb_inner("v", ns, vt, custom_types)?;
 
                 if k_coerce_code == "k" && v_coerce_code == "v" {
                     nm.to_string()
@@ -433,11 +459,9 @@ mod filters {
             | Type::Optional { .. }
             | Type::Sequence { .. }
             | Type::Set { .. }
-            | Type::Map { .. } => format!(
-                "RustBuffer.check_lower_{}({})",
-                class_name_rb_inner(&canonical_name(type_))?,
-                nm
-            ),
+            | Type::Map { .. } => {
+                format!("RustBuffer.check_lower_{}({})", canonical_name(type_), nm)
+            }
             Type::Custom { name, .. } => {
                 if let Some(cfg) = config.custom_types.get(name) {
                     if let Some(type_name) = &cfg.type_name {
@@ -501,14 +525,14 @@ mod filters {
             | Type::Float32
             | Type::Float64 => nm.to_string(),
             Type::Boolean => format!("({nm} ? 1 : 0)"),
-            Type::String => format!("RustBuffer.allocFromString({nm})"),
-            Type::Bytes => format!("RustBuffer.allocFromBytes({nm})"),
             Type::Object { name, .. } => {
                 format!("({}.uniffi_lower {nm})", class_name_rb_inner(name)?)
             }
             Type::CallbackInterface { name, .. } => {
                 format!(
-                    "raise(NotImplementedError, \"Callback interface {name} is not yet supported in the Ruby bindings\")"
+                    "(CallbackInterface{}FfiConverter.lower {})",
+                    class_name_rb_inner(name)?,
+                    nm
                 )
             }
             Type::Enum { .. }
@@ -517,12 +541,12 @@ mod filters {
             | Type::Sequence { .. }
             | Type::Set { .. }
             | Type::Timestamp
+            | Type::String
+            | Type::Bytes
             | Type::Duration
-            | Type::Map { .. } => format!(
-                "RustBuffer.alloc_from_{}({})",
-                class_name_rb_inner(&canonical_name(type_))?,
-                nm
-            ),
+            | Type::Map { .. } => {
+                format!("RustBuffer.alloc_from_{}({})", canonical_name(type_), nm)
+            }
             Type::Box { .. } => unreachable!(),
             Type::Custom { .. } => unreachable!("Custom types should be handled before dispatch"),
         })
@@ -586,20 +610,18 @@ mod filters {
             | Type::UInt64 => format!("{nm}.to_i"),
             Type::Float32 | Type::Float64 => format!("{nm}.to_f"),
             Type::Boolean => format!("1 == {nm}"),
-            Type::String => format!("{nm}.consumeIntoString"),
-            Type::Bytes => format!("{nm}.consumeIntoBytes"),
             Type::Object { name, .. } => {
-                format!("{}.uniffi_allocate({nm})", class_name_rb_inner(name)?)
+                format!("{}.uniffi_lift({nm})", class_name_rb_inner(name)?)
             }
             Type::CallbackInterface { name, .. } => {
                 format!(
-                    "raise(NotImplementedError, \"Callback interface {name} is not yet supported in the Ruby bindings\")"
+                    "(CallbackInterface{}FfiConverter.lift {nm})",
+                    class_name_rb_inner(name)?
                 )
             }
             Type::Enum { .. } => {
                 format!(
-                    "{}.consumeInto{}",
-                    nm,
+                    "{nm}.consume_into_{}",
                     class_name_rb_inner(&canonical_name(type_))?
                 )
             }
@@ -608,12 +630,10 @@ mod filters {
             | Type::Sequence { .. }
             | Type::Set { .. }
             | Type::Timestamp
+            | Type::String
+            | Type::Bytes
             | Type::Duration
-            | Type::Map { .. } => format!(
-                "{}.consumeInto{}",
-                nm,
-                class_name_rb_inner(&canonical_name(type_))?
-            ),
+            | Type::Map { .. } => format!("{nm}.consume_into_{}", canonical_name(type_)),
             Type::Box { .. } => unreachable!(),
             Type::Custom { name, builtin, .. } => {
                 let lifted = lift_rb_inner(nm, builtin, custom_types)?;
@@ -695,6 +715,24 @@ mod test_type {
             }),
             "OptionalSequenceTypeExample"
         );
+
+        let map = Type::Map {
+            key_type: Box::new(Type::UInt32),
+            value_type: Box::new(Type::UInt32),
+        };
+        assert_eq!(canonical_name(&map), "MapU32U32");
+        assert_eq!(
+            canonical_name(&Type::Enum {
+                module_path: "foo".to_string(),
+                name: "HTMLError".to_string()
+            }),
+            "TypeHTMLError"
+        );
+    }
+
+    #[test]
+    fn test_class_name() {
+        assert_eq!(class_name_rb_inner("Example").unwrap(), "Example");
     }
 }
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/CallbackInterfaceImpl.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/CallbackInterfaceImpl.rb
@@ -1,0 +1,127 @@
+{#
+// Template to generate a vtable implementation for a callback interface.
+// This template is used by the `CallbackInterfaceTemplate.rb` (for pure callback interfaces)
+// and `ObjectTemplate.rb` (for trait interfaces with ObjectImpl::CallbackTrait).
+//
+// Expected variable: cbi_name (the callback interface name string)
+#}
+{%- let cbi = ci.get_callback_interface_definition(cbi_name).unwrap() %}
+{%- let vtable_def = cbi.vtable_definition() %}
+{%- let vtable_methods = cbi.vtable_methods() %}
+{%- let ffi_init_callback = cbi.ffi_init_callback() %}
+
+# Callback interface vtable implementation for {{ cbi_name }}.
+module UniffiCallbackInterface{{ cbi_name|class_name_rb }}
+
+  {%- for (ffi_callback, method)  in vtable_methods.iter() %}
+
+  # Callback method for {{ method.name() }}
+  {{ method.name()|enum_name_rb }}_CALLBACK = Proc.new do |uniffi_handle, {%- for arg in method.arguments() %} {{ arg.name()|var_name_rb }},{% endfor %} uniffi_out_return, uniffi_call_status|
+    uniffi_obj = {{ self::canonical_name(cbi.as_type().borrow()) }}FfiConverter.lift uniffi_handle
+
+    make_call = Proc.new do
+      uniffi_obj.{{ method.name()|fn_name_rb }}(
+        {%- for arg in method.arguments() %}
+        {{ arg.name()|lift_rb(arg.as_type().borrow(), config) }}{% if !loop.last %},{% endif %}
+        {%- endfor %}
+      )
+    end
+
+    {%- match method.return_type() %}
+    {%- when Some with (return_type) %}
+    write_return_value = Proc.new do |v|
+      lowered = {{ "v"|lower_rb(return_type, config) }}
+      {%- let ffi_type_name = return_type|ffi_write_return_rb %}
+      {%- if ffi_type_name == "rustbuffer" %}
+      # Write a RustBuffer struct into the out pointer
+      out_buf = RustBuffer.new uniffi_out_return
+      out_buf[:capacity] = lowered[:capacity]
+      out_buf[:len] = lowered[:len]
+      out_buf[:data] = lowered[:data]
+      {%- else %}
+      uniffi_out_return.{{ ffi_type_name }}(lowered)
+      {%- endif %}
+    end
+    {%- when None %}
+    # No return value, so do nothing.
+    write_return_value = Proc.new { |_v| }
+    {%- endmatch %}
+
+    {%- match method.throws_type() %}
+    {%- when None %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call(
+      uniffi_call_status,
+      make_call,
+      write_return_value
+    )
+    {%- when Some with (error_type) %}
+    {%- match error_type %}
+    {%- when Type::Enum { name, .. } %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_with_error(
+      uniffi_call_status,
+      make_call,
+      write_return_value,
+      {{ name|class_name_rb }},
+      Proc.new { |e| {{ "e"|lower_rb(error_type, config) }} }
+    )
+    {%- when Type::Object { name, .. } %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_with_error(
+      uniffi_call_status,
+      make_call,
+      write_return_value,
+      {{ name|class_name_rb }},
+      Proc.new { |e| {{ "e"|lower_rb(error_type, config) }} }
+    )
+    {%- when Type::Custom { builtin, .. } %}
+    {%- match builtin.borrow() %}
+    {%- when Type::Enum { name, .. } %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_with_error(
+      uniffi_call_status,
+      make_call,
+      write_return_value,
+      {{ name|class_name_rb }},
+      Proc.new { |e| {{ "e"|lower_rb(builtin, config) }} }
+    )
+    {%- when Type::Object { name, .. } %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_with_error(
+      uniffi_call_status,
+      make_call,
+      write_return_value,
+      {{ name|class_name_rb }},
+      Proc.new { |e| {{ "e"|lower_rb(builtin, config) }} }
+    )
+    {%- else %}
+    raise RuntimeError, "Unsupported custom error type for callback interface"
+    {%- endmatch %}
+    {%- else %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call(
+      uniffi_call_status,
+      make_call,
+      write_return_value
+    )
+    {%- endmatch %}
+    {%- endmatch %}
+  end
+  {%- endfor %}
+
+  # Free callback: removes the handle from the map.
+  UNIFFI_FREE_CALLBACK = Proc.new do |uniffi_handle|
+    {{ self::canonical_name(cbi.as_type().borrow()) }}FfiConverter.handle_map.remove uniffi_handle
+  end
+
+  # Clone callback: clones the handle in the map.
+  UNIFFI_CLONE_CALLBACK = Proc.new do |uniffi_handle|
+    {{ self::canonical_name(cbi.as_type().borrow()) }}FfiConverter.handle_map.clone_handle uniffi_handle
+  end
+
+  # Create the VTable struct instance.
+  UNIFFI_VTABLE = UniFFILib::{{ vtable_def.name() }}.new
+  UNIFFI_VTABLE[:uniffi_free] = UNIFFI_FREE_CALLBACK
+  UNIFFI_VTABLE[:uniffi_clone] = UNIFFI_CLONE_CALLBACK
+  {%- for (ffi_callback, method)  in vtable_methods.iter() %}
+  UNIFFI_VTABLE[:{{ method.name() }}] = {{ method.name()|enum_name_rb }}_CALLBACK
+  {%- endfor %}
+
+  # Register the VTable with Rust.
+  UniFFILib.{{ ffi_init_callback.name() }}(UNIFFI_VTABLE)
+end

--- a/uniffi_bindgen/src/bindings/ruby/templates/CallbackInterfaceRuntime.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/CallbackInterfaceRuntime.rb
@@ -1,0 +1,20 @@
+# Base class for callback interface FfiConverters.
+# Stores Ruby callback objects in a handle map, and converts to/from integer handles.
+
+class CallbackInterfaceFfiConverter
+  attr_reader :handle_map
+
+  def initialize
+    @handle_map = UniffiHandleMap.new
+  end
+
+  def lift(handle)
+    @handle_map.get handle
+  end
+
+  def lower(cb)
+    @handle_map.insert cb
+  end
+end
+
+private_constant :CallbackInterfaceFfiConverter

--- a/uniffi_bindgen/src/bindings/ruby/templates/CallbackInterfaceTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/CallbackInterfaceTemplate.rb
@@ -1,0 +1,16 @@
+{%- let cbi = ci.get_callback_interface_definition(name).unwrap() %}
+{%- let cbi_name = name %}
+{%- let interface_name = cbi.name() %}
+
+class {{ interface_name }}
+  {% for meth in cbi.methods() -%}
+  def {{ meth.name()|fn_name_rb }}(**_args)
+    raise NoMethodError, 'method should be implemented in concrete class'
+  end
+  {% endfor %}
+end
+
+# The FfiConverter for the {{ name }} callback interface.
+{{ self::canonical_name(cbi.as_type().borrow()) }}FfiConverter = CallbackInterfaceFfiConverter.new
+
+{% include "CallbackInterfaceImpl.rb" %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/EnumTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/EnumTemplate.rb
@@ -13,9 +13,12 @@ class {{ e.name()|class_name_rb }}
     raise RuntimeError, '{{ e.name()|class_name_rb }} cannot be instantiated directly'
   end
 
+  {%- let methods = e.methods() %}
+  {%- include "MethodImpls.rb" %}
+
   # Each enum variant is a nested class of the enum itself.
   {% for variant in e.variants() -%}
-  class {{ variant.name()|enum_name_rb }}
+  class {{ variant.name()|enum_name_rb }} < {{ e.name()|class_name_rb }}
     {%- let named_fields = variant.has_fields() && !variant.fields()[0].name().is_empty() %}
     {% if variant.has_fields() %}
     {%- if named_fields %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/ErrorTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/ErrorTemplate.rb
@@ -82,16 +82,16 @@ end
 
 # Map error modules to the RustBuffer method name that reads them
 ERROR_MODULE_TO_READER_METHOD = {
-{%- for e in ci.enum_definitions() %}
-{% if ci.is_name_used_as_error(e.name()) %}
-     {{ e.name()|class_name_rb }} => :readType{{ e.name()|class_name_rb }},
+{% for e in ci.enum_definitions() %}
+{%- if ci.is_name_used_as_error(e.name()) -%}
+  {{ e.name()|class_name_rb }} => :read_{{ self::canonical_name(e.as_type().borrow()) }},
 {% endif %}
-{%- endfor %}
+{%- endfor -%}
 {% for obj in ci.object_definitions() %}
-{% if ci.is_name_used_as_error(obj.name()) %}
-     '{{ obj.name()|class_name_rb }}' => :readType{{ obj.name()|class_name_rb }},
+{%- if ci.is_name_used_as_error(obj.name()) -%}
+  '{{ obj.name()|class_name_rb }}' => :read_{{ self::canonical_name(obj.as_type().borrow()) }},
 {% endif %}
-{%- endfor %}
+{%- endfor -%}
 }
 
 private_constant :ERROR_MODULE_TO_READER_METHOD, :CALL_SUCCESS, :CALL_ERROR, :CALL_PANIC,
@@ -142,7 +142,7 @@ def self.rust_call_with_error(error_module, fn_name, *args)
     # with the message.  But if that code panics, then it just sends back
     # an empty buffer.
     if status.error_buf.len > 0
-      raise InternalError, status.error_buf.consumeIntoString()
+      raise InternalError, {{ "status.error_buf"|lift_rb(&Type::String, config) }}
     else
       raise InternalError, "Rust panic"
     end

--- a/uniffi_bindgen/src/bindings/ruby/templates/HandleMap.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/HandleMap.rb
@@ -1,0 +1,56 @@
+# A handle map for converting Ruby objects to/from integer handles.
+#
+# When passing callback interface or trait interface objects to Ruby, we store
+# the Ruby object in this map and pass the integer handle to Rust. When Rust
+# calls back, we look up the Ruby object by its handle.
+#
+# Ruby-created handles are always odd (staring at 1, incrementing by 2).
+# Rust-created handles are always even. This convention lets us distinguish
+# the source in lift/lower without extra metadata.
+
+
+class UniffiHandleMap
+  def initialize
+    @lock = Monitor.new
+    @map = {}
+    @counter = 1 # Start at 1 (odd), increment by 2
+  end
+
+  def insert(obj)
+    @lock.synchronize do
+      handle = @counter
+      @counter += 2
+      @map[handle] = obj
+      handle
+    end
+  end
+
+  def get(handle)
+    @lock.synchronize do
+      obj = @map[handle]
+      raise InternalError, "UniffiHandleMap.get: invalid handle #{handle}" if obj.nil?
+      obj
+    end
+  end
+
+  def clone_handle(handle)
+    @lock.synchronize do
+      obj = @map[handle]
+      raise InternalError, "UniffiHandleMap.clone_handle: invalid handle #{handle}" if obj.nil?
+      new_handle = @counter
+      @counter += 2
+      @map[new_handle] = obj
+      new_handle
+    end
+  end
+
+  def remove(handle)
+    @lock.synchronize do
+      obj = @map.delete(handle)
+      raise InternalError, "UniffiHandleMap.remove: invalid handle #{handle}" if obj.nil?
+      obj
+    end
+  end
+end
+
+private_constant :UniffiHandleMap

--- a/uniffi_bindgen/src/bindings/ruby/templates/Helpers.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/Helpers.rb
@@ -16,3 +16,63 @@ def self.uniffi_bytes(v)
   raise TypeError, "no implicit conversion of #{v} into String" unless v.respond_to?(:to_str)
   v.to_str
 end
+
+# Callback return codes
+UNIFFI_CALLBACK_SUCCESS = 0
+UNIFFI_CALLBACK_ERROR = 1
+UNIFFI_CALLBACK_UNEXPECTED_ERROR = 2
+
+# Call a method on a callback interface object, catching and reporting errors
+# to Rust via the call_status.
+def self.uniffi_trait_interface_call(call_status, make_call, write_return_value)
+  begin
+    write_return_value.call make_call.call
+  rescue => e
+    call_status[:code] = UNIFFI_CALLBACK_UNEXPECTED_ERROR
+    buf = {{ "e.inspect"|lower_rb(&Type::String, config) }}
+    error_buf = call_status[:error_buf]
+    error_buf[:capacity] = buf[:capacity]
+    error_buf[:len] = buf[:len]
+    error_buf[:data] = buf[:data]
+  end
+end
+
+# Same as above, but for methods that can throw a specific error type
+def self.uniffi_trait_interface_call_with_error(call_status, make_call, write_return_value, error_type, lower_error)
+  begin
+    result = make_call.call
+    write_return_value.call result
+  rescue StandardError => e
+    if uniffi_is_error_type?(e, error_type)
+      call_status[:code] = UNIFFI_CALLBACK_ERROR
+      buf = lower_error.call e
+      error_buf = call_status[:error_buf]
+      error_buf[:capacity] = buf[:capacity]
+      error_buf[:len] = buf[:len]
+      error_buf[:data] = buf[:data]
+    else
+      call_status[:code] = UNIFFI_CALLBACK_UNEXPECTED_ERROR
+      buf = {{ "e.inspect"|lower_rb(&Type::String, config) }}
+      error_buf = call_status[:error_buf]
+      error_buf[:capacity] = buf[:capacity]
+      error_buf[:len] = buf[:len]
+      error_buf[:data] = buf[:data]
+    end
+  end
+end
+
+# Check if an exception is a variant of the given error type.
+# Error types in Ruby are either modules (non-flat enums) or classes (flat enums),
+# with variant classes as constant within them.
+def self.uniffi_is_error_type?(e, error_type)
+  # Object-as-error: error_type is a class itself (e.g. MyError < StandardError)
+  if error_type.is_a?(Class) && e.is_a?(error_type)
+    return true
+  end
+
+  # Enum error: error_type is a module with class constants for each variant
+  error_type.constants.any? do |c|
+    klass = error_type.const_get c
+    klass.is_a?(Class) && e.is_a?(klass)
+  end
+end

--- a/uniffi_bindgen/src/bindings/ruby/templates/MethodImpls.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/MethodImpls.rb
@@ -1,0 +1,25 @@
+{# Shared template for generating instance methods on Records and non-flat Enums.
+# The caller must bind `methods` in the scope before including this file, e.g.:
+#   {% let methods = rec.methods() %}
+#   {% include "MethodImpls.rb" %}
+# Async methods are skipped (not implemented in Ruby yet).
+#}
+{% for meth in methods -%}
+{%- if meth.is_async() %}{% continue %}{%- endif %}
+{%- match meth.return_type() -%}
+
+{%- when Some with (return_type) -%}
+def {{ meth.name()|fn_name_rb }}{% call rb::arg_list_decl(meth) %}{% endcall %}
+  {%- call rb::setup_args_extra_indent(meth) %}{% endcall %}
+  result = {% call rb::to_ffi_call_with_lower_self(meth) %}{% endcall %}
+  return {{ "result"|lift_rb(return_type, config) }}
+end
+
+{%- when None %}
+def {{ meth.name()|fn_name_rb }}{% call rb::arg_list_decl(meth) %}{% endcall %}
+  {%- call rb::setup_args_extra_indent(meth) %}{% endcall %}
+  result = {% call rb::to_ffi_call_with_lower_self(meth) %}{% endcall %}
+end
+
+{%- endmatch %}
+{% endfor %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/NamespaceLibraryTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/NamespaceLibraryTemplate.rb
@@ -9,9 +9,29 @@ module UniFFILib
   ffi_lib '{{ config.cdylib_name() }}'
   {% endif %}
 
-  {% for func in ci.iter_ffi_function_definitions_non_async() -%}
+  # Define FFI callback types and structs (vtables, etc.)
+  {% for def in ci.ffi_definitions() %}
+  {%- match def -%}
+
+  {%- when FfiDefinition::CallbackFunction(cb_fn) %}
+  callback :{{ cb_fn.name() }},
+    [{%- for arg in cb_fn.arguments() %}{{ arg.type_().borrow()|type_ffi }}, {% endfor -%}
+    {%- if cb_fn.has_rust_call_status_arg() -%}RustCallStatus.by_ref{% endif -%}],
+    {% match cb_fn.return_type() %}{% when Some with (type_) %}{{ type_|type_ffi }}{% when None %}:void{% endmatch %}
+
+  {%- when FfiDefinition::Struct(ffi_struct) %}
+  class {{ ffi_struct.name() }} < FFI::Struct
+    layout(
+      {%- for field in ffi_struct.fields() %}
+      :{{ field.name() }}, {{ field.type_().borrow()|type_ffi }}{% if !loop.last %},{% endif %}
+      {%- endfor %}
+    )
+  end
+
+  {%- when FfiDefinition::Function(func) %}
   attach_function :{{ func.name() }},
     {%- call rb::arg_list_ffi_decl(func) %}{% endcall %},
     {% match func.return_type() %}{% when Some with (type_) %}{{ type_|type_ffi }}{% when None %}:void{% endmatch %}
+  {%- endmatch %}
   {% endfor %}
 end

--- a/uniffi_bindgen/src/bindings/ruby/templates/ObjectTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/ObjectTemplate.rb
@@ -21,11 +21,55 @@ class {{ obj.name()|class_name_rb }}{% if ci.is_name_used_as_error(obj.name()) %
     end
   end
 
+  {%- if obj.has_callback_interface() %}
+  # HandleMap for trait interface: stores Ruby-native objects keyed by odd handles.
+  @uniffi_handle_map = UniffiHandleMap.new
+
+  class << self
+    attr_reader :uniffi_handle_map
+  end
+
+  # For trait interfaces: check that the object is either a Rust-backed instance or
+  # responds to the required interface methods.
+  def self.uniffi_check_lower(inst)
+    {%- for method in obj.methods() %}
+    if !inst.respond_to?(:{{ method.name()|fn_name_rb }})
+      raise TypeError.new "Expected a {{ obj.name()|class_name_rb }} instance or an object implementing the interface, got #{inst}"
+    end
+    {%- endfor %}
+  end
+
+  def uniffi_clone_handle
+    return ::{{ci.namespace()|class_name_rb }}.rust_call(
+      :{{ obj.ffi_object_clone().name() }},
+      @handle
+    )
+  end
+
+  # For trait interfaces: lowering distinguishes between Rust-backed and Ruby-native instances.
+  def self.uniffi_lower(inst)
+    if inst.is_a?(self) && inst.instance_variable_defined?(:@handle)
+      inst.uniffi_clone_handle()
+    else
+      @uniffi_handle_map.insert(inst)
+    end
+  end
+
+  # For trait interfaces: lifting distinguishes even handles (Rust) from odd handles (Ruby).
+  def self.uniffi_lift(handle)
+    if (handle & 1) == 0
+      uniffi_allocate handle
+    else
+      @uniffi_handle_map.remove handle
+    end
+  end
+  
+  {%- else %}
   # A private helper for lowering instances into a raw handle.
   # This does an explicit typecheck, because accidentally lowering a different type of
   # object in a place where this type is expected, could lead to memory unsafety.
   def self.uniffi_check_lower(inst)
-    if not inst.is_a? self
+    if !inst.is_a? self
       raise TypeError.new "Expected a {{ obj.name()|class_name_rb }} instance, got #{inst}"
     end
   end
@@ -40,6 +84,11 @@ class {{ obj.name()|class_name_rb }}{% if ci.is_name_used_as_error(obj.name()) %
   def self.uniffi_lower(inst)
     return inst.uniffi_clone_handle()
   end
+
+  def self.uniffi_lift(handle)
+    uniffi_allocate handle
+  end
+  {%- endif %}
 
   {%- match obj.primary_constructor() %}
   {%- when Some with (cons) %}
@@ -82,3 +131,12 @@ class {{ obj.name()|class_name_rb }}{% if ci.is_name_used_as_error(obj.name()) %
   {%- let trait_methods = obj.uniffi_trait_methods() %}
   {%- include "UniffiTraitImpls.rb" %}
 end
+
+{%- if obj.has_callback_interface() %}
+{# For trait interfaces, generate and register the vtable. #}
+{%- let vtable = obj.vtable().expect("trait interface must have a vtable") %}
+{%- let vtable_methods = obj.vtable_methods() %}
+{%- let ffi_init_callback = obj.ffi_init_callback() %}
+{%- let cbi_name = obj.name() %}
+{%- include "TraitInterfaceVtable.rb" %}
+{%- endif %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/RecordTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RecordTemplate.rb
@@ -13,6 +13,9 @@ class {{ rec.name()|class_name_rb }}
     {%- endfor %}
   end
 
+  {%- let methods = rec.methods() %}
+  {%- include "MethodImpls.rb" %}
+
   {%- let trait_methods = rec.uniffi_trait_methods() %}
   {%- if trait_methods.eq_eq.is_none() %}
   def ==(other)

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -28,86 +28,86 @@ class RustBufferBuilder
   end
 
   {% for typ in ci.iter_local_types() -%}
-  {%- let canonical_type_name = self::canonical_name(typ).borrow()|class_name_rb -%}
+  {%- let canonical_type_name = self::canonical_name(typ) -%}
   {%- match typ -%}
 
   {% when Type::Int8 -%}
 
-  def write_I8(v)
+  def write_{{ canonical_type_name }}(v)
     v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i8", -2**7, 2**7)
     pack_into(1, 'c', v)
   end
 
   {% when Type::UInt8 -%}
 
-  def write_U8(v)
+  def write_{{ canonical_type_name }}(v)
     v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u8", 0, 2**8)
     pack_into(1, 'c', v)
   end
 
   {% when Type::Int16 -%}
 
-  def write_I16(v)
+  def write_{{ canonical_type_name }}(v)
     v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i16", -2**15, 2**15)
     pack_into(2, 's>', v)
   end
 
   {% when Type::UInt16 -%}
 
-  def write_U16(v)
+  def write_{{ canonical_type_name }}(v)
     v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u16", 0, 2**16)
     pack_into(2, 'S>', v)
   end
 
   {% when Type::Int32 -%}
 
-  def write_I32(v)
+  def write_{{ canonical_type_name }}(v)
     v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i32", -2**31, 2**31)
     pack_into(4, 'l>', v)
   end
 
   {% when Type::UInt32 -%}
 
-  def write_U32(v)
+  def write_{{ canonical_type_name }}(v)
     v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u32", 0, 2**32)
     pack_into(4, 'L>', v)
   end
 
   {% when Type::Int64 -%}
 
-  def write_I64(v)
+  def write_{{ canonical_type_name }}(v)
     v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i64", -2**63, 2**63)
     pack_into(8, 'q>', v)
   end
 
   {% when Type::UInt64 -%}
 
-  def write_U64(v)
+  def write_{{ canonical_type_name }}(v)
     v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u64", 0, 2**64)
     pack_into(8, 'Q>', v)
   end
 
   {% when Type::Float32 -%}
 
-  def write_F32(v)
+  def write_{{ canonical_type_name }}(v)
     pack_into(4, 'g', v)
   end
 
   {% when Type::Float64 -%}
 
-  def write_F64(v)
+  def write_{{ canonical_type_name }}(v)
     pack_into(8, 'G', v)
   end
 
   {% when Type::Boolean -%}
 
-  def write_Bool(v)
+  def write_{{ canonical_type_name }}(v)
     pack_into(1, 'c', v ? 1 : 0)
   end
 
   {% when Type::String -%}
 
-  def write_String(v)
+  def write_{{ canonical_type_name }}(v)
     v = ::{{ ci.namespace()|class_name_rb }}::uniffi_utf8(v)
     pack_into 4, 'l>', v.bytes.size
     write v
@@ -115,7 +115,7 @@ class RustBufferBuilder
 
   {% when Type::Bytes -%}
 
-  def write_Bytes(v)
+  def write_{{ canonical_type_name }}(v)
     v = ::{{ ci.namespace()|class_name_rb }}::uniffi_bytes(v)
     pack_into 4, 'l>', v.bytes.size
     write v
@@ -184,13 +184,41 @@ class RustBufferBuilder
     if v.{{ variant.name()|var_name_rb }}?
       pack_into(4, 'l>', {{ loop.index }})
       {%- for field in variant.fields() %}
-        self.write_{{ self::canonical_name(field.as_type().borrow()).borrow()|class_name_rb }}(v.{% call rb::field_name(field, loop.index) %}{% endcall %})
+        self.write_{{ self::canonical_name(field.as_type().borrow()) }}(v.{% call rb::field_name(field, loop.index) %}{% endcall %})
       {%- endfor %}
     end
     {%- endfor %}
     {%- endif %}
  end
-   {% endif %}
+  {% else %}
+  {%- let e = ci.get_enum_definition(enum_name).unwrap() -%}
+  # The Error type {{ enum_name }} - write for callback error returns.
+
+  def write_{{ canonical_type_name }}(v)
+    {%- if e.is_flat() %}
+    {%- for variant in e.variants() %}
+    if v.is_a?({{ enum_name|class_name_rb }}::{{ variant.name()|class_name_rb }})
+      pack_into 4, 'l>', {{ loop.index }}
+      return
+    end
+    {%- endfor %}
+    {%- else -%}
+    {%- for variant in e.variants() %}
+    if v.is_a?({{ enum_name|class_name_rb }}::{{ variant.name()|class_name_rb }})
+      pack_into 4, 'l>', {{ loop.index }}
+      {%- for field in variant.fields() %}
+        {%- if field.name().is_empty() %}
+        self.write_{{ self::canonical_name(field.as_type().borrow()) }}(v[{{ loop.index0 }}])
+        {%- else %}
+        self.write_{{ self::canonical_name(field.as_type().borrow()) }}(v.{{ field.name()|var_name_rb }})
+        {%- endif %}
+      {%- endfor %}
+      return
+    end
+    {%- endfor %}
+    {%- endif %}
+  end
+  {% endif %}
 
   {% when Type::Record { name: record_name, .. } -%}
   {%- let rec = ci.get_record_definition(record_name).unwrap() -%}
@@ -198,7 +226,7 @@ class RustBufferBuilder
 
   def write_{{ canonical_type_name }}(v)
     {%- for field in rec.fields() %}
-    self.write_{{ self::canonical_name(field.as_type().borrow()).borrow()|class_name_rb }}(v.{{ field.name()|var_name_rb }})
+    self.write_{{ self::canonical_name(field.as_type().borrow()) }}(v.{{ field.name()|var_name_rb }})
     {%- endfor %}
   end
 
@@ -210,7 +238,7 @@ class RustBufferBuilder
       pack_into(1, 'c', 0)
     else
       pack_into(1, 'c', 1)
-      self.write_{{ self::canonical_name(inner_type).borrow()|class_name_rb }}(v)
+      self.write_{{ self::canonical_name(inner_type) }}(v)
     end
   end
 
@@ -221,7 +249,7 @@ class RustBufferBuilder
     pack_into(4, 'l>', items.size)
 
     items.each do |item|
-      self.write_{{ self::canonical_name(inner_type).borrow()|class_name_rb }}(item)
+      self.write_{{ self::canonical_name(inner_type) }}(item)
     end
   end
 
@@ -232,19 +260,19 @@ class RustBufferBuilder
     pack_into(4, 'l>', items.size)
 
     items.each do |item|
-      self.write_{{ self::canonical_name(inner_type).borrow()|class_name_rb }}(item)
+      self.write_{{ self::canonical_name(inner_type) }}(item)
     end
   end
 
-  {% when Type::Map { key_type: k, value_type: inner_type } -%}
-  # The Map<T> type for {{ self::canonical_name(inner_type) }}.
+  {% when Type::Map { key_type: k, value_type: v } -%}
+  # The Map<T> type for {{ canonical_type_name }}.
 
   def write_{{ canonical_type_name }}(items)
     pack_into(4, 'l>', items.size)
 
     items.each do |k, v|
-      write_String(k)
-      self.write_{{ self::canonical_name(inner_type).borrow()|class_name_rb }}(v)
+      self.write_{{ self::canonical_name(k) }}(k)
+      self.write_{{ self::canonical_name(v) }}(v)
     end
   end
 
@@ -253,20 +281,27 @@ class RustBufferBuilder
   {%- when Some(cfg) %}{%- if cfg.has_conversion() %}
   # Custom type {{ name }}: applies lower, then writes builtin `{{ self::canonical_name(builtin) }}`
   def write_{{ canonical_type_name }}(v)
-    write_{{ self::canonical_name(builtin).borrow()|class_name_rb }}({{ cfg.lower("v") }})
+    write_{{ self::canonical_name(builtin) }}({{ cfg.lower("v") }})
   end
   {%- else %}
   # The Custom type {{ name }} delegates serialization to its builtin type.
   def write_{{ canonical_type_name }}(v)
-    write_{{ self::canonical_name(builtin).borrow()|class_name_rb }}(v)
+    write_{{ self::canonical_name(builtin) }}(v)
   end
   {%- endif %}
   {%- when None %}
   # The Custom type {{ name }} delegates serialization to its builtin type.
   def write_{{ canonical_type_name }}(v)
-    write_{{ self::canonical_name(builtin).borrow()|class_name_rb }}(v)
+    write_{{ self::canonical_name(builtin) }}(v)
   end
   {%- endmatch %}
+
+  {% when Type::CallbackInterface { name, .. } -%}
+  # The CallbackInterface type {{ name }}: write a uint64 handle.
+  def write_{{ canonical_type_name }}(v)
+    handle = {{ self::canonical_name(typ) }}FfiConverter.lower(v)
+    pack_into 8, 'Q>', handle
+  end
 
   {%- else -%}
   # This type is not yet supported in the Ruby backend.

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
@@ -22,72 +22,72 @@ class RustBufferStream
   end
 
   {% for typ in ci.iter_local_types() -%}
-  {%- let canonical_type_name = self::canonical_name(typ).borrow()|class_name_rb -%}
+  {%- let canonical_type_name = self::canonical_name(typ) -%}
   {%- match typ -%}
 
   {% when Type::Int8 -%}
 
-  def readI8
+  def read_{{ self::canonical_name(typ) }}
     unpack_from 1, 'c'
   end
 
   {% when Type::UInt8 -%}
 
-  def readU8
+  def read_{{ self::canonical_name(typ) }}
     unpack_from 1, 'c'
   end
 
   {% when Type::Int16 -%}
 
-  def readI16
+  def read_{{ self::canonical_name(typ) }}
     unpack_from 2, 's>'
   end
 
   {% when Type::UInt16 -%}
 
-  def readU16
+  def read_{{ self::canonical_name(typ) }}
     unpack_from 2, 'S>'
   end
 
   {% when Type::Int32 -%}
 
-  def readI32
+  def read_{{ self::canonical_name(typ) }}
     unpack_from 4, 'l>'
   end
 
   {% when Type::UInt32 -%}
 
-  def readU32
+  def read_{{ self::canonical_name(typ) }}
     unpack_from 4, 'L>'
   end
 
   {% when Type::Int64 -%}
 
-  def readI64
+  def read_{{ self::canonical_name(typ) }}
     unpack_from 8, 'q>'
   end
 
   {% when Type::UInt64 -%}
 
-  def readU64
+  def read_{{ self::canonical_name(typ) }}
     unpack_from 8, 'Q>'
   end
 
   {% when Type::Float32 -%}
 
-  def readF32
+  def read_{{ self::canonical_name(typ) }}
     unpack_from 4, 'g'
   end
 
   {% when Type::Float64 -%}
 
-  def readF64
+  def read_{{ self::canonical_name(typ) }}
     unpack_from 8, 'G'
   end
 
   {% when Type::Boolean -%}
 
-  def readBool
+  def read_{{ self::canonical_name(typ) }}
     v = unpack_from 1, 'c'
 
     return false if v == 0
@@ -98,7 +98,7 @@ class RustBufferStream
 
   {% when Type::String -%}
 
-  def readString
+  def read_{{ self::canonical_name(typ) }}
     size = unpack_from 4, 'l>'
 
     raise InternalError, 'Unexpected negative string length' if size.negative?
@@ -108,7 +108,7 @@ class RustBufferStream
 
   {% when Type::Bytes -%}
 
-  def readBytes
+  def read_{{ self::canonical_name(typ) }}
     size = unpack_from 4, 'l>'
 
     raise InternalError, 'Unexpected negative byte string length' if size.negative?
@@ -120,7 +120,7 @@ class RustBufferStream
   # The Timestamp type.
   ONE_SECOND_IN_NANOSECONDS = 10**9
 
-  def read{{ canonical_type_name }}
+  def read_{{ canonical_type_name }}
     seconds = unpack_from 8, 'q>'
     nanoseconds = unpack_from 4, 'L>'
 
@@ -143,7 +143,7 @@ class RustBufferStream
   {% when Type::Duration -%}
   # The Duration type.
 
-  def read{{ canonical_type_name }}
+  def read_{{ canonical_type_name }}
     seconds = unpack_from 8, 'q>'
     nanoseconds = unpack_from 4, 'L>'
 
@@ -153,9 +153,9 @@ class RustBufferStream
   {% when Type::Object with { name: object_name, .. } -%}
   # The Object type {{ object_name }}.
 
-  def read{{ canonical_type_name }}
+  def read_{{ canonical_type_name }}
     handle = unpack_from 8, 'Q>'
-    return {{ object_name|class_name_rb }}.uniffi_allocate(handle)
+    return {{ object_name|class_name_rb }}.uniffi_lift(handle)
   end
 
   {% when Type::Enum { name, .. } -%}
@@ -164,7 +164,7 @@ class RustBufferStream
   {% let enum_name = name %}
   # The Enum type {{ enum_name }}.
 
-  def read{{ canonical_type_name }}
+  def read_{{ canonical_type_name }}
     variant = unpack_from 4, 'l>'
     {% if e.is_flat() -%}
     {%- for variant in e.variants() %}
@@ -181,7 +181,7 @@ class RustBufferStream
         {%- let named_fields = !variant.fields()[0].name().is_empty() %}
         return {{ enum_name|class_name_rb }}::{{ variant.name()|enum_name_rb }}.new(
             {%- for field in variant.fields() %}
-            {% if named_fields %}{{ field.name()|var_name_rb }}: {% endif %}self.read{{ self::canonical_name(field.as_type().borrow()).borrow()|class_name_rb }}(){% if loop.last %}{% else %},{% endif %}
+            {% if named_fields %}{{ field.name()|var_name_rb }}: {% endif %}self.read_{{ self::canonical_name(field.as_type().borrow()) }}(){% if loop.last %}{% else %},{% endif %}
             {%- endfor %}
         )
         {%- else %}
@@ -199,13 +199,13 @@ class RustBufferStream
 
   # The Error type {{ error_name }}
 
-  def read{{ canonical_type_name }}
+  def read_{{ canonical_type_name }}
     variant = unpack_from 4, 'l>'
     {% if e.is_flat() -%}
     {%- for variant in e.variants() %}
     if variant == {{ loop.index }}
       return {{ error_name|class_name_rb }}::{{ variant.name()|class_name_rb }}.new(
-        readString()
+        read_{{ self::canonical_name(&Type::String) }}()
       )
     end
     {%- endfor %}
@@ -218,7 +218,7 @@ class RustBufferStream
         {%- let named_fields = !variant.fields()[0].name().is_empty() %}
         return {{ error_name|class_name_rb }}::{{ variant.name()|class_name_rb }}.new(
             {%- for field in variant.fields() %}
-            {% if named_fields %}{{ field.name()|var_name_rb }}: {% endif %}read{{ self::canonical_name(field.as_type().borrow()).borrow()|class_name_rb }}(){% if loop.last %}{% else %},{% endif %}
+            {% if named_fields %}{{ field.name()|var_name_rb }}: {% endif %}read_{{ self::canonical_name(&field.as_type()) }}(){% if loop.last %}{% else %},{% endif %}
             {%- endfor %}
         )
         {%- else %}
@@ -236,24 +236,24 @@ class RustBufferStream
   {%- let rec = ci.get_record_definition(record_name).unwrap() -%}
   # The Record type {{ record_name }}.
 
-  def read{{ canonical_type_name }}
+  def read_{{ canonical_type_name }}
     {{ rec.name()|class_name_rb }}.new(
       {%- for field in rec.fields() %}
-      {{ field.name()|var_name_rb }}: read{{ self::canonical_name(field.as_type().borrow()).borrow()|class_name_rb }}{% if loop.last %}{% else %},{% endif %}
+      {{ field.name()|var_name_rb }}: read_{{ self::canonical_name(field.as_type().borrow()) }}{% if loop.last %}{% else %},{% endif %}
       {%- endfor %}
     )
   end
 
-  {% when Type::Optional { inner_type } -%}
+  {% when Type::Optional { inner_type } %}
   # The Optional<T> type for {{ self::canonical_name(inner_type) }}.
 
-  def read{{ canonical_type_name }}
+  def read_{{ canonical_type_name }}
     flag = unpack_from 1, 'c'
 
     if flag == 0
       return nil
     elsif flag == 1
-      return read{{ self::canonical_name(inner_type).borrow()|class_name_rb }}
+      return read_{{ self::canonical_name(inner_type) }}
     else
       raise InternalError, 'Unexpected flag byte for {{ canonical_type_name }}'
     end
@@ -262,7 +262,7 @@ class RustBufferStream
   {% when Type::Sequence { inner_type } -%}
   # The Sequence<T> type for {{ self::canonical_name(inner_type) }}.
 
-  def read{{ canonical_type_name }}
+  def read_{{ canonical_type_name }}
     count = unpack_from 4, 'l>'
 
     raise InternalError, 'Unexpected negative sequence length' if count.negative?
@@ -270,7 +270,7 @@ class RustBufferStream
     items = []
 
     count.times do
-      items.append read{{ self::canonical_name(inner_type).borrow()|class_name_rb }}
+      items.append read_{{ self::canonical_name(inner_type) }}
     end
 
     items
@@ -279,7 +279,7 @@ class RustBufferStream
   {% when Type::Set { inner_type } -%}
   # The Set<T> type for {{ self::canonical_name(inner_type) }}.
 
-  def read{{ canonical_type_name }}
+  def read_{{ canonical_type_name }}
     count = unpack_from 4, 'l>'
 
     raise InternalError, 'Unexpected negative set size' if count.negative?
@@ -287,23 +287,23 @@ class RustBufferStream
     items = Set.new
 
     count.times do
-      items.add read{{ self::canonical_name(inner_type).borrow()|class_name_rb }}
+      items.add read_{{ self::canonical_name(inner_type) }}
     end
 
     items
   end
 
-  {% when Type::Map { key_type: k, value_type: inner_type } -%}
-  # The Map<T> type for {{ self::canonical_name(inner_type) }}.
+  {% when Type::Map { key_type: k, value_type: v } -%}
+  # The Map<T> type for {{ canonical_type_name }}.
 
-  def read{{ canonical_type_name }}
+  def read_{{ canonical_type_name }}
     count = unpack_from 4, 'l>'
     raise InternalError, 'Unexpected negative map size' if count.negative?
 
     items = {}
     count.times do
-      key = readString
-      items[key] = read{{ self::canonical_name(inner_type).borrow()|class_name_rb }}
+      key = read_{{ self::canonical_name(k) }}
+      items[key] = read_{{ self::canonical_name(v) }}
     end
 
     items
@@ -313,26 +313,34 @@ class RustBufferStream
   {%- match config.custom_types.get(name.as_str()) %}
   {%- when Some(cfg) %}{%- if cfg.has_conversion() %}
   # Custom type {{ name }}: reads builtin `{{ self::canonical_name(builtin) }}`, then applies lift.
-  def read{{ canonical_type_name }}
-    raw = read{{ self::canonical_name(builtin).borrow()|class_name_rb }}
+  def read_{{ canonical_type_name }}
+    raw = read_{{ self::canonical_name(builtin) }}
     {{ cfg.lift("raw") }}
   end
   {%- else %}
   # The Custom type {{ name }} delegates deserialization to its builtin type.
-  def read{{ canonical_type_name }}
-    read{{ self::canonical_name(builtin).borrow()|class_name_rb }}
+  def read_{{ canonical_type_name }}
+    read_{{ self::canonical_name(builtin) }}
   end
   {%- endif %}
   {%- when None %}
   # The Custom type {{ name }} delegates deserialization to its builtin type.
-  def read{{ canonical_type_name }}
-    read{{ self::canonical_name(builtin).borrow()|class_name_rb }}
+  def read_{{ canonical_type_name }}
+    read_{{ self::canonical_name(builtin) }}
   end
   {%- endmatch %}
 
+  {% when Type::CallbackInterface { name, .. } -%}
+
+  # The CallbackInterface type {{ name }}: read a uint64 handle.
+  def read_{{ canonical_type_name }}
+    handle = unpack_from 8, 'Q>'
+    {{ self::canonical_name(typ) }}FfiConverter.lift handle
+  end
+
   {%- else -%}
   # This type is not yet supported in the Ruby backend.
-  def read{{ canonical_type_name }}
+  def read_{{ canonical_type_name }}
     raise InternalError, 'RustBufferStream.read not implemented yet for {{ canonical_type_name }}'
   end
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
@@ -67,14 +67,14 @@ class RustBuffer < FFI::Struct
   {% when Type::String -%}
   # The primitive String type.
 
-  def self.allocFromString(value)
+  def self.alloc_from_{{ canonical_type_name }}(value)
     RustBuffer.allocWithBuilder do |builder|
       builder.write value.encode('utf-8')
       return builder.finalize
     end
   end
 
-  def consumeIntoString
+  def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
       return stream.read(stream.remaining).force_encoding(Encoding::UTF_8)
     end
@@ -83,16 +83,16 @@ class RustBuffer < FFI::Struct
   {% when Type::Bytes -%}
   # The primitive Bytes type.
 
-  def self.allocFromBytes(value)
+  def self.alloc_from_{{ canonical_type_name }}(value)
     RustBuffer.allocWithBuilder do |builder|
-      builder.write_Bytes(value)
+      builder.write_{{ canonical_type_name }}(value)
       return builder.finalize
     end
   end
 
-  def consumeIntoBytes
+  def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.readBytes
+      return stream.read_{{ canonical_type_name }}
     end
   end
 
@@ -104,9 +104,9 @@ class RustBuffer < FFI::Struct
     end
   end
 
-  def consumeInto{{ canonical_type_name }}
+  def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read{{ canonical_type_name }}
+      return stream.read_{{ canonical_type_name }}
     end
   end
 
@@ -118,9 +118,9 @@ class RustBuffer < FFI::Struct
     end
   end
 
-  def consumeInto{{ canonical_type_name }}
+  def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read{{ canonical_type_name }}
+      return stream.read_{{ canonical_type_name }}
     end
   end
 
@@ -141,9 +141,9 @@ class RustBuffer < FFI::Struct
     end
   end
 
-  def consumeInto{{ canonical_type_name }}
+  def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read{{ canonical_type_name }}
+      return stream.read_{{ canonical_type_name }}
     end
   end
 
@@ -176,16 +176,25 @@ class RustBuffer < FFI::Struct
     end
   end
 
-  def consumeInto{{ canonical_type_name }}
+  def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read{{ canonical_type_name }}
+      return stream.read_{{ canonical_type_name }}
     end
   end
   {% else %}
-  # Enum used as error - generate consumeInto for use as a return value
-  def consumeInto{{ canonical_type_name }}
+  {%- let e = ci.get_enum_definition(enum_name).unwrap() -%}
+  # Error enum - generate alloc_from for callback error serialization
+  def self.alloc_from_{{ canonical_type_name }}(v)
+    RustBuffer.allocWithBuilder do |builder|
+      builder.write_{{ canonical_type_name }}(v)
+      return builder.finalize
+    end
+  end
+
+  # Enum used as error - generate consume_into_ for use as a return value
+  def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read{{ canonical_type_name }}
+      return stream.read_{{ canonical_type_name }}
     end
   end
   {% endif %}
@@ -194,7 +203,7 @@ class RustBuffer < FFI::Struct
   # The Optional<T> type for {{ self::canonical_name(inner_type) }}.
 
   def self.check_lower_{{ canonical_type_name }}(v)
-    if not v.nil?
+    if !v.nil?
       {{ "v"|check_lower_rb(inner_type.borrow(), config) }}
     end
   end
@@ -206,9 +215,9 @@ class RustBuffer < FFI::Struct
     end
   end
 
-  def consumeInto{{ canonical_type_name }}
+  def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read{{ canonical_type_name }}
+      return stream.read_{{ canonical_type_name }}
     end
   end
 
@@ -228,9 +237,9 @@ class RustBuffer < FFI::Struct
     end
   end
 
-  def consumeInto{{ canonical_type_name }}
+  def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read{{ canonical_type_name }}
+      return stream.read_{{ canonical_type_name }}
     end
   end
 
@@ -250,19 +259,19 @@ class RustBuffer < FFI::Struct
     end
   end
 
-  def consumeInto{{ canonical_type_name }}
+  def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read{{ canonical_type_name }}
+      return stream.read_{{ canonical_type_name }}
     end
   end
 
-  {% when Type::Map { key_type: k, value_type: inner_type } -%}
-  # The Map<T> type for {{ self::canonical_name(inner_type) }}.
+  {% when Type::Map { key_type: k, value_type: v } %}
+  # The Map<T> type for {{ canonical_type_name }}.
 
   def self.check_lower_{{ canonical_type_name }}(v)
     v.each do |k, v|
       {{ "k"|check_lower_rb(k.borrow(), config) }}
-      {{ "v"|check_lower_rb(inner_type.borrow(), config) }}
+      {{ "v"|check_lower_rb(v.borrow(), config) }}
     end
   end
 
@@ -273,9 +282,9 @@ class RustBuffer < FFI::Struct
     end
   end
 
-  def consumeInto{{ canonical_type_name }}
+  def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read{{ canonical_type_name }}
+      return stream.read_{{ canonical_type_name }}
     end
   end
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/TraitInterfaceVtable.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/TraitInterfaceVtable.rb
@@ -1,0 +1,128 @@
+{#
+// Template to generate a vtable implementation for a trait interface (Object with CallbackTrait).
+// Included by ObjectTemplate.rb when obj.has_callback_interface() is true.
+//
+// Expected variables from ObjectTemplate.rb:
+//   obj - the Object definition
+//   vtable - the FfiType for the vtable struct
+//   vtable_methods - Vec<(FfiCallbackFunction, Method)>
+//   ffi_init_callback - the FfiFunction for init
+//   cbi_name - the object name (name as obj.name())
+#}
+{%- let vtable_def = obj.vtable_definition().unwrap() %}
+
+# Trait interface vtable implementation for {{ cbi_name }}.
+module UniffiCallbackInterface{{ cbi_name|class_name_rb }}
+
+  {%- for (ffi_callback, method)  in vtable_methods.iter() %}
+
+  # Callback method for {{ method.name() }}
+  {{ method.name()|enum_name_rb }}_CALLBACK = Proc.new do |uniffi_handle, {%- for arg in method.arguments() %} {{ arg.name()|var_name_rb }},{% endfor %} uniffi_out_return, uniffi_call_status|
+    uniffi_obj = {{ cbi_name|class_name_rb }}.uniffi_handle_map.get(uniffi_handle)
+
+    make_call = Proc.new do
+      uniffi_obj.{{ method.name()|fn_name_rb }}(
+        {%- for arg in method.arguments() %}
+        {{ arg.name()|lift_rb(arg.as_type().borrow(), config) }}{% if !loop.last %},{% endif %}
+        {%- endfor %}
+      )
+    end
+
+    {%- match method.return_type() %}
+    {%- when Some with (return_type) %}
+    write_return_value = Proc.new do |v|
+      lowered = {{ "v"|lower_rb(return_type, config) }}
+      {%- let ffi_type_name = return_type|ffi_write_return_rb %}
+      {%- if ffi_type_name == "rustbuffer" %}
+      # Write a RustBuffer struct into the out pointer
+      out_buf = RustBuffer.new uniffi_out_return
+      out_buf[:capacity] = lowered[:capacity]
+      out_buf[:len] = lowered[:len]
+      out_buf[:data] = lowered[:data]
+      {%- else %}
+      uniffi_out_return.{{ ffi_type_name }}(lowered)
+      {%- endif %}
+    end
+    {%- when None %}
+    # No return value, so do nothing.
+    write_return_value = Proc.new { |_v| }
+    {%- endmatch %}
+
+    {%- match method.throws_type() %}
+    {%- when None %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call(
+      uniffi_call_status,
+      make_call,
+      write_return_value
+    )
+    {%- when Some with (error_type) %}
+    {%- match error_type %}
+    {%- when Type::Enum { name, .. } %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_with_error(
+      uniffi_call_status,
+      make_call,
+      write_return_value,
+      {{ name|class_name_rb }},
+      Proc.new { |e| {{ "e"|lower_rb(error_type, config) }} }
+    )
+    {%- when Type::Object { name, .. } %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_with_error(
+      uniffi_call_status,
+      make_call,
+      write_return_value,
+      {{ name|class_name_rb }},
+      Proc.new { |e| {{ "e"|lower_rb(error_type, config) }} }
+    )
+    {%- when Type::Custom { builtin, .. } %}
+    {%- match builtin.borrow() %}
+    {%- when Type::Enum { name, .. } %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_with_error(
+      uniffi_call_status,
+      make_call,
+      write_return_value,
+      {{ name|class_name_rb }},
+      Proc.new { |e| {{ "e"|lower_rb(builtin, config) }} }
+    )
+    {%- when Type::Object { name, .. } %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_with_error(
+      uniffi_call_status,
+      make_call,
+      write_return_value,
+      {{ name|class_name_rb }},
+      Proc.new { |e| {{ "e"|lower_rb(builtin, config) }} }
+    )
+    {%- else %}
+    raise RuntimeError, "Unsupported custom error type for trait interface"
+    {%- endmatch %}
+    {%- else %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call(
+      uniffi_call_status,
+      make_call,
+      write_return_value
+    )
+    {%- endmatch %}
+    {%- endmatch %}
+  end
+  {%- endfor %}
+
+  # Free callback: removes the handle from the map.
+  UNIFFI_FREE_CALLBACK = Proc.new do |uniffi_handle|
+    {{ cbi_name|class_name_rb }}.uniffi_handle_map.remove uniffi_handle
+  end
+
+  # Clone callback: clones the handle in the map.
+  UNIFFI_CLONE_CALLBACK = Proc.new do |uniffi_handle|
+    {{ cbi_name|class_name_rb }}.uniffi_handle_map.clone_handle(uniffi_handle)
+  end
+
+  # Create the VTable struct instance.
+  UNIFFI_VTABLE = UniFFILib::{{ vtable_def.name() }}.new
+  UNIFFI_VTABLE[:uniffi_free] = UNIFFI_FREE_CALLBACK
+  UNIFFI_VTABLE[:uniffi_clone] = UNIFFI_CLONE_CALLBACK
+  {%- for (ffi_callback, method)  in vtable_methods.iter() %}
+  UNIFFI_VTABLE[:{{ method.name() }}] = {{ method.name()|enum_name_rb }}_CALLBACK
+  {%- endfor %}
+
+  # Register the VTable with Rust.
+  UniFFILib.{{ ffi_init_callback.name() }}(UNIFFI_VTABLE)
+end

--- a/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
@@ -64,6 +64,30 @@ values[{{- field_num - 1 -}}]
 )
 {%- endmacro -%}
 
+{%- macro to_ffi_call_with_lower_self(func) -%}
+    {%- match func.throws_type() -%}
+    {%- when Some(Type::Custom { builtin, .. }) -%}
+      {%- match builtin.borrow() -%}
+      {%- when Type::Enum { name, .. } -%}
+      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+      {%- when Type::Object { name, .. } -%}
+      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+      {%- else -%}
+      ::{{ ci.namespace()|class_name_rb }}.rust_call
+      {%- endmatch -%}
+    {%- when Some(Type::Enum { name, .. }) -%}
+      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+    {%- when Some(Type::Object { name, .. }) -%}
+      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
+    {%- else -%}
+      ::{{ ci.namespace()|class_name_rb }}.rust_call(
+    {%- endmatch -%}
+    :{{ func.ffi_func().name() }},
+    {{ func|lower_method_self_rb(config) }},
+    {%- call _arg_list_ffi_call(func) %}{% endcall -%}
+)
+{%- endmacro -%}
+
 {%- macro _arg_list_ffi_call(func) %}
     {%- for arg in func.arguments() %}
         {{- arg.name()|var_name_rb|lower_rb(arg.as_type().borrow(), config) }}
@@ -92,7 +116,8 @@ values[{{- field_num - 1 -}}]
 // Note unfiltered name but type_ffi filters.
 -#}
 {%- macro arg_list_ffi_decl(func) %}
-    [{%- for arg in func.arguments() -%}{{ arg.type_().borrow()|type_ffi }}, {% endfor -%} RustCallStatus.by_ref]
+    [{%- for arg in func.arguments() -%}{{ arg.type_().borrow()|type_ffi }}, {% endfor -%}
+    {%- if func.has_rust_call_status_arg() -%}RustCallStatus.by_ref{% endif -%}]
 {%- endmacro -%}
 
 {%- macro setup_args(func) %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/wrapper.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/wrapper.rb
@@ -16,10 +16,16 @@
 require 'ffi'
 require 'set'
 
+{%- if ci.has_callback_definitions() %}
+require 'monitor'
+{%- endif %}
 
 module {{ ci.namespace()|class_name_rb }}
   {% include "Helpers.rb" %}
 
+  {%- if ci.has_callback_definitions() %}
+  {% include "HandleMap.rb" %}
+  {%- endif %}
   {% include "RustBufferTemplate.rb" %}
   {% include "RustBufferStream.rb" %}
   {% include "RustBufferBuilder.rb" %}
@@ -28,6 +34,9 @@ module {{ ci.namespace()|class_name_rb }}
   {% include "ErrorTemplate.rb" %}
 
   {% include "NamespaceLibraryTemplate.rb" %}
+  {%- if ci.has_callback_definitions() %}
+  {% include "CallbackInterfaceRuntime.rb" %}
+  {%- endif %}
 
   # Custom type definitions.
 
@@ -72,6 +81,11 @@ module {{ ci.namespace()|class_name_rb }}
 
   {% for obj in ci.object_definitions() %}
   {% include "ObjectTemplate.rb" %}
+  {% endfor %}
+
+  {% for cbi in ci.callback_interface_definitions() %}
+  {%- let name = cbi.name() %}
+  {% include "CallbackInterfaceTemplate.rb" %}
   {% endfor %}
 end
 


### PR DESCRIPTION
Hello Uniffi Team!

The main thing that this PR tries to accomplish is: **add support for sync callbacks and trait interfaces for ruby**. No async calls for now. PR adding both will be too large. An additional goal was to keep improving `bindgen-tests` for ruby. 

I also found that:
- few tests needed cleanup (copy-paste issues from my previous PR)
- ruby classes for enums and records couldn't have methods
- HashMap can only have string keys
- there were lots of places in code where class/method names were assumed to match expectations from another file

Since I was discovering (and addressing) these while implementing callbacks and trait interfaces, I didn't split changes into multiple PRs, but I will if PR volume becomes an issue for code review (please let me know).

I've also added tests into "examples" and "fixtures", please let me know if any of those are undesirable because of introduction of `bindgen-tests`(which I like much more TBH :) ).

I've tested these changes on my projects using `uniffi` and I cannot spot any issues so far.
Please let me know if you have any suggestions or concerns.
Thank you!