### PR TITLE
feat: scope callback vtables per realm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
   library before generating bindings.
   See [#2841](https://github.com/mozilla/uniffi-rs/pull/2841).
   Use `uniffi-bindgen [generation-options] src:[rust-crate-name]` to test this out.
+- The foreign-callback vtable cell now holds one registration per realm, so several instances of a
+  foreign runtime (Node worker threads, JVM classloaders, Python sub-interpreters) can share one
+  cdylib without the last one to register owning every callback in the process.
+  A realm is identified by bits the bindings tag into the top of the handles they mint.
+  Existing bindings are unaffected and need no regeneration: they register into realm 0 and read
+  back from realm 0.
+  See [#2958](https://github.com/mozilla/uniffi-rs/pull/2958).
 - Added `uniffi-bindgen-kotlin-jni`, an experimental JNI-based Kotlin bindgen.
   Benchmarks show large improvements in performance and we believe this will be more stable than the
   current Kotlin bindings.  However, the code is very fresh so use at your own risk.

--- a/uniffi_core/src/ffi/foreigncallbacks.rs
+++ b/uniffi_core/src/ffi/foreigncallbacks.rs
@@ -9,29 +9,81 @@
 //! storing the callback.
 
 use std::{
-    ptr::{null_mut, NonNull},
-    sync::atomic::{AtomicPtr, Ordering},
+    ptr::NonNull,
+    sync::{PoisonError, RwLock},
 };
 
-// Cell type that stores any NonNull<T>
+/// Bit position of the realm identifier inside a foreign handle.
+///
+/// A realm is one instance of a foreign runtime: a Node worker thread, a JVM classloader, a
+/// Python sub-interpreter. Several can load the same cdylib in one process, and each registers
+/// its own callback vtable pointing at its own runtime.
+///
+/// Foreign bindings reserve only the lowest bit of a handle, which must be set so a foreign
+/// handle is distinguishable from a Rust pointer. The top bits are free, so a realm tags every
+/// handle it mints and the tag travels back into Rust with the handle. This split leaves each
+/// realm 2^48 handles and allows 2^16 realms.
+pub const UNIFFI_REALM_SHIFT: u32 = 48;
+
+/// Identifier of the realm that minted `handle`.
+///
+/// An untagged handle yields 0, so bindings that do not tag keep working unchanged: they
+/// register into realm 0 and read back from realm 0.
+pub const fn uniffi_realm_of_handle(handle: u64) -> u64 {
+    handle >> UNIFFI_REALM_SHIFT
+}
+
+/// Cell type that stores one `NonNull<T>` per realm.
+///
+/// Registration happens once per realm at startup, so the realm list is tiny and effectively
+/// write-once. A linear scan of it costs less than hashing, and is dwarfed in any case by the
+/// foreign call that every lookup precedes.
 #[doc(hidden)]
-pub struct UniffiForeignPointerCell<T>(AtomicPtr<T>);
+pub struct UniffiForeignPointerCell<T>(RwLock<Vec<(u64, NonNull<T>)>>);
 
 impl<T> UniffiForeignPointerCell<T> {
     pub const fn new() -> Self {
-        Self(AtomicPtr::new(null_mut()))
+        Self(RwLock::new(Vec::new()))
+    }
+
+    /// Store the pointer registered by `realm`, replacing any previous registration for it.
+    pub fn set_for_realm(&self, realm: u64, callback: NonNull<T>) {
+        let mut realms = self.0.write().unwrap_or_else(PoisonError::into_inner);
+        match realms.iter_mut().find(|(id, _)| *id == realm) {
+            Some((_, registered)) => *registered = callback,
+            None => realms.push((realm, callback)),
+        }
     }
 
     pub fn set(&self, callback: NonNull<T>) {
-        self.0.store(callback.as_ptr(), Ordering::Relaxed);
+        self.set_for_realm(0, callback);
+    }
+
+    /// Look up the pointer registered by the realm that minted `handle`.
+    ///
+    /// Falls back to realm 0 when that realm registered nothing, which is what a handle minted
+    /// by bindings that do not tag looks like.
+    pub fn get_for_handle(&self, handle: u64) -> &T {
+        let realm = uniffi_realm_of_handle(handle);
+        let realms = self.0.read().unwrap_or_else(PoisonError::into_inner);
+        let registered = realms
+            .iter()
+            .find(|(id, _)| *id == realm)
+            .or_else(|| realms.iter().find(|(id, _)| *id == 0))
+            .map(|(_, registered)| *registered);
+        drop(realms);
+
+        // The pointer is owned by the foreign bindings and outlives every call into Rust, which
+        // is the same contract the single-pointer cell relied on.
+        unsafe {
+            registered
+                .expect("Foreign pointer not set.  This is likely a uniffi bug.")
+                .as_ref()
+        }
     }
 
     pub fn get(&self) -> &T {
-        unsafe {
-            NonNull::new(self.0.load(Ordering::Relaxed))
-                .expect("Foreign pointer not set.  This is likely a uniffi bug.")
-                .as_mut()
-        }
+        self.get_for_handle(0)
     }
 }
 
@@ -43,3 +95,70 @@ impl<T> Default for UniffiForeignPointerCell<T> {
 
 unsafe impl<T> Send for UniffiForeignPointerCell<T> {}
 unsafe impl<T> Sync for UniffiForeignPointerCell<T> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn handle_in(realm: u64, n: u64) -> u64 {
+        (realm << UNIFFI_REALM_SHIFT) | (n << 1) | 1
+    }
+
+    #[test]
+    fn realm_is_read_from_the_top_bits_and_untagged_means_realm_zero() {
+        assert_eq!(uniffi_realm_of_handle(1), 0);
+        assert_eq!(uniffi_realm_of_handle(handle_in(0, 7)), 0);
+        assert_eq!(uniffi_realm_of_handle(handle_in(3, 7)), 3);
+        // The realm is whatever the top bits hold, so nothing needs clamping.
+        assert_eq!(
+            uniffi_realm_of_handle(u64::MAX),
+            u64::MAX >> UNIFFI_REALM_SHIFT
+        );
+    }
+
+    #[test]
+    fn each_realm_reads_back_its_own_registration() {
+        let (mut a, mut b) = (1u32, 2u32);
+        let cell = UniffiForeignPointerCell::new();
+
+        cell.set_for_realm(0, NonNull::from(&mut a));
+        cell.set_for_realm(3, NonNull::from(&mut b));
+
+        // The registrations do not overwrite each other, which is the whole point.
+        assert_eq!(*cell.get_for_handle(handle_in(0, 1)), 1);
+        assert_eq!(*cell.get_for_handle(handle_in(3, 1)), 2);
+    }
+
+    #[test]
+    fn re_registering_a_realm_replaces_it_without_growing_the_list() {
+        let (mut a, mut b) = (1u32, 2u32);
+        let cell = UniffiForeignPointerCell::new();
+
+        cell.set_for_realm(5, NonNull::from(&mut a));
+        cell.set_for_realm(5, NonNull::from(&mut b));
+
+        assert_eq!(*cell.get_for_handle(handle_in(5, 1)), 2);
+        assert_eq!(cell.0.read().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn a_realm_that_registered_nothing_falls_back_to_realm_zero() {
+        let mut a = 1u32;
+        let cell = UniffiForeignPointerCell::new();
+        cell.set(NonNull::from(&mut a));
+
+        assert_eq!(*cell.get_for_handle(handle_in(9, 1)), 1);
+        assert_eq!(*cell.get(), 1);
+    }
+
+    #[test]
+    fn a_realm_beyond_any_fixed_bound_still_registers() {
+        let mut a = 7u32;
+        let cell = UniffiForeignPointerCell::new();
+        let realm = u64::MAX >> UNIFFI_REALM_SHIFT;
+
+        cell.set_for_realm(realm, NonNull::from(&mut a));
+
+        assert_eq!(*cell.get_for_handle(handle_in(realm, 1)), 7);
+    }
+}

--- a/uniffi_macros/src/export/callback_interface.rs
+++ b/uniffi_macros/src/export/callback_interface.rs
@@ -36,6 +36,13 @@ pub(super) fn trait_impl(
         &uniffi_meta::init_callback_vtable_fn_symbol_name(mod_path, &trait_name),
         Span::call_site(),
     );
+    let init_realm_ident = Ident::new(
+        &format!(
+            "{}_for_realm",
+            uniffi_meta::init_callback_vtable_fn_symbol_name(mod_path, &trait_name)
+        ),
+        Span::call_site(),
+    );
     let methods = items
         .iter()
         .map(|item| match item {
@@ -50,7 +57,7 @@ pub(super) fn trait_impl(
     let uniffi_foreign_handle_method = for_trait_interface.then(|| {
         quote! {
             fn uniffi_foreign_handle(&self) -> ::std::option::Option<::uniffi::Handle> {
-                let vtable = #vtable_cell.get();
+                let vtable = #vtable_cell.get_for_handle(self.handle);
                 ::std::option::Option::Some(::uniffi::Handle::from_raw_unchecked((vtable.uniffi_clone)(self.handle)))
             }
         }
@@ -110,6 +117,12 @@ pub(super) fn trait_impl(
             #vtable_cell.set(vtable);
         }
 
+        #[allow(missing_docs)]
+        #[unsafe(no_mangle)]
+        pub extern "C" fn #init_realm_ident(realm: u64, vtable: ::std::ptr::NonNull<#vtable_type>) {
+            #vtable_cell.set_for_realm(realm, vtable);
+        }
+
         #[derive(Debug)]
         struct #trait_impl_ident {
             handle: u64,
@@ -132,7 +145,7 @@ pub(super) fn trait_impl(
 
         impl ::std::ops::Drop for #trait_impl_ident {
             fn drop(&mut self) {
-                let vtable = #vtable_cell.get();
+                let vtable = #vtable_cell.get_for_handle(self.handle);
                 (vtable.uniffi_free)(self.handle);
             }
         }
@@ -244,7 +257,7 @@ fn gen_method_impl(sig: &FnSignature, vtable_cell: &Ident) -> syn::Result<TokenS
     if !is_async {
         Ok(quote! {
             fn #ident(#self_param, #(#params),*) -> #return_ty {
-                let vtable = #vtable_cell.get();
+                let vtable = #vtable_cell.get_for_handle(self.handle);
                 let mut uniffi_call_status: ::uniffi::RustCallStatus = ::std::default::Default::default();
                 let mut uniffi_return_value: #lift_return_type = ::uniffi::FfiDefault::ffi_default();
                 (vtable.#ident)(self.handle, #(#lower_exprs,)* &mut uniffi_return_value, &mut uniffi_call_status);
@@ -254,7 +267,7 @@ fn gen_method_impl(sig: &FnSignature, vtable_cell: &Ident) -> syn::Result<TokenS
     } else {
         Ok(quote! {
             async fn #ident(#self_param, #(#params),*) -> #return_ty {
-                let vtable = #vtable_cell.get();
+                let vtable = #vtable_cell.get_for_handle(self.handle);
                 ::uniffi::foreign_async_call::<_, #return_ty, crate::UniFfiTag>(
                     move |uniffi_future_callback, uniffi_future_callback_data, uniffi_foreign_future_dropped_callback| {
                         (vtable.#ident)(


### PR DESCRIPTION
Fixes #2957. Related to #2295, which asks for several languages in one process; this is the same root cause reached with one language and several realms of it.

## The problem

Several instances of a foreign runtime can load one cdylib in a single process: Node worker threads, JVM classloaders, Python sub-interpreters. Each registers its own callback vtable.

`UniffiForeignPointerCell` held exactly one pointer and `set` is an unconditional store, so the last realm to register owned every callback in the process.

Foreign handles then made it silent instead of loud. Each realm mints handles from its own map starting at the same value, so realm A's handle 3 and realm B's handle 3 are the same number. A call dispatched into the wrong realm resolves to a real object there rather than failing, so callers get wrong data instead of an error. I measured 0 of 12 Node worker realms behaving correctly.

## The change

The cell holds one registration per realm. A realm is identified by bits the foreign bindings tag into the top of every handle they mint, which is free space: only the lowest bit is reserved, to distinguish a foreign handle from a Rust pointer. The tag travels with the handle back into Rust, so `get_for_handle` routes a call to the realm that owns the object.

Every lookup site in the generated trait impl already has `self.handle` in scope, so the codegen change is `get()` to `get_for_handle(self.handle)` at four sites.

The realm is carried as a `u64` end to end and registrations live in a `Vec`, so there is no ceiling on how many realms may share an image and no width conversion anywhere on the path. Registration happens once per realm at startup, so the list is tiny and effectively write-once; a linear scan costs less than hashing and is dwarfed by the foreign call each lookup precedes.

## Backward compatibility

Nothing existing has to change, in any language.

- `set` and `get` keep their signatures and mean realm 0.
- An untagged handle reads as realm 0, and a realm with no registration falls back to realm 0, so bindings that know nothing about realms behave exactly as before.
- Registration gains an additive `..._for_realm` symbol rather than changing the signature of the existing one.
- `uniffi_meta` and `uniffi_bindgen` are untouched, so no checksum moves and no bindings need regenerating.

I checked that last point by running bindings generated against stock 0.31.0, without regenerating them, on a library built with this patch: a checksum change would have thrown `ApiChecksumMismatch` at import. They loaded and passed, including a four-worker-realm test.

## Tests

Five unit tests on the cell: realm extraction from the top bits, untagged handles reading as realm 0, two realms reading back their own registration rather than overwriting each other, re-registration replacing in place, fallback to realm 0 for an unregistered realm, and a realm at the top of the range to show there is no fixed bound.

`cargo test -p uniffi_core` is green (40 + 2), `cargo clippy -p uniffi_core --all-targets` is clean, and `cargo fmt` has been run.

## What this does not do

It gives each realm its own vtable registration. It does not tag handles: that is the foreign bindings' side of the contract, and each set of bindings has to opt in by minting tagged handles and calling `..._for_realm`. Bindings that do nothing keep working as realm 0.

I have the Node side of this working against a local build and can follow up with it, or with a second language, if that would help review.

One design note for #2295: the identity that matters is the foreign runtime instance rather than the language. Two Node worker realms are both JS, so a language index would give them the same value and they would still collide. Scoping by runtime instance also separates two languages, so it is the strictly finer of the two.
