### PR TITLE
Loosen toml semver for uniffi_macros

### DIFF
--- a/uniffi_macros/Cargo.toml
+++ b/uniffi_macros/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
 syn = { version = "2.0", features = ["full", "visit-mut"] }
-toml = "1.1.0"
+toml = ">=0.9, <2"
 uniffi_build = { path = "../uniffi_build", version = "=0.31.1", optional = true }
 uniffi_meta = { path = "../uniffi_meta", version = "=0.31.1" }
 


### PR DESCRIPTION
Make the TOML version requirement match the one from `uniffi_bindgen`. This is more flexible and lessens the requirements for downstream projects. The uniffi_bindgen one was changed in
https://github.com/mozilla/uniffi-rs/pull/2885, I think the uniffi_macros came from a PR that was started before that was merged in.