### PR TITLE
Fix compile error message to point out missing `CARGO_MANIFEST_DIR`

### DIFF
--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -240,7 +240,7 @@ pub fn include_scaffolding(udl_stem: TokenStream) -> TokenStream {
             Ok(path) => path.display().to_string(),
             Err(_) => {
                 return quote! {
-                    compile_error!("This macro assumes the crate has a build.rs script, but $OUT_DIR is not present");
+                    compile_error!("This macro assumes to be run as part of the crate build, but `CARGO_MANIFEST_DIR` is not present");
                 }.into();
             }
         };


### PR DESCRIPTION
Previously it was talking about `OUT_DIR`, which is the same error message as above, but that IS present.
What's not present is `CARGO_MANIFEST_DIR` as used by `util::manifest_path`.

---

I ran into that in some ... uh, unrelated hacky experiment and it was confusing.
Can't really run into that using a normal Cargo-powered project setup though.