### PR TITLE
Kotlin: stop emitting unused expressions in generated bindings

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
@@ -81,6 +81,8 @@ internal object IntegrityCheckingUniffiLib {
         uniffiCheckApiChecksums(this)
 {%- endif %}
     }
+
+    internal fun ensureInitialized() = Unit
     {% filter indent(4) %}
     {%- call decl_kotlin_functions(ci.iter_ffi_function_integrity_checks()) %}{% endcall %}
     {% endfilter %}
@@ -100,6 +102,8 @@ internal object UniffiLib {
         {{ fn_item }}
         {% endfor %}
     }
+
+    internal fun ensureInitialized() = Unit
     {#- XXX - this `filter indent` doesn't seem to work, even though the one above does? #}
     {% filter indent(4) %}
     {%- call decl_kotlin_functions(ci.iter_ffi_function_definitions_excluding_integrity_checks()) %}{% endcall %}
@@ -132,8 +136,8 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
  * @suppress
  */
 public fun uniffiEnsureInitialized() {
-    IntegrityCheckingUniffiLib
-    // UniffiLib() initialized as objects are used, but we still need to explicitly
-    // reference it so initialization across crates works as expected.
-    UniffiLib
+    // Call arbitrary methods on IntegrityCheckingUniffiLib and UniffiLib to ensure that
+    // their init blocks run. This ensures initialization across crates works as expected.
+    IntegrityCheckingUniffiLib.ensureInitialized()
+    UniffiLib.ensureInitialized()
 }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/macros.kt
@@ -95,7 +95,7 @@
         {%- when Some(return_type) %}
         { {{ return_type|lift_fn }}(it) },
         {%- when None %}
-        { Unit },
+        { },
         {% endmatch %}
         // Error FFI converter
         {%- match callable.throws_type() %}


### PR DESCRIPTION
The default warnings changed in Kotlin 2.4, which Firefox is using, but `uniffi-rs` seemingly isn't yet. Regardless, we should fix the warnings.

This came up during the `application-services` monorepo work in Firefox. Full stack on Phabricator here: https://phabricator.services.mozilla.com/D313774