### PR TITLE
Fix object method kind

### DIFF
--- a/uniffi_bindgen/src/pipeline/general/nodes.rs
+++ b/uniffi_bindgen/src/pipeline/general/nodes.rs
@@ -313,7 +313,7 @@ pub struct Interface {
     pub docstring: Option<String>,
     #[map_node(objects::constructors(self.constructors, context)?)]
     pub constructors: Vec<Constructor>,
-    #[map_node(objects::interface_methods(self.methods, self.imp, context)?)]
+    #[map_node(objects::interface_methods(self.methods, context)?)]
     pub methods: Vec<Method>,
     pub trait_impls: Vec<ObjectTraitImpl>,
     pub imp: ObjectImpl,

--- a/uniffi_bindgen/src/pipeline/general/objects.rs
+++ b/uniffi_bindgen/src/pipeline/general/objects.rs
@@ -123,19 +123,9 @@ pub fn methods(methods: Vec<initial::Method>, context: &Context) -> Result<Vec<M
     methods_with_kind(methods, CallableKind::Method { self_type }, context)
 }
 
-pub fn interface_methods(
-    methods: Vec<initial::Method>,
-    imp: ObjectImpl,
-    context: &Context,
-) -> Result<Vec<Method>> {
+pub fn interface_methods(methods: Vec<initial::Method>, context: &Context) -> Result<Vec<Method>> {
     let self_type = context.self_type()?;
-    let kind = match imp {
-        ObjectImpl::Trait(_) => CallableKind::VTableMethod {
-            self_type,
-            for_callback_interface: false,
-        },
-        ObjectImpl::Struct => CallableKind::Method { self_type },
-    };
+    let kind = CallableKind::Method { self_type };
     methods_with_kind(methods, kind, context)
 }
 


### PR DESCRIPTION
Don't generate VTableMethod for trait interfaces.  The docs explicitly say we should only use VTableMethod for methods inside the vtable object.