### PR TITLE
fix source-parsing pipeline and kotlin-jni bindgen for large real-world crate graphs

### DIFF
--- a/uniffi-bindgen-kotlin-jni/src/bindings/templates/shared/FfiBuffer.kt
+++ b/uniffi-bindgen-kotlin-jni/src/bindings/templates/shared/FfiBuffer.kt
@@ -45,6 +45,14 @@ fun writeString(buf: java.nio.ByteBuffer, offset: kotlin.Int, value: kotlin.Stri
     Scaffolding.ffiBufferWriteString(buf, offset, value)
 }
 
+fun readBytes(buf: java.nio.ByteBuffer, offset: kotlin.Int): kotlin.ByteArray {
+    return Scaffolding.ffiBufferReadBytes(buf, offset)
+}
+
+fun writeBytes(buf: java.nio.ByteBuffer, offset: kotlin.Int, value: kotlin.ByteArray) {
+    Scaffolding.ffiBufferWriteBytes(buf, offset, value)
+}
+
 fun readBuffer(buf: java.nio.ByteBuffer, offset: kotlin.Int): java.nio.ByteBuffer {
     return Scaffolding.ffiBufferReadBuffer(buf, offset).order(java.nio.ByteOrder.nativeOrder())
 }

--- a/uniffi-bindgen-kotlin-jni/src/bindings/templates/shared/Scaffolding.kt
+++ b/uniffi-bindgen-kotlin-jni/src/bindings/templates/shared/Scaffolding.kt
@@ -4,6 +4,8 @@ object Scaffolding {
     @JvmStatic external fun ffiBufferFree(buf: java.nio.ByteBuffer)
     @JvmStatic external fun ffiBufferReadString(buf: java.nio.ByteBuffer, offset: kotlin.Int): kotlin.String
     @JvmStatic external fun ffiBufferWriteString(buf: java.nio.ByteBuffer, offset: kotlin.Int, value: kotlin.String)
+    @JvmStatic external fun ffiBufferReadBytes(buf: java.nio.ByteBuffer, offset: kotlin.Int): kotlin.ByteArray
+    @JvmStatic external fun ffiBufferWriteBytes(buf: java.nio.ByteBuffer, offset: kotlin.Int, value: kotlin.ByteArray)
     @JvmStatic external fun ffiBufferReadBuffer(buf: java.nio.ByteBuffer, offset: kotlin.Int): java.nio.ByteBuffer
     @JvmStatic external fun ffiBufferWriteBuffer(buf: java.nio.ByteBuffer, offset: kotlin.Int, value: java.nio.ByteBuffer)
 

--- a/uniffi-bindgen-kotlin-jni/src/pipeline/ffi_buffer.rs
+++ b/uniffi-bindgen-kotlin-jni/src/pipeline/ffi_buffer.rs
@@ -63,6 +63,9 @@ impl FfiBufferLayoutOracle {
             Type::UInt64 | Type::Int64 | Type::Float64 => Layout::from_size_align(8, 8)?,
             // One 8-byte handle
             Type::Interface { .. } => Layout::from_size_align(8, 8)?,
+            // 8-byte seconds at offset 0, 4-byte nanoseconds at offset 8
+            // (see the timestamp/duration scaffolding templates)
+            Type::Timestamp | Type::Duration => Layout::from_size_align(12, 8)?,
             // (data, length, capacity) fields
             Type::String | Type::Bytes => Layout::from_size_align(24, 8)?,
             // (data, size) fields

--- a/uniffi-bindgen-kotlin-jni/src/pipeline/ffi_buffer.rs
+++ b/uniffi-bindgen-kotlin-jni/src/pipeline/ffi_buffer.rs
@@ -64,7 +64,7 @@ impl FfiBufferLayoutOracle {
             // One 8-byte handle
             Type::Interface { .. } => Layout::from_size_align(8, 8)?,
             // (data, length, capacity) fields
-            Type::String => Layout::from_size_align(24, 8)?,
+            Type::String | Type::Bytes => Layout::from_size_align(24, 8)?,
             // (data, size) fields
             Type::Sequence { .. } | Type::Map { .. } | Type::Set { .. } => {
                 Layout::from_size_align(16, 8)?

--- a/uniffi-bindgen-kotlin-jni/src/pipeline/types.rs
+++ b/uniffi-bindgen-kotlin-jni/src/pipeline/types.rs
@@ -267,6 +267,7 @@ impl TypeNode {
             Type::Float64 => "uniffi::ffibuffer::write_f64".into(),
             Type::Boolean => "uniffi::ffibuffer::write_bool".into(),
             Type::String => "uniffi::ffibuffer::write_string".into(),
+            Type::Bytes => "uniffi::ffibuffer::write_vec_u8".into(),
             _ => format!("write_type_{id}"),
         }
     }
@@ -287,6 +288,7 @@ impl TypeNode {
             Type::Float64 => "uniffi::ffibuffer::read_f64".into(),
             Type::Boolean => "uniffi::ffibuffer::read_bool".into(),
             Type::String => "uniffi::ffibuffer::read_string".into(),
+            Type::Bytes => "uniffi::ffibuffer::read_vec_u8".into(),
             _ => format!("read_type_{id}"),
         }
     }
@@ -407,6 +409,7 @@ impl TypeNode {
             Type::Float64 => "writeDouble".into(),
             Type::Boolean => "writeBoolean".into(),
             Type::String => "writeString".into(),
+            Type::Bytes => "writeBytes".into(),
             _ => format!("writeType{id}"),
         }
     }
@@ -427,6 +430,7 @@ impl TypeNode {
             Type::Float64 => "readDouble".into(),
             Type::Boolean => "readBoolean".into(),
             Type::String => "readString".into(),
+            Type::Bytes => "readBytes".into(),
             _ => format!("readType{id}"),
         }
     }

--- a/uniffi-bindgen-kotlin-jni/src/scaffolding/templates/callback_interface.rs
+++ b/uniffi-bindgen-kotlin-jni/src/scaffolding/templates/callback_interface.rs
@@ -1,6 +1,7 @@
 {%- let type_name = cbi.self_type.type_rs %}
 {%- let trait_name = "{}::{}"|format(cbi.module_path, cbi.name_rs()) %}
 
+#[derive(Clone, Debug)]
 struct {{ cbi.impl_struct_rs() }} {
     handle: i64,
 }

--- a/uniffi-bindgen-kotlin-jni/src/scaffolding/templates/ffi_buffer.rs
+++ b/uniffi-bindgen-kotlin-jni/src/scaffolding/templates/ffi_buffer.rs
@@ -79,6 +79,42 @@ unsafe extern "system" fn Java_uniffi_Scaffolding_ffiBufferWriteString(
 }
 
 #[unsafe(no_mangle)]
+unsafe extern "system" fn Java_uniffi_Scaffolding_ffiBufferReadBytes(
+    env: *mut uniffi_jni::JNIEnv,
+    _: *mut uniffi_jni::jclass,
+    buf: uniffi_jni::jobject,
+    offset: ::std::primitive::i32,
+) -> uniffi_jni::jbyteArray {
+    unsafe {
+        uniffi_jni::rust_call_with_env(env, |env| {
+            let (ptr, capacity) = uniffi_jni::lift_buffer(env, buf)?;
+            let ptr = ptr.add(offset as ::std::primitive::usize);
+            let v = uniffi::ffibuffer::read_vec_u8(ptr)?;
+            uniffi_jni::lower_vec_u8(env, v)
+        })
+    }
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "system" fn Java_uniffi_Scaffolding_ffiBufferWriteBytes(
+    env: *mut uniffi_jni::JNIEnv,
+    _: *mut uniffi_jni::jclass,
+    buf: uniffi_jni::jobject,
+    offset: ::std::primitive::i32,
+    value: uniffi_jni::jbyteArray,
+) {
+    unsafe {
+        uniffi_jni::rust_call_with_env(env, |env| {
+            let v = uniffi_jni::lift_vec_u8(env, value)?;
+            let (ptr, _) = uniffi_jni::lift_buffer(env, buf)?;
+            let ptr = ptr.add(offset as ::std::primitive::usize);
+            uniffi::ffibuffer::write_vec_u8(ptr, v)?;
+            uniffi::Result::Ok(())
+        })
+    }
+}
+
+#[unsafe(no_mangle)]
 unsafe extern "system" fn Java_uniffi_Scaffolding_ffiBufferReadBuffer(
     env: *mut uniffi_jni::JNIEnv,
     _: *mut uniffi_jni::jclass,

--- a/uniffi-bindgen-kotlin-jni/src/scaffolding/templates/map.rs
+++ b/uniffi-bindgen-kotlin-jni/src/scaffolding/templates/map.rs
@@ -1,15 +1,27 @@
+{#-
+  These functions are generic over the container: hand-written FFI impls can expose
+  third-party containers with builtin container metadata, so the Rust type at a use
+  site isn't necessarily the std container.  Call sites always have a concrete type
+  for inference: a record field, a function argument, or a function return value.
+-#}
 {%- let type_name = map.self_type.type_rs %}
+{%- let item_type = "({}, {})"|format(map.key.type_rs, map.value.type_rs) %}
 {%- let lift_from_parts = "lift_from_parts_{}"|format(map.self_type.id) %}
 {%- let lower_into_parts = "lower_into_parts_{}"|format(map.self_type.id) %}
 
-unsafe fn {{ lower_into_parts }}(
-    value: {{ type_name }},
-) -> uniffi::Result<(*mut ::std::primitive::u8, ::std::primitive::usize)> {
+unsafe fn {{ lower_into_parts }}<C>(
+    value: C,
+) -> uniffi::Result<(*mut ::std::primitive::u8, ::std::primitive::usize)>
+where
+    C: ::std::iter::IntoIterator<Item = {{ item_type }}>,
+    C::IntoIter: ::std::iter::ExactSizeIterator,
+{
     unsafe {
-        let capacity = value.len() * {{ map.item_size }};
+        let items = value.into_iter();
+        let capacity = items.len() * {{ map.item_size }};
         let ptr = uniffi::ffibuffer::alloc(capacity)?;
         let mut pos = ptr;
-        for (k, v) in value {
+        for (k, v) in items {
             {{ map.key.write_fn_rs() }}(pos, k)?;
             {{ map.value.write_fn_rs() }}(pos.add({{ map.value_offset }}), v)?;
             pos = pos.add({{ map.item_size }});
@@ -18,58 +30,84 @@ unsafe fn {{ lower_into_parts }}(
     }
 }
 
-unsafe fn {{ lift_from_parts }}(
+unsafe fn {{ lift_from_parts }}<C>(
     ptr: *mut ::std::primitive::u8,
     capacity: ::std::primitive::usize,
-) -> uniffi::Result<{{ type_name }}> {
+) -> uniffi::Result<C>
+where
+    C: ::std::iter::FromIterator<{{ item_type }}>,
+{
     let mut do_lift = || {
-        unsafe {
-            let mut pos = ptr;
-            let length = capacity / {{ map.item_size }};
-            let mut map = {{ type_name }}::with_capacity(length);
-            for _ in 0..length {
-                map.insert(
-                    {{ map.key.read_fn_rs() }}(pos)?,
-                    {{ map.value.read_fn_rs() }}(pos.add({{ map.value_offset }}))?,
-                );
-                pos = pos.add({{ map.item_size }});
-            }
-            uniffi::Result::Ok(map)
-        }
+        let length = capacity / {{ map.item_size }};
+        let mut pos = ptr;
+        (0..length)
+            .map(|_| {
+                let item = unsafe {
+                    (
+                        {{ map.key.read_fn_rs() }}(pos)?,
+                        {{ map.value.read_fn_rs() }}(pos.add({{ map.value_offset }}))?,
+                    )
+                };
+                pos = unsafe { pos.add({{ map.item_size }}) };
+                uniffi::Result::Ok(item)
+            })
+            .collect::<uniffi::Result<C>>()
     };
     let result = do_lift();
-    uniffi::ffibuffer::free(ptr, capacity);
+    unsafe { uniffi::ffibuffer::free(ptr, capacity) };
     result
 }
 
-unsafe fn {{ map.self_type.lower_fn_rs() }}(
+unsafe fn {{ map.self_type.lower_fn_rs() }}<C>(
     uniffi_env: *mut uniffi_jni::JNIEnv,
-    value: {{ type_name }},
-) -> uniffi::Result<uniffi_jni::jobject> {
-    let (ptr, capacity) = {{ lower_into_parts }}(value)?;
-    uniffi_jni::lower_buffer(uniffi_env, ptr, capacity)
+    value: C,
+) -> uniffi::Result<uniffi_jni::jobject>
+where
+    C: ::std::iter::IntoIterator<Item = {{ item_type }}>,
+    C::IntoIter: ::std::iter::ExactSizeIterator,
+{
+    unsafe {
+        let (ptr, capacity) = {{ lower_into_parts }}(value)?;
+        uniffi_jni::lower_buffer(uniffi_env, ptr, capacity)
+    }
 }
 
-unsafe fn {{ map.self_type.lift_fn_rs() }}(
+unsafe fn {{ map.self_type.lift_fn_rs() }}<C>(
     uniffi_env: *mut uniffi_jni::JNIEnv,
     byte_buffer: uniffi_jni::jobject,
-) -> uniffi::Result<{{ type_name }}> {
-    let (ptr, capacity) = uniffi_jni::lift_buffer(uniffi_env, byte_buffer)?;
-    {{ lift_from_parts }}(ptr, capacity)
+) -> uniffi::Result<C>
+where
+    C: ::std::iter::FromIterator<{{ item_type }}>,
+{
+    unsafe {
+        let (ptr, capacity) = uniffi_jni::lift_buffer(uniffi_env, byte_buffer)?;
+        {{ lift_from_parts }}(ptr, capacity)
+    }
 }
 
-unsafe fn {{ map.self_type.write_fn_rs() }}(
+unsafe fn {{ map.self_type.write_fn_rs() }}<C>(
     buf_ptr: *mut ::std::primitive::u8,
-    value: {{ type_name }},
-) -> uniffi::Result<()> {
-    let (ptr, capacity) = {{ lower_into_parts }}(value)?;
-    uniffi::ffibuffer::write_buffer(buf_ptr, ptr, capacity)?;
-    uniffi::Result::Ok(())
+    value: C,
+) -> uniffi::Result<()>
+where
+    C: ::std::iter::IntoIterator<Item = {{ item_type }}>,
+    C::IntoIter: ::std::iter::ExactSizeIterator,
+{
+    unsafe {
+        let (ptr, capacity) = {{ lower_into_parts }}(value)?;
+        uniffi::ffibuffer::write_buffer(buf_ptr, ptr, capacity)?;
+        uniffi::Result::Ok(())
+    }
 }
 
-unsafe fn {{ map.self_type.read_fn_rs() }}(
+unsafe fn {{ map.self_type.read_fn_rs() }}<C>(
     ptr: *mut ::std::primitive::u8,
-) -> uniffi::Result<{{ type_name }}> {
-    let (ptr, capacity) = uniffi::ffibuffer::read_buffer(ptr)?;
-    {{ lift_from_parts }}(ptr, capacity)
+) -> uniffi::Result<C>
+where
+    C: ::std::iter::FromIterator<{{ item_type }}>,
+{
+    unsafe {
+        let (ptr, capacity) = uniffi::ffibuffer::read_buffer(ptr)?;
+        {{ lift_from_parts }}(ptr, capacity)
+    }
 }

--- a/uniffi-bindgen-kotlin-jni/src/scaffolding/templates/sequence.rs
+++ b/uniffi-bindgen-kotlin-jni/src/scaffolding/templates/sequence.rs
@@ -1,15 +1,27 @@
+{#-
+  These functions are generic over the container: hand-written FFI impls can expose
+  third-party containers with builtin container metadata, so the Rust type at a use
+  site isn't necessarily the std container.  Call sites always have a concrete type
+  for inference: a record field, a function argument, or a function return value.
+-#}
 {%- let type_name = seq.self_type.type_rs %}
+{%- let item_type = seq.inner.type_rs %}
 {%- let lift_from_parts = "lift_from_parts_{}"|format(seq.self_type.id) %}
 {%- let lower_into_parts = "lower_into_parts_{}"|format(seq.self_type.id) %}
 
-unsafe fn {{ lower_into_parts }}(
-    value: {{ type_name }},
-) -> uniffi::Result<(*mut ::std::primitive::u8, ::std::primitive::usize)> {
+unsafe fn {{ lower_into_parts }}<C>(
+    value: C,
+) -> uniffi::Result<(*mut ::std::primitive::u8, ::std::primitive::usize)>
+where
+    C: ::std::iter::IntoIterator<Item = {{ item_type }}>,
+    C::IntoIter: ::std::iter::ExactSizeIterator,
+{
     unsafe {
-        let capacity = value.len() * {{ seq.item_size }};
+        let items = value.into_iter();
+        let capacity = items.len() * {{ seq.item_size }};
         let ptr = uniffi::ffibuffer::alloc(capacity)?;
         let mut pos = ptr;
-        for v in value {
+        for v in items {
             {{ seq.inner.write_fn_rs() }}(pos, v)?;
             pos = pos.add({{ seq.item_size }});
         }
@@ -17,59 +29,83 @@ unsafe fn {{ lower_into_parts }}(
     }
 }
 
-unsafe fn {{ lift_from_parts }}(
+unsafe fn {{ lift_from_parts }}<C>(
     ptr: *mut ::std::primitive::u8,
     capacity: ::std::primitive::usize,
-) -> uniffi::Result<{{ type_name }}> {
+) -> uniffi::Result<C>
+where
+    C: ::std::iter::FromIterator<{{ item_type }}>,
+{
     let mut do_lift = || {
+        let length = capacity / {{ seq.item_size }};
         let mut pos = ptr;
-        unsafe {
-            let length = capacity / {{ seq.item_size }};
-            let mut vec = {{ type_name }}::with_capacity(length);
-            for _ in 0..length {
-                vec.push({{ seq.inner.read_fn_rs() }}(pos)?);
-                pos = pos.add({{ seq.item_size }});
-            }
-            uniffi::Result::Ok(vec)
-        }
+        (0..length)
+            .map(|_| {
+                let item = unsafe { {{ seq.inner.read_fn_rs() }}(pos) }?;
+                pos = unsafe { pos.add({{ seq.item_size }}) };
+                uniffi::Result::Ok(item)
+            })
+            .collect::<uniffi::Result<C>>()
     };
     let result = do_lift();
-    uniffi::ffibuffer::free(ptr, capacity);
+    unsafe { uniffi::ffibuffer::free(ptr, capacity) };
     result
 }
 
 {% if !seq.is_primitive_array %}
 
-unsafe fn {{ seq.self_type.lower_fn_rs() }}(
+unsafe fn {{ seq.self_type.lower_fn_rs() }}<C>(
     uniffi_env: *mut uniffi_jni::JNIEnv,
-    value: {{ type_name }},
-) -> uniffi::Result<uniffi_jni::jobject> {
-    let (ptr, capacity) = {{ lower_into_parts }}(value)?;
-    uniffi_jni::lower_buffer(uniffi_env, ptr, capacity)
+    value: C,
+) -> uniffi::Result<uniffi_jni::jobject>
+where
+    C: ::std::iter::IntoIterator<Item = {{ item_type }}>,
+    C::IntoIter: ::std::iter::ExactSizeIterator,
+{
+    unsafe {
+        let (ptr, capacity) = {{ lower_into_parts }}(value)?;
+        uniffi_jni::lower_buffer(uniffi_env, ptr, capacity)
+    }
 }
 
-unsafe fn {{ seq.self_type.lift_fn_rs() }}(
+unsafe fn {{ seq.self_type.lift_fn_rs() }}<C>(
     uniffi_env: *mut uniffi_jni::JNIEnv,
     byte_buffer: uniffi_jni::jobject,
-) -> uniffi::Result<{{ type_name }}> {
-    let (ptr, capacity) = uniffi_jni::lift_buffer(uniffi_env, byte_buffer)?;
-    {{ lift_from_parts }}(ptr, capacity)
+) -> uniffi::Result<C>
+where
+    C: ::std::iter::FromIterator<{{ item_type }}>,
+{
+    unsafe {
+        let (ptr, capacity) = uniffi_jni::lift_buffer(uniffi_env, byte_buffer)?;
+        {{ lift_from_parts }}(ptr, capacity)
+    }
 }
 
 {%- endif %}
 
-unsafe fn {{ seq.self_type.write_fn_rs() }}(
+unsafe fn {{ seq.self_type.write_fn_rs() }}<C>(
     buf_ptr: *mut ::std::primitive::u8,
-    value: {{ type_name }},
-) -> uniffi::Result<()> {
-    let (ptr, capacity) = {{ lower_into_parts }}(value)?;
-    uniffi::ffibuffer::write_buffer(buf_ptr, ptr, capacity)?;
-    uniffi::Result::Ok(())
+    value: C,
+) -> uniffi::Result<()>
+where
+    C: ::std::iter::IntoIterator<Item = {{ item_type }}>,
+    C::IntoIter: ::std::iter::ExactSizeIterator,
+{
+    unsafe {
+        let (ptr, capacity) = {{ lower_into_parts }}(value)?;
+        uniffi::ffibuffer::write_buffer(buf_ptr, ptr, capacity)?;
+        uniffi::Result::Ok(())
+    }
 }
 
-unsafe fn {{ seq.self_type.read_fn_rs() }}(
+unsafe fn {{ seq.self_type.read_fn_rs() }}<C>(
     ptr: *mut ::std::primitive::u8,
-) -> uniffi::Result<{{ type_name }}> {
-    let (ptr, capacity) = uniffi::ffibuffer::read_buffer(ptr)?;
-    {{ lift_from_parts }}(ptr, capacity)
+) -> uniffi::Result<C>
+where
+    C: ::std::iter::FromIterator<{{ item_type }}>,
+{
+    unsafe {
+        let (ptr, capacity) = uniffi::ffibuffer::read_buffer(ptr)?;
+        {{ lift_from_parts }}(ptr, capacity)
+    }
 }

--- a/uniffi-bindgen-kotlin-jni/src/scaffolding/templates/set.rs
+++ b/uniffi-bindgen-kotlin-jni/src/scaffolding/templates/set.rs
@@ -1,15 +1,28 @@
+{#-
+  These functions are generic over the container: hand-written FFI impls can expose
+  third-party containers (e.g. `indexmap::IndexSet`) with builtin container metadata,
+  so the Rust type at a use site isn't necessarily the std container.  Call sites
+  always have a concrete type for inference: a record field, a function argument, or
+  a function return value.
+-#}
 {%- let type_name = set.self_type.type_rs %}
+{%- let item_type = set.inner.type_rs %}
 {%- let lift_from_parts = "lift_from_parts_{}"|format(set.self_type.id) %}
 {%- let lower_into_parts = "lower_into_parts_{}"|format(set.self_type.id) %}
 
-unsafe fn {{ lower_into_parts }}(
-    value: {{ type_name }},
-) -> uniffi::Result<(*mut ::std::primitive::u8, ::std::primitive::usize)> {
+unsafe fn {{ lower_into_parts }}<C>(
+    value: C,
+) -> uniffi::Result<(*mut ::std::primitive::u8, ::std::primitive::usize)>
+where
+    C: ::std::iter::IntoIterator<Item = {{ item_type }}>,
+    C::IntoIter: ::std::iter::ExactSizeIterator,
+{
     unsafe {
-        let capacity = value.len() * {{ set.item_size }};
+        let items = value.into_iter();
+        let capacity = items.len() * {{ set.item_size }};
         let ptr = uniffi::ffibuffer::alloc(capacity)?;
         let mut pos = ptr;
-        for v in value {
+        for v in items {
             {{ set.inner.write_fn_rs() }}(pos, v)?;
             pos = pos.add({{ set.item_size }});
         }
@@ -17,55 +30,79 @@ unsafe fn {{ lower_into_parts }}(
     }
 }
 
-unsafe fn {{ lift_from_parts }}(
+unsafe fn {{ lift_from_parts }}<C>(
     ptr: *mut ::std::primitive::u8,
     capacity: ::std::primitive::usize,
-) -> uniffi::Result<{{ type_name }}> {
+) -> uniffi::Result<C>
+where
+    C: ::std::iter::FromIterator<{{ item_type }}>,
+{
     let mut do_lift = || {
-        unsafe {
-            let mut pos = ptr;
-            let length = capacity / {{ set.item_size }};
-            let mut set = {{ type_name }}::with_capacity(length);
-            for _ in 0..length {
-                set.insert({{ set.inner.read_fn_rs() }}(pos)?);
-                pos = pos.add({{ set.item_size }});
-            }
-            uniffi::Result::Ok(set)
-        }
+        let length = capacity / {{ set.item_size }};
+        let mut pos = ptr;
+        (0..length)
+            .map(|_| {
+                let item = unsafe { {{ set.inner.read_fn_rs() }}(pos) }?;
+                pos = unsafe { pos.add({{ set.item_size }}) };
+                uniffi::Result::Ok(item)
+            })
+            .collect::<uniffi::Result<C>>()
     };
     let result = do_lift();
-    uniffi::ffibuffer::free(ptr, capacity);
+    unsafe { uniffi::ffibuffer::free(ptr, capacity) };
     result
 }
 
-unsafe fn {{ set.self_type.lower_fn_rs() }}(
+unsafe fn {{ set.self_type.lower_fn_rs() }}<C>(
     uniffi_env: *mut uniffi_jni::JNIEnv,
-    value: {{ type_name }},
-) -> uniffi::Result<uniffi_jni::jobject> {
-    let (ptr, capacity) = {{ lower_into_parts }}(value)?;
-    uniffi_jni::lower_buffer(uniffi_env, ptr, capacity)
+    value: C,
+) -> uniffi::Result<uniffi_jni::jobject>
+where
+    C: ::std::iter::IntoIterator<Item = {{ item_type }}>,
+    C::IntoIter: ::std::iter::ExactSizeIterator,
+{
+    unsafe {
+        let (ptr, capacity) = {{ lower_into_parts }}(value)?;
+        uniffi_jni::lower_buffer(uniffi_env, ptr, capacity)
+    }
 }
 
-unsafe fn {{ set.self_type.lift_fn_rs() }}(
+unsafe fn {{ set.self_type.lift_fn_rs() }}<C>(
     uniffi_env: *mut uniffi_jni::JNIEnv,
     byte_buffer: uniffi_jni::jobject,
-) -> uniffi::Result<{{ type_name }}> {
-    let (ptr, capacity) = uniffi_jni::lift_buffer(uniffi_env, byte_buffer)?;
-    {{ lift_from_parts }}(ptr, capacity)
+) -> uniffi::Result<C>
+where
+    C: ::std::iter::FromIterator<{{ item_type }}>,
+{
+    unsafe {
+        let (ptr, capacity) = uniffi_jni::lift_buffer(uniffi_env, byte_buffer)?;
+        {{ lift_from_parts }}(ptr, capacity)
+    }
 }
 
-unsafe fn {{ set.self_type.write_fn_rs() }}(
+unsafe fn {{ set.self_type.write_fn_rs() }}<C>(
     buf_ptr: *mut ::std::primitive::u8,
-    value: {{ type_name }},
-) -> uniffi::Result<()> {
-    let (ptr, capacity) = {{ lower_into_parts }}(value)?;
-    uniffi::ffibuffer::write_buffer(buf_ptr, ptr, capacity)?;
-    uniffi::Result::Ok(())
+    value: C,
+) -> uniffi::Result<()>
+where
+    C: ::std::iter::IntoIterator<Item = {{ item_type }}>,
+    C::IntoIter: ::std::iter::ExactSizeIterator,
+{
+    unsafe {
+        let (ptr, capacity) = {{ lower_into_parts }}(value)?;
+        uniffi::ffibuffer::write_buffer(buf_ptr, ptr, capacity)?;
+        uniffi::Result::Ok(())
+    }
 }
 
-unsafe fn {{ set.self_type.read_fn_rs() }}(
+unsafe fn {{ set.self_type.read_fn_rs() }}<C>(
     ptr: *mut ::std::primitive::u8,
-) -> uniffi::Result<{{ type_name }}> {
-    let (ptr, capacity) = uniffi::ffibuffer::read_buffer(ptr)?;
-    {{ lift_from_parts }}(ptr, capacity)
+) -> uniffi::Result<C>
+where
+    C: ::std::iter::FromIterator<{{ item_type }}>,
+{
+    unsafe {
+        let (ptr, capacity) = uniffi::ffibuffer::read_buffer(ptr)?;
+        {{ lift_from_parts }}(ptr, capacity)
+    }
 }

--- a/uniffi_bindgen/src/pipeline/general/sort.rs
+++ b/uniffi_bindgen/src/pipeline/general/sort.rs
@@ -31,16 +31,20 @@ pub fn sort_ffi_definitions(
 // first.
 struct DependencySorter<L: DependencyLogic> {
     logic: L,
-    unsorted: IndexMap<String, L::Item>,
+    // Multiple items can share a name: when sorting definitions across namespaces, a type
+    // used outside its defining namespace has both its real definition and an
+    // `External` marker under the same canonical name.  Keep all of them — a map keyed by
+    // name alone would silently drop definitions.
+    unsorted: IndexMap<String, Vec<L::Item>>,
     sorted: Vec<L::Item>,
 }
 
 impl<L: DependencyLogic> DependencySorter<L> {
     fn new(items: impl IntoIterator<Item = L::Item>, logic: L) -> Self {
-        let unsorted: IndexMap<_, _> = items
-            .into_iter()
-            .map(|i| (logic.item_name(&i), i))
-            .collect();
+        let mut unsorted: IndexMap<String, Vec<L::Item>> = IndexMap::new();
+        for i in items {
+            unsorted.entry(logic.item_name(&i)).or_default().push(i);
+        }
         Self {
             unsorted,
             sorted: vec![],
@@ -56,16 +60,20 @@ impl<L: DependencyLogic> DependencySorter<L> {
     }
 
     fn recurse(&mut self, current_name: String) {
-        let Some(current_item) = self.unsorted.shift_remove(&current_name) else {
+        let Some(current_items) = self.unsorted.shift_remove(&current_name) else {
             // If `current_name` is not in unsorted, then we've already processed the item
             return;
         };
         // Add all dependents first
-        for name in self.logic.dependency_names(&current_item) {
+        let dependency_names: Vec<String> = current_items
+            .iter()
+            .flat_map(|item| self.logic.dependency_names(item))
+            .collect();
+        for name in dependency_names {
             self.recurse(name);
         }
-        // Then add the current item
-        self.sorted.push(current_item);
+        // Then add the current items
+        self.sorted.extend(current_items);
     }
 }
 
@@ -216,5 +224,120 @@ impl DependencyLogic for TypeDefinitionDependencyLogic {
             }
             TypeDefinition::External(_) => vec![],
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test item: a name, a marker to tell same-named items apart, and dependency names
+    struct TestItem {
+        name: &'static str,
+        marker: &'static str,
+        deps: Vec<&'static str>,
+    }
+
+    struct TestLogic;
+
+    impl DependencyLogic for TestLogic {
+        type Item = TestItem;
+
+        fn item_name(&self, item: &TestItem) -> String {
+            item.name.to_string()
+        }
+
+        fn dependency_names(&self, item: &TestItem) -> Vec<String> {
+            item.deps.iter().map(|s| s.to_string()).collect()
+        }
+    }
+
+    fn sort(items: Vec<TestItem>) -> Vec<&'static str> {
+        DependencySorter::new(items, TestLogic)
+            .sort()
+            .into_iter()
+            .map(|i| i.marker)
+            .collect()
+    }
+
+    #[test]
+    fn test_dependencies_sort_before_dependents() {
+        let order = sort(vec![
+            TestItem {
+                name: "TypeRecord",
+                marker: "record",
+                deps: vec!["TypeInner", "String"],
+            },
+            TestItem {
+                name: "String",
+                marker: "string",
+                deps: vec![],
+            },
+            TestItem {
+                name: "TypeInner",
+                marker: "inner",
+                deps: vec!["String"],
+            },
+        ]);
+        assert_eq!(order, vec!["string", "inner", "record"]);
+    }
+
+    #[test]
+    fn test_same_named_items_are_all_kept() {
+        // Multiple definitions can share a name: a type used outside its defining
+        // namespace has both its real definition and an `External` marker under the
+        // same canonical name (e.g. `TypeDefinition::Custom` in the defining namespace
+        // and `TypeDefinition::External` in the using one).  The sorter must keep all
+        // of them — dropping the real definition breaks consumers that need it, like
+        // the FFI type oracles.
+        let order = sort(vec![
+            TestItem {
+                name: "TypeRecord",
+                marker: "record",
+                deps: vec!["TypeCounter"],
+            },
+            TestItem {
+                name: "TypeCounter",
+                marker: "external",
+                deps: vec![],
+            },
+            TestItem {
+                name: "TypeCounter",
+                marker: "custom",
+                deps: vec!["String"],
+            },
+            TestItem {
+                name: "String",
+                marker: "string",
+                deps: vec![],
+            },
+        ]);
+
+        // All four definitions survive
+        assert_eq!(order.len(), 4);
+        let pos = |marker| order.iter().position(|m| *m == marker).unwrap();
+        // Both same-named definitions are present ...
+        assert!(order.contains(&"external"));
+        assert!(order.contains(&"custom"));
+        // ... and dependencies still come before dependents
+        assert!(pos("string") < pos("custom"));
+        assert!(pos("custom") < pos("record"));
+    }
+
+    #[test]
+    fn test_dependency_cycles_terminate() {
+        let order = sort(vec![
+            TestItem {
+                name: "TypeA",
+                marker: "a",
+                deps: vec!["TypeB"],
+            },
+            TestItem {
+                name: "TypeB",
+                marker: "b",
+                deps: vec!["TypeA"],
+            },
+        ]);
+        assert_eq!(order.len(), 2);
     }
 }

--- a/uniffi_core/src/ffi/ffibuffer.rs
+++ b/uniffi_core/src/ffi/ffibuffer.rs
@@ -190,6 +190,65 @@ pub unsafe fn write_string(ptr: *mut u8, mut value: String) -> Result<()> {
     }
 }
 
+/// Read a byte vector value
+///
+/// Like strings, byte vectors are deconstructed into their raw parts (data, length, and
+/// capacity), the raw parts are casted to `u64` values, then written to the buffer,
+/// so the total size is 24 bytes and the alignment is 8.
+///
+/// # Safety
+///
+/// * There must be at least 24 bytes of capacity remaining in the pointer.
+/// * The position must be aligned to 8 bytes
+/// * The other side of the FFI must have written a byte vector to the current address
+pub unsafe fn read_vec_u8(ptr: *mut u8) -> Result<Vec<u8>> {
+    // Safety:
+    //
+    // * ptr is properly aligned and has enough space left
+    // * We assume the foreign side wrote the correct value to the buffer
+    Ok(unsafe {
+        let ptr = ptr.cast::<u64>();
+        let data: u64 = ptr.read();
+        let length: u64 = ptr.add(1).read();
+        let capacity: u64 = ptr.add(2).read();
+        trace!("ffibuffer::read_vec_u8 ({ptr:?} -> {data:x}, {length}, {capacity})");
+        Vec::from_raw_parts(
+            ptr::with_exposed_provenance_mut(data as usize),
+            length as usize,
+            capacity as usize,
+        )
+    })
+}
+
+/// Write a byte vector value
+///
+/// Like strings, byte vectors are deconstructed into their raw parts (data, length, and
+/// capacity), the raw parts are casted to `u64` values, then written to the buffer,
+/// so the total size is 24 bytes and the alignment is 8.
+///
+/// # Safety
+///
+/// * There must be at least 24 bytes of capacity remaining in the pointer.
+/// * The position must be aligned to 8 bytes
+pub unsafe fn write_vec_u8(ptr: *mut u8, mut value: Vec<u8>) -> Result<()> {
+    // Safety:
+    //
+    // * ptr is properly aligned and has enough space left
+    unsafe {
+        let data = value.as_mut_ptr().expose_provenance() as u64;
+        let length = value.len() as u64;
+        let capacity = value.capacity() as u64;
+        trace!("ffibuffer::write_vec_u8  ({ptr:?} -> {data:x}, {length}, {capacity})");
+        // Leak the vec, then write the components to the buffer.
+        mem::forget(value);
+        let ptr = ptr.cast::<u64>();
+        ptr.write(data);
+        ptr.add(1).write(length);
+        ptr.add(2).write(capacity);
+        Ok(())
+    }
+}
+
 /// Read a nested FFI buffer
 ///
 /// Like strings, these are deconstructed into their raw parts, casted to `u64` values,

--- a/uniffi_parse_rs/src/ir.rs
+++ b/uniffi_parse_rs/src/ir.rs
@@ -182,7 +182,7 @@ impl Ir {
 
         // Resolve the items
         let mut resolved_map = HashMap::new();
-        // `LookupCache::empty()`, not `new()`: the custom type registry can only be
+        // `LookupCache::empty()`, not `new()`: the type mapping registry can only be
         // built once the items it maps are resolved, which is what's happening here.
         let mut cache = LookupCache::empty();
         for crate_root in self.crate_roots.values() {

--- a/uniffi_parse_rs/src/ir.rs
+++ b/uniffi_parse_rs/src/ir.rs
@@ -151,7 +151,7 @@ impl Ir {
     }
 
     pub fn into_metadata_group_map(self) -> Result<MetadataGroupMap> {
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&self);
         self.crate_roots_and_paths()
             .map(|(mut module_path, module)| {
                 let mut group = MetadataGroup {
@@ -182,7 +182,9 @@ impl Ir {
 
         // Resolve the items
         let mut resolved_map = HashMap::new();
-        let mut cache = LookupCache::default();
+        // `LookupCache::empty()`, not `new()`: the custom type registry can only be
+        // built once the items it maps are resolved, which is what's happening here.
+        let mut cache = LookupCache::empty();
         for crate_root in self.crate_roots.values() {
             crate_root.try_visit_modules_and_paths(|module, rpath| {
                 let Some(unresolved) = unresolved_map.remove(&module.id) else {

--- a/uniffi_parse_rs/src/paths.rs
+++ b/uniffi_parse_rs/src/paths.rs
@@ -256,12 +256,12 @@ impl<'ir> RPath<'ir> {
                     Ok(RPath::new(item))
                 }
                 None => {
-                    // The path points into an unparsed crate.  A `custom_type!` may still
-                    // cover it, if its underlying type aliases the same path.
+                    // The path points into an unparsed crate.  A `custom_type!` may still cover it,
+                    // if its underlying type aliases the same path.
                     if namespace == Namespace::Type {
-                        if let Some(custom_type_path) = cache.external_custom_type(path) {
-                            trace!("  resolved to custom type: {custom_type_path}");
-                            return Ok(custom_type_path);
+                        if let Some(mapped) = cache.external_type_mapping(path) {
+                            trace!("  resolved to type mapping: {mapped}");
+                            return Ok(mapped);
                         }
                     }
                     trace!("  not found");
@@ -695,25 +695,20 @@ pub struct LookupCache<'ir> {
     // Cached results for `RPath::public_path_to_item()`
     // This maps path strings to lookup results
     pub public_paths: HashMap<String, Result<ItemNames>>,
-    // Custom types indexed by the type they cover.  Empty by default; built from the
-    // IR by [LookupCache::new].
-    custom_types: CustomTypeRegistry<'ir>,
+    // Type mappings indexed by the type they cover
+    type_mappings: TypeMappingRegistry<'ir>,
 }
 
 impl<'ir> LookupCache<'ir> {
     /// Create a lookup cache for a fully-resolved IR
-    ///
-    /// [LookupCache::default] leaves the custom type registry empty.  That's the right
-    /// choice while the IR is still being resolved (the `custom_type!` items don't exist
-    /// yet); anything resolving types afterwards should use this constructor.
     pub fn new(ir: &'ir Ir) -> Self {
         Self {
-            custom_types: CustomTypeRegistry::new(ir),
+            type_mappings: TypeMappingRegistry::new(ir),
             ..Self::empty()
         }
     }
 
-    /// A cache with an empty custom type registry: lookups resolve as if no custom types
+    /// A cache with an empty type mapping registry: lookups resolve as if no mappings
     /// were registered
     ///
     /// This is correct in exactly two places — while the IR is still being resolved (the
@@ -724,50 +719,55 @@ impl<'ir> LookupCache<'ir> {
             children: HashMap::new(),
             children_resolving: HashSet::new(),
             public_paths: HashMap::new(),
-            custom_types: CustomTypeRegistry::default(),
+            type_mappings: TypeMappingRegistry::default(),
         }
     }
 
-    /// Look up the custom type registered for the item at `item_path`
+    /// Look up the type mapping registered for the item at `item_path`
     ///
     /// `uniffi::custom_type!` is type-keyed in the macro flow: the generated FFI impls apply
     /// wherever the type is named, no matter where the macro was invoked.  When parsing sources
     /// we resolve names lexically, so a path can reach the underlying type (a type alias or a
     /// non-UniFFI type) without ever passing through the module that invoked `custom_type!`.
-    /// This maps such items back to their custom type.
-    pub fn registered_custom_type(&self, item_path: &RPath<'ir>) -> Option<RPath<'ir>> {
+    /// This maps such items back to their custom type — or, for hand-written `TypeId` impls,
+    /// to the builtin container the impl's `TYPE_ID_META` declares.
+    pub fn registered_type_mapping(&self, item_path: &RPath<'ir>) -> Option<RPath<'ir>> {
         // Don't map custom types to themselves
         if matches!(item_path.item(), Ok(Item::CustomType(_))) {
             return None;
         }
-        self.custom_types
+        self.type_mappings
             .by_item
             .get(&item_path.path_string())
             .cloned()
     }
 
-    /// Look up the custom type registered for a path into an unparsed crate
+    /// Look up the type mapping registered for a path into an unparsed crate
     ///
-    /// This handles custom types whose underlying type comes from a non-UniFFI crate,
+    /// This handles custom types (and hand-written `TypeId` impls) whose underlying type
+    /// comes from a non-UniFFI crate,
     /// e.g. `type Decimal = rust_decimal::Decimal;` + `uniffi::custom_type!(Decimal, String)`.
     /// Other modules can name the type as `use rust_decimal::Decimal`, which never resolves
     /// to an item since `rust_decimal` isn't parsed.
-    pub fn external_custom_type(&self, path: &Path) -> Option<RPath<'ir>> {
+    pub fn external_type_mapping(&self, path: &Path) -> Option<RPath<'ir>> {
         let key = external_path_key(path)?;
-        self.custom_types.by_external_path.get(&key).cloned()
+        self.type_mappings.by_external_path.get(&key).cloned()
     }
 }
 
-/// Custom types indexed by the Rust type they cover
+/// Type mappings indexed by the Rust type they cover
+///
+/// A mapping's value is the item to resolve the covered type to: the `custom_type!`
+/// item, or the builtin container declared by a hand-written `TypeId` impl.
 #[derive(Default)]
-struct CustomTypeRegistry<'ir> {
-    /// Canonical item path (`RPath::path_string`) of the underlying item -> custom type item
+struct TypeMappingRegistry<'ir> {
+    /// Canonical item path (`RPath::path_string`) of the underlying item -> mapped item
     by_item: HashMap<String, RPath<'ir>>,
-    /// Normalized textual path into an unparsed crate -> custom type item
+    /// Normalized textual path into an unparsed crate -> mapped item
     by_external_path: HashMap<String, RPath<'ir>>,
 }
 
-impl<'ir> CustomTypeRegistry<'ir> {
+impl<'ir> TypeMappingRegistry<'ir> {
     fn new(ir: &'ir Ir) -> Self {
         // Building the registry resolves paths itself.  Use a scratch cache — its
         // registry is empty, so those resolutions see "nothing registered" — and discard
@@ -789,6 +789,9 @@ impl<'ir> CustomTypeRegistry<'ir> {
                             item,
                             custom_type,
                         ),
+                        Item::UnresolvedImpl(imp) => {
+                            registry.register_type_id_impl(ir, cache, &module_path, module, imp)
+                        }
                         _ => (),
                     }
                 }
@@ -869,6 +872,112 @@ impl<'ir> CustomTypeRegistry<'ir> {
             }
         }
     }
+
+    /// Register a hand-written `TypeId` impl for a generic container type
+    ///
+    /// Generic types can't be covered by `custom_type!`.  Instead, crates expose generic
+    /// containers from non-UniFFI crates by hand-writing the FFI trait impls, and the
+    /// `TYPE_ID_META` const in the `TypeId` impl declares the wire shape:
+    ///
+    /// ```ignore
+    /// impl<T> TypeId<UniFfiTag> for IndexSet<T> {
+    ///     const TYPE_ID_META: MetadataBuffer =
+    ///         MetadataBuffer::from_code(metadata::codes::TYPE_HASH_SET).concat(T::TYPE_ID_META);
+    /// }
+    /// ```
+    ///
+    /// Parse that declaration and register the target type to resolve like the equivalent
+    /// builtin container (`HashSet<T>` here).
+    fn register_type_id_impl(
+        &mut self,
+        ir: &'ir Ir,
+        cache: &mut LookupCache<'ir>,
+        module_path: &RPath<'ir>,
+        module: &'ir Module,
+        imp: &syn::ItemImpl,
+    ) {
+        // `impl<..> TypeId<..> for ..`
+        let Some((None, trait_path, _)) = &imp.trait_ else {
+            return;
+        };
+        let Some(trait_seg) = trait_path.segments.last() else {
+            return;
+        };
+        if trait_seg.ident != "TypeId" {
+            return;
+        }
+        // `const TYPE_ID_META: MetadataBuffer = ..;`
+        let Some(expr) = imp.items.iter().find_map(|item| match item {
+            syn::ImplItem::Const(c) if c.ident == "TYPE_ID_META" => Some(&c.expr),
+            _ => None,
+        }) else {
+            return;
+        };
+        let Some((code, params)) = parse_type_id_meta_expr(expr) else {
+            return;
+        };
+        let builtin: &'static Item = match (code.as_str(), params.len()) {
+            ("TYPE_VEC", 1) => &Item::Builtin(BuiltinItem::Vec),
+            ("TYPE_OPTION", 1) => &Item::Builtin(BuiltinItem::Option),
+            ("TYPE_HASH_SET", 1) => &Item::Builtin(BuiltinItem::HashSet),
+            ("TYPE_HASH_MAP", 2) => &Item::Builtin(BuiltinItem::HashMap),
+            _ => return,
+        };
+        // The target type's generic arguments must be exactly the params concatenated into
+        // `TYPE_ID_META`, in the same order — the builtin resolves its generics positionally.
+        let syn::Type::Path(self_ty) = imp.self_ty.as_ref() else {
+            return;
+        };
+        let Some(self_seg) = self_ty.path.segments.last() else {
+            return;
+        };
+        let syn::PathArguments::AngleBracketed(args) = &self_seg.arguments else {
+            return;
+        };
+        let arg_idents: Vec<&Ident> = args
+            .args
+            .iter()
+            .filter_map(|arg| match arg {
+                syn::GenericArgument::Type(syn::Type::Path(p)) => p.path.get_ident(),
+                _ => None,
+            })
+            .collect();
+        if arg_idents.len() != args.args.len()
+            || arg_idents.len() != params.len()
+            || arg_idents.iter().zip(&params).any(|(a, b)| **a != *b)
+        {
+            return;
+        }
+        // Register the target's base path, without the generic arguments
+        let mut base_path = self_ty.path.clone();
+        if let Some(seg) = base_path.segments.last_mut() {
+            seg.arguments = syn::PathArguments::None;
+        }
+        let underlying = if let Some(ident) = base_path.get_ident() {
+            module_path.underlying_item(ir, cache, module, &ident.unraw())
+        } else {
+            match module_path.resolve_type_or_non_uniffi(ir, cache, &base_path) {
+                Ok(path) => Some(Underlying::Item(path)),
+                Err(e) if e.is_not_found() => Some(Underlying::External(base_path)),
+                Err(_) => None,
+            }
+        };
+        match underlying {
+            Some(Underlying::Item(path)) => {
+                self.by_item
+                    .entry(path.path_string())
+                    .or_insert_with(|| RPath::new(builtin));
+            }
+            Some(Underlying::External(path)) => {
+                if let Some(key) = external_path_key(&path) {
+                    self.by_external_path
+                        .entry(key)
+                        .or_insert_with(|| RPath::new(builtin));
+                }
+            }
+            None => (),
+        }
+    }
 }
 
 enum Underlying<'ir> {
@@ -878,7 +987,7 @@ enum Underlying<'ir> {
     External(Path),
 }
 
-/// Resolution helpers for building the custom type registry
+/// Resolution helpers for building the type mapping registry
 impl<'ir> RPath<'ir> {
     /// Find the non-special item a custom type's ident names in this module
     fn underlying_item(
@@ -934,9 +1043,65 @@ impl<'ir> RPath<'ir> {
     }
 }
 
+/// Parse a `TYPE_ID_META` expression of the form
+/// `MetadataBuffer::from_code(metadata::codes::TYPE_X).concat(T::TYPE_ID_META)..`
+///
+/// Returns the metadata code name and the generic params concatenated after it,
+/// in concatenation order.
+fn parse_type_id_meta_expr(mut expr: &syn::Expr) -> Option<(String, Vec<Ident>)> {
+    let mut params = vec![];
+    loop {
+        match expr {
+            // `<receiver>.concat(P::TYPE_ID_META)`
+            syn::Expr::MethodCall(call) if call.method == "concat" && call.args.len() == 1 => {
+                let syn::Expr::Path(arg) = &call.args[0] else {
+                    return None;
+                };
+                let mut segments = arg.path.segments.iter();
+                let (Some(param), Some(meta), None) =
+                    (segments.next(), segments.next(), segments.next())
+                else {
+                    return None;
+                };
+                if meta.ident != "TYPE_ID_META" {
+                    return None;
+                }
+                params.push(param.ident.clone());
+                expr = &call.receiver;
+            }
+            // `MetadataBuffer::from_code(metadata::codes::TYPE_X)`
+            syn::Expr::Call(call) if call.args.len() == 1 => {
+                let syn::Expr::Path(func) = call.func.as_ref() else {
+                    return None;
+                };
+                if func.path.segments.last()?.ident != "from_code" {
+                    return None;
+                }
+                let syn::Expr::Path(code) = &call.args[0] else {
+                    return None;
+                };
+                let code = code.path.segments.last()?.ident.to_string();
+                // Params were collected outermost-in; concatenation order is base-out
+                params.reverse();
+                return Some((code, params));
+            }
+            _ => return None,
+        }
+    }
+}
+
 /// Normalized key for a path that should point into an unparsed crate
+///
+/// The key is built from the segment idents only.  Generic arguments are allowed on the
+/// last segment (e.g. a field spelled `indexmap::IndexSet<Counter>`) — they're resolved
+/// separately, according to the item the path maps to.
 fn external_path_key(path: &Path) -> Option<String> {
-    if path.segments.len() < 2 || path.segments.iter().any(|seg| !seg.arguments.is_none()) {
+    if path.segments.len() < 2 {
+        return None;
+    }
+    let segments = path.segments.iter().collect::<Vec<_>>();
+    let (_, non_last_segments) = segments.split_last()?;
+    if non_last_segments.iter().any(|seg| !seg.arguments.is_none()) {
         return None;
     }
     Some(

--- a/uniffi_parse_rs/src/paths.rs
+++ b/uniffi_parse_rs/src/paths.rs
@@ -13,8 +13,8 @@ use proc_macro2::Span;
 use syn::{ext::IdentExt, spanned::Spanned, Ident, Path};
 
 use crate::{
-    files::FileId, BuiltinItem, Error, ErrorKind::*, Ir, Item, ItemNames, Module, Result, UseGlob,
-    UseItem,
+    files::FileId, BuiltinItem, CustomType, Error, ErrorKind::*, Ir, Item, ItemNames, Module,
+    Result, UseGlob, UseItem,
 };
 
 // For tests only, print tracing info.
@@ -256,6 +256,14 @@ impl<'ir> RPath<'ir> {
                     Ok(RPath::new(item))
                 }
                 None => {
+                    // The path points into an unparsed crate.  A `custom_type!` may still
+                    // cover it, if its underlying type aliases the same path.
+                    if namespace == Namespace::Type {
+                        if let Some(custom_type_path) = cache.external_custom_type(path) {
+                            trace!("  resolved to custom type: {custom_type_path}");
+                            return Ok(custom_type_path);
+                        }
+                    }
                     trace!("  not found");
                     Err(Error::new(self.file_id(), path.span(), NotFound))
                 }
@@ -660,7 +668,6 @@ impl fmt::Display for RPath<'_> {
 }
 
 /// Cache for path lookups
-#[derive(Default)]
 pub struct LookupCache<'ir> {
     // Cached results for `RPath::child`
     // This maps module id / ident / namespaces to lookup results
@@ -670,6 +677,257 @@ pub struct LookupCache<'ir> {
     // Cached results for `RPath::public_path_to_item()`
     // This maps path strings to lookup results
     pub public_paths: HashMap<String, Result<ItemNames>>,
+    // Custom types indexed by the type they cover.  Empty by default; built from the
+    // IR by [LookupCache::new].
+    custom_types: CustomTypeRegistry<'ir>,
+}
+
+impl<'ir> LookupCache<'ir> {
+    /// Create a lookup cache for a fully-resolved IR
+    ///
+    /// [LookupCache::default] leaves the custom type registry empty.  That's the right
+    /// choice while the IR is still being resolved (the `custom_type!` items don't exist
+    /// yet); anything resolving types afterwards should use this constructor.
+    pub fn new(ir: &'ir Ir) -> Self {
+        Self {
+            custom_types: CustomTypeRegistry::new(ir),
+            ..Self::empty()
+        }
+    }
+
+    /// A cache with an empty custom type registry: lookups resolve as if no custom types
+    /// were registered
+    ///
+    /// This is correct in exactly two places — while the IR is still being resolved (the
+    /// items the registry maps don't exist yet), and for the registry build itself.
+    /// Everything else should use [LookupCache::new].
+    pub(crate) fn empty() -> Self {
+        Self {
+            children: HashMap::new(),
+            children_resolving: HashSet::new(),
+            public_paths: HashMap::new(),
+            custom_types: CustomTypeRegistry::default(),
+        }
+    }
+
+    /// Look up the custom type registered for the item at `item_path`
+    ///
+    /// `uniffi::custom_type!` is type-keyed in the macro flow: the generated FFI impls apply
+    /// wherever the type is named, no matter where the macro was invoked.  When parsing sources
+    /// we resolve names lexically, so a path can reach the underlying type (a type alias or a
+    /// non-UniFFI type) without ever passing through the module that invoked `custom_type!`.
+    /// This maps such items back to their custom type.
+    pub fn registered_custom_type(&self, item_path: &RPath<'ir>) -> Option<RPath<'ir>> {
+        // Don't map custom types to themselves
+        if matches!(item_path.item(), Ok(Item::CustomType(_))) {
+            return None;
+        }
+        self.custom_types
+            .by_item
+            .get(&item_path.path_string())
+            .cloned()
+    }
+
+    /// Look up the custom type registered for a path into an unparsed crate
+    ///
+    /// This handles custom types whose underlying type comes from a non-UniFFI crate,
+    /// e.g. `type Decimal = rust_decimal::Decimal;` + `uniffi::custom_type!(Decimal, String)`.
+    /// Other modules can name the type as `use rust_decimal::Decimal`, which never resolves
+    /// to an item since `rust_decimal` isn't parsed.
+    pub fn external_custom_type(&self, path: &Path) -> Option<RPath<'ir>> {
+        let key = external_path_key(path)?;
+        self.custom_types.by_external_path.get(&key).cloned()
+    }
+}
+
+/// Custom types indexed by the Rust type they cover
+#[derive(Default)]
+struct CustomTypeRegistry<'ir> {
+    /// Canonical item path (`RPath::path_string`) of the underlying item -> custom type item
+    by_item: HashMap<String, RPath<'ir>>,
+    /// Normalized textual path into an unparsed crate -> custom type item
+    by_external_path: HashMap<String, RPath<'ir>>,
+}
+
+impl<'ir> CustomTypeRegistry<'ir> {
+    fn new(ir: &'ir Ir) -> Self {
+        // Building the registry resolves paths itself.  Use a scratch cache — its
+        // registry is empty, so those resolutions see "nothing registered" — and discard
+        // it afterwards, so nothing memoized under that assumption survives into the
+        // caller's cache.
+        let cache = &mut LookupCache::empty();
+        let mut registry = Self::default();
+        for (root_path, root_module) in ir.crate_roots_and_paths() {
+            let mut stack = vec![(root_path, root_module)];
+            while let Some((module_path, module)) = stack.pop() {
+                for item in module.items.iter() {
+                    match item {
+                        Item::Module(m) => stack.push((module_path.append_child(item), m)),
+                        Item::CustomType(custom_type) => registry.register_custom_type(
+                            ir,
+                            cache,
+                            &module_path,
+                            module,
+                            item,
+                            custom_type,
+                        ),
+                        _ => (),
+                    }
+                }
+            }
+        }
+        registry
+    }
+
+    fn register_custom_type(
+        &mut self,
+        ir: &'ir Ir,
+        cache: &mut LookupCache<'ir>,
+        module_path: &RPath<'ir>,
+        module: &'ir Module,
+        custom_type_item: &'ir Item,
+        custom_type: &CustomType,
+    ) {
+        let custom_type_path = module_path.append_child(custom_type_item);
+        // Find the Rust item the custom type ident names, ignoring special items
+        // (the custom type itself shadows the name in its own module).
+        let mut underlying =
+            match module_path.underlying_item(ir, cache, module, &custom_type.ident.unraw()) {
+                Some(Underlying::Item(path)) => path,
+                Some(Underlying::External(path)) => {
+                    if let Some(key) = external_path_key(&path) {
+                        self.by_external_path.entry(key).or_insert(custom_type_path);
+                    }
+                    return;
+                }
+                // The custom type ident doesn't name anything else, so there's nothing to map
+                // (name resolution finds the custom type directly in this case).
+                None => return,
+            };
+
+        // Register the underlying item, following type alias chains so that references to
+        // any point of the chain resolve to the custom type.
+        let mut seen = HashSet::new();
+        loop {
+            let alias_target = match underlying.item() {
+                // A generic alias can't correspond to a (non-generic) custom type
+                Ok(Item::Type(alias)) if alias.generics.params.is_empty() => Some(&alias.ty),
+                Ok(Item::NonUniffi(..)) => None,
+                _ => return,
+            };
+            let key = underlying.path_string();
+            if !seen.insert(key.clone()) {
+                return; // alias cycle
+            }
+            self.by_item
+                .entry(key)
+                .or_insert_with(|| custom_type_path.clone());
+
+            // Follow the alias target if it's a plain, non-generic path
+            let Some(syn::Type::Path(target)) = alias_target.map(Box::as_ref) else {
+                return;
+            };
+            if target.qself.is_some()
+                || target
+                    .path
+                    .segments
+                    .iter()
+                    .any(|seg| !seg.arguments.is_none())
+            {
+                return;
+            }
+            let Ok(parent) = underlying.parent() else {
+                return;
+            };
+            match parent.resolve_type_or_non_uniffi(ir, cache, &target.path) {
+                Ok(next) => underlying = next,
+                Err(e) if e.is_not_found() => {
+                    if let Some(key) = external_path_key(&target.path) {
+                        self.by_external_path.entry(key).or_insert(custom_type_path);
+                    }
+                    return;
+                }
+                Err(_) => return,
+            }
+        }
+    }
+}
+
+enum Underlying<'ir> {
+    /// The custom type covers an item we parsed
+    Item(RPath<'ir>),
+    /// The custom type covers a path into an unparsed crate
+    External(Path),
+}
+
+/// Resolution helpers for building the custom type registry
+impl<'ir> RPath<'ir> {
+    /// Find the non-special item a custom type's ident names in this module
+    fn underlying_item(
+        &self,
+        ir: &'ir Ir,
+        cache: &mut LookupCache<'ir>,
+        module: &'ir Module,
+        ident: &Ident,
+    ) -> Option<Underlying<'ir>> {
+        let mut use_globs = vec![];
+        for item in module.items.iter() {
+            if item.is_special() {
+                continue;
+            }
+            match item {
+                Item::Type(_) | Item::NonUniffi(..) if item.ident().as_ref() == Some(ident) => {
+                    return Some(Underlying::Item(self.append_child(item)));
+                }
+                Item::UseItem(use_item) if use_item.ident == *ident => {
+                    return match self.resolve_type_or_non_uniffi(ir, cache, &use_item.path) {
+                        Ok(path) => Some(Underlying::Item(path)),
+                        Err(e) if e.is_not_found() => {
+                            Some(Underlying::External(use_item.path.clone()))
+                        }
+                        Err(_) => None,
+                    };
+                }
+                Item::UseGlob(use_glob) => use_globs.push(use_glob),
+                _ => (),
+            }
+        }
+        for namespace in [Namespace::Type, Namespace::NonUniffiType] {
+            if let Ok(Some(child)) =
+                self.child_glob_use(ir, cache, ident, use_globs.clone(), namespace)
+            {
+                return Some(Underlying::Item(child.path));
+            }
+        }
+        None
+    }
+
+    /// Resolve a path in the type namespace, falling back to non-UniFFI types
+    fn resolve_type_or_non_uniffi(
+        &self,
+        ir: &'ir Ir,
+        cache: &mut LookupCache<'ir>,
+        path: &Path,
+    ) -> Result<RPath<'ir>> {
+        match self.resolve(ir, cache, path, Namespace::Type) {
+            Err(e) if e.is_not_found() => self.resolve(ir, cache, path, Namespace::NonUniffiType),
+            result => result,
+        }
+    }
+}
+
+/// Normalized key for a path that should point into an unparsed crate
+fn external_path_key(path: &Path) -> Option<String> {
+    if path.segments.len() < 2 || path.segments.iter().any(|seg| !seg.arguments.is_none()) {
+        return None;
+    }
+    Some(
+        path.segments
+            .iter()
+            .map(|seg| seg.ident.unraw().to_string())
+            .collect::<Vec<_>>()
+            .join("::"),
+    )
 }
 
 fn get_builtin_item(path: &Path) -> Option<&'static Item> {
@@ -816,7 +1074,7 @@ pub mod tests {
     #[test]
     fn test_resolve_item() {
         let ir = Ir::new_for_test(&["paths"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "paths::mod1", "Mod1Record"),
@@ -835,7 +1093,7 @@ pub mod tests {
     #[test]
     fn test_resolve_item_with_super_keyword() {
         let ir = Ir::new_for_test(&["paths"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(
@@ -874,7 +1132,7 @@ pub mod tests {
     #[test]
     fn test_resolve_item_with_self_keyword() {
         let ir = Ir::new_for_test(&["paths"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "paths", "mod3::Mod3Record"),
@@ -920,7 +1178,7 @@ pub mod tests {
     #[test]
     fn test_resolve_item_with_crate_keyword() {
         let ir = Ir::new_for_test(&["paths"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(
@@ -945,7 +1203,7 @@ pub mod tests {
     #[test]
     fn test_resolve_item_with_rust_keyword() {
         let ir = Ir::new_for_test(&["paths"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "paths", "r#break"),
@@ -961,7 +1219,7 @@ pub mod tests {
     #[test]
     fn test_use_remote_type() {
         let ir = Ir::new_for_test(&["paths", "paths2", "paths3"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "paths", "RemoteRecord"),
@@ -977,7 +1235,7 @@ pub mod tests {
     #[test]
     fn test_resolve_item_with_implicate_crate_lookup() {
         let ir = Ir::new_for_test(&["paths", "paths2"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             // `paths2` doesn't exist in `mod3`, so this should lookup a top-level crate
@@ -1004,7 +1262,7 @@ pub mod tests {
     #[test]
     fn test_resolve_item_with_use() {
         let ir = Ir::new_for_test(&["paths", "paths2"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "paths2", "TestRecord"),
@@ -1036,7 +1294,7 @@ pub mod tests {
     #[test]
     fn test_name_conflicts() {
         let ir = Ir::new_for_test(&["name_conflicts"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "name_conflicts", "Record"),
@@ -1086,7 +1344,6 @@ pub mod tests {
     fn test_raw_ident() {
         // Test that we "unraw" idents before matching them by removing the `r#` prefix
         let mut ir = Ir::new_for_test(&["raw_idents"]);
-        let mut cache = LookupCache::default();
 
         ir.add_udl_metadata(
             "raw_idents",
@@ -1101,6 +1358,7 @@ pub mod tests {
             .into()],
         )
         .unwrap();
+        let mut cache = LookupCache::new(&ir);
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "raw_idents", "r#Record"),
             Ok("raw_idents::Record".to_string()),
@@ -1114,7 +1372,7 @@ pub mod tests {
     #[test]
     fn test_same_item_imported_different_ways() {
         let ir = Ir::new_for_test(&["paths"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "paths", "Mod2Record"),

--- a/uniffi_parse_rs/src/paths.rs
+++ b/uniffi_parse_rs/src/paths.rs
@@ -275,8 +275,15 @@ impl<'ir> RPath<'ir> {
         ident: &Ident,
         namespace: Namespace,
     ) -> Result<ChildItem<'ir>> {
-        // Special case `super` and `crate`, no need to check the cache for this one.
-        if ident == "super" {
+        // Special case `self`, `super` and `crate`, no need to check the cache for these.
+        if ident == "self" {
+            // `self` refers to the current module (e.g. `use self::submodule::Item`,
+            // where `self::` disambiguates a module from an external crate with the same name).
+            return Ok(ChildItem {
+                path: self.clone(),
+                vis: Visibility::Public,
+            });
+        } else if ident == "super" {
             return match self.parent() {
                 Ok(path) => Ok(ChildItem {
                     path,
@@ -872,6 +879,41 @@ pub mod tests {
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "paths", "mod3::Mod3Record"),
             Ok("paths::mod1::mod2::mod3::Mod3Record".to_string()),
+        );
+
+        // Leading `self::` refers to the current module
+        assert_eq!(
+            run_resolve_item(&ir, &mut cache, "paths::mod1", "self::Mod1Record"),
+            Ok("paths::mod1::Mod1Record".to_string()),
+        );
+        assert_eq!(
+            run_resolve_item(
+                &ir,
+                &mut cache,
+                "paths::mod1",
+                "self::mod2::mod3::Mod3Record"
+            ),
+            Ok("paths::mod1::mod2::mod3::Mod3Record".to_string()),
+        );
+        assert_eq!(
+            run_resolve_item(&ir, &mut cache, "paths::mod1", "self::missing::MyRecord"),
+            Err(ErrorKind::NotFound),
+        );
+
+        // Named import through `self::` (`use self::inner::SelfUseRecord as ...` in mod6)
+        assert_eq!(
+            run_resolve_item(&ir, &mut cache, "paths::mod6", "SelfUseRecordRenamed"),
+            Ok("paths::mod6::inner::SelfUseRecord".to_string()),
+        );
+        // Glob re-export through `self::` (`pub use self::inner::*;` in mod6)
+        assert_eq!(
+            run_resolve_item(&ir, &mut cache, "paths::mod6", "SelfGlobRecord"),
+            Ok("paths::mod6::inner::SelfGlobRecord".to_string()),
+        );
+        // ... and the re-exported item is visible from outside the module
+        assert_eq!(
+            run_resolve_item(&ir, &mut cache, "paths", "mod6::SelfGlobRecord"),
+            Ok("paths::mod6::inner::SelfGlobRecord".to_string()),
         );
     }
 

--- a/uniffi_parse_rs/src/paths.rs
+++ b/uniffi_parse_rs/src/paths.rs
@@ -409,10 +409,22 @@ impl<'ir> RPath<'ir> {
             }
         }
         match found {
-            Some((_, Item::UseRemoteType(path))) => Ok(Some(ChildItem {
-                path: self.resolve(ir, cache, path, namespace)?,
-                vis: Visibility::Public,
-            })),
+            Some((_, Item::UseRemoteType(path))) => {
+                match self.resolve(ir, cache, path, namespace) {
+                    Ok(path) => Ok(Some(ChildItem {
+                        path,
+                        vis: Visibility::Public,
+                    })),
+                    // `use_remote_type!(implementing_crate::Type)` doesn't require `Type`
+                    // to live at that path: the macro resolves `Type` in the invoking
+                    // module's scope and only uses `implementing_crate` for its
+                    // `UniFfiTag`.  Fall through to the module's regular items (e.g. a
+                    // `type Decimal = rust_decimal::Decimal;` alias next to the macro
+                    // invocation).
+                    Err(e) if e.is_not_found() => Ok(None),
+                    Err(e) => Err(e),
+                }
+            }
             Some((_, item)) => Ok(Some(ChildItem {
                 path: self.append_child(item),
                 vis: Visibility::Public,
@@ -453,6 +465,12 @@ impl<'ir> RPath<'ir> {
         }
         let mut found: Option<FoundItem<'ir>> = None;
         for item in module.items.iter() {
+            // Special items are handled by `child_special_item` before this runs.  Seeing
+            // them again here would report spurious name conflicts, e.g. between a
+            // `use_remote_type!` invocation and the type alias it covers.
+            if item.is_special() {
+                continue;
+            }
             if let Some(item_ident) = item.ident() {
                 if &item_ident == ident && namespace.matches(item) {
                     if let Some(found) = found {
@@ -1172,6 +1190,26 @@ pub mod tests {
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "paths", "mod6::SelfGlobRecord"),
             Ok("paths::mod6::inner::SelfGlobRecord".to_string()),
+        );
+    }
+
+    #[test]
+    fn test_use_remote_type_falls_through_to_local_items() {
+        let ir = Ir::new_for_test(&["paths", "paths2", "paths3"]);
+        let mut cache = LookupCache::new(&ir);
+
+        // `use_remote_type!(paths3::ExternalRemote)` names a path that doesn't resolve
+        // (`paths3` has no `ExternalRemote`).  Per the macro's semantics the type is
+        // resolved in the invoking module's scope, so resolution must fall through to
+        // the local alias instead of failing.
+        assert_eq!(
+            run_resolve_item(
+                &ir,
+                &mut cache,
+                "paths::remote_fallthrough",
+                "ExternalRemote"
+            ),
+            Ok("paths::remote_fallthrough::ExternalRemote".to_string()),
         );
     }
 

--- a/uniffi_parse_rs/src/public_paths.rs
+++ b/uniffi_parse_rs/src/public_paths.rs
@@ -228,7 +228,7 @@ mod test {
     use super::*;
 
     pub fn run_public_path_to_item(ir: &Ir, item_path: &str) -> ItemNames {
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(ir);
         let crate_path = path_for_module(ir, item_path.split("::").next().unwrap());
         let item = crate_path
             .resolve(

--- a/uniffi_parse_rs/src/test_src/custom_type_paths.rs
+++ b/uniffi_parse_rs/src/test_src/custom_type_paths.rs
@@ -1,0 +1,52 @@
+// Custom types resolved by the type they cover, not the module the macro was invoked in.
+//
+// The `custom_type!` invocations live in `registrations`; other modules name the
+// underlying types directly (through aliases, non-UniFFI structs, or paths into
+// unparsed crates) and must still resolve to the custom type.
+
+mod types {
+    // A non-UniFFI type covered by a custom type registered in another module
+    pub struct Concrete { }
+
+    // An alias to a type from an unparsed crate, covered by a custom type in another module
+    pub type ExternalAlias = external_crate::ExternalType;
+}
+
+mod registrations {
+    use crate::types::{Concrete, ExternalAlias};
+
+    uniffi::custom_type!(Concrete, String, {
+        remote,
+        into: |obj| obj.to_string(),
+        try_from: |s| s.parse(),
+    });
+
+    uniffi::custom_type!(ExternalAlias, String, {
+        remote,
+        into: |obj| obj.to_string(),
+        try_from: |s| s.parse(),
+    });
+
+    // A custom type over a local alias to an unparsed crate.  Other modules import the
+    // external type directly (`use external_crate2::Direct`) and never see this alias.
+    type Direct = external_crate2::Direct;
+
+    uniffi::custom_type!(Direct, String, {
+        remote,
+        into: |obj| obj.to_string(),
+        try_from: |s| s.parse(),
+    });
+}
+
+mod usage {
+    use external_crate2::Direct;
+
+    use crate::types::{Concrete, ExternalAlias};
+
+    #[derive(uniffi::Record)]
+    pub struct UsesCustomTypes {
+        pub concrete: Concrete,
+        pub aliased: ExternalAlias,
+        pub direct: Direct,
+    }
+}

--- a/uniffi_parse_rs/src/test_src/custom_type_paths2.rs
+++ b/uniffi_parse_rs/src/test_src/custom_type_paths2.rs
@@ -1,0 +1,17 @@
+// Mirrors a binding crate that reuses custom types implemented by `custom_type_paths`:
+// a local alias to the unparsed crate, plus `use_remote_type!` naming the implementing
+// crate.  The alias target must resolve to the custom type registered over in
+// `custom_type_paths`.
+
+type Direct = external_crate2::Direct;
+
+uniffi::use_remote_type!(custom_type_paths::Direct);
+
+mod usage2 {
+    use external_crate2::Direct;
+
+    #[derive(uniffi::Record)]
+    pub struct BindingRecord {
+        pub direct: Direct,
+    }
+}

--- a/uniffi_parse_rs/src/test_src/paths.rs
+++ b/uniffi_parse_rs/src/test_src/paths.rs
@@ -101,3 +101,13 @@ mod mod6 {
     // Named import through `self::`
     use self::inner::SelfUseRecord as SelfUseRecordRenamed;
 }
+
+// `use_remote_type!` whose path doesn't resolve: the macro's semantics are "the type
+// named by the LAST segment, in the invoking module's scope" — the first segment only
+// names the crate implementing the FFI traits.  Resolution must fall through to the
+// module's regular items instead of failing.
+mod remote_fallthrough {
+    pub type ExternalRemote = unparsed_crate::ExternalRemote;
+
+    uniffi::use_remote_type!(paths3::ExternalRemote);
+}

--- a/uniffi_parse_rs/src/test_src/paths.rs
+++ b/uniffi_parse_rs/src/test_src/paths.rs
@@ -83,3 +83,21 @@ mod mod5 {
     use super::*;
     use crate::mod1::mod2::*;
 }
+
+// `self::` paths: `self` refers to the current module.
+// The `self::` prefix is how real-world code disambiguates a module from an
+// external crate with the same name (e.g. a `http` module vs the `http` crate).
+mod mod6 {
+    mod inner {
+        #[derive(uniffi::Record)]
+        pub struct SelfGlobRecord { }
+
+        #[derive(uniffi::Record)]
+        pub struct SelfUseRecord { }
+    }
+
+    // Glob re-export through `self::`
+    pub use self::inner::*;
+    // Named import through `self::`
+    use self::inner::SelfUseRecord as SelfUseRecordRenamed;
+}

--- a/uniffi_parse_rs/src/test_src/type_id_impls.rs
+++ b/uniffi_parse_rs/src/test_src/type_id_impls.rs
@@ -1,0 +1,44 @@
+// Hand-written FFI trait impls for generic container types from non-UniFFI crates.
+//
+// `custom_type!` can't cover generic types.  Instead, the `TYPE_ID_META` const in a
+// hand-written `TypeId` impl declares the wire shape, and paths to the target type
+// resolve like the equivalent builtin container.
+
+mod ffi {
+    use fake_indexmap::{IndexMap, IndexSet, Reversed};
+
+    impl<T> uniffi::TypeId<crate::UniFfiTag> for IndexSet<T>
+    where
+        T: uniffi::TypeId<crate::UniFfiTag>,
+    {
+        const TYPE_ID_META: uniffi::MetadataBuffer =
+            uniffi::MetadataBuffer::from_code(uniffi::metadata::codes::TYPE_HASH_SET)
+                .concat(T::TYPE_ID_META);
+    }
+
+    impl<K, V> uniffi::TypeId<crate::UniFfiTag> for IndexMap<K, V> {
+        const TYPE_ID_META: uniffi::MetadataBuffer =
+            uniffi::MetadataBuffer::from_code(uniffi::metadata::codes::TYPE_HASH_MAP)
+                .concat(K::TYPE_ID_META)
+                .concat(V::TYPE_ID_META);
+    }
+
+    // The concatenation order doesn't match the type's parameter order, so the builtin's
+    // positional generics wouldn't line up: this impl must NOT be registered.
+    impl<K, V> uniffi::TypeId<crate::UniFfiTag> for Reversed<K, V> {
+        const TYPE_ID_META: uniffi::MetadataBuffer =
+            uniffi::MetadataBuffer::from_code(uniffi::metadata::codes::TYPE_HASH_MAP)
+                .concat(V::TYPE_ID_META)
+                .concat(K::TYPE_ID_META);
+    }
+}
+
+mod usage {
+    use fake_indexmap::{IndexMap, IndexSet};
+
+    #[derive(uniffi::Record)]
+    pub struct UsesContainers {
+        pub set: IndexSet<u32>,
+        pub map: IndexMap<String, u32>,
+    }
+}

--- a/uniffi_parse_rs/src/types.rs
+++ b/uniffi_parse_rs/src/types.rs
@@ -385,11 +385,12 @@ impl<'ir> RPath<'ir> {
                     Ok(path) => path,
                     Err(e) if e.is_not_found() => {
                         // The path doesn't name a UniFFI item, but it may name a non-UniFFI
-                        // type that a `uniffi::custom_type!` elsewhere covers.
+                        // type that a `uniffi::custom_type!` or a hand-written `TypeId` impl
+                        // elsewhere covers.
                         match self
                             .resolve(ir, cache, &ty_path.path, Namespace::NonUniffiType)
                             .ok()
-                            .and_then(|path| cache.registered_custom_type(&path))
+                            .and_then(|path| cache.registered_type_mapping(&path))
                         {
                             Some(custom_type_path) => custom_type_path,
                             None => return Err(e),
@@ -402,7 +403,7 @@ impl<'ir> RPath<'ir> {
                 // registered for the item this path resolves to (e.g. a type alias in another
                 // module), resolve to the custom type instead.
                 if matches!(path_to_type.item()?, Item::Type(_) | Item::NonUniffi(..)) {
-                    if let Some(custom_type_path) = cache.registered_custom_type(&path_to_type) {
+                    if let Some(custom_type_path) = cache.registered_type_mapping(&path_to_type) {
                         path_to_type = custom_type_path;
                     }
                 }
@@ -1093,6 +1094,51 @@ pub mod tests {
                 &mut cache,
                 "custom_type_paths",
                 "external_crate2::Other"
+            ),
+            Err(ErrorKind::NotFound),
+        );
+    }
+
+    #[test]
+    fn test_resolve_types_with_hand_written_type_id_impls() {
+        let ir = Ir::new_for_test(&["type_id_impls"]);
+        let mut cache = LookupCache::new(&ir);
+
+        // `IndexSet<T>` declares `TYPE_HASH_SET` in its hand-written `TypeId` impl
+        assert_eq!(
+            run_resolve_type(&ir, &mut cache, "type_id_impls::usage", "IndexSet<u32>"),
+            Ok(Type::HashSet(Box::new(Type::UInt32))),
+        );
+        // `IndexMap<K, V>` declares `TYPE_HASH_MAP`
+        assert_eq!(
+            run_resolve_type(
+                &ir,
+                &mut cache,
+                "type_id_impls::usage",
+                "IndexMap<String, u32>"
+            ),
+            Ok(Type::HashMap(
+                Box::new(Type::String),
+                Box::new(Type::UInt32)
+            )),
+        );
+        // The same types, named by full path
+        assert_eq!(
+            run_resolve_type(
+                &ir,
+                &mut cache,
+                "type_id_impls",
+                "fake_indexmap::IndexSet<u32>"
+            ),
+            Ok(Type::HashSet(Box::new(Type::UInt32))),
+        );
+        // `Reversed<K, V>` concatenates its params in the wrong order: not registered
+        assert_eq!(
+            run_resolve_type(
+                &ir,
+                &mut cache,
+                "type_id_impls",
+                "fake_indexmap::Reversed<String, u32>"
             ),
             Err(ErrorKind::NotFound),
         );

--- a/uniffi_parse_rs/src/types.rs
+++ b/uniffi_parse_rs/src/types.rs
@@ -516,11 +516,17 @@ impl<'ir> RPath<'ir> {
                 }
                 let trait_path = self.resolve(ir, cache, trait_bounds[0], Namespace::Type)?;
                 match trait_path.item()? {
-                    Item::Trait(tr) => Ok(Type::Trait {
-                        module_path: self.path_string(),
-                        name: tr.ident.unraw().to_string(),
-                        export_ty: tr.attrs.export_ty,
-                    }),
+                    Item::Trait(tr) => {
+                        // Use the trait's own public path, not the referencing module's —
+                        // the reference must match the metadata generated for the trait's
+                        // definition, which may live in another module or crate.
+                        let names = trait_path.public_path_to_item(ir, cache)?;
+                        Ok(Type::Trait {
+                            module_path: names.module_path,
+                            name: names.name,
+                            export_ty: tr.attrs.export_ty,
+                        })
+                    }
                     Item::Udl(uniffi_meta::Type::Object {
                         module_path,
                         name,
@@ -1127,6 +1133,16 @@ pub mod tests {
                 export_ty: TraitExportType::TraitInterface(TraitKind::RustOnly),
             })
         );
+        // Referenced from another module, the type must carry the trait's own module path,
+        // matching the metadata generated for the trait's definition
+        assert_eq!(
+            run_resolve_type(&ir, &mut cache, "types", "dyn mod1::TraitInterface"),
+            Ok(Type::Trait {
+                module_path: "types::mod1".into(),
+                name: "TraitInterface".into(),
+                export_ty: TraitExportType::TraitInterface(TraitKind::RustOnly),
+            })
+        );
         assert_eq!(
             run_resolve_type(
                 &ir,
@@ -1594,7 +1610,8 @@ pub mod tests {
                 None
             ),
             Ok(uniffi_meta::Type::Object {
-                module_path: "types".into(),
+                // The trait's own module path, not the referencing module's
+                module_path: "types::mod1".into(),
                 name: "TraitInterface".into(),
                 imp: ObjectImpl::Trait(TraitKind::RustOnly),
             }),
@@ -1650,7 +1667,8 @@ pub mod tests {
             run_resolve_arg(&ir, &mut cache, "types", "&dyn mod1::TraitInterface", None),
             Ok(ArgType {
                 ty: uniffi_meta::Type::Object {
-                    module_path: "types".into(),
+                    // The trait's own module path, not the referencing module's
+                    module_path: "types::mod1".into(),
                     name: "TraitInterface".into(),
                     imp: ObjectImpl::Trait(TraitKind::RustOnly),
                 },

--- a/uniffi_parse_rs/src/types.rs
+++ b/uniffi_parse_rs/src/types.rs
@@ -380,7 +380,32 @@ impl<'ir> RPath<'ir> {
                 if ty_path.path.is_ident("Self") {
                     return Ok(Type::SelfTy);
                 }
-                let path_to_type = self.resolve(ir, cache, &ty_path.path, Namespace::Type)?;
+                let mut path_to_type = match self.resolve(ir, cache, &ty_path.path, Namespace::Type)
+                {
+                    Ok(path) => path,
+                    Err(e) if e.is_not_found() => {
+                        // The path doesn't name a UniFFI item, but it may name a non-UniFFI
+                        // type that a `uniffi::custom_type!` elsewhere covers.
+                        match self
+                            .resolve(ir, cache, &ty_path.path, Namespace::NonUniffiType)
+                            .ok()
+                            .and_then(|path| cache.registered_custom_type(&path))
+                        {
+                            Some(custom_type_path) => custom_type_path,
+                            None => return Err(e),
+                        }
+                    }
+                    Err(e) => return Err(e),
+                };
+                // `custom_type!` is type-keyed in the macro flow: it applies wherever the type
+                // is named, not only where the macro was invoked.  If a custom type is
+                // registered for the item this path resolves to (e.g. a type alias in another
+                // module), resolve to the custom type instead.
+                if matches!(path_to_type.item()?, Item::Type(_) | Item::NonUniffi(..)) {
+                    if let Some(custom_type_path) = cache.registered_custom_type(&path_to_type) {
+                        path_to_type = custom_type_path;
+                    }
+                }
                 // We can use `mem::take` to remove the generic_params and use them for this lookup.
                 // If we need to recurse another level, we want a new set of generic params anyways.
                 let generics = GenericArgs::new_with_context_params(
@@ -822,7 +847,7 @@ pub mod tests {
     #[test]
     fn test_resolve_builtin_types() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_type(&ir, &mut cache, "types", "()"),
@@ -911,7 +936,7 @@ pub mod tests {
     #[test]
     fn test_resolve_user_types() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_type(&ir, &mut cache, "types::mod1", "String"),
@@ -966,7 +991,7 @@ pub mod tests {
     #[test]
     fn test_resolve_custom_types() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_type(&ir, &mut cache, "types", "JsonObject"),
@@ -1013,9 +1038,70 @@ pub mod tests {
     }
 
     #[test]
+    fn test_resolve_custom_types_by_target_path() {
+        let ir = Ir::new_for_test(&["custom_type_paths"]);
+        let mut cache = LookupCache::new(&ir);
+
+        let custom = |name: &str| {
+            Ok(Type::Custom {
+                module_path: "custom_type_paths::registrations".into(),
+                name: name.into(),
+                builtin: Box::new(Type::String),
+            })
+        };
+
+        // A non-UniFFI type covered by a custom type registered in another module
+        assert_eq!(
+            run_resolve_type(&ir, &mut cache, "custom_type_paths::usage", "Concrete"),
+            custom("Concrete"),
+        );
+        // A type alias covered by a custom type registered in another module
+        assert_eq!(
+            run_resolve_type(&ir, &mut cache, "custom_type_paths::usage", "ExternalAlias"),
+            custom("ExternalAlias"),
+        );
+        // A type imported directly from an unparsed crate, covered by a custom type
+        // over a local alias to the same path
+        assert_eq!(
+            run_resolve_type(&ir, &mut cache, "custom_type_paths::usage", "Direct"),
+            custom("Direct"),
+        );
+
+        // The same types, named by path instead of through use statements
+        assert_eq!(
+            run_resolve_type(&ir, &mut cache, "custom_type_paths", "types::Concrete"),
+            custom("Concrete"),
+        );
+        assert_eq!(
+            run_resolve_type(&ir, &mut cache, "custom_type_paths", "types::ExternalAlias"),
+            custom("ExternalAlias"),
+        );
+        assert_eq!(
+            run_resolve_type(
+                &ir,
+                &mut cache,
+                "custom_type_paths",
+                "external_crate2::Direct"
+            ),
+            custom("Direct"),
+        );
+
+        // Paths into unparsed crates without a covering custom type still fail
+        assert_eq!(
+            run_resolve_type(
+                &ir,
+                &mut cache,
+                "custom_type_paths",
+                "external_crate2::Other"
+            ),
+            Err(ErrorKind::NotFound),
+        );
+    }
+
+    #[test]
     fn test_resolve_compound_types() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_type(&ir, &mut cache, "types", "Vec<String>"),
@@ -1123,7 +1209,7 @@ pub mod tests {
     #[test]
     fn test_resolve_type_trait_objects() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_type(&ir, &mut cache, "types::mod1", "dyn TraitInterface"),
@@ -1197,7 +1283,7 @@ pub mod tests {
     #[test]
     fn test_resolve_type_with_type_aliases() {
         let ir = Ir::new_for_test(&["type_aliases"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_type(&ir, &mut cache, "type_aliases", "RecordAlias"),
@@ -1341,7 +1427,7 @@ pub mod tests {
     #[test]
     fn test_resolve_box_types() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         // Right now we just ignore the box since it doesn't make a difference in the generated
         // bindings.  If we want to use this to generate scaffolding, then we'll need something
@@ -1368,7 +1454,7 @@ pub mod tests {
     #[test]
     fn test_resolve_type_references() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_type(&ir, &mut cache, "types::mod1", "&std::primitive::u32"),
@@ -1399,7 +1485,7 @@ pub mod tests {
     #[test]
     fn test_remote_types() {
         let ir = Ir::new_for_test(&["remote_types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_uniffi_meta_type(&ir, &mut cache, "remote_types", "AnyhowError", None),
@@ -1421,7 +1507,6 @@ pub mod tests {
     #[test]
     fn test_udl_types() {
         let mut ir = Ir::new_for_test(&["udl_types", "udl_types_crate2"]);
-        let mut cache = LookupCache::default();
         ir.add_udl_metadata(
             "udl_types",
             vec![
@@ -1461,6 +1546,7 @@ pub mod tests {
             ],
         )
         .unwrap();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_uniffi_meta_type(&ir, &mut cache, "udl_types::mod1", "UdlRecord", None),
@@ -1576,7 +1662,7 @@ pub mod tests {
     #[test]
     fn test_result_uniffi_meta() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_uniffi_meta_type(&ir, &mut cache, "types", "TestRecord", None),
@@ -1641,7 +1727,7 @@ pub mod tests {
     #[test]
     fn test_result_arg() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_arg(&ir, &mut cache, "types", "TestRecord", None),
@@ -1722,7 +1808,6 @@ pub mod tests {
     #[test]
     fn test_raw_ident() {
         let mut ir = Ir::new_for_test(&["raw_idents"]);
-        let mut cache = LookupCache::default();
         ir.add_udl_metadata(
             "raw_idents",
             vec![uniffi_meta::RecordMetadata {
@@ -1736,6 +1821,7 @@ pub mod tests {
             .into()],
         )
         .unwrap();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_uniffi_meta_type(&ir, &mut cache, "raw_idents", "RecordWrapper", None),

--- a/uniffi_parse_rs/src/types.rs
+++ b/uniffi_parse_rs/src/types.rs
@@ -1099,6 +1099,34 @@ pub mod tests {
     }
 
     #[test]
+    fn test_resolve_custom_types_from_another_crate() {
+        // `custom_type_paths2` mirrors a binding crate: it names types whose custom
+        // types are implemented by `custom_type_paths` (declared via `use_remote_type!`
+        // plus a local alias).
+        let ir = Ir::new_for_test(&["custom_type_paths", "custom_type_paths2"]);
+        let mut cache = LookupCache::new(&ir);
+
+        let custom = Ok(Type::Custom {
+            module_path: "custom_type_paths::registrations".into(),
+            name: "Direct".into(),
+            builtin: Box::new(Type::String),
+        });
+
+        // Through the local alias next to `use_remote_type!` — the macro's path
+        // (`custom_type_paths::Direct`) doesn't resolve, so resolution falls through
+        // to the alias, whose external target is covered by the custom type.
+        assert_eq!(
+            run_resolve_type(&ir, &mut cache, "custom_type_paths2", "Direct"),
+            custom,
+        );
+        // Through a direct import from the unparsed crate
+        assert_eq!(
+            run_resolve_type(&ir, &mut cache, "custom_type_paths2::usage2", "Direct"),
+            custom,
+        );
+    }
+
+    #[test]
     fn test_resolve_compound_types() {
         let ir = Ir::new_for_test(&["types"]);
         let mut cache = LookupCache::new(&ir);


### PR DESCRIPTION
## What's fixed

Pointing the new Rust-source parsing pipeline (`uniffi_parse_rs`) and the
experimental `uniffi-bindgen-kotlin-jni` at a large existing workspace
(two UniFFI crates, many modules, several non-UniFFI dependencies) hit a
series of issues. Each commit fixes one of them, with tests.

### `uniffi_parse_rs` — path/type resolution

- **Leading `self::` path segments didn't resolve.** `RPath::child()`
  special-cased `super` and `crate` but not `self`, so common
  disambiguating imports like `pub use self::http::*;` (where a module
  shares its name with a crate) failed with "Unknown item".
- **`dyn Trait` references carried the wrong module path.** The
  referencing module's path was used instead of the trait's own public
  path, so a trait object referenced from another module or crate matched
  no definition ("type module path not found").
- **Custom types now resolve by the type they cover, not only by name in
  the module that invoked `custom_type!`.** The macro flow is type-keyed
  (the generated impls apply wherever the type is named), but source
  parsing resolved names lexically, so a type alias in another module, a
  non-UniFFI type, or a direct import from an unparsed crate
  (`use rust_decimal::Decimal` covered by
  `type Decimal = rust_decimal::Decimal;` + `custom_type!(Decimal, String)`)
  failed with "Unknown item". A registry, built once per `LookupCache`,
  maps each custom type's underlying type back to the custom type.
- **`use_remote_type!(implementing_crate::Type)` no longer requires
  `Type` to live at that path.** Matching the macro's semantics (the type
  resolves in the invoking module's scope; the first segment only names
  the crate), resolution falls through to the module's own items instead
  of failing — and shadowing a covered alias no longer reports a spurious
  name conflict.
- **Generic containers exposed through hand-written FFI impls resolve.**
  `custom_type!` can't cover generics; crates expose e.g.
  `indexmap::IndexSet<T>` with hand-written trait impls whose
  `TYPE_ID_META` declares the wire shape. The parser now reads that
  declaration and resolves the target like the equivalent builtin
  container (`TYPE_VEC` / `TYPE_OPTION` / `TYPE_HASH_SET` / `TYPE_HASH_MAP`),
  skipping impls whose `concat` order doesn't match the type's parameters.

### `uniffi_bindgen`

- **The dependency sort silently dropped same-named definitions.** When
  sorting type definitions across namespaces, a type used outside its
  defining namespace has both its real definition and an `External`
  marker under the same canonical name; keying by name alone kept only
  one, breaking downstream consumers (e.g. the kotlin-jni FFI type oracle
  failing with "Can't find FFI types for Custom { … }").

### `uniffi-bindgen-kotlin-jni`

- **`Vec<u8>` fields inside FFI buffers** ("No FFI buffer Layout for
  Bytes"): packed like `String` as (data, length, capacity), with the
  matching JNI bridges and Kotlin wrappers.
- **`Timestamp` / `Duration` fields inside FFI buffers** ("No FFI buffer
  Layout for Duration"): the layout entry matching what the templates
  already generate (8-byte seconds + 4-byte nanoseconds).
- **Container scaffolding is generic over the container type**, so types
  like `IndexSet<T>` declared via `TYPE_ID_META` (see above) compile:
  lowering takes `impl IntoIterator<Item = T>`, lifting returns
  `C: FromIterator<T>`; every call site has a concrete type to infer from.
- **Generated callback impls derive `Clone, Debug`**, required when an exported
  foreign trait has a `Clone`/`Debug` supertrait.

---

Disclaimer: CC Fable model helps me to port our 4-years-old project to use the newest kotlin jni binding.
Please let me know if you need to split this into small PRs.