### PR TITLE
Add async support for ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Custom Types can have docstrings in some languages ([#2853](https://github.com/mozilla/uniffi-rs/pull/2853))
 - Ruby: Expose standard Rust traits for generated ruby code (#2883)
 - Ruby: Add support for sync foreign traits ([#2916](https://github.com/mozilla/uniffi-rs/pull/2916))
+- Ruby: Add async support ([#2923](https://github.com/mozilla/uniffi-rs/pull/2923))
 - Added zero-copy transfer of `&[u8]` / `[ByRef] bytes` arguments from foreign code to Rust. Kotlin (`java.nio.ByteBuffer`, must be direct), Swift (`Data`), and Python (`bytes`-like, buffer protocol) pass byte buffers as pointer + length (`ForeignBytes`) rather than copying through `RustBuffer`. Not yet supported on Ruby, and not yet supported in async functions on any language ([#2878](https://github.com/mozilla/uniffi-rs/pull/2878)).
 - `#[uniffi::export(async_runtime = "tokio")]` can now be applied to trait exports, wrapping each method's FFI scaffolding future in `async_compat::Compat` the same way it does for inherent impls and free functions ([#2899](https://github.com/mozilla/uniffi-rs/pull/2899)).
 - Added support for using `HashSet` with proc-macros

--- a/bindgen-tests/README.md
+++ b/bindgen-tests/README.md
@@ -40,14 +40,14 @@ This has a few advantages:
     * Swift
         * Add a Swift test case file in `bindgen-tests/swift/tests`
         * Add a test function for the new test case in `bindgen-tests/swift/src/lib.rs`
-    * Kotlin: TODO
-    * Python: TODO
-    * Ruby: TODO
+    * Kotlin: TODO (see `bindgen-tests/kotlin/` — partially implemented)
+    * Python: see `bindgen-tests/python/tests/`
+    * Ruby: see `bindgen-tests/ruby/tests/`
 
 ## Migration plan
 
-The tests are only currently supported for Swift, the next step is making them work for the other
-bindings languages.
+Swift was the first language migrated; Ruby and Python suites also exist under `bindgen-tests/`.
+Kotlin support is still being ported.
 
 After that, we'll want to keep the existing fixtures for a while, since these tests may not be testing everything.
 New tests should be added here if possible.

--- a/bindgen-tests/ruby/src/lib.rs
+++ b/bindgen-tests/ruby/src/lib.rs
@@ -109,6 +109,11 @@ mod test {
         run_tests(test_dir(), "tests/rust_traits.rb");
     }
 
+    #[test]
+    fn test_futures() {
+        run_tests(test_dir(), "tests/futures.rb");
+    }
+
     fn test_dir() -> &'static Utf8Path {
         static TEST_TEMPDIR: OnceLock<Utf8PathBuf> = OnceLock::new();
         TEST_TEMPDIR.get_or_init(|| {

--- a/bindgen-tests/ruby/tests/futures.rb
+++ b/bindgen-tests/ruby/tests/futures.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uniffi_bindgen_tests'
+
+class TestFutures < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  class AsyncCallbackImpl
+    @@ref_count = 0
+
+    def self.reset_ref_count
+      @@ref_count = 0
+    end
+
+    def self.define_finalizer
+      Proc.new { |_id| @@ref_count -= 1 }
+    end
+
+    def initialize(value)
+      @value = value
+      @@ref_count += 1
+      ObjectSpace.define_finalizer(self, self.class.define_finalizer)
+    end
+
+    def noop
+    end
+
+    def get_value
+      @value
+    end
+
+    def set_value(value)
+      @value = value
+    end
+
+    def throw_if_equal(numbers)
+      if numbers.a == numbers.b
+        raise UniffiBindgenTests::TestError::Failure1.new
+      end
+      numbers
+    end
+  end
+
+  def test_simple_calls
+    assert_equal 42, UniffiBindgenTests.async_roundtrip_u8(42)
+    assert_equal -42, UniffiBindgenTests.async_roundtrip_i8(-42)
+    assert_equal 42, UniffiBindgenTests.async_roundtrip_u16(42)
+    assert_equal -42, UniffiBindgenTests.async_roundtrip_i16(-42)
+    assert_equal 42, UniffiBindgenTests.async_roundtrip_u32(42)
+    assert_equal -42, UniffiBindgenTests.async_roundtrip_i32(-42)
+    assert_equal 42, UniffiBindgenTests.async_roundtrip_u64(42)
+    assert_equal -42, UniffiBindgenTests.async_roundtrip_i64(-42)
+    assert_equal 0.5, UniffiBindgenTests.async_roundtrip_f32(0.5)
+    assert_equal -0.5, UniffiBindgenTests.async_roundtrip_f64(-0.5)
+    assert_equal 'hi', UniffiBindgenTests.async_roundtrip_string('hi')
+    assert_equal [42], UniffiBindgenTests.async_roundtrip_vec([42])
+    assert_equal(
+      { 'hello' => 'world' }, 
+      UniffiBindgenTests.async_roundtrip_map({ 'hello' => 'world' })
+    )
+  end
+
+  def test_errors
+    assert_raises(TestError::Failure1) { UniffiBindgenTests.async_throw_error }
+  end
+
+  def test_methods
+    obj = AsyncInterface.new 'Alice'
+    assert_equal 'Alice', obj.name
+
+    obj2 = UniffiBindgenTests.async_roundtrip_obj obj
+    assert_equal 'Alice', obj2.name
+  end
+
+  def test_async_callback_interfaces
+    cbi = AsyncCallbackImpl.new 42
+
+    UniffiBindgenTests.invoke_test_async_callback_interface_noop cbi
+
+    assert_equal 42, UniffiBindgenTests.invoke_test_async_callback_interface_get_value(cbi)
+    UniffiBindgenTests.invoke_test_async_callback_interface_set_value cbi, 43
+    assert_equal 43, UniffiBindgenTests.invoke_test_async_callback_interface_get_value(cbi)
+
+    assert_raises(TestError::Failure1) do
+      UniffiBindgenTests.invoke_test_async_callback_interface_throw_if_equal(
+        cbi,
+        CallbackInterfaceNumbers.new(a: 10, b: 10)
+      )
+    end
+
+    assert_equal(
+      CallbackInterfaceNumbers.new(a: 10, b: 11),
+      UniffiBindgenTests.invoke_test_async_callback_interface_throw_if_equal(
+        cbi,
+        CallbackInterfaceNumbers.new(a: 10, b: 11)
+      )
+    )
+ end
+end

--- a/bindgen-tests/ruby/tests/trait_interfaces.rb
+++ b/bindgen-tests/ruby/tests/trait_interfaces.rb
@@ -157,6 +157,138 @@ class TestTraitInterfaces < Test::Unit::TestCase
   end
 end
 
+class TestAsyncTraitInterfaces < Test::Unit::TestCase
+  include UniffiBindgenTests
+
+  class AsyncTraitImpl < AsyncTestTraitInterface
+    @@ref_count = 0
+
+    def self.reset_ref_count
+      @@ref_count = 0
+    end
+
+    def self.ref_count
+      @@ref_count
+    end
+
+    def self.define_finalizer
+      Proc.new { |_id| @@ref_count -= 1 }
+    end
+
+    def initialize(value)
+      @value = value
+      @@ref_count += 1
+      ObjectSpace.define_finalizer(self, self.class.define_finalizer)
+    end
+
+    def noop
+    end
+
+    def get_value
+      @value
+    end
+
+    def set_value(value)
+      @value = value
+    end
+
+    def throw_if_equal(numbers)
+      if numbers.a == numbers.b
+        raise UniffiBindgenTests::TestError::Failure1.new
+      end
+      numbers
+    end
+  end
+
+  def check_async_rust_impl(async_rust_trait_impl)
+    async_rust_trait_impl.noop
+
+    assert_equal 42, async_rust_trait_impl.get_value
+
+    async_rust_trait_impl.set_value(43)
+    assert_equal 43, async_rust_trait_impl.get_value
+
+    assert_raises(TestError::Failure1) do
+      async_rust_trait_impl.throw_if_equal(CallbackInterfaceNumbers.new(a: 10, b: 10))
+    end
+
+    assert_equal(
+      async_rust_trait_impl.throw_if_equal(CallbackInterfaceNumbers.new(a: 10, b: 11)),
+      CallbackInterfaceNumbers.new(a: 10, b: 11)
+    )
+  end
+
+  def check_async_rb_impl(async_rb_trait_impl)
+    UniffiBindgenTests.invoke_async_test_trait_interface_noop async_rb_trait_impl
+
+    assert_equal 42, UniffiBindgenTests.invoke_async_test_trait_interface_get_value(async_rb_trait_impl)
+    UniffiBindgenTests.invoke_async_test_trait_interface_set_value async_rb_trait_impl, 43
+    assert_equal 43, UniffiBindgenTests.invoke_async_test_trait_interface_get_value(async_rb_trait_impl)
+
+    assert_raises(TestError::Failure1) do
+      async_rb_trait_impl.throw_if_equal(CallbackInterfaceNumbers.new(a: 10, b: 10))
+    end
+
+    assert_equal(
+      async_rb_trait_impl.throw_if_equal(CallbackInterfaceNumbers.new(a: 10, b: 11)),
+      CallbackInterfaceNumbers.new(a: 10, b: 11)
+    )
+  end
+
+  def test_async_rust_impl
+    check_async_rust_impl UniffiBindgenTests.create_async_test_trait_interface(42)	
+  end
+
+  def test_async_rust_impl_roundtripped
+    impl = UniffiBindgenTests.roundtrip_async_test_trait_interface(
+      UniffiBindgenTests.create_async_test_trait_interface(42)
+    )
+
+    check_async_rust_impl impl
+  end
+
+  def test_async_rust_impl_roundtripped_list
+    impl = UniffiBindgenTests.roundtrip_async_test_trait_interface_list(
+      [UniffiBindgenTests.create_async_test_trait_interface(42)]
+    )[0]
+
+    check_async_rust_impl impl
+  end
+
+  def test_async_rb_impl
+    impl = AsyncTraitImpl.new(42)
+    check_async_rb_impl impl
+    # rubocop:disable Lint/UselessAssignment
+    impl = nil
+    # rubocop:enable Lint/UselessAssignment
+    GC.start
+
+    assert_equal 0, AsyncTraitImpl.ref_count
+  end
+
+  def test_async_rb_impl_roundtripped
+    impl = UniffiBindgenTests.roundtrip_async_test_trait_interface(AsyncTraitImpl.new(42))
+    check_async_rb_impl impl
+    # rubocop:disable Lint/UselessAssignment
+    impl = nil
+    # rubocop:enable Lint/UselessAssignment
+    GC.start
+
+    assert_equal 0, AsyncTraitImpl.ref_count
+  end
+
+  def test_async_rb_impl_roundtripped_list
+    impl = UniffiBindgenTests.roundtrip_async_test_trait_interface_list([AsyncTraitImpl.new(42)])[0]
+    check_async_rb_impl impl
+    # rubocop:disable Lint/UselessAssignment
+    impl = nil
+    # rubocop:enable Lint/UselessAssignment
+    GC.start
+
+    assert_equal 0, AsyncTraitImpl.ref_count
+  end
+end
+
 class TestRustOnlyTraitInterfaces < Test::Unit::TestCase
   include UniffiBindgenTests
 

--- a/docs/manual/src/Motivation.md
+++ b/docs/manual/src/Motivation.md
@@ -30,7 +30,7 @@ Using UniFFI, you can:
 * Run `uniffi-bindgen generate ... -l kotlin` (see [the bindgen docs](./tutorial/foreign_language_bindings.md) for omitted arg details)
   to generate a Kotlin library that can load your shared library
   and expose it to Kotlin code using your nice high-level component API!
-  * Or `-l swift` or `-l python` to produce bindings for other languages.
+  * Or `-l swift` or `-l python` or `-l ruby` to produce bindings for other languages.
 
 ## Why?
 

--- a/docs/manual/src/bindings.md
+++ b/docs/manual/src/bindings.md
@@ -1,6 +1,6 @@
 # Generating bindings
 
-"Bindings" is the term for the non-Rust side of the environment - the generated Python, Swift or Kotlin code which drives the examples.
+"Bindings" is the term for the non-Rust side of the environment - the generated Python, Swift, Kotlin or Ruby code which drives the examples.
 
 UniFFI comes with a `uniffi_bindgen` which generates these bindings. For introductory
 information, see [Foreign Language Bindings in the tutorial](./tutorial/foreign_language_bindings.md).

--- a/docs/manual/src/configuration.md
+++ b/docs/manual/src/configuration.md
@@ -11,7 +11,7 @@ We support:
 * a "global configuration" for your project, as described below.
 
 In all cases, you should see the documentation for the builtin bindings
-([Kotlin](./kotlin/configuration.md), [Python](./python/configuration.md), [Swift](./swift/configuration.md)), or external bindings docs.
+([Kotlin](./kotlin/configuration.md), [Python](./python/configuration.md), [Swift](./swift/configuration.md), [Ruby](./ruby/configuration.md)), or external bindings docs.
 
 # Global configuration
 

--- a/docs/manual/src/foreign_traits.md
+++ b/docs/manual/src/foreign_traits.md
@@ -1,7 +1,7 @@
 # Foreign traits
 
 UniFFI traits can be implemented by foreign code.
-This means traits implemented in Python/Swift/Kotlin etc can provide Rust code with capabilities not easily implemented in Rust, such as:
+This means traits implemented in Python/Swift/Kotlin/Ruby, etc. can provide Rust code with capabilities not easily implemented in Rust, such as:
 
  * device APIs not directly available to Rust.
  * provide glue to clip together Rust components at runtime.

--- a/docs/manual/src/futures.md
+++ b/docs/manual/src/futures.md
@@ -1,6 +1,6 @@
 # Async/Future support
 
-UniFFI supports exposing async Rust functions over the FFI. It can convert a Rust `Future`/`async fn` to and from foreign native futures (`async`/`await` in Python/Swift, `suspend fun` in Kotlin etc.)
+UniFFI supports exposing async Rust functions over the FFI. It can convert a Rust `Future`/`async fn` to and from foreign native futures (`async`/`await` in Python/Swift/Ruby, `suspend fun` in Kotlin etc.)
 
 Check out the [examples](https://github.com/mozilla/uniffi-rs/tree/main/examples/futures) or the more terse and thorough [fixtures](https://github.com/mozilla/uniffi-rs/tree/main/fixtures/futures).
 
@@ -96,6 +96,12 @@ Use `uniffi_set_event_loop()` to handle this case.
 It should be called before the Rust code makes the async call and passed an eventloop to use.
 
 Note that `uniffi_set_event_loop` cannot be glob-imported because it's not part of the library's `__all__`.
+
+### Ruby: thread-based async
+
+Unlike Python and Swift, Ruby has no native async/await. When Rust calls an async Ruby callback
+method, UniFFI spawns a new OS thread for each invocation. There is no event loop requirement,
+though a Fiber scheduler is supported for the Ruby -> Rust polling direction.
 
 ## Cancelling async code.
 

--- a/docs/manual/src/index.md
+++ b/docs/manual/src/index.md
@@ -19,9 +19,11 @@ This process can take place either during the build process or be manually initi
 UniFFI comes with full support for Kotlin, Swift and Python; unless specified otherwise, you can expect all features in
 this manual will work for these languages.
 
-We also have partial legacy support for Ruby; the UniFFI team keeps the existing Ruby support working but tends to not
-add new features to that language. It seems possible that Ruby support will be split into its own crate at some point, but
-in the meantime we welcome improvements and contributions to Ruby.
+UniFFI also ships Ruby bindings. Most features described in this manual work for Ruby as well;
+see the [Ruby configuration](./ruby/configuration.md) page for language-specific options.
+The UniFFI team keeps the existing Ruby support working but tends to not add new features to that language.
+A few features are not yet available on Ruby (like docstrings in generated bindings).
+It seems possible that Ruby support will be split into its own crate at some point.
 
 There are also many 3rd party bindings - please see our [README](https://github.com/mozilla/uniffi-rs/blob/main/README.md) for references.
 These languages may require older versions of UniFFI and may have partial or non-existant support for some features; see the

--- a/docs/manual/src/proc_macro/renaming.md
+++ b/docs/manual/src/proc_macro/renaming.md
@@ -87,3 +87,11 @@ let result = renamedFunction(record: record)
 let obj = RenamedObject.renamedConstructor(value: 123)
 let value = obj.renamedMethod()
 ```
+
+```ruby
+# Ruby
+record = RenamedRecord.new(renamed_field: 42)
+result = renamed_function(record)
+obj = RenamedObject.renamed_constructor(123)
+value = obj.renamed_method
+```

--- a/docs/manual/src/ruby/configuration.md
+++ b/docs/manual/src/ruby/configuration.md
@@ -1,0 +1,34 @@
+# Configuration
+
+The generated Ruby modules can be configured using a `uniffi.toml` configuration file.
+
+## Available options
+
+| Configuration name | Default  | Description |
+| ------------------ | -------- | ----------- |
+| `cdylib_name`      | `uniffi_{namespace}`[^1] | The name of the compiled Rust library containing the FFI implementation (not needed when using `generate --library`). |
+| `cdylib_path`      | | An explicit path to the shared library, passed as the `ffi_lib` argument. |
+| `custom_types`     | | A map which controls how custom types are exposed to Ruby. See the [custom types section of the manual](../types/custom_types.md#custom-types-in-the-bindings-code) |
+| `rename`           | | A map to rename types, functions, methods, and their members in the generated Ruby bindings. See the [renaming section](../renaming.md). |
+| `exclude`          | | A list of crate names to exclude when generating bindings for a library (library mode). |
+
+[^1]: The namespace is derived from the crate name or UDL file name.
+
+## Prerequisites
+
+Ruby bindings require the [`ffi` gem](https://github.com/ffi/ffi). See [docs/contributing.md](https://github.com/mozilla/uniffi-rs/blob/main/docs/contributing.md) for setup instructions.
+
+## Examples
+
+Custom Types:
+
+```toml
+# Assuming a Custom Type named Url using a String as the builtin.
+[bindings.ruby.custom_types.Url]
+type_name = "URI"
+imports = ["uri"]
+lift = "URI.parse({})"
+lower = "{}.to_s"
+```
+
+Refer to [`examples/custom-types/uniffi.toml`](https://github.com/mozilla/uniffi-rs/blob/main/examples/custom-types/uniffi.toml) for a complete example.

--- a/docs/manual/src/tutorial/foreign_language_bindings.md
+++ b/docs/manual/src/tutorial/foreign_language_bindings.md
@@ -98,6 +98,14 @@ cargo run --bin uniffi-bindgen generate src/math.udl --language swift
 ```
 then check out `src/math.swift`
 
+### Ruby
+
+Run
+```
+cargo run --bin uniffi-bindgen generate src/math.udl --language ruby
+```
+then check out `src/math.rb`
+
 Note that these commands could be integrated as part of your gradle/Xcode build process.
 
 This is it, you have an MVP integration of UniFFI in your project.

--- a/docs/manual/src/types/bytes.md
+++ b/docs/manual/src/types/bytes.md
@@ -52,6 +52,7 @@ Each binding maps `[ByRef] bytes` to a natural zero-copy type:
 | Kotlin  | `java.nio.ByteBuffer`    | Must be a *direct* buffer (`ByteBuffer.allocateDirect(...)`). |
 | Swift   | `Data`                   | The call runs inside `Data.withUnsafeBytes`.                  |
 | Python  | `bytes`                  | The `bytes` object's stable internal pointer is used.         |
+| Ruby    | `String(BINARY)`         | Uses `String` with `Encoding::BINARY`.                        |
 
 Passing a non-direct `ByteBuffer` from Kotlin raises an
 `IllegalArgumentException` at the call site, matching JNA's

--- a/docs/manual/src/types/custom_types.md
+++ b/docs/manual/src/types/custom_types.md
@@ -219,7 +219,7 @@ The behavior of the generated scaffolding will be:
 
 ## Custom types in the bindings code
 
-*Note: The facility described in this document is not yet available for the Ruby bindings.*
+Ruby supports the same `[bindings.ruby.custom_types]` configuration; see `[examples/custom-types/uniffi.toml](https://github.com/mozilla/uniffi-rs/blob/main/examples/custom-types/uniffi.toml)`.
 
 By default, the foreign bindings just see the builtin type - eg, the bindings will get an integer
 for the `Handle`.

--- a/docs/manual/src/types/interfaces.md
+++ b/docs/manual/src/types/interfaces.md
@@ -155,8 +155,6 @@ class PyButton(uniffi_module.Button):
 uniffi_module.press(PyButton())
 ```
 
-Note: This is currently only supported on Python, Kotlin, and Swift.
-
 ### Traits example
 
 See the ["traits" example](https://github.com/mozilla/uniffi-rs/tree/main/examples/traits) for more.

--- a/docs/manual/src/types/uniffi_traits.md
+++ b/docs/manual/src/types/uniffi_traits.md
@@ -38,12 +38,14 @@ The bindings will generate:
 * Python: The object will have a `__repr__` method that returns the value implemented by the `Debug` trait.
 * Swift: Will generate a `public var debugDescription: String {..}` method on the object, allowing, eg, `String(reflecting: ob)` to be used.
 * Kotlin: Will generate `override fun toString(): String {..}` (although will prefer the `Display` implementation if it exists).
+* Ruby: Will generate `#inspect` (Debug) and `#to_s` (Display) methods.
 
 Whereas `Eq` would generate:
 
 * Python: The object will have `__eq__(self, other)` and `__ne__(self, other)` methods.
 * Swift: Will generate `public static func == (self: .., other: ..)`
 * Kotlin: Will generate `override fun equals(other: Any?): Boolean` and have the object extend `Comparable<>`.
+* Ruby: Will generate `#==` and `#hash` methods.
 
 etc.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,6 +35,7 @@ Each example has the following structure:
   * Kotlin `tests/bindings/test_<namespace>.kts`
   * Swift `tests/bindings/test_<namespace>.swift`
   * Python `tests/bindings/test_<namespace>.py`
+  * Ruby `tests/bindings/test_<namespace>.rb`
 
 If you want to try them out, you will need:
 
@@ -65,5 +66,5 @@ With that in place, try the following:
     This will generate the foreign-language bindings for Kotlin, which load the compiled Rust code
     and use the C FFI generated above to interact with it.
     You can view the generated code in `./src/uniffi/<namespace>/<namespace>.kt`.
-  * Try using `--language swift` or `--language python` to explore the foreign-language bindings
+  * Try using `--language swift`, `--language python`, or `--language ruby` to explore the foreign-language bindings
     generated for other languages.

--- a/examples/async-api-client/tests/bindings/test_async_api_client.rb
+++ b/examples/async-api-client/tests/bindings/test_async_api_client.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test/unit'
+require 'async_api_client'
+
+class RbHttpClient
+  def fetch(url, credentials)
+    raise AsyncApiClient::ApiError::Http.new('Unauthorized') unless credentials == 'username:password'
+
+    # Fake HTTP response
+    ::Kernel.sleep(0.01)
+    if url == 'https://api.github.com/repos/mozilla/uniffi-rs/issues/2017'
+      AsyncApiClient.test_response_data
+    else
+      raise AsyncApiClient::ApiError::Http.new("Wrong URL: #{url}")
+    end
+  end
+end
+
+class RbTaskRunner
+  def run_task(task)
+    task.execute
+  end
+end
+
+class TestAsyncApiClient < Test::Unit::TestCase
+  def test_api_client
+    client = AsyncApiClient::ApiClient.new(RbHttpClient.new, RbTaskRunner.new)
+    issue = client.get_issue('mozilla', 'uniffi-rs', 2017)
+
+    assert_equal 'Foreign-implemented async traits', issue.title
+  end
+end

--- a/examples/async-api-client/tests/test_generated_bindings.rs
+++ b/examples/async-api-client/tests/test_generated_bindings.rs
@@ -2,4 +2,5 @@ uniffi::build_foreign_language_testcases!(
     "tests/bindings/test_async_api_client.kts",
     "tests/bindings/test_async_api_client.swift",
     "tests/bindings/test_async_api_client.py",
+    "tests/bindings/test_async_api_client.rb",
 );

--- a/examples/futures/tests/bindings/test.rb
+++ b/examples/futures/tests/bindings/test.rb
@@ -1,0 +1,4 @@
+require 'uniffi_example_futures'
+
+result = UniffiExampleFutures.say_after 200, 'Alice'
+raise "Expected 'Hello, Alice!', got '#{result}'" unless result == 'Hello, Alice!'

--- a/examples/futures/tests/test_generated_bindings.rs
+++ b/examples/futures/tests/test_generated_bindings.rs
@@ -1,1 +1,1 @@
-uniffi::build_foreign_language_testcases!("tests/bindings/test.py",);
+uniffi::build_foreign_language_testcases!("tests/bindings/test.py", "tests/bindings/test.rb");

--- a/fixtures/error-types/tests/bindings/test.rb
+++ b/fixtures/error-types/tests/bindings/test.rb
@@ -29,6 +29,12 @@ class TestErrorTypes < Test::Unit::TestCase
     assert_equal 'because uniffi told me so', e.link(0)
   end
 
+  def test_async_error_interface
+    e = assert_raises(ErrorTypes::ErrorInterface) { ErrorTypes.aoops }
+
+    assert_equal 'async-oops', e.message
+  end
+
   def test_get_error_returns_without_raising
     e = ErrorTypes.get_error 'the error'
 

--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -54,7 +54,13 @@ impl TimerFuture {
             let mut shared_state: MutexGuard<_> = thread_shared_state.lock().unwrap();
             shared_state.completed = true;
 
-            if let Some(waker) = shared_state.waker.take() {
+            // Release the lock BEFORE waking to avoid deadlocks: waker.wake()
+            // may invoke a foreign callback that re-polls this future, which
+            // would need to acquire shared_state again.
+            let waker = shared_state.waker.take();
+            drop(shared_state);
+
+            if let Some(waker) = waker {
                 waker.wake();
             }
         });

--- a/fixtures/futures/tests/bindings/test_futures.rb
+++ b/fixtures/futures/tests/bindings/test_futures.rb
@@ -1,0 +1,443 @@
+# frozen_string_literal: true
+
+require 'test/unit'
+require 'futures'
+
+class TestFutures < Test::Unit::TestCase
+  def test_always_ready
+    assert_equal true, Futures.always_ready
+  end
+
+  def test_void
+    assert_nil Futures.void
+  end
+
+  def test_sleep
+    start = now()
+    Futures.sleep 200
+
+    assert_in_delta 0.2, now - start, 0.1
+  end
+
+  def test_sequential_futures
+    start = now()
+    result_alice = Futures.say_after 100, 'Alice'
+    result_bob = Futures.say_after 200, 'Bob'
+
+    assert_operator now - start, :>=, 0.3
+    assert_equal result_alice, 'Hello, Alice!'
+    assert_equal result_bob, 'Hello, Bob!'
+  end
+
+  def test_concurrent_tasks
+    start = now()
+    alice = Thread.new { Futures.say_after(100, 'Alice') }
+    bob = Thread.new { Futures.say_after(200, 'Bob') }
+    result_alice = alice.value
+    result_bob = bob.value
+
+    delta = now - start
+
+    assert_operator delta, :>=, 0.2
+    assert_operator delta, :<, 0.4
+
+    assert_equal result_alice, 'Hello, Alice!'
+    assert_equal result_bob, 'Hello, Bob!'
+  end
+
+  def test_async_methods
+    megaphone = Futures::Megaphone.new
+    t0 = now()
+    result_alice = megaphone.say_after(200, 'Alice')
+
+    assert_operator now - t0, :>=, 0.2
+    assert_equal result_alice, 'HELLO, ALICE!'
+  end
+
+  def test_async_constructors
+    megaphone = Futures::Megaphone.secondary
+    result_alice = megaphone.say_after(0, 'Alice')
+    assert_equal result_alice, 'HELLO, ALICE!'
+
+    udl_megaphone = Futures::UdlMegaphone.secondary
+    result_udl = udl_megaphone.say_after(0, 'udl')
+    assert_equal result_udl, 'HELLO, UDL!'
+  end
+
+  def test_async_trait_interface_methods
+    traits = Futures.get_say_after_traits
+    start = now()
+    result1 = traits[0].say_after(100, 'Alice')
+    result2 = traits[1].say_after(100, 'Bob')
+
+    assert_operator now - start, :>=, 0.2
+    assert_equal result1, 'Hello, Alice!'
+    assert_equal result2, 'Hello, Bob!'
+  end
+
+  def test_udl_async_trait_interface_methods
+    traits = Futures.get_say_after_udl_traits
+    t0 = now()
+    result1 = traits[0].say_after(100, 'Alice')
+    result2 = traits[1].say_after(100, 'Bob')
+    t_delta = now - t0
+
+    assert_equal result1, 'Hello, Alice!'
+    assert_equal result2, 'Hello, Bob!'
+
+    assert_operator t_delta, :>=, 0.2
+  end
+
+  def test_tokio_async_trait_interface_methods
+    traits = Futures.get_say_after_tokio_traits
+
+    start = now()
+
+    result1 = traits[0].say_after(100, 'Alice')
+    result2 = traits[1].say_after(100, 'Bob')
+
+    assert_operator now - start, :>=, 0.2
+    assert_equal result1, 'Hello, Alice (with Tokio)!'
+    assert_equal result2, 'Hello, Bob (with Tokio)!'
+  end
+
+  def test_foreign_async_trait_interface_methods
+    trait_obj = RbAsyncParser.new
+
+    assert_equal Futures.as_string_using_trait(trait_obj, 1, 42), '42'
+    assert_equal Futures.try_from_string_using_trait(trait_obj, 1, '42'), 42
+    assert_raises(Futures::ParserError::NotAnInt) do
+      Futures.try_from_string_using_trait(trait_obj, 1, 'fourty-two')
+    end
+
+    assert_raises(Futures::ParserError::UnexpectedError) do
+      Futures.try_from_string_using_trait trait_obj, 1, 'force-unexpected-exception'
+    end
+
+    Futures.delay_using_trait(trait_obj, 1)
+    Futures.try_delay_using_trait(trait_obj, '1')
+
+    assert_raises(Futures::ParserError::NotAnInt) do
+      Futures.try_delay_using_trait(trait_obj, 'one')
+    end
+
+    completed_delays_before = trait_obj.completed_delays
+    Futures.cancel_delay_using_trait trait_obj, 10
+    # sleep long enough so that the `delay()` call would finish if it wasn't cancelled.
+    sleep 0.1
+    # If the task was cancelled, then completed_delays won't have increased
+    assert_equal trait_obj.completed_delays, completed_delays_before
+
+    # check that all foreign future handles were released
+    assert_equal Futures::UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.size, 0
+    assert_equal Futures::UNIFFI_ASYNC_HANDLE_MAP.size, 0
+  end
+
+  def test_async_object_param
+    megaphone = Futures.new_megaphone()
+    t0 = now()
+    result_alice = Futures.say_after_with_megaphone(megaphone, 200, 'Alice')
+
+    assert_operator now - t0, :>=, 0.2
+    assert_equal result_alice, 'HELLO, ALICE!'
+  end
+
+  def test_with_tokio_runtime
+    t0 = now()
+    result_alice = Futures.say_after_with_tokio(200, 'Alice')
+
+    assert_operator now - t0, :>=, 0.2
+    assert_equal result_alice, 'Hello, Alice (with Tokio)!'
+  end
+
+  def test_fallible
+    assert_equal 42, Futures.fallible_me(false)
+    assert_raises(Futures::MyError::Foo) { Futures.fallible_me true }
+
+    megaphone = Futures.new_megaphone
+    assert_equal 42, megaphone.fallible_me(false)
+
+    assert_raises(Futures::MyError::Foo) { megaphone.fallible_me(true) }
+  end
+
+  def test_fallible_struct
+    assert_equal 42, Futures.fallible_struct(false).fallible_me(false)
+    assert_raises(Futures::MyError::Foo) { Futures.fallible_struct true }
+  end
+
+  def test_record
+    result = Futures.new_my_record 'foo', 42
+
+    assert_instance_of Futures::MyRecord, result
+    assert_equal result.a, 'foo'
+    assert_equal result.b, 42
+  end
+
+  def test_greet
+    assert_equal 'Hello, World', Futures.greet('World')
+  end
+
+  def test_shared_resource_no_cancellation
+    Futures.use_shared_resource(
+      Futures::SharedResourceOptions.new(release_after_ms: 100, timeout_ms: 1000)
+    )
+    Futures.use_shared_resource(
+      Futures::SharedResourceOptions.new(release_after_ms: 0, timeout_ms: 1000)
+    )
+  end
+
+  # Test a future that uses a lock and that is cancelled.
+  def test_shared_resource_cancellation
+    thread = Thread.new do
+      Futures.use_shared_resource(
+        Futures::SharedResourceOptions.new(release_after_ms: 5000, timeout_ms: 100)
+      )
+    end
+
+    thread.report_on_exception = false
+    sleep 0.05 # let the thread acquire the Tokio mutext
+    thread.raise # cancel - drops the Rust future, releasing the mutex guard
+    thread.join rescue nil
+
+    # If cancellation freed the future correctly, the mutext is released and this succeeds
+    Futures.use_shared_resource(
+      Futures::SharedResourceOptions.new(release_after_ms: 0, timeout_ms: 1000)
+    )
+  end
+
+  def test_deadlock_stress
+    50.times do |i|
+      threads = 4.times.map do
+        t = Thread.new do
+          Futures.use_shared_resource(
+            Futures::SharedResourceOptions.new(release_after_ms: 5000, timeout_ms: 10)
+          )
+        end
+        t.report_on_exception = false
+        t
+      end
+
+      sleep 0.01
+      threads.each(&:raise) # cancel
+
+      threads.each do |t|
+        begin
+          t.join(2)
+        rescue Exception
+          # Expected - thread died from RuntimeError (our raise) or AsyncError::Timeout
+          next
+        end
+        # join returned nil (timeout) - thread is stuck
+        if !t.alive?
+          next # Thread finished between join timeout and alive? check
+        end
+
+        t.kill
+        flunk "Deadlock detected in iteration #{i}"
+      end
+    end
+  end
+
+  def test_cancel
+    thread = Thread.new { Futures.say_after 200, 'Alice' }
+    thread.report_on_exception = false
+    sleep 0.1 # let the poll loop start
+    thread.raise # interrupt wait_readable -> ensure fires cancel+free
+    thread.join rescue nil
+
+    assert !thread.alive?, 'Future was not canceled'
+
+    # No leaked pipe handles
+    assert_equal Futures::UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.size, 0
+    assert_equal Futures::UNIFFI_ASYNC_HANDLE_MAP.size, 0
+  end
+
+  # --- Fiber::Scheduler tests ---
+  # These verify that async calls work with Ruby's cooperative fiber concurrency,
+  # yielding the fiber on IO wait and resuming when the Rust future completes.
+  def test_fiber_concurrent_tasks
+    results = []
+    t0 = now()
+
+    run_with_scheduler do
+      Fiber.schedule { results << Futures.say_after(200, 'Alice') }
+      Fiber.schedule { results << Futures.say_after(200, 'Bob') }
+    end
+
+    delta = now - t0
+
+    assert_equal 2, results.size
+    assert_include results, 'Hello, Alice!'
+    assert_include results, 'Hello, Bob!'
+
+    # Both run concurrently on one thread - should complete in ~200ms, not ~400ms
+    assert_operator delta, :>=, 0.2
+    assert_operator delta, :<, 0.4
+  end
+
+  def test_fiber_async_methods
+    result = nil
+
+    run_with_scheduler do
+      Fiber.schedule { result = Futures.new_megaphone.say_after 100, 'Alice' }
+    end
+
+    assert_equal 'HELLO, ALICE!', result
+  end
+
+  def test_fiber_async_constructors
+    result = nil
+
+    run_with_scheduler do
+      Fiber.schedule { result = Futures::Megaphone.secondary.say_after 0, 'Alice' }
+    end
+
+    assert_equal 'HELLO, ALICE!', result
+  end
+
+  def test_fiber_fallible
+    ok_result = nil
+    error_class = nil
+
+    run_with_scheduler do
+      Fiber.schedule { ok_result = Futures.fallible_me(false) }
+      Fiber.schedule do
+        Futures.fallible_me true
+      rescue StandardError => e
+        error_class = e.class
+      end
+    end
+
+    assert_equal 42, ok_result
+    assert_equal Futures::MyError::Foo, error_class
+  end
+
+  def now
+    Process.clock_gettime Process::CLOCK_MONOTONIC
+  end
+
+  # Minimal Fiber::Scheduler for testing (no external gems required).
+  # Implements just enough of the scheduler interface to support IO#wait_readable
+  # which is used by uniffi_rust_call_async
+  class MinimalScheduler
+    def initialize
+      @readable = {}
+      @waiting = []
+      @ready = []
+    end
+
+    def io_wait(io, events, _timeout = nil)
+      @readable[io] = Fiber.current
+      Fiber.yield
+      events
+    end
+
+    def kernel_sleep(duration = nil)
+      return unless duration
+
+      @waiting << [Fiber.current, Process.clock_gettime(Process::CLOCK_MONOTONIC) + duration]
+      Fiber.yield
+    end
+
+    def block(blocker, timeout = nil); end
+    def unblock(blocker, fiber); end
+
+    def fiber(&block)
+      f = Fiber.new(blocking: false, &block)
+      f.resume
+      f
+    end
+
+    def fiber_interrupt(fiber, exception)
+      # 1. Pull the fiber out of any wait state to avoid double-resumption
+      @readable.delete_if { |_, f| f == fiber }
+      @waiting.delete_if { |f, _| f == fiber }
+
+      # 2. Queue it up to be interrupted in the main loop
+      @ready << [fiber, exception]
+    end
+
+    def close
+      until @readable.empty? && @waiting.empty? && @ready.empty?
+
+        # 1. Process ready/interrupted fibers immediately
+        while (pair = @ready.shift)
+          f, exception = pair
+          # Raise the exception inside the fiber at the point it called Fiber.yield
+          f.raise(exception) if f.alive? 
+        end
+
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        @waiting.select { |_, t| t < now }.each do |pair|
+          @waiting.delete(pair)
+          pair[0].resume
+        end
+
+        rds = @readable.keys
+
+        break if rds.empty? && @waiting.empty? && @ready.empty?
+        next if rds.empty?
+
+        # If there are no waiting fibers, default to a 0.1s max timeout
+        t = @waiting.empty? ? 0.1 : [0.001, @waiting.map { |_, deadline| deadline - now }.min].max
+        ready = IO.select(rds, nil, nil, t)
+
+        (ready&.first || []).each do |io|
+          f = @readable.delete(io)
+          f&.resume
+        end
+      end
+    end
+  end
+
+  # Run block with a minimal Fiber::Scheduler, then cleanup.
+  def run_with_scheduler
+    scheduler = MinimalScheduler.new
+    Fiber.set_scheduler scheduler
+    yield
+    scheduler.close
+  ensure
+    Fiber.set_scheduler nil
+  end
+
+  class RbAsyncParser < Futures::AsyncParser
+    attr_accessor :completed_delays
+
+    def initialize
+      @completed_delays = 0
+    end
+
+    def as_string(delay_ms, value)
+      Kernel.sleep(delay_ms / 1000.0)
+      value.to_s
+    end
+
+    def try_from_string(delay_ms, value)
+      Kernel.sleep(delay_ms / 1000.0)
+
+      raise RuntimeError('UnexpectedException') if value == 'force-unexpected-exception'
+
+      begin
+        Integer(value)
+      rescue ArgumentError
+        raise Futures::ParserError::NotAnInt
+      end
+    end
+
+    def delay(delay_ms)
+      Kernel.sleep(delay_ms / 1000.0)
+      @completed_delays += 1
+    end
+
+    def try_delay(delay_ms)
+      begin
+        delay_ms = Integer(delay_ms)
+      rescue ArgumentError
+        raise Futures::ParserError::NotAnInt
+      end
+
+      Kernel.sleep(delay_ms / 1000.0)
+      @completed_delays += 1
+    end
+  end
+end

--- a/fixtures/futures/tests/test_generated_bindings.rs
+++ b/fixtures/futures/tests/test_generated_bindings.rs
@@ -2,4 +2,5 @@ uniffi::build_foreign_language_testcases!(
     "tests/bindings/test_futures.py",
     "tests/bindings/test_futures.swift",
     "tests/bindings/test_futures.kts",
+    "tests/bindings/test_futures.rb",
 );

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
     - ./swift/xcode.md
 
   - 'Python': ./python/configuration.md
+  - 'Ruby': ./ruby/configuration.md
 
   - 'WASM':
     - ./wasm/configuration.md

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -219,6 +219,38 @@ mod filters {
         })
     }
 
+    /// Return the Ruby default value for an FFI return type (used in async error callbacks).
+    #[askama::filter_fn]
+    pub fn ffi_default_value_rb(
+        return_type: &Type,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
+        let ffi_type = FfiType::from(return_type);
+        Ok(match &ffi_type {
+            FfiType::Int8
+            | FfiType::UInt8
+            | FfiType::Int16
+            | FfiType::UInt16
+            | FfiType::Int32
+            | FfiType::UInt32
+            | FfiType::Int64
+            | FfiType::UInt64
+            | FfiType::Handle => "0".to_string(),
+            FfiType::Float32 | FfiType::Float64 => "0.0".to_string(),
+            FfiType::RustBuffer(_) => "RustBuffer.new".to_string(),
+            _ => panic!("Unsupported FFI return type for callback: {ffi_type:?}"),
+        })
+    }
+
+    /// Return the ForeignFutureResult struct name for a method's return type.
+    #[askama::filter_fn]
+    pub fn foreign_future_result_rb(
+        method: &Method,
+        _: &dyn askama::Values,
+    ) -> Result<String, askama::Error> {
+        Ok(method.foreign_future_ffi_result_struct().name().to_string())
+    }
+
     fn default_rb_inner(default: &DefaultValue) -> Result<String, askama::Error> {
         let DefaultValue::Literal(literal) = default else {
             unimplemented!("not supported.");

--- a/uniffi_bindgen/src/bindings/ruby/templates/Async.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/Async.rb
@@ -1,0 +1,184 @@
+# RustFuture poll codes
+UNIFFI_RUST_FUTURE_POLL_READY = 0
+UNIFFI_RUST_FUTURE_POLL_WAKE = 1
+
+# Handle map for storing write-end IO objects used by the continuation callbacks.
+UNIFFI_ASYNC_HANDLE_MAP = UniffiHandleMap.new
+
+# Continuation callback for async functions.
+# Called by Rust when the future is ready to make progress.
+# Writes the poll code to the pipe so the waiting thread/fiber can continue.
+#
+# Exceptions must never escape this Proc.
+# Rust invokes it directly via FFI, so any unhandled Ruby exception would be caught
+# by Ruby-FFI, which swallows it (prints a warning) and returns a garbage value to Rust.
+# The poll code Rust receives would be invalid, causing the Ruby polling loop to
+# never see POLL_READY and block forever.
+UNIFFI_CONTINUATION_CALLBACK = Proc.new do |data, poll_code|
+  begin
+    wr = UNIFFI_ASYNC_HANDLE_MAP.get data
+
+    # This can only be blocking if pipe if full. Rust will never try to call continuation
+    # callback more than once (so will not fill it up), hence this call should never block.
+    wr.putc poll_code
+  rescue Exception
+    # Swallow exception. A leak or a hang is better than a hard VM segfault.
+  end
+end
+
+# Poll a Rust future to completion.
+#
+# This works both with and without a Fiber::Scheduler:
+# - Without scheduler: wait_readable blocks with a timeout, releasing the GVL
+#   so the callback can fire from foreign threads (works around MRI limitation
+#   where rb_thread_call_with_gvl cannot wake up threads in indefinite sleep).
+# - With scheduler: wait_readable hooks into io_wait, yielding the fiber.
+#
+# cancel_fn is called in the ensure block when exception interrupts an in-flight poll.
+# This guarantees Rust fires the continuation callback so the handle-map entry is released
+# and the pipe is drained before we free the future.
+def self.uniffi_rust_call_async(rust_future, poll_fn, cancel_fn, complete_fn, free_fn, lift_func, error_ffi_converter)
+  rd = wr = nil
+  handle = nil
+  poll_in_flight = false
+
+  begin
+    rd, wr = IO.pipe
+    wr.sync = true # avoid buffering and delayed read for rd.wait_readable
+    handle = UNIFFI_ASYNC_HANDLE_MAP.insert wr
+
+    loop do
+      poll_in_flight = true
+      UniFFILib.public_send(poll_fn, rust_future, UNIFFI_CONTINUATION_CALLBACK, handle)
+
+      # Blocks until the continuation callback writes to the pipe.
+      # Releases the GVL so the callback can fire from foreign threads.
+      # With a Fiber::Scheduler, this hooks into io_wait for non-blocking concurrency.
+      rd.wait_readable
+      poll_code = rd.getbyte
+      poll_in_flight = false
+
+      break if poll_code == UNIFFI_RUST_FUTURE_POLL_READY
+    end
+
+    result = if error_ffi_converter.nil?
+      ::{{ ci.namespace()|class_name_rb }}.rust_call(complete_fn, rust_future)
+    else
+      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error(error_ffi_converter, complete_fn, rust_future)
+    end
+
+    lift_func.call(result)
+  ensure
+    # Defer any further Thread#raise / Timeout during cleanup so all steps execute
+    # automatically. Without this, a second raise during wait_readable(0.5) would skip
+    # handle-map removal, pipe close, and free_fn - leaking FDs and Rust memory.
+    Thread.handle_interrupt(Exception => :never) do
+      if poll_in_flight
+        # An exception interrupted an in-flight poll. Cancel and drain the byte
+        # the continuation callback will write so we don't leak the pipe.
+        UniFFILib.public_send(cancel_fn, rust_future)
+        # rd.wait_readable may time out and return nil if the poll was never actually sent
+        # (raise landed between poll_in_flight=true and the FFI call).
+        if rd.wait_readable(0.5)
+          rd.getbyte
+        end
+      end
+
+      # Remove handle first so any late-firing callback's `get` raises (swallowed by rescue).
+      UNIFFI_ASYNC_HANDLE_MAP.remove(handle) rescue nil if handle
+      rd&.close rescue nil
+      wr&.close rescue nil
+      UniFFILib.public_send(free_fn, rust_future)
+    end
+  end
+end
+
+{%- if ci.has_async_callback_interface_definition() %}
+# Exception raised when a foreign future is canceled.
+class UniffiInternalCancelled < RuntimeError; end
+
+# User callback that raises it will be considered a Rust-side cancellation.
+private_constant :UniffiInternalCancelled
+
+# Handle map for storing Threads executing foreign async callbacks.
+UNIFFI_FOREIGN_FUTURE_HANDLE_MAP = UniffiHandleMap.new
+
+# One-shot claim flag: the first caller to `claim!` wins; all subsequent callers
+# are no-ops. Used to enforce the at-most-once contract on uniffi_future_callback.
+class UniffiOnceFlag
+  def initialize
+    @mutex = Mutex.new
+    @claimed = false
+  end
+
+  # Returns true if this caller won the race (first to claim), false otherwise.
+  def claim!
+    @mutex.synchronize do
+      first = !@claimed
+      @claimed = true
+      first
+    end
+  end
+end
+
+# Called by Rust when the foreign future is dropped (i.e. canceled or completed successfully).
+# Raises UniffiInternalCancelled in the worker thread so make_call can exit early,
+# but only if the thread hasn't already completed and claimed the once flag.
+# Stored as a constant to prevent GC from collecting the Proc while Rust holds the pointer.
+UNIFFI_FOREIGN_FUTURE_DROPPED_CALLBACK = Proc.new do |handle|
+  thread, once = UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.remove handle
+  thread.raise(UniffiInternalCancelled, 'Future was canceled') if once.claim! && thread&.alive?
+end
+
+# Execute a foreign async callback method in a background thread.
+# Enforces the at-most-once guarantee on handle_success / handle_error: whichever
+# fires first (normal completion or Rust-side drop) suppresses the other.
+def self.uniffi_trait_interface_call_async(make_call, uniffi_out_dropped_callback, handle_success, handle_error, error_type = nil, lower_error = nil)
+  once = UniffiOnceFlag.new
+
+  thread = Thread.new do
+    begin
+      # Phase 1: run the user's async method.
+      # UniffiInternalCancelled exits silently. Other exceptions are forwarded as errors.
+      # handle_success is intentionally called outside this rescue so exceptions from it
+      # cannot re-enter handle_error (which would be a double-call on the Rust sender).
+      begin
+        result = make_call.call
+      rescue UniffiInternalCancelled
+        next
+      rescue Exception => e # We have to catch all errors to prevent Rust future from hanging forever.
+        next unless once.claim!
+
+        if !error_type.nil? && ::{{ ci.namespace()|class_name_rb }}.uniffi_is_error_type?(e, error_type)
+          handle_error.call(UNIFFI_CALLBACK_ERROR, lower_error.call(e))
+        else
+          handle_error.call(UNIFFI_CALLBACK_UNEXPECTED_ERROR, {{ "e.inspect"|lower_rb(&Type::String, config) }})
+        end
+        next
+      end
+
+      # Phase 2: deliver the result to Rust. Skipped if dropped_callback already fired.
+      handle_success.call(result) if once.claim!
+    rescue UniffiInternalCancelled
+      # Thread#raise landed between phases or during Phase 2 - silently exit.
+      # Rust already dropped the future (that's why dropped_callback fired), so no response needed.
+    rescue Exception => e
+      # handle_success/handle_error/lower_error raised - send a generic error so Rust doesn't hang.
+      # once was already claimed, so only attempt this if we can still claim (e.g. lowering failed
+      # before handle_error was called due to short-circuit evaluation).
+      begin
+        handle_error.call(UNIFFI_CALLBACK_UNEXPECTED_ERROR, {{ "e.inspect"|lower_rb(&Type::String, config) }})
+      rescue Exception
+        # If even this fails, Rust will hang. Nothing more we can do.
+      end
+    end
+  end
+
+  # Note: the thread may have already completed by this point, but that's safe.
+  # Rust cannot invoke dropped_callback until this function returns.
+  # possesses the ForeignFuture struct we're populating here.
+  handle = UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.insert([thread, once])
+  uniffi_out_dropped_callback[:handle] = handle
+  uniffi_out_dropped_callback[:free] = UNIFFI_FOREIGN_FUTURE_DROPPED_CALLBACK
+end
+{%- endif %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/CallbackInterfaceImpl.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/CallbackInterfaceImpl.rb
@@ -15,93 +15,25 @@ module UniffiCallbackInterface{{ cbi_name|class_name_rb }}
 
   {%- for (ffi_callback, method)  in vtable_methods.iter() %}
 
+  {%- if method.is_async() %}
+  # Async callback method for {{ method.name() }}
+  {{ method.name()|enum_name_rb }}_CALLBACK = Proc.new do |uniffi_handle, {%- for arg in method.arguments() %} {{ arg.name()|var_name_rb }},{% endfor %} uniffi_future_callback, uniffi_callback_data, uniffi_out_dropped_callback|
+    uniffi_obj = CallbackInterface{{ cbi_name|class_name_rb }}FfiConverter.lift uniffi_handle
+    {%- call rb::make_call_proc(method) %}{% endcall %}
+    {%- call rb::async_handle_success_proc(method) %}{% endcall %}
+    {%- call rb::async_handle_error_proc(method) %}{% endcall %}
+    {%- call rb::async_throws_dispatch(method) %}{% endcall %}
+  end
+
+  {%- else %}
   # Callback method for {{ method.name() }}
   {{ method.name()|enum_name_rb }}_CALLBACK = Proc.new do |uniffi_handle, {%- for arg in method.arguments() %} {{ arg.name()|var_name_rb }},{% endfor %} uniffi_out_return, uniffi_call_status|
     uniffi_obj = {{ self::canonical_name(cbi.as_type().borrow()) }}FfiConverter.lift uniffi_handle
-
-    make_call = Proc.new do
-      uniffi_obj.{{ method.name()|fn_name_rb }}(
-        {%- for arg in method.arguments() %}
-        {{ arg.name()|lift_rb(arg.as_type().borrow(), config) }}{% if !loop.last %},{% endif %}
-        {%- endfor %}
-      )
-    end
-
-    {%- match method.return_type() %}
-    {%- when Some with (return_type) %}
-    write_return_value = Proc.new do |v|
-      lowered = {{ "v"|lower_rb(return_type, config) }}
-      {%- let ffi_type_name = return_type|ffi_write_return_rb %}
-      {%- if ffi_type_name == "rustbuffer" %}
-      # Write a RustBuffer struct into the out pointer
-      out_buf = RustBuffer.new uniffi_out_return
-      out_buf[:capacity] = lowered[:capacity]
-      out_buf[:len] = lowered[:len]
-      out_buf[:data] = lowered[:data]
-      {%- else %}
-      uniffi_out_return.{{ ffi_type_name }}(lowered)
-      {%- endif %}
-    end
-    {%- when None %}
-    # No return value, so do nothing.
-    write_return_value = Proc.new { |_v| }
-    {%- endmatch %}
-
-    {%- match method.throws_type() %}
-    {%- when None %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call(
-      uniffi_call_status,
-      make_call,
-      write_return_value
-    )
-    {%- when Some with (error_type) %}
-    {%- match error_type %}
-    {%- when Type::Enum { name, .. } %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_with_error(
-      uniffi_call_status,
-      make_call,
-      write_return_value,
-      {{ name|class_name_rb }},
-      Proc.new { |e| {{ "e"|lower_rb(error_type, config) }} }
-    )
-    {%- when Type::Object { name, .. } %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_with_error(
-      uniffi_call_status,
-      make_call,
-      write_return_value,
-      {{ name|class_name_rb }},
-      Proc.new { |e| {{ "e"|lower_rb(error_type, config) }} }
-    )
-    {%- when Type::Custom { builtin, .. } %}
-    {%- match builtin.borrow() %}
-    {%- when Type::Enum { name, .. } %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_with_error(
-      uniffi_call_status,
-      make_call,
-      write_return_value,
-      {{ name|class_name_rb }},
-      Proc.new { |e| {{ "e"|lower_rb(builtin, config) }} }
-    )
-    {%- when Type::Object { name, .. } %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_with_error(
-      uniffi_call_status,
-      make_call,
-      write_return_value,
-      {{ name|class_name_rb }},
-      Proc.new { |e| {{ "e"|lower_rb(builtin, config) }} }
-    )
-    {%- else %}
-    raise RuntimeError, "Unsupported custom error type for callback interface"
-    {%- endmatch %}
-    {%- else %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call(
-      uniffi_call_status,
-      make_call,
-      write_return_value
-    )
-    {%- endmatch %}
-    {%- endmatch %}
+    {%- call rb::make_call_proc(method) %}{% endcall %}
+    {%- call rb::write_return_value_proc(method) %}{% endcall %}
+    {%- call rb::sync_throws_dispatch(method) %}{% endcall %}
   end
+  {%- endif %}
   {%- endfor %}
 
   # Free callback: removes the handle from the map.

--- a/uniffi_bindgen/src/bindings/ruby/templates/HandleMap.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/HandleMap.rb
@@ -51,6 +51,11 @@ class UniffiHandleMap
       obj
     end
   end
+
+  # Used for testing/debugging purposes
+  def size
+    @lock.synchronize { @map.size }
+  end
 end
 
 private_constant :UniffiHandleMap

--- a/uniffi_bindgen/src/bindings/ruby/templates/Helpers.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/Helpers.rb
@@ -24,40 +24,24 @@ UNIFFI_CALLBACK_UNEXPECTED_ERROR = 2
 
 # Call a method on a callback interface object, catching and reporting errors
 # to Rust via the call_status.
-def self.uniffi_trait_interface_call(call_status, make_call, write_return_value)
+# If error_type is provided, known errors of that type are reported as UNIFFI_CALLBACK_ERROR;
+# all other errors are reported as UNIFFI_CALLBACK_UNEXPECTED_ERROR.
+def self.uniffi_trait_interface_call(call_status, make_call, write_return_value, error_type = nil, lower_error = nil)
   begin
     write_return_value.call make_call.call
-  rescue => e
-    call_status[:code] = UNIFFI_CALLBACK_UNEXPECTED_ERROR
-    buf = {{ "e.inspect"|lower_rb(&Type::String, config) }}
+  rescue StandardError => e
+    buf = if !error_type.nil? && uniffi_is_error_type?(e, error_type)
+      call_status[:code] = UNIFFI_CALLBACK_ERROR
+      lower_error.call e
+    else
+      call_status[:code] = UNIFFI_CALLBACK_UNEXPECTED_ERROR
+      {{ "e.inspect"|lower_rb(&Type::String, config) }}
+    end
+
     error_buf = call_status[:error_buf]
     error_buf[:capacity] = buf[:capacity]
     error_buf[:len] = buf[:len]
     error_buf[:data] = buf[:data]
-  end
-end
-
-# Same as above, but for methods that can throw a specific error type
-def self.uniffi_trait_interface_call_with_error(call_status, make_call, write_return_value, error_type, lower_error)
-  begin
-    result = make_call.call
-    write_return_value.call result
-  rescue StandardError => e
-    if uniffi_is_error_type?(e, error_type)
-      call_status[:code] = UNIFFI_CALLBACK_ERROR
-      buf = lower_error.call e
-      error_buf = call_status[:error_buf]
-      error_buf[:capacity] = buf[:capacity]
-      error_buf[:len] = buf[:len]
-      error_buf[:data] = buf[:data]
-    else
-      call_status[:code] = UNIFFI_CALLBACK_UNEXPECTED_ERROR
-      buf = {{ "e.inspect"|lower_rb(&Type::String, config) }}
-      error_buf = call_status[:error_buf]
-      error_buf[:capacity] = buf[:capacity]
-      error_buf[:len] = buf[:len]
-      error_buf[:data] = buf[:data]
-    end
   end
 end
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/ObjectTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/ObjectTemplate.rb
@@ -92,16 +92,32 @@ class {{ obj.name()|class_name_rb }}{% if ci.is_name_used_as_error(obj.name()) %
 
   {%- match obj.primary_constructor() %}
   {%- when Some with (cons) %}
+  {%- if cons.is_async() %}
+  def initialize({% call rb::arg_list_decl(cons) %}{% endcall %})
+    {%- call rb::setup_args_extra_indent(cons) %}{% endcall %}
+    handle = {% call rb::to_ffi_call_async_constructor(cons) %}{% endcall %}
+    @handle = handle
+    ObjectSpace.define_finalizer(self, self.class.uniffi_define_finalizer_by_handle(handle, self.object_id))
+  end
+  {%- else %}
   def initialize({% call rb::arg_list_decl(cons) %}{% endcall -%})
     {%- call rb::setup_args_extra_indent(cons) %}{% endcall %}
     handle = {% call rb::to_ffi_call(cons) %}{% endcall %}
     @handle = handle
     ObjectSpace.define_finalizer(self, self.class.uniffi_define_finalizer_by_handle(handle, self.object_id))
   end
+  {%- endif %}
   {%- when None %}
   {%- endmatch %}
 
   {% for cons in obj.alternate_constructors() -%}
+  {%- if cons.is_async() %}
+  def self.{{ cons.name()|fn_name_rb }}({% call rb::arg_list_decl(cons) %}{% endcall %})
+    {%- call rb::setup_args_extra_indent(cons) %}{% endcall %}
+    # Call the (fallible) async function before creating any half-baked object instances.
+    return uniffi_allocate({% call rb::to_ffi_call_async_constructor(cons) %}{% endcall %})
+  end
+  {%- else %}
   def self.{{ cons.name()|fn_name_rb }}({% call rb::arg_list_decl(cons) %}{% endcall %})
     {%- call rb::setup_args_extra_indent(cons) %}{% endcall %}
     # Call the (fallible) function before creating any half-baked object instances.
@@ -109,9 +125,16 @@ class {{ obj.name()|class_name_rb }}{% if ci.is_name_used_as_error(obj.name()) %
     # and just create a new instance with the required handle.
     return uniffi_allocate({% call rb::to_ffi_call(cons) %}{% endcall %})
   end
+  {%- endif %}
   {% endfor %}
 
   {% for meth in obj.methods() -%}
+  {%- if meth.is_async() %}
+  def {{ meth.name()|fn_name_rb }}({% call rb::arg_list_decl(meth) %}{% endcall %})
+    {%- call rb::setup_args_extra_indent(meth) %}{% endcall %}
+    {% call rb::to_ffi_call_with_prefix_async("uniffi_clone_handle()", meth) %}{% endcall %}
+  end
+  {%- else %}
   {%- match meth.return_type() -%}
 
   {%- when Some with (return_type) -%}
@@ -127,6 +150,7 @@ class {{ obj.name()|class_name_rb }}{% if ci.is_name_used_as_error(obj.name()) %
       {% call rb::to_ffi_call_with_prefix("uniffi_clone_handle()", meth) %}{% endcall %}
   end
   {% endmatch %}
+  {%- endif %}
   {% endfor %}
   {%- let trait_methods = obj.uniffi_trait_methods() %}
   {%- include "UniffiTraitImpls.rb" %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/TopLevelFunctionTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/TopLevelFunctionTemplate.rb
@@ -1,3 +1,11 @@
+{%- if func.is_async() %}
+
+def self.{{ func.name()|fn_name_rb }}({%- call rb::arg_list_decl(func) %}{% endcall -%})
+  {%- call rb::setup_args(func) %}{% endcall %}
+  {% call rb::to_ffi_call_async(func) %}{% endcall %}
+end
+{%- else %}
+
 {%- match func.return_type() -%}
 {%- when Some with (return_type) %}
 
@@ -14,3 +22,4 @@ def self.{{ func.name()|fn_name_rb }}({%- call rb::arg_list_decl(func) %}{% endc
   {% call rb::to_ffi_call(func) %}{% endcall %}
 end
 {% endmatch %}
+{%- endif %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/TraitInterfaceVtable.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/TraitInterfaceVtable.rb
@@ -16,93 +16,25 @@ module UniffiCallbackInterface{{ cbi_name|class_name_rb }}
 
   {%- for (ffi_callback, method)  in vtable_methods.iter() %}
 
+  {%- if method.is_async() %}
+  # Async callback method for {{ method.name() }}
+  {{ method.name()|enum_name_rb }}_CALLBACK = Proc.new do |uniffi_handle, {%- for arg in method.arguments() %} {{ arg.name()|var_name_rb }},{% endfor %} uniffi_future_callback, uniffi_callback_data, uniffi_out_dropped_callback|
+    uniffi_obj = {{ cbi_name|class_name_rb }}.uniffi_handle_map.get(uniffi_handle)
+    {%- call rb::make_call_proc(method) %}{% endcall %}
+    {%- call rb::async_handle_success_proc(method) %}{% endcall %}
+    {%- call rb::async_handle_error_proc(method) %}{% endcall %}
+    {%- call rb::async_throws_dispatch(method) %}{% endcall %}
+  end
+
+  {%- else %}
   # Callback method for {{ method.name() }}
   {{ method.name()|enum_name_rb }}_CALLBACK = Proc.new do |uniffi_handle, {%- for arg in method.arguments() %} {{ arg.name()|var_name_rb }},{% endfor %} uniffi_out_return, uniffi_call_status|
     uniffi_obj = {{ cbi_name|class_name_rb }}.uniffi_handle_map.get(uniffi_handle)
-
-    make_call = Proc.new do
-      uniffi_obj.{{ method.name()|fn_name_rb }}(
-        {%- for arg in method.arguments() %}
-        {{ arg.name()|lift_rb(arg.as_type().borrow(), config) }}{% if !loop.last %},{% endif %}
-        {%- endfor %}
-      )
-    end
-
-    {%- match method.return_type() %}
-    {%- when Some with (return_type) %}
-    write_return_value = Proc.new do |v|
-      lowered = {{ "v"|lower_rb(return_type, config) }}
-      {%- let ffi_type_name = return_type|ffi_write_return_rb %}
-      {%- if ffi_type_name == "rustbuffer" %}
-      # Write a RustBuffer struct into the out pointer
-      out_buf = RustBuffer.new uniffi_out_return
-      out_buf[:capacity] = lowered[:capacity]
-      out_buf[:len] = lowered[:len]
-      out_buf[:data] = lowered[:data]
-      {%- else %}
-      uniffi_out_return.{{ ffi_type_name }}(lowered)
-      {%- endif %}
-    end
-    {%- when None %}
-    # No return value, so do nothing.
-    write_return_value = Proc.new { |_v| }
-    {%- endmatch %}
-
-    {%- match method.throws_type() %}
-    {%- when None %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call(
-      uniffi_call_status,
-      make_call,
-      write_return_value
-    )
-    {%- when Some with (error_type) %}
-    {%- match error_type %}
-    {%- when Type::Enum { name, .. } %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_with_error(
-      uniffi_call_status,
-      make_call,
-      write_return_value,
-      {{ name|class_name_rb }},
-      Proc.new { |e| {{ "e"|lower_rb(error_type, config) }} }
-    )
-    {%- when Type::Object { name, .. } %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_with_error(
-      uniffi_call_status,
-      make_call,
-      write_return_value,
-      {{ name|class_name_rb }},
-      Proc.new { |e| {{ "e"|lower_rb(error_type, config) }} }
-    )
-    {%- when Type::Custom { builtin, .. } %}
-    {%- match builtin.borrow() %}
-    {%- when Type::Enum { name, .. } %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_with_error(
-      uniffi_call_status,
-      make_call,
-      write_return_value,
-      {{ name|class_name_rb }},
-      Proc.new { |e| {{ "e"|lower_rb(builtin, config) }} }
-    )
-    {%- when Type::Object { name, .. } %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_with_error(
-      uniffi_call_status,
-      make_call,
-      write_return_value,
-      {{ name|class_name_rb }},
-      Proc.new { |e| {{ "e"|lower_rb(builtin, config) }} }
-    )
-    {%- else %}
-    raise RuntimeError, "Unsupported custom error type for trait interface"
-    {%- endmatch %}
-    {%- else %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call(
-      uniffi_call_status,
-      make_call,
-      write_return_value
-    )
-    {%- endmatch %}
-    {%- endmatch %}
+    {%- call rb::make_call_proc(method) %}{% endcall %}
+    {%- call rb::write_return_value_proc(method) %}{% endcall %}
+    {%- call rb::sync_throws_dispatch(method) %}{% endcall %}
   end
+  {%- endif %}
   {%- endfor %}
 
   # Free callback: removes the handle from the map.

--- a/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
@@ -16,48 +16,33 @@ values[{{- field_num - 1 -}}]
 {{ field.name()|var_name_rb }}
 {%- endif -%}
 {%- endmacro -%}
-  
-{%- macro to_ffi_call(func) -%}
+
+{#- Helper: emit the opening of a rust_call or rust_call_with_error call. -#}
+{%- macro rust_call_head(func) -%}
     {%- match func.throws_type() -%}
     {%- when Some(Type::Custom { builtin, .. }) -%}
       {%- match builtin.borrow() -%}
-      {%- when Type::Enum { name, .. } -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
-      {%- when Type::Object { name, .. } -%}
+      {%- when Type::Enum { name, .. } | Type::Object { name, .. } -%}
       ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
       {%- else -%}
       ::{{ ci.namespace()|class_name_rb }}.rust_call
       {%- endmatch -%}
-    {%- when Some(Type::Enum { name, .. }) -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
-    {%- when Some(Type::Object { name, .. }) -%}
+    {%- when Some(Type::Enum { name, .. }) | Some(Type::Object { name, .. }) -%}
       ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
     {%- else -%}
       ::{{ ci.namespace()|class_name_rb }}.rust_call(
     {%- endmatch -%}
+{%- endmacro -%}
+  
+{%- macro to_ffi_call(func) -%}
+    {%- call rust_call_head(func) %}{% endcall -%}
     :{{ func.ffi_func().name() }},
     {%- call _arg_list_ffi_call(func) %}{% endcall -%}
 )
 {%- endmacro -%}
 
 {%- macro to_ffi_call_with_prefix(prefix, func) -%}
-    {%- match func.throws_type() -%}
-    {%- when Some(Type::Custom { builtin, .. }) -%}
-      {%- match builtin.borrow() -%}
-      {%- when Type::Enum { name, .. } -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
-      {%- when Type::Object { name, .. } -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
-      {%- else -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call
-      {%- endmatch -%}
-    {%- when Some(Type::Enum { name, .. }) -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
-    {%- when Some(Type::Object { name, .. }) -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
-    {%- else -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call(
-    {%- endmatch -%}
+    {%- call rust_call_head(func) %}{% endcall -%}
     :{{ func.ffi_func().name() }},
     {{- prefix }},
     {%- call _arg_list_ffi_call(func) %}{% endcall -%}
@@ -65,23 +50,7 @@ values[{{- field_num - 1 -}}]
 {%- endmacro -%}
 
 {%- macro to_ffi_call_with_lower_self(func) -%}
-    {%- match func.throws_type() -%}
-    {%- when Some(Type::Custom { builtin, .. }) -%}
-      {%- match builtin.borrow() -%}
-      {%- when Type::Enum { name, .. } -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
-      {%- when Type::Object { name, .. } -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
-      {%- else -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call
-      {%- endmatch -%}
-    {%- when Some(Type::Enum { name, .. }) -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
-    {%- when Some(Type::Object { name, .. }) -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
-    {%- else -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call(
-    {%- endmatch -%}
+    {%- call rust_call_head(func) %}{% endcall -%}
     :{{ func.ffi_func().name() }},
     {{ func|lower_method_self_rb(config) }},
     {%- call _arg_list_ffi_call(func) %}{% endcall -%}
@@ -120,6 +89,63 @@ values[{{- field_num - 1 -}}]
     {%- if func.has_rust_call_status_arg() -%}RustCallStatus.by_ref{% endif -%}]
 {%- endmacro -%}
 
+{#- Helper: emit the error class name or nil for async rust calls. -#}
+{%- macro throws_error_class_expr(func) %}
+    {%- match func.throws_type() %}
+    {%- when Some(Type::Custom { builtin, .. }) %}
+      {%- match builtin.borrow() %}
+      {%- when Type::Enum { name, .. } | Type::Object { name, .. } %}
+    {{ name|class_name_rb }}
+      {%- else %}
+    nil
+      {%- endmatch %}
+    {%- when Some(Type::Enum { name, .. }) | Some(Type::Object { name, .. }) %}
+    {{ name|class_name_rb }}
+    {%- else %}
+    nil
+    {%- endmatch %}
+{%- endmacro %}
+
+{%- macro to_ffi_call_async(func, prefix = "") -%}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_rust_call_async(
+      UniFFILib.{{ func.ffi_func().name() }}(
+        {%- if !prefix.is_empty() %}{{- prefix }},{% endif %}
+        {%- call _arg_list_ffi_call(func) %}{% endcall -%}
+      ),
+      :{{ func.ffi_rust_future_poll(ci) }},
+      :{{ func.ffi_rust_future_cancel(ci) }},
+      :{{ func.ffi_rust_future_complete(ci) }},
+      :{{ func.ffi_rust_future_free(ci) }},
+      {%- match func.return_type() %}
+      {%- when Some with (return_type) %}
+      Proc.new { |v| {{ "v"|lift_rb(return_type, config) }} },
+      {%- when None %}
+      Proc.new { |v| nil },
+      {%- endmatch %}
+      {%- call throws_error_class_expr(func) %}{% endcall %}
+    )
+{%- endmacro %}
+
+{#- Async constructor variant: uses identity lift to return raw handle for uniffi_allocate -#}
+{%- macro to_ffi_call_async_constructor(func) %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_rust_call_async(
+      UniFFILib.{{ func.ffi_func().name() }}(
+        {%- call _arg_list_ffi_call(func) %}{% endcall -%}
+      ),
+      :{{ func.ffi_rust_future_poll(ci) }},
+      :{{ func.ffi_rust_future_cancel(ci) }},
+      :{{ func.ffi_rust_future_complete(ci) }},
+      :{{ func.ffi_rust_future_free(ci) }},
+      Proc.new { |v| v },
+      {%- call throws_error_class_expr(func) %}{% endcall %}
+    )
+{%- endmacro %}
+
+{#- Thin wrapper: delegates to to_ffi_call_async with an explicit prefix. -#}
+{%- macro to_ffi_call_with_prefix_async(prefix, func) -%}
+    {%- call to_ffi_call_async(func, prefix) %}{% endcall %}
+{%- endmacro %}
+
 {%- macro setup_args(func) %}
     {%- for arg in func.arguments() %}
     {{ arg.name()|var_name_rb }} = {{ arg.name()|var_name_rb|coerce_rb(ci.namespace()|class_name_rb, arg.as_type().borrow(), config) }}
@@ -133,3 +159,184 @@ values[{{- field_num - 1 -}}]
         {{ arg.name()|var_name_rb|check_lower_rb(arg.as_type().borrow(), config) }}
         {%- endfor %}
 {%- endmacro -%}
+
+{#-
+// Build the `make_call` Proc for callback/trait-interface methods (sync and async).
+// Requires `uniffi_obj` to be in caller scope.
+-#}
+{%- macro make_call_proc(method) %}
+    make_call = Proc.new do
+      uniffi_obj.{{ method.name()|fn_name_rb }}(
+        {%- for arg in method.arguments() %}
+        {{ arg.name()|lift_rb(arg.as_type().borrow(), config) }}{% if !loop.last %},{% endif %}
+        {%- endfor %}
+      )
+    end
+{%- endmacro %}
+
+{#-
+// Build the `handle_success` Proc for async callback/trait-interface methods.
+// Requires `uniffi_future_callback` and `uniffi_callback_data` in the caller scope.
+-#}
+{%- macro async_handle_success_proc(method) %}
+    handle_success = Proc.new do |return_value|
+      result_struct = UniFFILib::{{ method|foreign_future_result_rb }}.new
+      {%- match method.return_type() %}
+      {%- when Some with (return_type) %}
+      result_struct[:return_value] = {{ "return_value"|lower_rb(return_type, config) }}
+      result_struct[:call_status] = RustCallStatus.new
+      {%- when None %}
+      result_struct[:call_status] = RustCallStatus.new
+      {%- endmatch %}
+      uniffi_future_callback.call(uniffi_callback_data, result_struct)
+    end
+{%- endmacro %}
+
+{#-
+// Build the `handle_error` Proc for async callback/trait-interface methods.
+// Requires `uniffi_future_callback` and `uniffi_callback_data` in the caller scope.
+-#}
+{%- macro async_handle_error_proc(method) %}
+    handle_error = Proc.new do |status_code, error_buf|
+      result_struct = UniFFILib::{{ method|foreign_future_result_rb }}.new
+      {%- match method.return_type() %}
+      {%- when Some with (return_type) %}
+      result_struct[:return_value] = {{ return_type|ffi_default_value_rb }}
+      {%- when None %}
+      {%- endmatch %}
+
+      error_status = RustCallStatus.new
+      error_status[:code] = status_code
+      error_status[:error_buf] = error_buf
+
+      result_struct[:call_status] = error_status
+
+      uniffi_future_callback.call(uniffi_callback_data, result_struct)
+    end
+{%- endmacro %}
+
+
+{#-
+// Build the `write_return_value` Proc for sync callback/trait-interface methods.
+// Requires `uniffi_out_return` in the caller scope.
+-#}
+{%- macro write_return_value_proc(method) %}
+    {%- match method.return_type() %}
+    {%- when Some with (return_type) %}
+    write_return_value = Proc.new do |v|
+      lowered = {{ "v"|lower_rb(return_type, config) }}
+      {%- let ffi_type_name = return_type|ffi_write_return_rb %}
+      {%- if ffi_type_name == "rustbuffer" %}
+      # Write a RustBuffer struct into the out pointer
+      out_buf = RustBuffer.new uniffi_out_return
+      out_buf[:capacity] = lowered[:capacity]
+      out_buf[:len] = lowered[:len]
+      out_buf[:data] = lowered[:data]
+      {%- else %}
+      uniffi_out_return.{{ ffi_type_name }}(lowered)
+      {%- endif %}
+    end
+    {%- when None %}
+    # No return value, so do nothing
+    write_return_value = Proc.new { |_v| }
+    {%- endmatch %}
+{%- endmacro %}
+
+{#-
+// Dispatch the throws type for a sync callback/trait-interface method.
+// Caller must have in scope: uniffi_call_status, make_call, write_return_value.
+-#}
+{%- macro sync_throws_dispatch(method) %}
+    {%- match method.throws_type() %}
+    {%- when None %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call(
+      uniffi_call_status,
+      make_call,
+      write_return_value,
+    )
+    {%- when Some with (error_type) %}
+    {%- match error_type %}
+    {%- when Type::Enum { name, .. } | Type::Object { name, .. } %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call(
+      uniffi_call_status,
+      make_call,
+      write_return_value,
+      {{ name|class_name_rb }},
+      Proc.new { |e| {{ "e"|lower_rb(error_type, config) }} }
+    )
+    {%- when Type::Custom { builtin, .. } %}
+    {%- match builtin.borrow() %}
+    {%- when Type::Enum { name, .. } | Type::Object { name, .. } %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call(
+      uniffi_call_status,
+      make_call,
+      write_return_value,
+      {{ name|class_name_rb }},
+      Proc.new { |e| {{ "e"|lower_rb(builtin, config) }} }
+    )
+    {%- else %}
+    raise RuntimeError, "Unsupported custom error type"
+    {%- endmatch %}
+    {%- else %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call(
+      uniffi_call_status,
+      make_call,
+      write_return_value
+    )
+    {%- endmatch %}
+    {%- endmatch %}
+{%- endmacro %}
+
+{#-
+// Dispatch the throws type for an async callback/trait-interface method.
+// Caller must have in scope: make_call, uniffi_out_dropped_callback, handle_success, handle_error.
+-#}
+{%- macro async_throws_dispatch(method) %}
+    {%- match method.throws_type() %}
+    {%- when None %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_async(
+      make_call,
+      uniffi_out_dropped_callback,
+      handle_success,
+      handle_error,
+    )
+    {%- when Some with (error_type) %}
+    {%- match error_type %}
+    {%- when Type::Enum { name, .. } | Type::Object { name, .. } %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_async(
+      make_call,
+      uniffi_out_dropped_callback,
+      handle_success,
+      handle_error,
+      {{ name|class_name_rb }},
+      Proc.new { |e| {{ "e"|lower_rb(error_type, config) }} }
+    )
+    {%- when Type::Custom { builtin, .. } %}
+    {%- match builtin.borrow() %}
+    {%- when Type::Enum { name, .. } | Type::Object { name, .. } %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_async(
+      make_call,
+      uniffi_out_dropped_callback,
+      handle_success,
+      handle_error,
+      {{ name|class_name_rb }},
+      Proc.new { |e| {{ "e"|lower_rb(builtin, config) }} }
+    )
+    {%- else %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_async(
+      make_call,
+      uniffi_out_dropped_callback,
+      handle_success,
+      handle_error,
+    )
+    {%- endmatch %}
+    {%- else %}
+    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_async(
+      make_call,
+      uniffi_out_dropped_callback,
+      handle_success,
+      handle_error,
+    )
+    {%- endmatch %}
+    {%- endmatch %}
+{%- endmacro %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/wrapper.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/wrapper.rb
@@ -16,7 +16,7 @@
 require 'ffi'
 require 'set'
 
-{%- if ci.has_callback_definitions() %}
+{%- if ci.has_callback_definitions() || ci.has_async_fns() %}
 require 'monitor'
 {%- endif %}
 
@@ -24,6 +24,9 @@ module {{ ci.namespace()|class_name_rb }}
   {% include "Helpers.rb" %}
 
   {%- if ci.has_callback_definitions() %}
+  {% include "HandleMap.rb" %}
+  {%- endif %}
+  {%- if ci.has_async_fns() && !ci.has_callback_definitions() %}
   {% include "HandleMap.rb" %}
   {%- endif %}
   {% include "RustBufferTemplate.rb" %}
@@ -34,6 +37,9 @@ module {{ ci.namespace()|class_name_rb }}
   {% include "ErrorTemplate.rb" %}
 
   {% include "NamespaceLibraryTemplate.rb" %}
+  {%- if ci.has_async_fns() %}
+  {% include "Async.rb" %}
+  {%- endif %}
   {%- if ci.has_callback_definitions() %}
   {% include "CallbackInterfaceRuntime.rb" %}
   {%- endif %}

--- a/uniffi_core/src/ffi/rustfuture/future.rs
+++ b/uniffi_core/src/ffi/rustfuture/future.rs
@@ -184,7 +184,7 @@ pub struct RustFuture<FfiType, Callback = RustFutureContinuationBoundCallback> {
     // This Mutex should never block if our code is working correctly, since there should not be
     // multiple threads calling [Self::poll] and/or [Self::complete] at the same time.
     future: Mutex<WrappedFuture<FfiType>>,
-    scheduler: Mutex<Scheduler<Callback>>,
+    scheduler: Scheduler<Callback>,
 }
 
 impl<FfiType, Callback> RustFuture<FfiType, Callback>
@@ -198,7 +198,7 @@ where
     {
         Self {
             future: Mutex::new(WrappedFuture::new(future)),
-            scheduler: Mutex::new(Scheduler::new()),
+            scheduler: Scheduler::new(),
         }
     }
 
@@ -213,16 +213,16 @@ where
             trace!("RustFuture::poll is ready (cancelled: {cancelled})");
             callback.invoke(RustFuturePoll::Ready)
         } else {
-            self.scheduler.lock().unwrap().store(callback);
+            self.scheduler.store(callback);
         }
     }
 
     pub fn is_cancelled(&self) -> bool {
-        self.scheduler.lock().unwrap().is_cancelled()
+        self.scheduler.is_cancelled()
     }
 
     pub fn cancel(&self) {
-        self.scheduler.lock().unwrap().cancel();
+        self.scheduler.cancel();
     }
 
     pub fn complete(&self, call_status: &mut RustCallStatus) -> FfiType
@@ -234,7 +234,7 @@ where
 
     pub fn free(&self) {
         // Call cancel() to send any leftover data to the continuation callback
-        self.scheduler.lock().unwrap().cancel();
+        self.scheduler.cancel();
         // Ensure we drop our inner future, releasing all held references
         self.future.lock().unwrap().free();
     }
@@ -262,7 +262,7 @@ where
 
     unsafe fn waker_wake(ptr: *const ()) {
         trace!("RustFuture::waker_wake called ({ptr:?})");
-        Self::recreate_arc(ptr).scheduler.lock().unwrap().wake();
+        Self::recreate_arc(ptr).scheduler.wake();
     }
 
     unsafe fn waker_wake_by_ref(ptr: *const ()) {
@@ -270,7 +270,7 @@ where
         // For wake_by_ref, we can use the pointer directly, without consuming it to re-create the
         // arc.
         let ptr = ptr.cast::<Self>();
-        (*ptr).scheduler.lock().unwrap().wake();
+        (*ptr).scheduler.wake();
     }
 
     unsafe fn waker_drop(ptr: *const ()) {

--- a/uniffi_core/src/ffi/rustfuture/scheduler.rs
+++ b/uniffi_core/src/ffi/rustfuture/scheduler.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::mem;
+use std::sync::Mutex;
 
 use crate::{RustFutureContinuationBoundCallback, RustFuturePoll};
 
@@ -18,9 +19,12 @@ use crate::{RustFutureContinuationBoundCallback, RustFuturePoll};
 ///   immediately or the next time we get a callback.
 /// * If `cancel()` is called, the same will happen and the schedule will stay in the cancelled
 ///   state, invoking any future callbacks as soon as they're stored.
+///
+/// All callbacks are invoked outside the internal lock to prevent ABBA deadlocks with foreign
+/// runtime locks. See `wake()` for more details.
 
 #[derive(Debug)]
-pub enum Scheduler<Callback = RustFutureContinuationBoundCallback> {
+enum State<Callback> {
     /// No continuations set, neither wake() nor cancel() called.
     Empty,
     /// `wake()` was called when there was no continuation set.  The next time `store` is called,
@@ -31,6 +35,10 @@ pub enum Scheduler<Callback = RustFutureContinuationBoundCallback> {
     Cancelled,
     /// Continuation set, the next time `wake()`  is called is called, we should invoke it.
     Set(Callback),
+}
+
+pub struct Scheduler<Callback = RustFutureContinuationBoundCallback> {
+    state: Mutex<State<Callback>>,
 }
 
 /// Callback function that the scheduler stores
@@ -52,57 +60,95 @@ impl<Callback: RustFutureCallback> Default for Scheduler<Callback> {
 
 impl<Callback: RustFutureCallback> Scheduler<Callback> {
     pub fn new() -> Self {
-        Self::Empty
+        Self {
+            state: Mutex::new(State::Empty),
+        }
     }
 
     /// Store new continuation data if we are in the `Empty` state.  If we are in the `Waked` or
     /// `Cancelled` state, call the continuation immediately with the data.
-    pub fn store(&mut self, callback: Callback) {
-        match self {
-            Self::Empty => *self = Self::Set(callback),
-            Self::Set(_) => {
-                trace!(
-                    "store: observed `Self::Set` state.  Is poll() being called from multiple threads at once?"
-                );
-                let Self::Set(old_callback) = mem::replace(self, Self::Set(callback)) else {
-                    unreachable!();
-                };
-                old_callback.invoke(RustFuturePoll::Wake);
+    pub fn store(&self, callback: Callback) {
+        let to_invoke = {
+            let mut state = self.state.lock().unwrap();
+
+            match *state {
+                State::Empty => {
+                    *state = State::Set(callback);
+                    None
+                }
+                State::Set(_) => {
+                    trace!(
+                        "store: observed `Self::Set` state.  Is poll() being called from multiple threads at once?"
+                    );
+                    let State::Set(old_callback) = mem::replace(&mut *state, State::Set(callback))
+                    else {
+                        unreachable!();
+                    };
+                    Some((old_callback, RustFuturePoll::Wake))
+                }
+                State::Waked => {
+                    *state = State::Empty;
+                    Some((callback, RustFuturePoll::Wake))
+                }
+                State::Cancelled => Some((callback, RustFuturePoll::Ready)),
             }
-            Self::Waked => {
-                *self = Self::Empty;
-                callback.invoke(RustFuturePoll::Wake);
-            }
-            Self::Cancelled => {
-                callback.invoke(RustFuturePoll::Ready);
-            }
+        };
+
+        if let Some((cb, poll)) = to_invoke {
+            cb.invoke(poll);
         }
     }
 
-    pub fn wake(&mut self) {
-        match self {
-            // If we had a continuation set, then call it and transition to the `Empty` state.
-            Self::Set(_) => {
-                let Self::Set(callback) = mem::replace(self, Self::Empty) else {
-                    unreachable!();
-                };
-                callback.invoke(RustFuturePoll::Wake);
+    /// Wake the scheduler.
+    ///
+    /// If a continuation callback is stored, it will be invoked with `RustFuturePoll::Wake`.
+    /// The callback is always invoked after releasing the internal lock to prevenet ABBA
+    /// deadlocks: the callback crosses the FFI into a foreign runtime that may need to acquire
+    /// a runtime lock (e.g. Ruby GVL or similar), while the foreign calling thread holds that
+    /// runtime lock and may call cancel/free (which require this lock).
+    pub fn wake(&self) {
+        let callback = {
+            let mut state = self.state.lock().unwrap();
+
+            match *state {
+                // If we had a continuation set, then call it and transition to the `Empty` state.
+                State::Set(_) => {
+                    let State::Set(callback) = mem::replace(&mut *state, State::Empty) else {
+                        unreachable!();
+                    };
+                    Some(callback)
+                }
+                // If we were in the `Empty` state, then transition to `Waked`.  The next time `store`
+                // is called, we will immediately call the continuation.
+                State::Empty => {
+                    *state = State::Waked;
+                    None
+                }
+                // This is a no-op if we were in the `Cancelled` or `Waked` state.
+                _ => None,
             }
-            // If we were in the `Empty` state, then transition to `Waked`.  The next time `store`
-            // is called, we will immediately call the continuation.
-            Self::Empty => *self = Self::Waked,
-            // This is a no-op if we were in the `Cancelled` or `Waked` state.
-            _ => (),
+        };
+
+        if let Some(cb) = callback {
+            cb.invoke(RustFuturePoll::Wake);
         }
     }
 
-    pub fn cancel(&mut self) {
-        if let Self::Set(callback) = mem::replace(self, Self::Cancelled) {
-            callback.invoke(RustFuturePoll::Ready);
+    pub fn cancel(&self) {
+        let callback = {
+            let mut state = self.state.lock().unwrap();
+            match mem::replace(&mut *state, State::Cancelled) {
+                State::Set(cb) => Some(cb),
+                _ => None,
+            }
+        };
+
+        if let Some(cb) = callback {
+            cb.invoke(RustFuturePoll::Ready);
         }
     }
 
     pub fn is_cancelled(&self) -> bool {
-        matches!(self, Self::Cancelled)
+        matches!(*self.state.lock().unwrap(), State::Cancelled)
     }
 }

--- a/uniffi_core/src/oneshot.rs
+++ b/uniffi_core/src/oneshot.rs
@@ -36,9 +36,16 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
 impl<T> Sender<T> {
     /// Send a value to the receiver
     pub fn send(self, value: T) {
-        let mut inner = self.0.lock().unwrap();
-        inner.value = Some(value);
-        if let Some(waker) = inner.waker.take() {
+        let waker = {
+            let mut inner = self.0.lock().unwrap();
+            inner.value = Some(value);
+            inner.waker.take()
+        };
+        // Wake AFTER releasing the lock. The waker eventually invokes the
+        // continuation callback, which crosses the FII and needs a runtime
+        // lock (e.g. Ruby's GVL). The calling thread holds that lock and may
+        // re-poll the future (Receiver::poll needs `inner`) - ABBA deadlock.
+        if let Some(waker) = waker {
             waker.wake();
         }
     }


### PR DESCRIPTION
Hello UniFFI team!

This PR focuses on support of async calls for ruby bindings (fixes #1871) for objects, top level functions and callback interfaces.

### Async

#### Foreign async callbacks are synchronous blocking calls in a thread
I decided to run foreign trait methods synchronously in `Thread.new`. This matches what Ruby can do without `async def`, but it differs from Python/Kotlin/Swift where foreign methods are truly async. Implementers must block until done. True async Ruby (e.g. `async` gem) would need internal blocking/waiting (I really wanted to keep dependencies minimal, at least for now).

#### Rust-side polling
The pipe + timed `wait_readable` approach seems reasonable MRI-specific way to release the `GVL`(Global VM Lock) and integrate with `Fiber::Scheduler#io_wait`. It allows for parallel execution in threads or using `Fiber::Scheduler`.

### Issues

#### Deadlock?
While implementing `fixtures/futures/tests/bindings/test_futures.rb`, I've noticed that tests would randomly get stuck. That rabbit hole got me into looking into how "futures", "scheduler" and "oneshot" work. 

I'm pretty sure that one (if not the main) reason is how Ruby is interfacing with Rust (because Python tests are fine). It seems like a common approach to release locks as soon as possible. Does this align with the intended design, or is there a historical reason the lock is held during the callback?  (FYI: `scheduler.rs` has more methods that lock during the callback). Would be really nice if someone can look at it closely.

Without these changes (in `uniffi_core`), I can reliably reproduce this problemt locally by:
```sh
cd fixtures/futures
for i in $(seq 1 100); do echo "=== Run $i ==="; timeout 30 cargo test _rb --features uniffi/ffi-trace -- --nocapture > /tmp/futures_test_$i.txt 2>&1; ret=$?; if [[ $ret -ne 0 ]]; then echo "FAILED (exit $ret) - output in /tmp/futures_test_$i.txt"; tail -40 /tmp/futures_test_$i.txt; break; else echo "PASSED"; fi; done
```
I'm attaching one of the files with debug messages, just in case.
[futures_test_8.txt](https://github.com/user-attachments/files/28861049/futures_test_8.txt)

#### Async methods for records/enums
I was going to also add support for [async methods for records and enums](https://github.com/saks/uniffi-rs/pull/4/changes/769058b3fa12af64bdd72900edcc52745ef98580), however that made some of the [kotlin tests fail](https://app.circleci.com/pipelines/github/saks/uniffi-rs/173/workflows/33596a0c-d459-4bc7-a74a-38ee5b466a72/jobs/816). Please let me know if I'm missing something here.

### Docs
With async being added in this PR, I believe that ruby is quite on par with the rest of the batch and I thought that it would be a good opportunity to update docs and tutorials with ruby-specific details. Sure easy to move it to another PR, please let me know if this is needed.

Please let me know if you have any questions or concerns.
Thank you!