### PR TITLE
Scaffolding tests (and #2881)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2273,6 +2273,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-scaffolding-tests"
+version = "1.0.0"
+dependencies = [
+ "uniffi",
+]
+
+[[package]]
 name = "uniffi_bindgen"
 version = "0.31.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
   "bindgen-tests/swift/omit-labels",
   "bindgen-tests/swift/bridging-header-compile",
   "bindgen-tests/swift/link-frameworks",
+  "scaffolding-tests",
 
   "fixtures/benchmarks",
   "fixtures/coverall",

--- a/scaffolding-tests/Cargo.toml
+++ b/scaffolding-tests/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "uniffi-scaffolding-tests"
+version = "1.0.0"
+
+[lib]
+crate-type = ["lib", "cdylib", "staticlib"]
+
+[dependencies]
+uniffi = { path = "../uniffi" }

--- a/scaffolding-tests/README.md
+++ b/scaffolding-tests/README.md
@@ -1,0 +1,5 @@
+# scaffolding-tests
+
+Test suite for UniFFI scaffolding.
+This test only covers the generated Rust code, not actually calling it from foreign languages
+(`uniffi-bindgen-tests` does that).

--- a/scaffolding-tests/src/lib.rs
+++ b/scaffolding-tests/src/lib.rs
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+mod method_names;
+
+#[test]
+fn test_generated_code_compiles() {
+    // No code here, since we're just testing if the generated code can be compiled.
+}
+
+uniffi::setup_scaffolding!();

--- a/scaffolding-tests/src/method_names.rs
+++ b/scaffolding-tests/src/method_names.rs
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This module tests method name conflicts
+// https://github.com/mozilla/uniffi-rs/issues/2881
+
+#[uniffi::export(rust, foreign)]
+pub trait ExportedTrait: Send + Sync {
+    fn conflicted_method_name(&self) -> String;
+}
+
+impl dyn ExportedTrait {
+    // Inherit method with the same name as the trait method name.
+    //
+    // UniFFI should use a fully-qualified function syntax to ensure the other method is called.
+    #[allow(unused)]
+    fn conflicted_method_name(&self) {}
+}

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -9,7 +9,7 @@ use std::iter;
 use super::attributes::AsyncRuntime;
 use crate::{
     ffiops,
-    fnsig::{FnKind, FnSignature},
+    fnsig::{FnKind, FnSignature, ReceiverArg},
 };
 
 pub(super) fn gen_fn_scaffolding(
@@ -130,7 +130,7 @@ impl ScaffoldingBits {
         self_ident: &Ident,
         is_trait: bool,
         udl_mode: bool,
-    ) -> Self {
+    ) -> syn::Result<Self> {
         let ident = &sig.ident;
         let self_type = if is_trait {
             quote! { dyn #self_ident }
@@ -151,7 +151,18 @@ impl ScaffoldingBits {
             }
         }));
         let call_params = sig.rust_call_params(true);
-        let rust_fn_call = quote! { uniffi_args.0.#ident(#call_params) };
+        let rust_fn_call = if is_trait {
+            // For traits use the fully-qualified function name to disambiguate
+            let receiver_expr = match sig.require_receiver()? {
+                ReceiverArg::Ref => quote! { &*uniffi_args.0 },
+                ReceiverArg::Arc => quote! { uniffi_args.0 },
+            };
+            quote! { <dyn #self_ident as #self_ident>::#ident(#receiver_expr, #call_params) }
+        } else {
+            // For non-traits use method call syntax, which papers over differences between Arc<T>
+            // and T.  Inherent methods always take precedence over other functions
+            quote! { uniffi_args.0.#ident(#call_params) }
+        };
         // UDL mode adds an extra conversion (#1749)
         let convert_result = if udl_mode && sig.looks_like_result {
             quote! { uniffi_result .map_err(::std::convert::Into::into) }
@@ -159,7 +170,7 @@ impl ScaffoldingBits {
             quote! { uniffi_result }
         };
 
-        Self {
+        Ok(Self {
             param_names: iter::once(quote! { uniffi_self_lowered })
                 .chain(sig.scaffolding_param_names())
                 .collect(),
@@ -169,7 +180,7 @@ impl ScaffoldingBits {
             lift_closure,
             rust_fn_call,
             convert_result,
-        }
+        })
     }
 
     fn new_for_constructor(sig: &FnSignature, self_ident: &Ident, udl_mode: bool) -> Self {
@@ -215,10 +226,10 @@ pub(super) fn gen_ffi_function(
     } = match &sig.kind {
         FnKind::Function => ScaffoldingBits::new_for_function(sig, udl_mode),
         FnKind::Method { self_ident, .. } => {
-            ScaffoldingBits::new_for_method(sig, self_ident, false, udl_mode)
+            ScaffoldingBits::new_for_method(sig, self_ident, false, udl_mode)?
         }
         FnKind::TraitMethod { self_ident, .. } => {
-            ScaffoldingBits::new_for_method(sig, self_ident, true, udl_mode)
+            ScaffoldingBits::new_for_method(sig, self_ident, true, udl_mode)?
         }
         FnKind::Constructor { self_ident, .. } => {
             ScaffoldingBits::new_for_constructor(sig, self_ident, udl_mode)

--- a/uniffi_macros/src/fnsig.rs
+++ b/uniffi_macros/src/fnsig.rs
@@ -230,6 +230,12 @@ impl FnSignature {
         quote! { #(#args),* }
     }
 
+    pub fn require_receiver(&self) -> syn::Result<ReceiverArg> {
+        self.receiver
+            .clone()
+            .ok_or_else(|| syn::Error::new(self.span, "Expected receiver argument"))
+    }
+
     /// Parameters expressions for each of our arguments
     pub fn params(&self) -> impl Iterator<Item = TokenStream> + '_ {
         self.args.iter().map(NamedArg::param)
@@ -465,6 +471,7 @@ impl Arg {
     }
 }
 
+#[derive(Clone)]
 pub(crate) enum ReceiverArg {
     Ref,
     Arc,


### PR DESCRIPTION
Starting the scaffolding-tests crate.  This is like bindgen-tests, but it targets the generated scaffolding code without round-tripping it through a foreign implementation.

Used https://github.com/mozilla/uniffi-rs/issues/2881 as the first test case and fixed it.