### PR TITLE
Adding note about UDL and custom types

### DIFF
--- a/docs/manual/src/types/custom_types.md
+++ b/docs/manual/src/types/custom_types.md
@@ -123,7 +123,10 @@ typedef i64 Handle;
 typedef dictionary LogRecord;
 ```
 
-**note**: you must still call the `custom_type!` or `custom_newtype!` macros in your Rust code, as described above.
+**Notes**:
+
+* You must still call the `custom_type!` or `custom_newtype!` macros in your Rust code, as described above.
+* The macro invocation must live in the root module of your crate.
 
 ## User-defined types
 

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -963,8 +963,10 @@ impl ComponentInterface {
             // new pipeline path; keep them consistent.
             anyhow::ensure!(
                 existing.builtin == defn.builtin && existing.module_path == defn.module_path,
-                "conflicting custom type definitions for {:?}",
+                "conflicting custom type definitions for {:?} ({} vs {})",
                 defn.name,
+                existing.module_path,
+                defn.module_path
             );
             // UDL provides docstring: None; proc-macro may provide Some.  Prefer Some.
             if defn.docstring.is_some() && existing.docstring.is_none() {


### PR DESCRIPTION
I think the best way to address #2968 is to just document the issue and leave it at that. I tried making the conflicting type detection code more lenient to avoid the issue, and that seems possible but it's a lot of work that I don't want to do just to continue to support UDL.

Also added some extra context to the error message.