### PR TITLE
Swift concurrency fixes for bindgen-tests

### DIFF
--- a/bindgen-tests/swift/tests/callback_interfaces.swift
+++ b/bindgen-tests/swift/tests/callback_interfaces.swift
@@ -2,20 +2,30 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import Foundation
 import uniffi_bindgen_tests
 
-var callbackRefCount = 0;
+// We want to mutate callbackRefCount from async swift code.
+// The simplest way to do that seems to be to mark it `nonisolated(unsafe)`.
+nonisolated(unsafe) var callbackRefCount = 0;
+// Let's use this lock whenever we mutate callbackRefCount, just to make sure that everything is
+// thread-safe.
+nonisolated(unsafe) var callbackRefCountLock = NSLock()
 
 final class Callback: TestCallbackInterface, @unchecked Sendable {
     var value: UInt32;
 
     init(value: UInt32) {
         self.value = value;
-        callbackRefCount += 1
+        callbackRefCountLock.withLock {
+            callbackRefCount += 1
+        }
     }
 
     deinit {
-        callbackRefCount -= 1
+        callbackRefCountLock.withLock {
+            callbackRefCount -= 1
+        }
     }
 
     func noop() {}
@@ -52,4 +62,6 @@ assert(invokeTestCallbackInterfaceEcho(cbi: cbi, s: "test-string") == "test-stri
 
 // The previcalls created a bunch of callback interface references.  Make sure they've been cleaned
 // up and the only remaining reference is for our `cbi` variable.
-assert(callbackRefCount == 1)
+callbackRefCountLock.withLock {
+    assert(callbackRefCount == 1)
+}

--- a/bindgen-tests/swift/tests/futures.swift
+++ b/bindgen-tests/swift/tests/futures.swift
@@ -5,100 +5,75 @@
 import Foundation
 import uniffi_bindgen_tests
 
-var dispatchGroup = DispatchGroup()
-
 // Primitive types
-dispatchGroup.enter()
-Task {
-    let returnedU8 = await asyncRoundtripU8(v: 42)
-    assert(returnedU8 == 42)
+let returnedU8 = await asyncRoundtripU8(v: 42)
+assert(returnedU8 == 42)
 
-    let returnedI8 = await asyncRoundtripI8(v: -42)
-    assert(returnedI8 == -42)
+let returnedI8 = await asyncRoundtripI8(v: -42)
+assert(returnedI8 == -42)
 
-    let returnedU16 = await asyncRoundtripU16(v: 42)
-    assert(returnedU16 == 42)
+let returnedU16 = await asyncRoundtripU16(v: 42)
+assert(returnedU16 == 42)
 
-    let returnedI16 = await asyncRoundtripI16(v: -42)
-    assert(returnedI16 == -42)
+let returnedI16 = await asyncRoundtripI16(v: -42)
+assert(returnedI16 == -42)
 
-    let returnedU32 = await asyncRoundtripU32(v: 42)
-    assert(returnedU32 == 42)
+let returnedU32 = await asyncRoundtripU32(v: 42)
+assert(returnedU32 == 42)
 
-    let returnedI32 = await asyncRoundtripI32(v: -42)
-    assert(returnedI32 == -42)
+let returnedI32 = await asyncRoundtripI32(v: -42)
+assert(returnedI32 == -42)
 
-    let returnedU64 = await asyncRoundtripU64(v: 42)
-    assert(returnedU64 == 42)
+let returnedU64 = await asyncRoundtripU64(v: 42)
+assert(returnedU64 == 42)
 
-    let returnedI64 = await asyncRoundtripI64(v: -42)
-    assert(returnedI64 == -42)
+let returnedI64 = await asyncRoundtripI64(v: -42)
+assert(returnedI64 == -42)
 
-    let returnedF32 = await asyncRoundtripF32(v: 0.5)
-    assert(returnedF32 == 0.5)
+let returnedF32 = await asyncRoundtripF32(v: 0.5)
+assert(returnedF32 == 0.5)
 
-    let returnedF64 = await asyncRoundtripF64(v: -0.5)
-    assert(returnedF64 == -0.5)
+let returnedF64 = await asyncRoundtripF64(v: -0.5)
+assert(returnedF64 == -0.5)
 
-    let returnedString = await asyncRoundtripString(v: "hi")
-    assert(returnedString == "hi")
+let returnedString = await asyncRoundtripString(v: "hi")
+assert(returnedString == "hi")
 
-    let returnedList = await asyncRoundtripVec(v: [42])
-    assert(returnedList == [42])
+let returnedList = await asyncRoundtripVec(v: [42])
+assert(returnedList == [42])
 
-    let returnedMap = await asyncRoundtripMap(v: ["hello": "world"])
-    assert(returnedMap == ["hello": "world"])
-
-    dispatchGroup.leave()
-}
-dispatchGroup.wait()
+let returnedMap = await asyncRoundtripMap(v: ["hello": "world"])
+assert(returnedMap == ["hello": "world"])
 
 // Errors
-dispatchGroup.enter()
-Task {
-    do {
-        try await asyncThrowError()
-        fatalError("expected asyncThrowError to throw")
-    } catch TestError.Failure1 {
-        // Expected
-    } catch {
-        fatalError("unexpected error \(error)")
-    }
-  dispatchGroup.leave()
+do {
+    try await asyncThrowError()
+    fatalError("expected asyncThrowError to throw")
+} catch TestError.Failure1 {
+    // Expected
+} catch {
+    fatalError("unexpected error \(error)")
 }
-dispatchGroup.wait()
 
 // Interfaces/methods
-dispatchGroup.enter()
-Task {
-    let obj = AsyncInterface(name: "Alice")
-    let objName = await obj.name()
-    assert(objName == "Alice")
+let obj = AsyncInterface(name: "Alice")
+let objName = await obj.name()
+assert(objName == "Alice")
 
-    let obj2 = await asyncRoundtripObj(v: obj)
-    let obj2Name = await obj2.name()
-    assert(obj2Name == "Alice")
+let obj2 = await asyncRoundtripObj(v: obj)
+let obj2Name = await obj2.name()
+assert(obj2Name == "Alice")
 
-    let rec = AsyncRecord(name: "Bob")
-    let recName = await rec.getName()
-    assert(recName == "Bob")
-
-    dispatchGroup.leave()
-}
-dispatchGroup.wait()
+let rec = AsyncRecord(name: "Bob")
+let recName = await rec.getName()
+assert(recName == "Bob")
 
 // Callback interfaces
-var asyncCallbackRefCount = 0
 class AsyncCallbackImpl: TestAsyncCallbackInterface, @unchecked Sendable {
     var value: UInt32;
 
     init(value: UInt32) {
         self.value = value;
-        asyncCallbackRefCount += 1
-    }
-
-    deinit {
-        asyncCallbackRefCount -= 1
     }
 
     func noop() async { }
@@ -119,36 +94,29 @@ class AsyncCallbackImpl: TestAsyncCallbackInterface, @unchecked Sendable {
     }
 }
 
-dispatchGroup.enter()
-Task {
-    let cbi = AsyncCallbackImpl(value: 42);
-    await invokeTestAsyncCallbackInterfaceNoop(cbi: cbi);
+let cbi = AsyncCallbackImpl(value: 42);
+await invokeTestAsyncCallbackInterfaceNoop(cbi: cbi);
 
-    var value = await invokeTestAsyncCallbackInterfaceGetValue(cbi: cbi)
-    assert(value == 42)
+var value = await invokeTestAsyncCallbackInterfaceGetValue(cbi: cbi)
+assert(value == 42)
 
-    await invokeTestAsyncCallbackInterfaceSetValue(cbi: cbi, value: 43);
-    value = await invokeTestAsyncCallbackInterfaceGetValue(cbi: cbi)
-    assert(value == 43)
+await invokeTestAsyncCallbackInterfaceSetValue(cbi: cbi, value: 43);
+value = await invokeTestAsyncCallbackInterfaceGetValue(cbi: cbi)
+assert(value == 43)
 
-    do {
-        let _ = try await invokeTestAsyncCallbackInterfaceThrowIfEqual(
-            cbi: cbi,
-            numbers: CallbackInterfaceNumbers(a: 10, b: 10)
-        )
-    } catch TestError.Failure1 {
-        // expected
-    } catch {
-        fatalError("unexpected error \(error)")
-    } 
-
-    let returnedNumbers = try! await invokeTestAsyncCallbackInterfaceThrowIfEqual(
+do {
+    let _ = try await invokeTestAsyncCallbackInterfaceThrowIfEqual(
         cbi: cbi,
-        numbers: CallbackInterfaceNumbers(a: 10, b: 11)
+        numbers: CallbackInterfaceNumbers(a: 10, b: 10)
     )
-    assert(returnedNumbers == CallbackInterfaceNumbers(a: 10, b: 11))
+} catch TestError.Failure1 {
+    // expected
+} catch {
+    fatalError("unexpected error \(error)")
+} 
 
-    dispatchGroup.leave()
-}
-dispatchGroup.wait()
-
+let returnedNumbers = try! await invokeTestAsyncCallbackInterfaceThrowIfEqual(
+    cbi: cbi,
+    numbers: CallbackInterfaceNumbers(a: 10, b: 11)
+)
+assert(returnedNumbers == CallbackInterfaceNumbers(a: 10, b: 11))

--- a/bindgen-tests/swift/tests/trait_interfaces.swift
+++ b/bindgen-tests/swift/tests/trait_interfaces.swift
@@ -5,19 +5,27 @@
 import Foundation
 import uniffi_bindgen_tests
 
-var dispatchGroup = DispatchGroup()
-var traitRefCount = 0;
+// We want to mutate traitRefCount from async swift code.
+// The simplest way to do that seems to be to mark it `nonisolated(unsafe)`.
+nonisolated(unsafe) var traitRefCount = 0;
+// Let's use this lock whenever we mutate traitRefCount, just to make sure that everything is
+// thread-safe.
+nonisolated(unsafe) var traitRefCountLock = NSLock()
 
 class TraitImpl: TestTraitInterface, @unchecked Sendable {
     var value: UInt32;
 
     init(value: UInt32) {
         self.value = value;
-        traitRefCount += 1
+        traitRefCountLock.withLock {
+            traitRefCount += 1
+        }
     }
 
     deinit {
-        traitRefCount -= 1
+        traitRefCountLock.withLock {
+            traitRefCount -= 1
+        }
     }
 
     func noop() { }
@@ -111,18 +119,27 @@ testSwiftImpl(traitImpl: TraitImpl(value: 42))
 testSwiftImpl(traitImpl: roundtripTestTraitInterface(interface: TraitImpl(value: 42)))
 testSwiftImpl(traitImpl: roundtripTestTraitInterfaceList(interfaces: [TraitImpl(value: 42)])[0])
 
-var asyncTraitRefCount = 0;
+// We want to mutate asyncTraitRefCount from async swift code.
+// The simplest way to do that seems to be to mark it `nonisolated(unsafe)`.
+nonisolated(unsafe) var asyncTraitRefCount = 0;
+// Let's use this lock whenever we mutate asyncTraitRefCount, just to make sure that everything is
+// thread-safe.
+nonisolated(unsafe) var asyncTraitRefCountLock = NSLock()
 
 class AsyncTraitImpl: AsyncTestTraitInterface, @unchecked Sendable {
     var value: UInt32;
 
     init(value: UInt32) {
         self.value = value;
-        asyncTraitRefCount += 1
+        asyncTraitRefCountLock.withLock {
+            asyncTraitRefCount += 1
+        }
     }
 
     deinit {
-        asyncTraitRefCount -= 1
+        asyncTraitRefCountLock.withLock {
+            asyncTraitRefCount -= 1
+        }
     }
 
     func noop() async { }
@@ -163,14 +180,9 @@ func testAsyncRustImpl(traitImpl: AsyncTestTraitInterface) async {
     assert(numbersReturn == CallbackInterfaceNumbers(a: 10, b: 11))
 }
 
-dispatchGroup.enter()
-Task {
-    await testAsyncRustImpl(traitImpl: createAsyncTestTraitInterface(value: 42))
-    await testAsyncRustImpl(traitImpl: roundtripAsyncTestTraitInterface(interface: createAsyncTestTraitInterface(value: 42)))
-    await testAsyncRustImpl(traitImpl: roundtripAsyncTestTraitInterfaceList(interfaces: [createAsyncTestTraitInterface(value: 42)])[0])
-    dispatchGroup.leave()
-}
-dispatchGroup.wait()
+await testAsyncRustImpl(traitImpl: createAsyncTestTraitInterface(value: 42))
+await testAsyncRustImpl(traitImpl: roundtripAsyncTestTraitInterface(interface: createAsyncTestTraitInterface(value: 42)))
+await testAsyncRustImpl(traitImpl: roundtripAsyncTestTraitInterfaceList(interfaces: [createAsyncTestTraitInterface(value: 42)])[0])
 
 func testAsyncSwiftImpl(traitImpl: AsyncTestTraitInterface) async {
     await invokeAsyncTestTraitInterfaceNoop(interface: traitImpl)
@@ -198,19 +210,18 @@ func testAsyncSwiftImpl(traitImpl: AsyncTestTraitInterface) async {
     assert(numbersReturn == CallbackInterfaceNumbers(a: 10, b: 11))
 }
 
-dispatchGroup.enter()
-Task {
-    await testAsyncSwiftImpl(traitImpl: AsyncTraitImpl(value: 42))
-    await testAsyncSwiftImpl(traitImpl: roundtripAsyncTestTraitInterface(interface: AsyncTraitImpl(value: 42)))
-    await testAsyncSwiftImpl(traitImpl: roundtripAsyncTestTraitInterfaceList(interfaces: [AsyncTraitImpl(value: 42)])[0])
-    dispatchGroup.leave()
-}
-dispatchGroup.wait()
+await testAsyncSwiftImpl(traitImpl: AsyncTraitImpl(value: 42))
+await testAsyncSwiftImpl(traitImpl: roundtripAsyncTestTraitInterface(interface: AsyncTraitImpl(value: 42)))
+await testAsyncSwiftImpl(traitImpl: roundtripAsyncTestTraitInterfaceList(interfaces: [AsyncTraitImpl(value: 42)])[0])
 
 // The previous calls created and destroyed a ton of references to the Swift-implemented trait
 // interfaces, check that the refcounts have gone back to 0.
-assert(traitRefCount == 0)
-assert(asyncTraitRefCount == 0)
+traitRefCountLock.withLock {
+    assert(traitRefCount == 0)
+}
+asyncTraitRefCountLock.withLock {
+    assert(asyncTraitRefCount == 0)
+}
 
 // Rust-only trait: smoke-test for the #[uniffi::export(rust)] codegen path
 func testRustOnlyImpl(impl: TestRustOnlyTraitInterface) {


### PR DESCRIPTION
Add `nonisolated(unsafe)` to global variables and put them behind a lock just in case there really was a concurrency issue with how we were accessing them.

Don't use DispatchGroups/Tasks to schedule the async code anymore, instead just call the async functions directly. The old code hangs Swift 6 It's not completely clear to me, but I think it has to do with the fact that the way we were creating tasks was not compatible with whatever async context Swift creates for the script.

This makes the tests pass for me in both swift 5 and swift 6 mode.