### PR TITLE
Handle ambiguous method names (#2881)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 - Fixed bug that sometimes prevented renaming items inside a submodule [#2792](https://github.com/mozilla/uniffi-rs/pull/2792)
 - Exempted `UniFfiTag` from `clippy::exhaustive_structs` since downstream projects may depend on it [#2809](https://github.com/mozilla/uniffi-rs/pull/2809)
+- Fixed compile errors when exporting ambiguous method names [#2937](https://github.com/mozilla/uniffi-rs/pull/2937)
 - Ruby: Code for all kinds of enums and custom types is now correctly generated #2880 and #2891
 
 ### ⚠️ Breaking Changes for external bindings authors ⚠️

--- a/bindgen-tests/lib/src/trait_interfaces.rs
+++ b/bindgen-tests/lib/src/trait_interfaces.rs
@@ -28,7 +28,9 @@ pub trait TestTraitInterface: Send + Sync {
     /// Get the internal value
     fn get_value(&self) -> u32;
     /// Set the internal value
-    fn set_value(&self, value: u32);
+    ///
+    /// Also, input an Arc to test that code path
+    fn set_value(self: Arc<Self>, value: u32);
 
     // Test inputting/outputting different types
     fn roundtrip_record(&self, value: SimpleRec) -> SimpleRec;
@@ -47,6 +49,16 @@ pub trait TestTraitInterface: Send + Sync {
     ) -> Result<CallbackInterfaceNumbers, TestError>;
 }
 
+impl dyn TestTraitInterface {
+    // Inherent method with the same name as the trait method name.
+    //
+    // UniFFI should use a fully-qualified function syntax to ensure the trait method is called.
+    #[allow(unused)]
+    fn get_value(&self) -> u32 {
+        10000
+    }
+}
+
 #[uniffi::export]
 pub fn invoke_test_trait_interface_noop(interface: Arc<dyn TestTraitInterface>) {
     interface.noop()
@@ -54,7 +66,7 @@ pub fn invoke_test_trait_interface_noop(interface: Arc<dyn TestTraitInterface>) 
 
 #[uniffi::export]
 pub fn invoke_test_trait_interface_get_value(interface: Arc<dyn TestTraitInterface>) -> u32 {
-    interface.get_value()
+    <dyn TestTraitInterface as TestTraitInterface>::get_value(interface.as_ref())
 }
 
 #[uniffi::export]
@@ -113,7 +125,7 @@ impl TestTraitInterface for TestTraitInterfaceImpl {
         self.value.load(Ordering::Relaxed)
     }
 
-    fn set_value(&self, value: u32) {
+    fn set_value(self: Arc<Self>, value: u32) {
         self.value.store(value, Ordering::Relaxed);
     }
 

--- a/uniffi_macros/src/export/scaffolding.rs
+++ b/uniffi_macros/src/export/scaffolding.rs
@@ -9,7 +9,7 @@ use std::iter;
 use super::attributes::AsyncRuntime;
 use crate::{
     ffiops,
-    fnsig::{FnKind, FnSignature},
+    fnsig::{FnKind, FnSignature, ReceiverArg},
 };
 
 pub(super) fn gen_fn_scaffolding(
@@ -130,7 +130,7 @@ impl ScaffoldingBits {
         self_ident: &Ident,
         is_trait: bool,
         udl_mode: bool,
-    ) -> Self {
+    ) -> syn::Result<Self> {
         let ident = &sig.ident;
         let self_type = if is_trait {
             quote! { dyn #self_ident }
@@ -151,7 +151,18 @@ impl ScaffoldingBits {
             }
         }));
         let call_params = sig.rust_call_params(true);
-        let rust_fn_call = quote! { uniffi_args.0.#ident(#call_params) };
+        let rust_fn_call = if is_trait {
+            // For traits use the fully-qualified function name to disambiguate
+            let receiver_expr = match sig.require_receiver()? {
+                ReceiverArg::Ref => quote! { &*uniffi_args.0 },
+                ReceiverArg::Arc => quote! { uniffi_args.0 },
+            };
+            quote! { <dyn #self_ident as #self_ident>::#ident(#receiver_expr, #call_params) }
+        } else {
+            // For non-traits use method call syntax, which papers over differences between Arc<T>
+            // and T.  Inherent methods always take precedence over other functions
+            quote! { uniffi_args.0.#ident(#call_params) }
+        };
         // UDL mode adds an extra conversion (#1749)
         let convert_result = if udl_mode && sig.looks_like_result {
             quote! { uniffi_result .map_err(::std::convert::Into::into) }
@@ -159,7 +170,7 @@ impl ScaffoldingBits {
             quote! { uniffi_result }
         };
 
-        Self {
+        Ok(Self {
             param_names: iter::once(quote! { uniffi_self_lowered })
                 .chain(sig.scaffolding_param_names())
                 .collect(),
@@ -169,7 +180,7 @@ impl ScaffoldingBits {
             lift_closure,
             rust_fn_call,
             convert_result,
-        }
+        })
     }
 
     fn new_for_constructor(sig: &FnSignature, self_ident: &Ident, udl_mode: bool) -> Self {
@@ -215,10 +226,10 @@ pub(super) fn gen_ffi_function(
     } = match &sig.kind {
         FnKind::Function => ScaffoldingBits::new_for_function(sig, udl_mode),
         FnKind::Method { self_ident, .. } => {
-            ScaffoldingBits::new_for_method(sig, self_ident, false, udl_mode)
+            ScaffoldingBits::new_for_method(sig, self_ident, false, udl_mode)?
         }
         FnKind::TraitMethod { self_ident, .. } => {
-            ScaffoldingBits::new_for_method(sig, self_ident, true, udl_mode)
+            ScaffoldingBits::new_for_method(sig, self_ident, true, udl_mode)?
         }
         FnKind::Constructor { self_ident, .. } => {
             ScaffoldingBits::new_for_constructor(sig, self_ident, udl_mode)

--- a/uniffi_macros/src/fnsig.rs
+++ b/uniffi_macros/src/fnsig.rs
@@ -230,6 +230,12 @@ impl FnSignature {
         quote! { #(#args),* }
     }
 
+    pub fn require_receiver(&self) -> syn::Result<ReceiverArg> {
+        self.receiver
+            .clone()
+            .ok_or_else(|| syn::Error::new(self.span, "Expected receiver argument"))
+    }
+
     /// Parameters expressions for each of our arguments
     pub fn params(&self) -> impl Iterator<Item = TokenStream> + '_ {
         self.args.iter().map(NamedArg::param)
@@ -465,6 +471,7 @@ impl Arg {
     }
 }
 
+#[derive(Clone)]
 pub(crate) enum ReceiverArg {
     Ref,
     Arc,


### PR DESCRIPTION
Also updated the `trait_interfaces` test to test the `self: Arc<Self>` codepath.