### PR TITLE
Support rust-only remote traits.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   Benchmarks show large improvements in performance and we believe this will be more stable than the
   current Kotlin bindings.  However, the code is very fresh so use at your own risk.
   See [#2911](https://github.com/mozilla/uniffi-rs/pull/2911).
+- Added support for remote trait interfaces - ie, traits defined in a crate which doesn't use
+  UniFFI. Use `#[uniffi::export(remote)]` or `[Trait, Remote]` in UDL. Foreign implementations are not supported, see the docs for more.
 
 ### What's Fixed
 - Kotlin: Fixed messages for error classes that inherit `Throwable`, but not `Exception`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2192,6 +2192,7 @@ dependencies = [
  "uniffi",
  "uniffi-example-custom-types",
  "uniffi-fixture-ext-types-custom-types",
+ "uniffi-fixture-ext-types-external-crate",
  "uniffi-fixture-ext-types-lib-one",
  "url",
 ]

--- a/docs/manual/src/types/remote_ext_types.md
+++ b/docs/manual/src/types/remote_ext_types.md
@@ -34,6 +34,18 @@ enum LogLevel {
 }
 ```
 
+Traits go through `#[uniffi::export]` rather than `#[uniffi::remote]`, so they use a `remote`
+argument instead:
+
+```rust
+// As above, this mirrors the definition from the remote crate; UniFFI generates the scaffolding
+// but doesn't output the trait itself.
+#[uniffi::export(remote)]
+pub trait Logger: Send + Sync {
+    fn log(&self, message: String);
+}
+```
+
 ## UDL
 
 Wrap the definition with `[Remote]` attribute:
@@ -47,6 +59,23 @@ enum LogLevel {
     "Debug",
     "Trace",
 };
+
+[Trait, Remote]
+interface Logger {
+    void log(string message);
+};
+```
+
+## Remote traits can't be foreign
+
+Supporting foreign implementations of a trait requires UniFFI to change the trait,
+which is impossible for a trait defined externally. `#[uniffi::export(remote, foreign)]` and
+`[Trait, Remote, WithForeign]` are therefore errors — only Rust can implement a remote trait.
+
+At time of writing, the change made to a non-remote trait is a new method:
+```
+#[doc(hidden)]
+fn uniffi_foreign_handle(&self) { ... }
 ```
 
 # External Types

--- a/fixtures/ext-types/external-crate/src/lib.rs
+++ b/fixtures/ext-types/external-crate/src/lib.rs
@@ -28,3 +28,7 @@ impl ExternalCrateInterface {
 pub enum ExternalCrateEnumInterface {
     Whatever,
 }
+
+pub trait ExternalCrateTrait: Send + Sync {
+    fn hello(&self) -> String;
+}

--- a/fixtures/ext-types/lib/src/ext-types-lib.udl
+++ b/fixtures/ext-types/lib/src/ext-types-lib.udl
@@ -18,6 +18,8 @@ namespace imported_types_lib {
 
     UniffiOneInterface get_uniffi_one_interface();
     ExternalCrateInterface get_external_crate_interface(string val);
+    ExternalCrateTrait get_external_crate_trait();
+    string invoke_external_crate_trait(ExternalCrateTrait t);
     UniffiOneProcMacroType get_uniffi_one_proc_macro_type(UniffiOneProcMacroType t);
     UniffiOneUDLTrait? get_uniffi_one_udl_trait(UniffiOneUDLTrait? t);
 };
@@ -76,6 +78,11 @@ enum ExternalCrateNonExhaustiveEnum {
 [Enum, Remote]
 interface ExternalCrateEnumInterface {
     Whatever();
+};
+
+[Trait, Remote]
+interface ExternalCrateTrait {
+    string hello();
 };
 
 // And a new type here to tie them all together.

--- a/fixtures/ext-types/lib/src/lib.rs
+++ b/fixtures/ext-types/lib/src/lib.rs
@@ -2,7 +2,7 @@ use custom_types::Handle;
 use ext_types_custom::{ANestedGuid, Guid, HandleU8, Ouid};
 use ext_types_external_crate::{
     ExternalCrateDictionary, ExternalCrateEnumInterface, ExternalCrateInterface,
-    ExternalCrateNonExhaustiveEnum,
+    ExternalCrateNonExhaustiveEnum, ExternalCrateTrait,
 };
 use std::sync::Arc;
 use uniffi_one::{
@@ -253,6 +253,23 @@ fn throw_uniffi_one_error_interface() -> Result<(), UniffiOneErrorInterface> {
 
 fn get_external_crate_interface(val: String) -> Arc<ExternalCrateInterface> {
     Arc::new(ExternalCrateInterface::new(val))
+}
+
+// An implementation of a trait defined in a crate which doesn't use UniFFI.
+struct ExternalCrateTraitImpl;
+
+impl ExternalCrateTrait for ExternalCrateTraitImpl {
+    fn hello(&self) -> String {
+        "external crate trait says hello".to_string()
+    }
+}
+
+fn get_external_crate_trait() -> Arc<dyn ExternalCrateTrait> {
+    Arc::new(ExternalCrateTraitImpl)
+}
+
+fn invoke_external_crate_trait(t: Arc<dyn ExternalCrateTrait>) -> String {
+    t.hello()
 }
 
 fn get_uniffi_one_udl_trait(

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.kts
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.kts
@@ -88,6 +88,11 @@ try {
 assert(ct.ecd.sval == "ecd")
 assert(getExternalCrateInterface("foo").value() == "foo")
 
+// A remote trait (ie, UDL `[Trait, Remote] interface`) we can use and pass around.
+val ect = getExternalCrateTrait()
+assert(ect.hello() == "external crate trait says hello")
+assert(invokeExternalCrateTrait(ect) == "external crate trait says hello")
+
 // Test that BindingRenamedType from uniffi-one is renamed to KotlinRenamedType via direct function call
 val renamedType = getBindingRenamedType("external_rename_test")
 assert(renamedType is KotlinRenamedType)

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.py
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.py
@@ -84,6 +84,11 @@ class TestIt(unittest.TestCase):
         self.assertEqual(ct.ecd.sval, "ecd");
         self.assertEqual(get_external_crate_interface("foo").value(), "foo")
 
+        # A remote trait (ie, UDL `[Trait, Remote] interface`) we can use and pass around.
+        t = get_external_crate_trait()
+        self.assertEqual(t.hello(), "external crate trait says hello")
+        self.assertEqual(invoke_external_crate_trait(t), "external crate trait says hello")
+
     def test_procmacro_types(self):
         t1 = UniffiOneProcMacroType(sval="hello")
         self.assertEqual(t1, get_uniffi_one_proc_macro_type(t1))

--- a/fixtures/ext-types/lib/tests/bindings/test_imported_types.swift
+++ b/fixtures/ext-types/lib/tests/bindings/test_imported_types.swift
@@ -99,6 +99,11 @@ do {
 assert(ct.ecd.sval == "ecd")
 assert(getExternalCrateInterface(val: "foo").value() == "foo")
 
+// A remote trait (ie, UDL `[Trait, Remote] interface`) we can use and pass around.
+let ect = getExternalCrateTrait()
+assert(ect.hello() == "external crate trait says hello")
+assert(invokeExternalCrateTrait(t: ect) == "external crate trait says hello")
+
 // Test that BindingRenamedType from uniffi-one is renamed to SwiftRenamedType via direct function call
 let renamedType = getBindingRenamedType(value: "external_rename_test")
 assert(renamedType == SwiftRenamedType(swiftValue: "external_rename_test"))

--- a/fixtures/ext-types/proc-macro-lib/Cargo.toml
+++ b/fixtures/ext-types/proc-macro-lib/Cargo.toml
@@ -23,6 +23,7 @@ uniffi = { workspace = true }
 
 uniffi-fixture-ext-types-lib-one = {path = "../uniffi-one"}
 uniffi-fixture-ext-types-custom-types = {path = "../custom-types"}
+uniffi-fixture-ext-types-external-crate = {path = "../external-crate"}
 
 # Reuse one of our examples.
 uniffi-example-custom-types = {path = "../../../examples/custom-types"}

--- a/fixtures/ext-types/proc-macro-lib/src/lib.rs
+++ b/fixtures/ext-types/proc-macro-lib/src/lib.rs
@@ -1,5 +1,6 @@
 use custom_types::Handle;
 use ext_types_custom::{Guid, Ouid2};
+use ext_types_external_crate::ExternalCrateTrait;
 use std::sync::Arc;
 use uniffi_one::{
     UniffiOneEnum, UniffiOneInterface, UniffiOneProcMacroType, UniffiOneRecordContainingInterface,
@@ -169,6 +170,33 @@ impl uniffi_one::UniffiOneTrait for UniffiOneTraitObject {
     fn hello(&self) -> String {
         "uniffi-one-trait-object".to_string()
     }
+}
+
+// A trait from a crate which doesn't use UniFFI - mirror the definition here and mark it
+// `remote`.
+#[uniffi::export(remote)]
+pub trait ExternalCrateTrait: Send + Sync {
+    fn hello(&self) -> String;
+}
+
+// Only Rust can implement it - here's one.
+struct ExternalCrateTraitImpl;
+
+impl ExternalCrateTrait for ExternalCrateTraitImpl {
+    fn hello(&self) -> String {
+        "external crate trait says hello".to_string()
+    }
+}
+
+// And use it.
+#[uniffi::export]
+fn get_external_crate_trait() -> Arc<dyn ExternalCrateTrait> {
+    Arc::new(ExternalCrateTraitImpl)
+}
+
+#[uniffi::export]
+fn invoke_external_crate_trait(t: Arc<dyn ExternalCrateTrait>) -> String {
+    t.hello()
 }
 
 // Some custom types via macros.

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.kts
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.kts
@@ -18,6 +18,11 @@ assert(getObjectsType(null).maybeInterface == null)
 assert(getObjectsType(null).maybeTrait == null)
 assert(getUniffiOneTrait(null) == null)
 
+// a `remote` trait we can use and pass around.
+val ect = getExternalCrateTrait()
+assert(ect.hello() == "external crate trait says hello")
+assert(invokeExternalCrateTrait(ect) == "external crate trait says hello")
+
 val url = java.net.URL("http://example.com/")
 assert(getUrl(url) ==  url)
 assert(getMaybeUrl(url)!! ==  url)

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.py
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.py
@@ -26,6 +26,11 @@ class TestIt(unittest.TestCase):
         self.assertEqual(ot.maybe_interface, None)
         self.assertEqual(get_uniffi_one_trait(None), None)
 
+        # `remote` trait we can use and pass around.
+        t = get_external_crate_trait()
+        self.assertEqual(t.hello(), "external crate trait says hello")
+        self.assertEqual(invoke_external_crate_trait(t), "external crate trait says hello")
+
     def test_get_url(self):
         url = urllib.parse.urlparse("http://example.com/")
         self.assertEqual(get_url(url), url)

--- a/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.swift
+++ b/fixtures/ext-types/proc-macro-lib/tests/bindings/test_imported_types.swift
@@ -17,6 +17,11 @@ assert(getObjectsType(value: nil).maybeInterface == nil)
 assert(getObjectsType(value: nil).maybeTrait == nil)
 assert(getUniffiOneTrait(t: nil) == nil)
 
+// a `remote` trait we can use and pass around.
+let ect = getExternalCrateTrait()
+assert(ect.hello() == "external crate trait says hello")
+assert(invokeExternalCrateTrait(t: ect) == "external crate trait says hello")
+
 let url = URL(string: "http://example.com/")!;
 assert(getUrl(url: url) ==  url)
 assert(getMaybeUrl(url: url)! == url)

--- a/fixtures/uitests/tests/ui/remote_trait_with_foreign.rs
+++ b/fixtures/uitests/tests/ui/remote_trait_with_foreign.rs
@@ -1,0 +1,26 @@
+fn main() {} /* empty main required by `trybuild` */
+
+// Foreign impls need UniFFI to add a hidden method to the trait, which is impossible for a
+// trait defined in another crate, so `remote` and the foreign flags conflict.
+
+#[uniffi::export(remote, foreign)]
+pub trait RemoteForeign: Send + Sync {
+    fn hello(&self) -> String;
+}
+
+#[uniffi::export(remote, rust, foreign)]
+pub trait RemoteRustAndForeign: Send + Sync {
+    fn hello(&self) -> String;
+}
+
+#[uniffi::export(remote, with_foreign)]
+pub trait RemoteWithForeign: Send + Sync {
+    fn hello(&self) -> String;
+}
+
+#[uniffi::export(remote, callback_interface)]
+pub trait RemoteCallbackInterface: Send + Sync {
+    fn hello(&self) -> String;
+}
+
+uniffi_macros::setup_scaffolding!();

--- a/fixtures/uitests/tests/ui/remote_trait_with_foreign.stderr
+++ b/fixtures/uitests/tests/ui/remote_trait_with_foreign.stderr
@@ -1,0 +1,23 @@
+error: remote traits can't be implemented by foreign code
+ --> tests/ui/remote_trait_with_foreign.rs:7:11
+  |
+7 | pub trait RemoteForeign: Send + Sync {
+  |           ^^^^^^^^^^^^^
+
+error: remote traits can't be implemented by foreign code
+  --> tests/ui/remote_trait_with_foreign.rs:12:11
+   |
+12 | pub trait RemoteRustAndForeign: Send + Sync {
+   |           ^^^^^^^^^^^^^^^^^^^^
+
+error: remote traits can't be implemented by foreign code
+  --> tests/ui/remote_trait_with_foreign.rs:17:11
+   |
+17 | pub trait RemoteWithForeign: Send + Sync {
+   |           ^^^^^^^^^^^^^^^^^
+
+error: remote traits can't be implemented by foreign code
+  --> tests/ui/remote_trait_with_foreign.rs:22:11
+   |
+22 | pub trait RemoteCallbackInterface: Send + Sync {
+   |           ^^^^^^^^^^^^^^^^^^^^^^^

--- a/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
+++ b/uniffi_bindgen/src/scaffolding/templates/ObjectTemplate.rs
@@ -3,7 +3,13 @@
 #}
 
 {%- if obj.is_trait_interface() %}
-#[::uniffi::export_for_udl{% if obj.has_callback_interface() %}(with_foreign){% endif %}]
+{%- if obj.has_callback_interface() %}
+#[::uniffi::export_for_udl(with_foreign)]
+{%- else if obj.remote() %}
+#[::uniffi::export_for_udl(remote)]
+{%- else %}
+#[::uniffi::export_for_udl]
+{%- endif %}
 pub trait r#{{ obj.name() }} {
     {%- for meth in obj.methods() %}
     {% if meth.is_async() %}async {% endif %}fn r#{{ meth.name() }}(

--- a/uniffi_macros/src/export.rs
+++ b/uniffi_macros/src/export.rs
@@ -228,8 +228,17 @@ pub fn rewrite_self_type(item: &mut Item) {
 }
 
 /// Alter the tokens wrapped with the `[uniffi::export]` if needed
-pub fn alter_input(item: &Item) -> TokenStream {
+pub fn alter_input(item: &Item, all_args: proc_macro::TokenStream) -> TokenStream {
     match item {
+        // Like all remote types, we don't emit the duplicate definition itself, just its ffi/metadata etc
+        Item::Trait(_)
+            if matches!(
+                syn::parse::<attributes::ExportTraitArgs>(all_args),
+                Ok(args) if args.remote.is_some()
+            ) =>
+        {
+            quote! {}
+        }
         Item::Trait(item_trait) => alter_trait(item_trait),
         _ => quote! { #item },
     }

--- a/uniffi_macros/src/export/attributes.rs
+++ b/uniffi_macros/src/export/attributes.rs
@@ -26,6 +26,7 @@ use uniffi_meta::UniffiTraitDiscriminants;
 ///
 /// `with_foreign` is a deprecated alias for `rust, foreign`.
 /// `callback_interface` is a deprecated legacy flag for Box-based foreign-only traits.
+/// `remote` is whether the trait is defined in an external non-uniffi-consuming crate.
 #[derive(Default)]
 pub struct ExportTraitArgs {
     pub(crate) async_runtime: Option<AsyncRuntime>,
@@ -37,6 +38,8 @@ pub struct ExportTraitArgs {
     pub(crate) rust: Option<kw::rust>,
     /// Include foreign instances in the FFI bridge.
     pub(crate) foreign: Option<kw::foreign>,
+    /// Is the trait a "remote type".
+    pub(crate) remote: Option<kw::remote>,
 }
 
 impl Parse for ExportTraitArgs {
@@ -75,6 +78,11 @@ impl UniffiAttributeArgs for ExportTraitArgs {
                 foreign: input.parse()?,
                 ..Self::default()
             })
+        } else if lookahead.peek(kw::remote) {
+            Ok(Self {
+                remote: input.parse()?,
+                ..Self::default()
+            })
         } else {
             Err(lookahead.error())
         }
@@ -90,6 +98,7 @@ impl UniffiAttributeArgs for ExportTraitArgs {
             with_foreign: either_attribute_arg(self.with_foreign, other.with_foreign)?,
             rust: either_attribute_arg(self.rust, other.rust)?,
             foreign: either_attribute_arg(self.foreign, other.foreign)?,
+            remote: either_attribute_arg(self.remote, other.remote)?,
         };
         let has_new_flags = merged.rust.is_some() || merged.foreign.is_some();
         let has_legacy_flags = merged.callback_interface.is_some() || merged.with_foreign.is_some();

--- a/uniffi_macros/src/export/item.rs
+++ b/uniffi_macros/src/export/item.rs
@@ -175,6 +175,16 @@ impl ExportItem {
             (kind, cb_only)
         };
 
+        if args.remote.is_some() && trait_kind.has_foreign() {
+            // Foreign implementations require us to add a hidden `uniffi_foreign_handle` method to
+            // the trait (see `alter_trait`), which is impossible for a trait defined in another
+            // crate.
+            return Err(syn::Error::new(
+                item.ident.span(),
+                "remote traits can't be implemented by foreign code",
+            ));
+        }
+
         if !item.generics.params.is_empty() || item.generics.where_clause.is_some() {
             return Err(syn::Error::new_spanned(
                 &item.generics,

--- a/uniffi_macros/src/export/trait_interface.rs
+++ b/uniffi_macros/src/export/trait_interface.rs
@@ -26,6 +26,8 @@ pub(super) fn gen_trait_scaffolding(
     trait_kind: TraitKind,
     docstring: String,
 ) -> syn::Result<TokenStream> {
+    // Note: `remote` traits can't have foreign impls; `ExportItem::from_trait` rejects that.
+    let remote = args.remote.is_some();
     let trait_name = ident_to_string(&self_ident);
     let trait_impl = trait_kind.has_foreign().then(|| {
         callback_interface::trait_impl(mod_path, &self_ident, &items, true)
@@ -109,7 +111,7 @@ pub(super) fn gen_trait_scaffolding(
         )
         .unwrap_or_else(syn::Error::into_compile_error)
     });
-    let ffi_converter_tokens = ffi_converter(&self_ident, trait_kind);
+    let ffi_converter_tokens = ffi_converter(&self_ident, trait_kind, remote);
 
     Ok(quote_spanned! { self_ident.span() =>
         #meta_static_var
@@ -120,9 +122,11 @@ pub(super) fn gen_trait_scaffolding(
     })
 }
 
-pub(crate) fn ffi_converter(trait_ident: &Ident, trait_kind: TraitKind) -> TokenStream {
-    // TODO: support defining remote trait interfaces
-    let remote = false;
+pub(crate) fn ffi_converter(
+    trait_ident: &Ident,
+    trait_kind: TraitKind,
+    remote: bool,
+) -> TokenStream {
     let impl_spec = tagged_impl_header("FfiConverterArc", &quote! { dyn #trait_ident }, remote);
     let lift_ref_impl_spec = tagged_impl_header("LiftRef", &quote! { dyn #trait_ident }, remote);
     // Implement `TypeId` for `dyn Trait` directly.  This is what we use to lookup the type ID for
@@ -181,6 +185,36 @@ pub(crate) fn ffi_converter(trait_ident: &Ident, trait_kind: TraitKind) -> Token
             }
         }
     };
+    // Wrap `obj` in a second arc and create the handle from that.
+    // https://mozilla.github.io/uniffi-rs/latest/internals/object_references.html
+    let lower_rust_obj = quote! {
+        {
+            use ::std::sync::Arc;
+            let obj: Arc<Arc<dyn #trait_ident>> = Arc::new(obj);
+            ::uniffi::ffi::Handle::from_arc(obj)
+        }
+    };
+    let lower = if trait_kind.has_foreign() {
+        // `obj` may store a foreign-generated handle, which we can return directly.
+        // `uniffi_foreign_handle` is the hidden trait method added by `alter_trait`.
+        quote! {
+            fn lower(obj: ::std::sync::Arc<Self>) -> Self::FfiType {
+                match obj.uniffi_foreign_handle() {
+                    // `uniffi_foreign_handle` cloned the handle for us.
+                    ::std::option::Option::Some(handle) => handle,
+                    // Obj is a Rust-implemented trait.
+                    ::std::option::Option::None => #lower_rust_obj
+                }
+            }
+        }
+    } else {
+        // Only Rust implements the trait, so there's never a foreign handle to return. This
+        // also means we don't need the `uniffi_foreign_handle` method in this case,
+        // which is what makes remote traits possible.
+        quote! {
+            fn lower(obj: ::std::sync::Arc<Self>) -> Self::FfiType #lower_rust_obj
+        }
+    };
     let trait_kind_code = match trait_kind {
         TraitKind::RustOnly => quote! { ::uniffi::metadata::codes::TRAIT_KIND_RUST_ONLY },
         TraitKind::Both => quote! { ::uniffi::metadata::codes::TRAIT_KIND_BOTH },
@@ -207,21 +241,7 @@ pub(crate) fn ffi_converter(trait_ident: &Ident, trait_kind: TraitKind) -> Token
         unsafe #impl_spec {
             type FfiType = ::uniffi::ffi::Handle;
 
-            fn lower(obj: ::std::sync::Arc<Self>) -> Self::FfiType {
-                match obj.uniffi_foreign_handle() {
-                    // Obj stores a foreign-generated handle that `uniffi_foreign_handle` just
-                    // cloned.  We can return that directly.
-                    ::std::option::Option::Some(handle) => handle,
-                    // Obj is a Rust-implemented trait.
-                    // Wrap `obj` in a second arc and create the handle from that.
-                    // https://mozilla.github.io/uniffi-rs/latest/internals/object_references.html
-                    ::std::option::Option::None => {
-                        use ::std::sync::Arc;
-                        let obj: Arc<Arc<dyn #trait_ident>> = Arc::new(obj);
-                        ::uniffi::ffi::Handle::from_arc(obj)
-                    }
-                }
-            }
+            #lower
 
             #try_lift
 

--- a/uniffi_macros/src/lib.rs
+++ b/uniffi_macros/src/lib.rs
@@ -101,7 +101,7 @@ fn do_export(
 ) -> TokenStream {
     let gen_output = || {
         let item = syn::parse(input)?;
-        let altered_input = keep_input.then(|| export::alter_input(&item));
+        let altered_input = keep_input.then(|| export::alter_input(&item, attr_args.clone()));
         let output = expand_export(item, attr_args, udl_mode)?;
         Ok(quote! {
             #altered_input

--- a/uniffi_udl/src/attributes.rs
+++ b/uniffi_udl/src/attributes.rs
@@ -441,6 +441,13 @@ impl TryFrom<&weedle::attribute::ExtendedAttributeList<'_>> for InterfaceAttribu
         if attrs.iter().any(|a| matches!(a, Attribute::Enum)) && !ok_for_enum {
             bail!("conflicting attributes on interface definition");
         }
+        // Foreign impls need UniFFI to add a hidden method to the trait, which is impossible for a
+        // trait defined in another crate.
+        if attrs.iter().any(|a| matches!(a, Attribute::Remote))
+            && attrs.iter().any(|a| matches!(a, Attribute::WithForeign))
+        {
+            bail!("remote traits can't be implemented by foreign code, so `[Remote]` and `[WithForeign]` conflict");
+        }
         Ok(Self(attrs))
     }
 }
@@ -936,6 +943,28 @@ mod test {
         let (_, node) = weedle::attribute::ExtendedAttributeList::parse("[WithForeign]").unwrap();
         let attrs = InterfaceAttributes::try_from(&node).unwrap();
         assert!(attrs.object_impl().is_err())
+    }
+
+    #[test]
+    fn test_remote_trait_attribute() {
+        let (_, node) = weedle::attribute::ExtendedAttributeList::parse("[Trait, Remote]").unwrap();
+        let attrs = InterfaceAttributes::try_from(&node).unwrap();
+        assert!(attrs.contains_remote());
+        assert_eq!(
+            attrs.object_impl().unwrap(),
+            ObjectImpl::Trait(TraitKind::RustOnly)
+        );
+
+        // Foreign impls need a hidden method added to the trait, which is impossible for a trait
+        // defined in another crate.
+        let (_, node) =
+            weedle::attribute::ExtendedAttributeList::parse("[Trait, Remote, WithForeign]")
+                .unwrap();
+        let err = InterfaceAttributes::try_from(&node).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "remote traits can't be implemented by foreign code, so `[Remote]` and `[WithForeign]` conflict"
+        );
     }
 
     #[test]


### PR DESCRIPTION
indirectly via #2823, fixes a `// TODO` and fits in fine.

rust-only limitation could probably be overcome later if someone cared enough.