### PR TITLE
Changes for the 0.32.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## [[UnreleasedUniFFIVersion]] (backend crates: [[UnreleasedBackendVersion]]) - (_[[ReleaseDate]]_)
 
+### What's Fixed
+- Kotlin: Fixed checksum failure on aarch64 ([#2935](https://github.com/mozilla/uniffi-rs/pull/2935/))
+
 [All changes in [[UnreleasedUniFFIVersion]]](https://github.com/mozilla/uniffi-rs/compare/v0.32.0...HEAD).
 
 ## v0.32.0 (backend crates: v0.32.0) - (_2026-06-30_)

--- a/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
@@ -120,7 +120,8 @@ private fun uniffiCheckContractApiVersion(lib: IntegrityCheckingUniffiLib) {
 @Suppress("UNUSED_PARAMETER")
 private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     {%- for (name, expected_checksum) in ci.iter_checksums() %}
-    if (lib.{{ name }}() != {{ expected_checksum }}) {
+    {#- please don't delete the mask: https://github.com/mozilla/uniffi-rs/pull/2935 #}
+    if ((lib.{{ name }}() and 0xFFFF) != {{ expected_checksum }}) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     {%- endfor %}


### PR DESCRIPTION
Cherry-picked https://github.com/mozilla/uniffi-rs/pull/2935 and added a CHANGELOG entry for it.

I think Mark has bigger plans for a 0.33 release, but there's a lot users who want this fix (see https://github.com/mozilla/uniffi-rs/issues/2939) so I think it's worth a patch release right now.