### PR TITLE
Fix const_evaluatable_unchecked warning in pointer-ffi async callback scaffolding

### DIFF
--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -2,6 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// Regression test for the async callback interface scaffolding; we want to avoid
+// needing `const_evaluatable_unchecked`, especially given that capability
+// is going to be removed by rustc eventually - see rust#76200.
+#![deny(const_evaluatable_unchecked)]
+
 use std::{
     future::Future,
     pin::Pin,

--- a/uniffi_macros/src/export/callback_interface.rs
+++ b/uniffi_macros/src/export/callback_interface.rs
@@ -595,13 +595,13 @@ fn gen_method_impl_pointer_ffi(
 
                     let (uniffi_callback, uniffi_receiver) = ::uniffi::pointer_ffi::start_foreign_future();
 
-                    let mut uniffi_ffi_buf = [
-                        0_u8;
-                        ::uniffi::ffi_buffer_size!(
+                    let mut uniffi_ffi_buf = {
+                        const UNIFFI_BUF_SIZE: usize = ::uniffi::ffi_buffer_size!(
                             (::uniffi::Handle, #(#scaffolding_param_types,)* ::uniffi::pointer_ffi::BoundCallbackFn),
                             (::std::option::Option<::uniffi::pointer_ffi::BoundCallbackFn>)
-                        )
-                    ];
+                        );
+                        [0_u8; UNIFFI_BUF_SIZE]
+                    };
                     let mut uniffi_args_buf = uniffi_ffi_buf.as_mut_slice();
                     // We're passing the handle by reference, so we can use `clone_for_ref` to
                     // avoid an arc clone


### PR DESCRIPTION
Note this is against the kotlin-pointer-ffi branch, and helps explain why app-services is hitting errors trying to bump to rust 1.94. app-services isn't actually on this branch (and earlier version of it maybe?), so it's not clear how easily a re-vendor for this branch will be - but it seems that we are going to want this regardless.

The pointer-FFI scaffolding for async callback interface methods used `ffi_buffer_size!` directly as an array length inside the generated `async` block. `ffi_buffer_size!` expands to an inline `const` block, and in array-length position inside a coroutine body that const inherits the coroutine's generics, so rustc 1.92+ fires `const_evaluatable_unchecked` (rust#76200) even though the size is fully concrete.

Hoist the length into a nested `const` item, which cannot reference the enclosing body's generics and so is not treated as generic-dependent.
