### PR TITLE
Escape /* and */ in Kotlin and Swift docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 - Python: event-loop lookup now prefers the calling thread's running loop, falling back to the one
   passed to `uniffi_set_event_loop`.
 - Python: rename `uniffi_set_event_loop` to `uniffi_set_default_event_loop`
+- Kotlin and Swift: escape `/*` and `*/` in docstrings, which previously generated code that would not compile
+  (via [#2411](https://github.com/mozilla/uniffi-rs/issues/2411)).
 
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.32.0...HEAD).
 

--- a/fixtures/docstring-proc-macro/src/lib.rs
+++ b/fixtures/docstring-proc-macro/src/lib.rs
@@ -127,4 +127,12 @@ uniffi::custom_type!(
 #[uniffi::export]
 pub fn test_long_docstring() {}
 
+/// <docstring-comment-open> contains a /* in the text
+#[uniffi::export]
+pub fn test_comment_open() {}
+
+/// <docstring-comment-close> contains a */ in the text
+#[uniffi::export]
+pub fn test_comment_close() {}
+
 uniffi::include_scaffolding!("docstring-proc-macro");

--- a/fixtures/docstring-proc-macro/tests/test_generated_bindings.rs
+++ b/fixtures/docstring-proc-macro/tests/test_generated_bindings.rs
@@ -19,6 +19,8 @@ mod tests {
         "<docstring-associated-error>",
         "<docstring-callback-method>",
         "<docstring-callback>",
+        "<docstring-comment-close>",
+        "<docstring-comment-open>",
         "<docstring-enum-variant-2>",
         "<docstring-enum-variant>",
         "<docstring-enum>",

--- a/fixtures/docstring/src/docstring.udl
+++ b/fixtures/docstring/src/docstring.udl
@@ -8,6 +8,12 @@ namespace uniffi_docstring {
     void test_multiline();
 
     [Throws=AssociatedErrorTest] void test_without_docstring();
+
+    /// <docstring-comment-open> contains a /* in the text
+    void test_comment_open();
+
+    /// <docstring-comment-close> contains a */ in the text
+    void test_comment_close();
 };
 
 /// <docstring-enum>

--- a/fixtures/docstring/src/lib.rs
+++ b/fixtures/docstring/src/lib.rs
@@ -58,6 +58,10 @@ pub fn test_without_docstring() -> Result<(), AssociatedErrorTest> {
     Ok(())
 }
 
+pub fn test_comment_open() {}
+
+pub fn test_comment_close() {}
+
 pub trait CallbackTest {
     fn test(&self);
 }

--- a/fixtures/docstring/tests/test_generated_bindings.rs
+++ b/fixtures/docstring/tests/test_generated_bindings.rs
@@ -19,6 +19,8 @@ mod tests {
         "<docstring-associated-error>",
         "<docstring-callback-method>",
         "<docstring-callback>",
+        "<docstring-comment-close>",
+        "<docstring-comment-open>",
         "<docstring-enum-variant-2>",
         "<docstring-enum-variant>",
         "<docstring-enum>",

--- a/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
+++ b/uniffi_bindgen/src/bindings/kotlin/gen_kotlin/mod.rs
@@ -1058,7 +1058,8 @@ mod filters {
         _: &dyn askama::Values,
         spaces: &i32,
     ) -> Result<String, askama::Error> {
-        let middle = textwrap::indent(&textwrap::dedent(docstring.as_ref()), " * ");
+        let escaped = docstring.as_ref().replace("*/", "*\\/").replace("/*", "/\\*");
+        let middle = textwrap::indent(&textwrap::dedent(&escaped), " * ");
         let wrapped = format!("/**\n{middle}\n */");
 
         let spaces = usize::try_from(*spaces).unwrap_or_default();

--- a/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
+++ b/uniffi_bindgen/src/bindings/swift/gen_swift/mod.rs
@@ -1188,7 +1188,8 @@ pub mod filters {
         _: &dyn askama::Values,
         spaces: &i32,
     ) -> Result<String, askama::Error> {
-        let middle = textwrap::indent(&textwrap::dedent(docstring), " * ");
+        let escaped = docstring.replace("*/", "*\\/").replace("/*", "/\\*");
+        let middle = textwrap::indent(&textwrap::dedent(&escaped), " * ");
         let wrapped = format!("/**\n{middle}\n */");
 
         let spaces = usize::try_from(*spaces).unwrap_or_default();


### PR DESCRIPTION
Fixes #2411.

Docstrings are emitted verbatim into a `/** ... */` block, so comment markers in the text change the structure of the generated code. A `*/` closes the block early and the rest of the line is parsed as code. A `/*` opens a block that is never closed, which swallows everything after it. Both cases produce Kotlin and Swift that doesn't compile.

Nested `/* ... */` is fine, since both languages allow nested block comments. Only the unbalanced cases break. Python is unaffected because it uses `"""`.

This escapes `*/` as `*\/` and `/*` as `/\*` in the Kotlin and Swift docstring filters.

Adds two functions to the `docstring` and `docstring-proc-macro` fixtures, one with a `/*` in the docstring and one with a `*/`. Without the fix, `kotlinc` and `swiftc` both reject the generated bindings. The Rust assertions on docstring content still pass in that state, since the text is present, just in the wrong place syntactically.

The TypeScript backend in `uniffi-bindgen-react-native` uses the same filter, where any `*/` breaks the output since TypeScript has no nested block comments. Fixed there in jhugman/uniffi-bindgen-react-native#438.

Ran the full suite in the Docker image. 226 test result lines, all passing.