### PR TITLE
Fix remote types for enums defined in UDL with `interface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### What's Fixed
 - Kotlin: Fixed messages for error classes that inherit `Throwable`, but not `Exception`.
+- Fix UDL remote enums, now allowing `[Enum, Remote] interface { ... }`
+  (via [#2823](https://github.com/mozilla/uniffi-rs/issues/2823)).
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.32.0...HEAD).
 

--- a/fixtures/ext-types/external-crate/src/lib.rs
+++ b/fixtures/ext-types/external-crate/src/lib.rs
@@ -24,3 +24,7 @@ impl ExternalCrateInterface {
         self.sval.clone()
     }
 }
+
+pub enum ExternalCrateEnumInterface {
+    Whatever,
+}

--- a/fixtures/ext-types/lib/src/ext-types-lib.udl
+++ b/fixtures/ext-types/lib/src/ext-types-lib.udl
@@ -73,6 +73,11 @@ enum ExternalCrateNonExhaustiveEnum {
     "Two",
 };
 
+[Enum, Remote]
+interface ExternalCrateEnumInterface {
+    Whatever();
+};
+
 // And a new type here to tie them all together.
 dictionary CombinedType {
     UniffiOneEnum uoe;
@@ -94,4 +99,5 @@ dictionary CombinedType {
 
     ExternalCrateDictionary ecd;
     ExternalCrateNonExhaustiveEnum ecnee;
+    ExternalCrateEnumInterface ecei;
 };

--- a/fixtures/ext-types/lib/src/lib.rs
+++ b/fixtures/ext-types/lib/src/lib.rs
@@ -1,7 +1,8 @@
 use custom_types::Handle;
 use ext_types_custom::{ANestedGuid, Guid, HandleU8, Ouid};
 use ext_types_external_crate::{
-    ExternalCrateDictionary, ExternalCrateInterface, ExternalCrateNonExhaustiveEnum,
+    ExternalCrateDictionary, ExternalCrateEnumInterface, ExternalCrateInterface,
+    ExternalCrateNonExhaustiveEnum,
 };
 use std::sync::Arc;
 use uniffi_one::{
@@ -34,6 +35,7 @@ pub struct CombinedType {
 
     pub ecd: ExternalCrateDictionary,
     pub ecnee: ExternalCrateNonExhaustiveEnum,
+    pub ecei: ExternalCrateEnumInterface,
 }
 
 fn get_combined_type(existing: Option<CombinedType>) -> CombinedType {
@@ -66,6 +68,7 @@ fn get_combined_type(existing: Option<CombinedType>) -> CombinedType {
 
         ecd: ExternalCrateDictionary { sval: "ecd".into() },
         ecnee: ExternalCrateNonExhaustiveEnum::One,
+        ecei: ExternalCrateEnumInterface::Whatever,
     })
 }
 

--- a/uniffi_udl/src/attributes.rs
+++ b/uniffi_udl/src/attributes.rs
@@ -410,9 +410,11 @@ impl TryFrom<&weedle::attribute::ExtendedAttributeList<'_>> for InterfaceAttribu
             Attribute::Remote => Ok(()),
             _ => bail!(format!("{attr:?} not supported for interface definition")),
         })?;
-        // If `[Enum]` can only also have `[Traits]`
-        let ok_for_enum =
-            attrs.len() == 1 || attrs.iter().any(|a| matches!(a, Attribute::Traits(_)));
+        // If `[Enum]` also allow any of `[Traits, Remote]`
+        let ok_for_enum = attrs.len() == 1
+            || attrs
+                .iter()
+                .any(|a| matches!(a, Attribute::Traits(_) | Attribute::Remote));
         if attrs.iter().any(|a| matches!(a, Attribute::Enum)) && !ok_for_enum {
             bail!("conflicting attributes on interface definition");
         }


### PR DESCRIPTION
`[Enum, Remote] interface { ... }` didn't work, via #2823