### PR TITLE
Fix Kotlin Throwable handling (#2903)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   current Kotlin bindings.  However, the code is very fresh so use at your own risk.
   See [#2911](https://github.com/mozilla/uniffi-rs/pull/2911).
 
+### What's Fixed
+- Kotlin: Fixed messages for error classes that inherit `Throwable`, but not `Exception`.
+
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.32.0...HEAD).
 
 ## v0.32.0 (backend crates: v0.32.0) - (_2026-06-30_)

--- a/bindgen-tests/kotlin/tests/callback_interfaces.kts
+++ b/bindgen-tests/kotlin/tests/callback_interfaces.kts
@@ -14,7 +14,7 @@ class CallbackImpl(var value: UInt) : TestCallbackInterface {
 
     override fun throwIfEqual(numbers: CallbackInterfaceNumbers): CallbackInterfaceNumbers {
         if (numbers.a == 6u && numbers.b == 7u) {
-            throw RuntimeException("unexpected failure")
+            throw UnexpectedFailure()
         } else if (numbers.a == numbers.b) {
             throw TestException.Failure1()
         } else {
@@ -26,6 +26,12 @@ class CallbackImpl(var value: UInt) : TestCallbackInterface {
         return s
     }
 }
+
+// Unexpected error that we'll throw.
+//
+// This inherits from Throwable, since we want to support errors that don't subclass Exception
+// (https://github.com/mozilla/uniffi-rs/issues/2903)
+class UnexpectedFailure : Throwable("unexpected failure")
 
 // Construct a callback interface to pass to rust
 val cbi = CallbackImpl(42u)

--- a/bindgen-tests/kotlin/tests/trait_interfaces.kts
+++ b/bindgen-tests/kotlin/tests/trait_interfaces.kts
@@ -13,7 +13,9 @@ class TraitImpl(var value: UInt) : TestTraitInterface {
     }
 
     override fun throwIfEqual(numbers: CallbackInterfaceNumbers): CallbackInterfaceNumbers {
-        if (numbers.a == numbers.b) {
+        if (numbers.a == 6u && numbers.b == 7u) {
+            throw UnexpectedFailure()
+        } else if (numbers.a == numbers.b) {
             throw TestException.Failure1()
         }
         return numbers
@@ -25,6 +27,12 @@ class TraitImpl(var value: UInt) : TestTraitInterface {
 
     override fun roundtripInterface(value: TestInterface): TestInterface = value
 }
+
+// Unexpected error that we'll throw.
+//
+// This inherits from Throwable, since we want to support errors that don't subclass Exception
+// (https://github.com/mozilla/uniffi-rs/issues/2903)
+class UnexpectedFailure : Throwable("unexpected failure")
 
 fun checkRustImpl(rustTraitImpl: TestTraitInterface) {
     rustTraitImpl.noop()
@@ -64,6 +72,17 @@ fun checkKtImpl(ktTraitImpl: TestTraitInterface) {
     } catch (e: TestException.Failure1) {
         // Expected
     }
+    // Test unexpected errors
+    try {
+        invokeTestTraitInterfaceThrowIfEqual(
+            ktTraitImpl,
+            CallbackInterfaceNumbers(a=6u, b=7u)
+        )
+        throw RuntimeException("Expected Kotlin implementation to throw an UnexpectedFailure")
+    } catch(e: TestException.Failure2) {
+        assert(e.data.contains("unexpected failure"))
+    }
+
     assert(
         invokeTestTraitInterfaceThrowIfEqual(
             ktTraitImpl,

--- a/uniffi-bindgen-kotlin-jni/tests/tests/callback_interfaces.kts
+++ b/uniffi-bindgen-kotlin-jni/tests/tests/callback_interfaces.kts
@@ -14,7 +14,7 @@ class CallbackImpl(var value: UInt) : TestCallbackInterface {
 
     override fun throwIfEqual(numbers: CallbackInterfaceNumbers): CallbackInterfaceNumbers {
         if (numbers.a == 6u && numbers.b == 7u) {
-            throw RuntimeException("unexpected failure")
+            throw UnexpectedFailure()
         } else if (numbers.a == numbers.b) {
             throw TestException.Failure1()
         } else {
@@ -26,6 +26,12 @@ class CallbackImpl(var value: UInt) : TestCallbackInterface {
         return s
     }
 }
+
+// Unexpected error that we'll throw.
+//
+// This inherits from Throwable, since we want to support errors that don't subclass Exception
+// (https://github.com/mozilla/uniffi-rs/issues/2903)
+class UnexpectedFailure : Throwable("unexpected failure")
 
 // Construct a callback interface to pass to rust
 val cbi = CallbackImpl(42u)

--- a/uniffi-bindgen-kotlin-jni/tests/tests/trait_interfaces.kts
+++ b/uniffi-bindgen-kotlin-jni/tests/tests/trait_interfaces.kts
@@ -13,7 +13,9 @@ class TraitImpl(var value: UInt) : TestTraitInterface {
     }
 
     override fun throwIfEqual(numbers: CallbackInterfaceNumbers): CallbackInterfaceNumbers {
-        if (numbers.a == numbers.b) {
+        if (numbers.a == 6u && numbers.b == 7u) {
+            throw UnexpectedFailure()
+        } else if (numbers.a == numbers.b) {
             throw TestException.Failure1()
         }
         return numbers
@@ -25,6 +27,12 @@ class TraitImpl(var value: UInt) : TestTraitInterface {
 
     override fun roundtripInterface(value: TestInterface): TestInterface = value
 }
+
+// Unexpected error that we'll throw.
+//
+// This inherits from Throwable, since we want to support errors that don't subclass Exception
+// (https://github.com/mozilla/uniffi-rs/issues/2903)
+class UnexpectedFailure : Throwable("unexpected failure")
 
 fun checkRustImpl(rustTraitImpl: TestTraitInterface) {
     rustTraitImpl.noop()
@@ -64,6 +72,17 @@ fun checkKtImpl(ktTraitImpl: TestTraitInterface) {
     } catch (e: TestException.Failure1) {
         // Expected
     }
+    // Test unexpected errors
+    try {
+        invokeTestTraitInterfaceThrowIfEqual(
+            ktTraitImpl,
+            CallbackInterfaceNumbers(a=6u, b=7u)
+        )
+        throw RuntimeException("Expected Kotlin implementation to throw an UnexpectedFailure")
+    } catch(e: TestException.Failure2) {
+        assert(e.data.contains("unexpected failure"))
+    }
+
     assert(
         invokeTestTraitInterfaceThrowIfEqual(
             ktTraitImpl,

--- a/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/Helpers.kt
@@ -101,7 +101,7 @@ internal inline fun<T> uniffiTraitInterfaceCall(
 ) {
     try {
         writeReturn(makeCall())
-    } catch(e: kotlin.Exception) {
+    } catch(e: kotlin.Throwable) {
         val err = try { e.stackTraceToString() } catch(_: Throwable) { "" }
         callStatus.code = UNIFFI_CALL_UNEXPECTED_ERROR
         callStatus.error_buf = {{ Type::String.borrow()|lower_fn }}(err)
@@ -116,7 +116,7 @@ internal inline fun<T, reified E: Throwable> uniffiTraitInterfaceCallWithError(
 ) {
     try {
         writeReturn(makeCall())
-    } catch(e: kotlin.Exception) {
+    } catch(e: kotlin.Throwable) {
         if (e is E) {
             callStatus.code = UNIFFI_CALL_ERROR
             callStatus.error_buf = lowerError(e)


### PR DESCRIPTION
Catch kotlin.Throwable rather than kotlin.Exception, which allows us to get the message correctly.  Also updated the tests for uniffi-bindgen-kotlin-jni, but we were actually already handling it right there.