### PR TITLE
fix(kotlin): Make sure uniffiCheckApiChecksums compares against the rust generated u16.

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
@@ -120,7 +120,8 @@ private fun uniffiCheckContractApiVersion(lib: IntegrityCheckingUniffiLib) {
 @Suppress("UNUSED_PARAMETER")
 private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     {%- for (name, expected_checksum) in ci.iter_checksums() %}
-    if (lib.{{ name }}() != {{ expected_checksum }}) {
+    {#- please don't delete the mask: https://github.com/mozilla/uniffi-rs/pull/2935 #}
+    if ((lib.{{ name }}() and 0xFFFF) != {{ expected_checksum }}) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     {%- endfor %}


### PR DESCRIPTION
This changeset is a followup to https://github.com/mozilla/uniffi-rs/issues/2740.

On AArch64, the unused upper bits of the return register are unspecified, and in rust (at the moment) they use the sign-extension of the 16-bit value (see https://github.com/rust-lang/rust/issues/97463#issuecomment-1140210248 for more information).
This means any checksum value greater than or equal to 0x8000 would carry 0xFFFF.
Checksum comparisons would thus always fail comparing a negative value with the expected valid one.
This changeset adds a 16 bits mask to checksums so we only compare the 16 relevant bits, and the check doesn't fail on AArch64 anymore.

I'm not 100% sure, but it looks like the project's CI matrix doesn't contain arm architectures, otherwise the Kotlin path `*/test_generated_bindings.rs` integration tests may have caught it.

If there's anything I can do to improve the fix or add more tests, please let me know!