### PR TITLE
Pipeline IDs

### DIFF
--- a/uniffi_bindgen/src/bindings/python/pipeline/context.rs
+++ b/uniffi_bindgen/src/bindings/python/pipeline/context.rs
@@ -12,11 +12,14 @@ pub struct Context {
     pub current_config: Option<PythonConfig>,
     pub module_namespace: Option<String>,
     pub recursive_type_names: HashSet<String>,
+    pub builtin_types: Option<BuiltinTypes>,
 }
 
 impl Context {
-    pub fn update_from_root(&mut self, root: &general::Root) {
+    pub fn update_from_root(&mut self, root: &general::Root) -> Result<()> {
         self.cdylib = root.cdylib.clone();
+        self.builtin_types = Some(root.builtin_types.clone().map_node(self)?);
+        Ok(())
     }
 
     pub fn update_from_namespace(&mut self, namespace: &general::Namespace) -> Result<()> {
@@ -38,6 +41,12 @@ impl Context {
         });
         self.recursive_type_names = recursive_type_names;
         Ok(())
+    }
+
+    pub fn builtin_types(&self) -> Result<BuiltinTypes> {
+        self.builtin_types
+            .clone()
+            .ok_or_else(|| anyhow!("Context.builtin_types not set"))
     }
 
     pub fn is_recursive(&self, name: &str) -> bool {

--- a/uniffi_bindgen/src/bindings/python/pipeline/modules.rs
+++ b/uniffi_bindgen/src/bindings/python/pipeline/modules.rs
@@ -31,7 +31,7 @@ pub fn map_namespace(namespace: general::Namespace, context: &Context) -> Result
         ffi_rustbuffer_reserve: namespace.ffi_rustbuffer_reserve,
         ffi_uniffi_contract_version: namespace.ffi_uniffi_contract_version,
         correct_contract_version: namespace.correct_contract_version,
-        string_type_node: namespace.string_type_node.map_node(context)?,
+        builtin_types: context.builtin_types()?,
     };
     // Generate exported names after mapping everything else.  This way we're sure all the renames
     // have taken effect.

--- a/uniffi_bindgen/src/bindings/python/pipeline/nodes.rs
+++ b/uniffi_bindgen/src/bindings/python/pipeline/nodes.rs
@@ -32,12 +32,29 @@ use_prev_node!(general::Type, types::map_type);
 /// Initial IR, this stores the metadata and other data
 #[derive(Debug, Clone, Node, MapNode)]
 #[map_node(from(general::Root))]
-#[map_node(update_context(context.update_from_root(&self)))]
+#[map_node(update_context(context.update_from_root(&self)?))]
 pub struct Root {
     /// In library mode, the library path the user passed to us
     pub cdylib: Option<String>,
     #[map_node(from(namespaces))]
     pub modules: IndexMap<String, Module>,
+    pub builtin_types: BuiltinTypes,
+}
+
+#[derive(Debug, Clone, MapNode, Node)]
+#[map_node(from(general::BuiltinTypes))]
+pub struct BuiltinTypes {
+    pub u8: TypeNode,
+    pub i8: TypeNode,
+    pub u16: TypeNode,
+    pub i16: TypeNode,
+    pub u32: TypeNode,
+    pub i32: TypeNode,
+    pub u64: TypeNode,
+    pub i64: TypeNode,
+    pub f32: TypeNode,
+    pub f64: TypeNode,
+    pub string: TypeNode,
 }
 
 #[derive(Debug, Clone, Node, MapNode, Template)]
@@ -65,7 +82,8 @@ pub struct Module {
     pub ffi_uniffi_contract_version: RustFfiFunctionName,
     // Correct contract version value
     pub correct_contract_version: String,
-    pub string_type_node: TypeNode,
+    // Copy builtin types so that we can use in from the `Module.py` template
+    pub builtin_types: BuiltinTypes,
 }
 
 // These structs exist so that we can easily deserialize the entire `uniffi.toml` file.

--- a/uniffi_bindgen/src/bindings/python/templates/Async.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Async.py
@@ -80,7 +80,7 @@ def _uniffi_trait_interface_call_async(make_call, uniffi_out_dropped_callback, h
             traceback.print_exc(file=sys.stderr)
             handle_error(
                 _UniffiRustCallStatus.CALL_UNEXPECTED_ERROR,
-                {{ string_type_node.ffi_converter_name }}.lower(repr(e)),
+                {{ builtin_types.string.ffi_converter_name }}.lower(repr(e)),
             )
         else:
             handle_success(call_result)
@@ -108,7 +108,7 @@ def _uniffi_trait_interface_call_async_with_error(make_call, uniffi_out_dropped_
             traceback.print_exc(file=sys.stderr)
             handle_error(
                 _UniffiRustCallStatus.CALL_UNEXPECTED_ERROR,
-                {{ string_type_node.ffi_converter_name }}.lower(repr(e)),
+                {{ builtin_types.string.ffi_converter_name }}.lower(repr(e)),
             )
     eventloop = _uniffi_get_event_loop()
     task = asyncio.run_coroutine_threadsafe(make_call_and_call_callback(), eventloop)

--- a/uniffi_bindgen/src/bindings/python/templates/ErrorTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/ErrorTemplate.py
@@ -83,7 +83,7 @@ class {{ e.self_type.ffi_converter_name }}(_UniffiConverterRustBuffer):
         if variant == {{ loop.index }}:
             return {{ type_name }}.{{ variant.name }}(
                 {%- if e.is_flat %}
-                {{ string_type_node.ffi_converter_name }}.read(buf),
+                {{ builtin_types.string.ffi_converter_name }}.read(buf),
                 {%- else %}
                 {%- for field in variant.fields %}
                 {{ field.ty.ffi_converter_name }}.read(buf),

--- a/uniffi_bindgen/src/bindings/python/templates/Helpers.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Helpers.py
@@ -62,7 +62,7 @@ def _uniffi_check_call_status(error_ffi_converter, call_status):
         # with the message.  But if that code panics, then it just sends back
         # an empty buffer.
         if call_status.error_buf.len > 0:
-            msg = {{ string_type_node.ffi_converter_name }}.lift(call_status.error_buf)
+            msg = {{ builtin_types.string.ffi_converter_name }}.lift(call_status.error_buf)
         else:
             msg = "Unknown rust panic"
         raise InternalError(msg)
@@ -75,7 +75,7 @@ def _uniffi_trait_interface_call(call_status, make_call, write_return_value):
         return write_return_value(make_call())
     except Exception as e:
         call_status.code = _UniffiRustCallStatus.CALL_UNEXPECTED_ERROR
-        call_status.error_buf = {{ string_type_node.ffi_converter_name }}.lower(repr(e))
+        call_status.error_buf = {{ builtin_types.string.ffi_converter_name }}.lower(repr(e))
 
 def _uniffi_trait_interface_call_with_error(call_status, make_call, write_return_value, error_type, lower_error):
     try:
@@ -86,4 +86,4 @@ def _uniffi_trait_interface_call_with_error(call_status, make_call, write_return
             call_status.error_buf = lower_error(e)
     except Exception as e:
         call_status.code = _UniffiRustCallStatus.CALL_UNEXPECTED_ERROR
-        call_status.error_buf = {{ string_type_node.ffi_converter_name }}.lower(repr(e))
+        call_status.error_buf = {{ builtin_types.string.ffi_converter_name }}.lower(repr(e))

--- a/uniffi_bindgen/src/pipeline/general/callable.rs
+++ b/uniffi_bindgen/src/pipeline/general/callable.rs
@@ -13,6 +13,7 @@ pub fn function_callable(func: &initial::Function, context: &Context) -> Result<
     let name = rename::func(func.name.clone(), context)?;
 
     Ok(Callable {
+        id: func.id,
         name,
         orig_name: func.orig_name.clone(),
         async_data: function_async_data(func, context)?,
@@ -51,6 +52,7 @@ pub fn method_callable_with_kind(
     let name = rename::method(meth.name.clone(), context)?;
 
     Ok(Callable {
+        id: meth.id,
         name,
         orig_name: meth.orig_name.clone(),
         arguments,
@@ -86,6 +88,7 @@ pub fn constructor_callable(cons: &initial::Constructor, context: &Context) -> R
     let name = rename::method(cons.name.clone(), context)?;
 
     Ok(Callable {
+        id: cons.id,
         name,
         orig_name: cons.orig_name.clone(),
         async_data: constructor_async_data(cons, interface_name, imp, context)?,

--- a/uniffi_bindgen/src/pipeline/general/context.rs
+++ b/uniffi_bindgen/src/pipeline/general/context.rs
@@ -20,6 +20,7 @@ pub struct Context {
     pub rename_tables: HashMap<String, toml::Table>,
     // Maps namespaces to exclude tables from the TOML config
     pub exclude_sets: HashMap<String, HashSet<String>>,
+    pub type_id_map: HashMap<Type, u64>,
 }
 
 impl Context {
@@ -34,6 +35,7 @@ impl Context {
             names_used_as_error: HashSet::default(),
             rename_tables: HashMap::default(),
             exclude_sets: HashMap::default(),
+            type_id_map: HashMap::default(),
         }
     }
 
@@ -103,6 +105,7 @@ impl Context {
             self.exclude_sets
                 .insert(namespace.name.clone(), exclude_set);
         }
+        self.populate_type_id_map(root)?;
         Ok(())
     }
 
@@ -145,20 +148,12 @@ impl Context {
     }
 
     pub fn update_from_record(&mut self, rec: &initial::Record) -> Result<()> {
-        self.current_type = Some(Type::Record {
-            namespace: self.namespace_name()?,
-            name: rec.name.clone(),
-            orig_name: rec.orig_name.clone(),
-        });
+        self.current_type = Some(types::type_for_record(rec, self)?);
         Ok(())
     }
 
     pub fn update_from_enum(&mut self, en: &initial::Enum) -> Result<()> {
-        self.current_type = Some(Type::Enum {
-            namespace: self.namespace_name()?,
-            name: en.name.clone(),
-            orig_name: en.orig_name.clone(),
-        });
+        self.current_type = Some(types::type_for_enum(en, self)?);
         Ok(())
     }
 
@@ -174,12 +169,7 @@ impl Context {
     }
 
     pub fn update_from_interface(&mut self, int: &initial::Interface) -> Result<()> {
-        self.current_type = Some(Type::Interface {
-            namespace: self.namespace_name()?,
-            name: int.name.clone(),
-            orig_name: int.orig_name.clone(),
-            imp: int.imp,
-        });
+        self.current_type = Some(types::type_for_interface(int, self)?);
         Ok(())
     }
 
@@ -187,21 +177,12 @@ impl Context {
         &mut self,
         cbi: &initial::CallbackInterface,
     ) -> Result<()> {
-        self.current_type = Some(Type::CallbackInterface {
-            namespace: self.namespace_name()?,
-            name: cbi.name.clone(),
-            orig_name: cbi.orig_name.clone(),
-        });
+        self.current_type = Some(types::type_for_callback_interface(cbi, self)?);
         Ok(())
     }
 
     pub fn update_from_custom_type(&mut self, custom: &initial::CustomType) -> Result<()> {
-        self.current_type = Some(Type::Custom {
-            namespace: self.namespace_name()?,
-            name: custom.name.clone(),
-            orig_name: custom.orig_name.clone(),
-            builtin: Box::new(custom.builtin.clone()),
-        });
+        self.current_type = Some(types::type_for_custom_type(custom, self)?);
         Ok(())
     }
 
@@ -224,5 +205,64 @@ impl Context {
             | Type::Custom { name, .. } => self.names_used_as_error.contains(name),
             _ => false,
         }
+    }
+
+    fn populate_type_id_map(&mut self, root: &initial::Root) -> Result<()> {
+        let mut type_id_counter = 0..;
+        let mut type_id_map = HashMap::new();
+        let mut add_type = |ty: Type| {
+            type_id_map
+                .entry(ty)
+                .or_insert_with(|| type_id_counter.next().unwrap());
+        };
+
+        // Add builtin types to `type_id_map` for the `BuiltinTypes` struct.
+        add_type(Type::UInt8);
+        add_type(Type::Int8);
+        add_type(Type::UInt16);
+        add_type(Type::Int16);
+        add_type(Type::UInt32);
+        add_type(Type::Int32);
+        add_type(Type::UInt64);
+        add_type(Type::Int64);
+        add_type(Type::Float32);
+        add_type(Type::Float64);
+        add_type(Type::String);
+        // Add types from the interface
+        root.visit(|ty: &Type| add_type(ty.clone()));
+        root.try_visit(|namespace: &initial::Namespace| {
+            self.current_namespace_name = Some(namespace.name.clone());
+            root.try_visit(|rec: &initial::Record| {
+                add_type(types::type_for_record(rec, self)?);
+                Ok(())
+            })?;
+            root.try_visit(|en: &initial::Enum| {
+                add_type(types::type_for_enum(en, self)?);
+                Ok(())
+            })?;
+            root.try_visit(|int: &initial::Interface| {
+                add_type(types::type_for_interface(int, self)?);
+                Ok(())
+            })?;
+            root.try_visit(|cbi: &initial::CallbackInterface| {
+                add_type(types::type_for_callback_interface(cbi, self)?);
+                Ok(())
+            })?;
+            root.try_visit(|custom: &initial::CustomType| {
+                add_type(types::type_for_custom_type(custom, self)?);
+                Ok(())
+            })?;
+            Ok(())
+        })?;
+        self.current_namespace_name = None;
+        self.type_id_map = type_id_map;
+        Ok(())
+    }
+
+    pub fn get_type_id(&self, ty: &Type) -> Result<u64> {
+        self.type_id_map
+            .get(ty)
+            .cloned()
+            .ok_or_else(|| anyhow!("Type not in type_id_map: {ty:?} {:#?}", self.type_id_map))
     }
 }

--- a/uniffi_bindgen/src/pipeline/general/infer_recursive_enums.rs
+++ b/uniffi_bindgen/src/pipeline/general/infer_recursive_enums.rs
@@ -202,6 +202,7 @@ mod tests {
 
     fn make_type_node(ty: Type) -> TypeNode {
         TypeNode {
+            id: 0, // not used for these tests
             canonical_name: "Test".to_string(),
             is_used_as_error: false,
             ffi_type: FfiType::RustBuffer(None),

--- a/uniffi_bindgen/src/pipeline/general/mod.rs
+++ b/uniffi_bindgen/src/pipeline/general/mod.rs
@@ -20,6 +20,7 @@ mod nodes;
 mod objects;
 mod records;
 mod rename;
+mod root;
 mod rust_buffer;
 mod rust_future;
 mod sort;

--- a/uniffi_bindgen/src/pipeline/general/namespaces.rs
+++ b/uniffi_bindgen/src/pipeline/general/namespaces.rs
@@ -60,7 +60,6 @@ pub fn map_namespace(namespace: initial::Namespace, context: &Context) -> Result
         ffi_rustbuffer_reserve: rust_buffer::rustbuffer_reserve_fn_name(context)?,
         ffi_uniffi_contract_version: checksums::ffi_uniffi_contract_version(&namespace),
         correct_contract_version: uniffi_meta::UNIFFI_CONTRACT_VERSION.to_string(),
-        string_type_node: Type::String.map_node(context)?,
         crate_name: namespace.crate_name,
         config_toml: namespace.config_toml,
         docstring: namespace.docstring,

--- a/uniffi_bindgen/src/pipeline/general/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/general/nodes.rs
@@ -13,11 +13,32 @@ use_prev_node!(initial::Type, types::map_type);
 /// Initial IR, this stores the metadata and other data
 #[derive(Debug, Clone, Node, MapNode)]
 #[map_node(from(initial::Root))]
-#[map_node(update_context(context.update_from_root(&self)?))]
+#[map_node(root::map_root)]
 pub struct Root {
     /// In library mode, the library path the user passed to us
     pub cdylib: Option<String>,
     pub namespaces: IndexMap<String, Namespace>,
+    pub builtin_types: BuiltinTypes,
+}
+
+/// Type nodes for builtin types
+///
+/// This is useful when bindings want to use one of these types. For example `Type::String` is
+/// needed to handle exceptions and `Type::UInt32` is used for enum discriminants.  This struct
+/// gives them an easy way to access the `TypeNode` those types.
+#[derive(Debug, Clone, Node)]
+pub struct BuiltinTypes {
+    pub u8: TypeNode,
+    pub i8: TypeNode,
+    pub u16: TypeNode,
+    pub i16: TypeNode,
+    pub u32: TypeNode,
+    pub i32: TypeNode,
+    pub u64: TypeNode,
+    pub i64: TypeNode,
+    pub f32: TypeNode,
+    pub f64: TypeNode,
+    pub string: TypeNode,
 }
 
 /// A Namespace is a crate which exposes a uniffi api.
@@ -43,9 +64,6 @@ pub struct Namespace {
     pub ffi_uniffi_contract_version: RustFfiFunctionName,
     // Correct contract version value
     pub correct_contract_version: String,
-    // TypeNode for String.  Strings are used in error handling, this ensures that the FFI
-    // converters for them are always defined and easy to lookup.
-    pub string_type_node: TypeNode,
 }
 
 #[derive(Debug, Clone, Node, MapNode)]
@@ -102,6 +120,7 @@ pub struct Method {
 /// Common data from Function/Method/Constructor
 #[derive(Debug, Clone, Node, MapNode)]
 pub struct Callable {
+    pub id: u64,
     pub name: String,
     pub orig_name: String,
     pub async_data: Option<AsyncData>,
@@ -429,6 +448,7 @@ pub struct TypeNode {
     ///     Many bindings will create a `UniffiConverter[canonical_name]` class.
     ///   - Creating a unique key for a type
     pub canonical_name: String,
+    pub id: u64,
     pub is_used_as_error: bool,
     pub ffi_type: FfiType,
     pub ty: Type,

--- a/uniffi_bindgen/src/pipeline/general/root.rs
+++ b/uniffi_bindgen/src/pipeline/general/root.rs
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::*;
+
+pub fn map_root(input: initial::Root, context: &Context) -> Result<Root> {
+    let mut context = context.clone();
+    context.update_from_root(&input)?;
+
+    Ok(Root {
+        cdylib: input.cdylib,
+        namespaces: input.namespaces.map_node(&context)?,
+        builtin_types: builtin_types(&context)?,
+    })
+}
+
+fn builtin_types(context: &Context) -> Result<BuiltinTypes> {
+    Ok(BuiltinTypes {
+        i8: Type::Int8.map_node(context)?,
+        u8: Type::UInt8.map_node(context)?,
+        i16: Type::Int16.map_node(context)?,
+        u16: Type::UInt16.map_node(context)?,
+        i32: Type::Int32.map_node(context)?,
+        u32: Type::UInt32.map_node(context)?,
+        i64: Type::Int64.map_node(context)?,
+        u64: Type::UInt64.map_node(context)?,
+        f32: Type::Float32.map_node(context)?,
+        f64: Type::Float64.map_node(context)?,
+        string: Type::String.map_node(context)?,
+    })
+}

--- a/uniffi_bindgen/src/pipeline/general/types.rs
+++ b/uniffi_bindgen/src/pipeline/general/types.rs
@@ -6,6 +6,7 @@ use super::*;
 
 pub fn map_type_node(ty: Type, context: &Context) -> Result<TypeNode> {
     Ok(TypeNode {
+        id: context.get_type_id(&ty)?,
         canonical_name: canonical_name(&ty),
         is_used_as_error: context.type_is_used_as_error(&ty),
         ffi_type: ffi_types::ffi_type(&ty, context)?,
@@ -109,5 +110,50 @@ pub fn map_type(mut ty: Type, context: &Context) -> Result<Type> {
         },
         // All other types can be returned unchanged
         _ => ty,
+    })
+}
+
+pub fn type_for_record(rec: &initial::Record, context: &Context) -> Result<Type> {
+    Ok(Type::Record {
+        namespace: context.namespace_name()?,
+        name: rec.name.clone(),
+        orig_name: rec.orig_name.clone(),
+    })
+}
+
+pub fn type_for_enum(en: &initial::Enum, context: &Context) -> Result<Type> {
+    Ok(Type::Enum {
+        namespace: context.namespace_name()?,
+        name: en.name.clone(),
+        orig_name: en.orig_name.clone(),
+    })
+}
+
+pub fn type_for_interface(int: &initial::Interface, context: &Context) -> Result<Type> {
+    Ok(Type::Interface {
+        namespace: context.namespace_name()?,
+        name: int.name.clone(),
+        orig_name: int.orig_name.clone(),
+        imp: int.imp,
+    })
+}
+
+pub fn type_for_callback_interface(
+    cbi: &initial::CallbackInterface,
+    context: &Context,
+) -> Result<Type> {
+    Ok(Type::CallbackInterface {
+        namespace: context.namespace_name()?,
+        name: cbi.name.clone(),
+        orig_name: cbi.orig_name.clone(),
+    })
+}
+
+pub fn type_for_custom_type(custom: &initial::CustomType, context: &Context) -> Result<Type> {
+    Ok(Type::Custom {
+        namespace: context.namespace_name()?,
+        name: custom.name.clone(),
+        orig_name: custom.orig_name.clone(),
+        builtin: Box::new(custom.builtin.clone()),
     })
 }

--- a/uniffi_bindgen/src/pipeline/initial/context.rs
+++ b/uniffi_bindgen/src/pipeline/initial/context.rs
@@ -2,10 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
 
 use super::*;
 
+#[derive(Default)]
 pub struct Context {
     // Map crate names to namespace names
     //
@@ -27,6 +34,8 @@ pub struct Context {
         BTreeMap<uniffi_meta::Type, uniffi_meta::ObjectTraitImplMetadata>,
     >,
     pub orig_names: BTreeMap<(String, String), String>,
+    // Uses an arc so we get a shared counter even if the context is cloned.
+    pub callable_id_counter: Arc<AtomicU64>,
 }
 
 impl Context {
@@ -44,6 +53,10 @@ impl Context {
             Some(orig_name) => orig_name.to_string(),
             None => type_name.to_string(),
         }
+    }
+
+    pub fn new_callable_id(&self) -> u64 {
+        self.callable_id_counter.fetch_add(1, Ordering::Relaxed)
     }
 
     pub fn methods_for_type(&self, module_path: &str, type_name: &str) -> Result<Vec<Method>> {

--- a/uniffi_bindgen/src/pipeline/initial/from_uniffi_meta.rs
+++ b/uniffi_bindgen/src/pipeline/initial/from_uniffi_meta.rs
@@ -264,6 +264,7 @@ impl UniffiMetaConverter {
             uniffi_traits: self.uniffi_traits,
             trait_impls: self.trait_impls,
             orig_names: self.orig_names,
+            ..Context::default()
         };
 
         let mut root = Root {

--- a/uniffi_bindgen/src/pipeline/initial/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/initial/nodes.rs
@@ -35,6 +35,8 @@ pub struct Namespace {
 pub struct Function {
     #[map_node(self.orig_name.unwrap_or_else(|| self.name.clone()))]
     pub orig_name: String,
+    #[map_node(context.new_callable_id())]
+    pub id: u64,
     pub name: String,
     pub is_async: bool,
     pub inputs: Vec<Argument>,
@@ -58,6 +60,8 @@ pub enum TypeDefinition {
 pub struct Constructor {
     #[map_node(self.orig_name.unwrap_or_else(|| self.name.clone()))]
     pub orig_name: String,
+    #[map_node(context.new_callable_id())]
+    pub id: u64,
     pub name: String,
     pub is_async: bool,
     pub inputs: Vec<Argument>,
@@ -72,6 +76,8 @@ pub struct Constructor {
 pub struct Method {
     #[map_node(self.orig_name.unwrap_or_else(|| self.name.clone()))]
     pub orig_name: String,
+    #[map_node(context.new_callable_id())]
+    pub id: u64,
     pub name: String,
     pub is_async: bool,
     pub inputs: Vec<Argument>,


### PR DESCRIPTION
Add `Callable.id` and `Type.id`.  These are useful when you need a unique ID for one of these, for example because you want to populate a hash map or generate a unique function name.

I prefer using a unique ID over canonical_name for that because it avoids name collisions in weird corner cases.  For example `HashMap<Foo, TypeBar>` and `HashMap<FooType, Bar>` both map to the same canonical name.  Also, the ID is unique over all crates.  `canonical_name` would also need to incorporate the namespace to make that true, which would increase the number of corner cases.

We're generating these in the Gecko JS pipeline and I also used them for uniffi-bindgen-kotlin-jni and I think other languages will want them as well.