### PR TITLE
fix(python): prefer the running event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - Kotlin: Fixed messages for error classes that inherit `Throwable`, but not `Exception`.
 - Fix UDL remote enums, now allowing `[Enum, Remote] interface { ... }`
   (via [#2823](https://github.com/mozilla/uniffi-rs/issues/2823)).
+- Python: event-loop lookup now prefers the calling thread's running loop, falling back to the one
+  passed to `uniffi_set_event_loop`.
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.32.0...HEAD).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   (via [#2823](https://github.com/mozilla/uniffi-rs/issues/2823)).
 - Python: event-loop lookup now prefers the calling thread's running loop, falling back to the one
   passed to `uniffi_set_event_loop`.
+- Python: rename `uniffi_set_event_loop` to `uniffi_set_default_event_loop`
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.32.0...HEAD).
 

--- a/docs/manual/src/futures.md
+++ b/docs/manual/src/futures.md
@@ -79,10 +79,10 @@ pub trait SayAfterTrait: Send + Sync {
 Traits with callback interface support that export async methods can be combined with async Rust code.
 See the [async-api-client example](https://github.com/mozilla/uniffi-rs/tree/main/examples/async-api-client) for an example of this.
 
-### Python: `uniffi_set_event_loop()`
+### Python: `uniffi_set_default_event_loop()`
 
-Python bindings export a function named `uniffi_set_event_loop()` which handles a corner case when
-integrating async Rust and Python code. `uniffi_set_event_loop()` is needed when Python async
+Python bindings export a function named `uniffi_set_default_event_loop()` which handles a corner case when
+integrating async Rust and Python code. `uniffi_set_default_event_loop()` is needed when Python async
 functions run outside of the eventloop, for example:
 
 * Rust code is executing outside of the eventloop.  Some examples:
@@ -92,10 +92,10 @@ functions run outside of the eventloop, for example:
   on the async call.
 
 In this case, we need an event loop to run the Python async function, but there's no eventloop set for the thread.
-Use `uniffi_set_event_loop()` to handle this case.
+Use `uniffi_set_default_event_loop()` to handle this case.
 It should be called before the Rust code makes the async call and passed an eventloop to use.
 
-Note that `uniffi_set_event_loop` cannot be glob-imported because it's not part of the library's `__all__`.
+Note that `uniffi_set_default_event_loop` cannot be glob-imported because it's not part of the library's `__all__`.
 
 ### Ruby: thread-based async
 

--- a/fixtures/futures/tests/bindings/test_futures.py
+++ b/fixtures/futures/tests/bindings/test_futures.py
@@ -291,5 +291,26 @@ class TestFutures(unittest.TestCase):
             await use_shared_resource(SharedResourceOptions(release_after_ms=0, timeout_ms=1000))
         asyncio.run(test())
 
+    def test_call_from_a_second_event_loop(self):
+        """A call is awaited on the loop making it, not on whichever one was set first.
+
+        `uniffi_set_event_loop` exists so a thread with no loop of its own has one to schedule a
+        callback on. A thread that IS running a loop needs no such fallback, and taking it there
+        builds the poll future on one loop and awaits it from another, which asyncio refuses with
+        "got Future attached to a different loop".
+        """
+        first = asyncio.new_event_loop()
+        try:
+            futures.uniffi_set_event_loop(first)
+
+            async def test():
+                self.assertEqual(await always_ready(), True)
+
+            # A second loop, of the kind `asyncio.run` makes: this is the one awaiting the call.
+            asyncio.run(test())
+        finally:
+            futures.uniffi_set_event_loop(None)
+            first.close()
+
 if __name__ == '__main__':
     unittest.main()

--- a/fixtures/futures/tests/bindings/test_futures.py
+++ b/fixtures/futures/tests/bindings/test_futures.py
@@ -294,14 +294,14 @@ class TestFutures(unittest.TestCase):
     def test_call_from_a_second_event_loop(self):
         """A call is awaited on the loop making it, not on whichever one was set first.
 
-        `uniffi_set_event_loop` exists so a thread with no loop of its own has one to schedule a
+        `uniffi_set_default_event_loop` exists so a thread with no loop of its own has one to schedule a
         callback on. A thread that IS running a loop needs no such fallback, and taking it there
         builds the poll future on one loop and awaits it from another, which asyncio refuses with
         "got Future attached to a different loop".
         """
         first = asyncio.new_event_loop()
         try:
-            futures.uniffi_set_event_loop(first)
+            futures.uniffi_set_default_event_loop(first)
 
             async def test():
                 self.assertEqual(await always_ready(), True)
@@ -309,7 +309,7 @@ class TestFutures(unittest.TestCase):
             # A second loop, of the kind `asyncio.run` makes: this is the one awaiting the call.
             asyncio.run(test())
         finally:
-            futures.uniffi_set_event_loop(None)
+            futures.uniffi_set_default_event_loop(None)
             first.close()
 
 if __name__ == '__main__':

--- a/uniffi_bindgen/src/bindings/python/templates/Async.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Async.py
@@ -24,10 +24,15 @@ def uniffi_set_event_loop(eventloop: asyncio.BaseEventLoop):
     _UNIFFI_GLOBAL_EVENT_LOOP = eventloop
 
 def _uniffi_get_event_loop():
-    if _UNIFFI_GLOBAL_EVENT_LOOP is not None:
-        return _UNIFFI_GLOBAL_EVENT_LOOP
-    else:
+    # A loop running on this thread owns the futures the call awaits, so it wins. The global is
+    # the fallback for threads that have none, which is what it was added for: preferring it
+    # everywhere hands one loop another loop's future as soon as a process runs two.
+    try:
         return asyncio.get_running_loop()
+    except RuntimeError:
+        if _UNIFFI_GLOBAL_EVENT_LOOP is not None:
+            return _UNIFFI_GLOBAL_EVENT_LOOP
+        raise
 
 # Continuation callback for async functions
 # lift the return value or error and resolve the future, causing the async function to resume.

--- a/uniffi_bindgen/src/bindings/python/templates/Async.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Async.py
@@ -17,9 +17,9 @@ This is needed if some async functions run outside of the eventloop, for example
       like `pollster` to block on the async call.
 
 In this case, we need an event loop to run the Python async function, but there's no eventloop set
-for the thread.  Use `uniffi_set_event_loop` to force an eventloop to be used in this case.
+for the thread.  Use `uniffi_set_default_event_loop` to force an eventloop to be used in this case.
 """
-def uniffi_set_event_loop(eventloop: asyncio.BaseEventLoop):
+def uniffi_set_default_event_loop(eventloop: asyncio.BaseEventLoop):
     global _UNIFFI_GLOBAL_EVENT_LOOP
     _UNIFFI_GLOBAL_EVENT_LOOP = eventloop
 

--- a/uniffi_bindgen/src/bindings/python/templates/Async.py
+++ b/uniffi_bindgen/src/bindings/python/templates/Async.py
@@ -32,7 +32,7 @@ def _uniffi_get_event_loop():
     except RuntimeError:
         if _UNIFFI_GLOBAL_EVENT_LOOP is not None:
             return _UNIFFI_GLOBAL_EVENT_LOOP
-        raise
+        raise RuntimeError("UniFFI error: no running event loop and uniffi_set_default_event_loop not called")
 
 # Continuation callback for async functions
 # lift the return value or error and resolve the future, causing the async function to resume.


### PR DESCRIPTION
Fixes #2961.

**What I was doing**

Calling a uniffi library from a process running more than one asyncio loop, having called `uniffi_set_event_loop` as the docs say.

**What happens**

Any call made from a loop other than the one passed to `uniffi_set_event_loop` raises `got Future attached to a different loop`.

**Why**

`_uniffi_get_event_loop` prefers the global over the loop running the call, and `_uniffi_rust_call_async` uses it both to `create_future()` and to receive the poll continuations.

```mermaid
sequenceDiagram
    participant B as Loop B (making the call)
    participant Lookup as _uniffi_get_event_loop
    participant A as Loop A (set globally)

    B->>Lookup: which loop?
    Lookup-->>B: A, because the global is set
    B->>A: create_future()
    A-->>B: a Future belonging to A
    B->>B: await it
    Note over B: RuntimeError
```

**The fix**

```diff
 def _uniffi_get_event_loop():
-    if _UNIFFI_GLOBAL_EVENT_LOOP is not None:
-        return _UNIFFI_GLOBAL_EVENT_LOOP
-    else:
-        return asyncio.get_running_loop()
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        if _UNIFFI_GLOBAL_EVENT_LOOP is None:
+            raise
+        return _UNIFFI_GLOBAL_EVENT_LOOP
```

The global is the fallback for threads with no loop of their own, which is what it was added for. `_uniffi_rust_call_async` is a coroutine, so it always has a running loop and never needs it. Nothing changes for a single loop process, where the running loop is the global.

**Test**

`test_call_from_a_second_event_loop` in the futures fixture. Checked both ways: it fails on this branch with the template change reverted, and passes with it.

Python and Swift fixtures pass here. Kotlin and Ruby I could not run locally (no `kotlinc`, no `ffi` gem); this touches only the Python templates.
