### PR TITLE
Fixed swift concurrency error (#2929)

### DIFF
--- a/uniffi_bindgen/src/bindings/swift/templates/Async.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Async.swift
@@ -49,9 +49,9 @@ fileprivate func uniffiFutureContinuationCallback(handle: UInt64, pollResult: In
 
 {%- if ci.has_async_callback_interface_definition() %}
 private func uniffiTraitInterfaceCallAsync<T>(
-    makeCall: @escaping () async throws -> T,
-    handleSuccess: @escaping (T) -> (),
-    handleError: @escaping (Int8, RustBuffer) -> (),
+    makeCall: @escaping @Sendable () async throws -> T,
+    handleSuccess: @escaping @Sendable (T) -> (),
+    handleError: @escaping @Sendable (Int8, RustBuffer) -> (),
     droppedCallback: UnsafeMutablePointer<UniffiForeignFutureDroppedCallbackStruct>
 ) {
     let task = Task {
@@ -80,10 +80,10 @@ private func uniffiTraitInterfaceCallAsync<T>(
 }
 
 private func uniffiTraitInterfaceCallAsyncWithError<T, E>(
-    makeCall: @escaping () async throws -> T,
-    handleSuccess: @escaping (T) -> (),
-    handleError: @escaping (Int8, RustBuffer) -> (),
-    lowerError: @escaping (E) -> RustBuffer,
+    makeCall: @escaping @Sendable () async throws -> T,
+    handleSuccess: @escaping @Sendable (T) -> (),
+    handleError: @escaping @Sendable (Int8, RustBuffer) -> (),
+    lowerError: @escaping @Sendable (E) -> RustBuffer,
     droppedCallback: UnsafeMutablePointer<UniffiForeignFutureDroppedCallbackStruct>
 ) {
     let task = Task {

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceImpl.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceImpl.swift
@@ -31,7 +31,16 @@ fileprivate struct {{ trait_impl }} {
             uniffiCallStatus: UnsafeMutablePointer<RustCallStatus>
             {%- endif %}
         ) in
-            let makeCall = {
+            {%- for arg in ffi_callback.arguments() %}
+            {%- if let FfiType::RustBuffer(_) = arg.type_() %}
+            {# RustBuffer is not a Sendable type because it stores a pointer.
+             # However, we coordinate with the Rust side of the FFI to ensure it's used in a thread-safe manner.
+             -#}
+            nonisolated(unsafe) let {{ arg.name()|var_name }} = {{ arg.name()|var_name }}
+            {%- endif %}
+            {%- endfor %}
+
+            let makeCall: @Sendable () {% if meth.is_async() %}async {% endif %}throws -> {{ meth.return_type()|return_type_name }} = {
                 () {% if meth.is_async() %}async {% endif %}throws -> {% match meth.return_type() %}{% when Some(t) %}{{ t|type_name }}{% when None %}(){% endmatch %} in
                 guard let uniffiObj = try? {{ ffi_converter_name }}.handleMap.get(handle: uniffiHandle) else {
                     throw UniffiInternalError.unexpectedStaleHandle
@@ -68,7 +77,7 @@ fileprivate struct {{ trait_impl }} {
             {%- endmatch %}
             {%- else %}
 
-            let uniffiHandleSuccess = { (returnValue: {{ meth.return_type()|return_type_name }}) in
+            let uniffiHandleSuccess: @Sendable ({{ meth.return_type()|return_type_name }}) -> () = { (returnValue) in
                 uniffiFutureCallback(
                     uniffiCallbackData,
                     {{ meth.foreign_future_ffi_result_struct().name()|ffi_struct_name }}(
@@ -79,7 +88,7 @@ fileprivate struct {{ trait_impl }} {
                     )
                 )
             }
-            let uniffiHandleError = { (statusCode, errorBuf) in
+            let uniffiHandleError: @Sendable (Int8, RustBuffer) -> () = { (statusCode, errorBuf) in
                 uniffiFutureCallback(
                     uniffiCallbackData,
                     {{ meth.foreign_future_ffi_result_struct().name()|ffi_struct_name }}(

--- a/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CallbackInterfaceTemplate.swift
@@ -70,6 +70,6 @@ public func {{ ffi_converter_name }}_lift(_ handle: UInt64) throws -> {{ type_na
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public func {{ ffi_converter_name }}_lower(_ v: {{ type_name }}) -> UInt64 {
+@Sendable public func {{ ffi_converter_name }}_lower(_ v: {{ type_name }}) -> UInt64 {
     return {{ ffi_converter_name }}.lower(v)
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/CustomType.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/CustomType.swift
@@ -86,7 +86,7 @@ public func FfiConverterType{{ name }}_lift(_ value: {{ ffi_type_name }}) throws
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public func FfiConverterType{{ name }}_lower(_ value: {{ type_name }}) -> {{ ffi_type_name }} {
+@Sendable public func FfiConverterType{{ name }}_lower(_ value: {{ type_name }}) -> {{ ffi_type_name }} {
     return FfiConverterType{{ name }}.lower(value)
 }
 

--- a/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/EnumTemplate.swift
@@ -93,6 +93,6 @@ public func {{ ffi_converter_name }}_lift(_ buf: RustBuffer) throws -> {{ type_n
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> RustBuffer {
+@Sendable public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> RustBuffer {
     return {{ ffi_converter_name }}.lower(value)
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ErrorTemplate.swift
@@ -121,6 +121,6 @@ public func {{ ffi_converter_name }}_lift(_ buf: RustBuffer) throws -> {{ type_n
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> RustBuffer {
+@Sendable public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> RustBuffer {
     return {{ ffi_converter_name }}.lower(value)
 }

--- a/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ObjectTemplate.swift
@@ -183,7 +183,7 @@ public func {{ ffi_converter_name }}_lift(_ handle: UInt64) throws -> {{ type_na
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> UInt64 {
+@Sendable public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> UInt64 {
     return {{ ffi_converter_name }}.lower(value)
 }
 
@@ -224,7 +224,7 @@ public func {{ ffi_converter_name }}__as_error_lift(_ buf: RustBuffer) throws ->
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public func {{ ffi_converter_name }}__as_error_lower(_ value: {{ type_name }}) -> RustBuffer {
+@Sendable public func {{ ffi_converter_name }}__as_error_lower(_ value: {{ type_name }}) -> RustBuffer {
     return {{ ffi_converter_name }}__as_error.lower(value)
 }
 

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -68,6 +68,6 @@ public func {{ ffi_converter_name }}_lift(_ buf: RustBuffer) throws -> {{ type_n
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> RustBuffer {
+@Sendable public func {{ ffi_converter_name }}_lower(_ value: {{ type_name }}) -> RustBuffer {
     return {{ ffi_converter_name }}.lower(value)
 }


### PR DESCRIPTION
I saw the error when running the bindgen-tests with Swift 6.3 and UNIFFI_TEST_SWIFT_VERSION=6. Fixed it by marking all closures @Sendable and also forcing the RustBuffer values to be Sendable via `nonisolated(unsafe)` which I got from https://github.com/swiftlang/swift/blob/dc600dc96ae7e992a879f679714c55d7dc8a0dd6/userdocs/diagnostics/sendable-closure-captures.md.