### PR TITLE
Ruby: add external/remote types support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   See [#2911](https://github.com/mozilla/uniffi-rs/pull/2911).
 - Added support for remote trait interfaces - ie, traits defined in a crate which doesn't use
   UniFFI. Use `#[uniffi::export(remote)]` or `[Trait, Remote]` in UDL. Foreign implementations are not supported, see the docs for more.
+- Ruby: Add `bindings.ruby.module_name` to set the generated module name. In library mode,
+  `[bindings.ruby.external_packages]` is auto-filled from each peer's `module_name`; a consumer
+  override that does not match is a bindgen error (via [#2980](https://github.com/mozilla/uniffi-rs/pull/2980)).
+- Ruby: Add external types support (via [#2980](https://github.com/mozilla/uniffi-rs/pull/2980)).
 
 ### What's Fixed
 - Kotlin: Fixed messages for error classes that inherit `Throwable`, but not `Exception`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,6 +1900,7 @@ dependencies = [
  "thiserror",
  "uniffi",
  "uniffi-bindgen-tests-external-types-source",
+ "uniffi-bindgen-tests-mid-types",
  "url",
 ]
 
@@ -1920,6 +1921,14 @@ dependencies = [
  "uniffi",
  "uniffi-bindgen-tests",
  "uniffi_bindgen",
+]
+
+[[package]]
+name = "uniffi-bindgen-tests-mid-types"
+version = "0.31.0"
+dependencies = [
+ "uniffi",
+ "uniffi-bindgen-tests-external-types-source",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
   "examples/traits",
 
   "bindgen-tests/external-types",
+  "bindgen-tests/mid-types",
   "bindgen-tests/lib",
   "bindgen-tests/kotlin",
   "bindgen-tests/kotlin/experimental-unsigned-types",

--- a/bindgen-tests/README.md
+++ b/bindgen-tests/README.md
@@ -14,8 +14,9 @@ This has a few advantages:
   If the `records` test fails, you can be pretty sure you have an issue with your record-related code.
   When the `examples/todolist` test fails, it's not so clear.
 * There's less crates involved.
-  If we wanted, we could publish the 2 test crates involved without too much overhead.
-  Publishing all of the examples/fixtures is a lot.
+  The shared suite is `bindgen-tests/lib` plus `external-types` (and `mid-types` for
+  nested fields that live in a further crate). Publishing those is still cheap
+  compared to the fixture graph.
 * Simplified test harness code.
   This kind-of follows from the last points.
   Since we only need to build a single library, we don't need so much abstraction.

--- a/bindgen-tests/external-types/src/lib.rs
+++ b/bindgen-tests/external-types/src/lib.rs
@@ -2,14 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 uniffi::setup_scaffolding!("uniffi_bindgen_tests_external_types_source");
 
-#[derive(uniffi::Record)]
+#[derive(uniffi::Record, Clone, Debug, PartialEq, Eq)]
 pub struct ExternalRec {
     pub a: u8,
 }
 
-#[derive(uniffi::Enum)]
+#[derive(uniffi::Enum, Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ExternalEnum {
     One,
     Two,
@@ -39,3 +41,32 @@ uniffi::custom_type!(ExternalCustomType, u64, {
     try_lift: |val| Ok(ExternalCustomType(val)),
     lower: |custom| custom.0,
 });
+
+pub struct ExternalUrl(String);
+
+uniffi::custom_type!(ExternalUrl, String, {
+    try_lift: |val| Ok(ExternalUrl(val)),
+    lower: |custom| custom.0,
+});
+
+/// Nested fields of this record are also defined in this crate. Serializing it
+/// from a consumer still has to call this crate's readers/writers for `en`/`rec`.
+#[derive(uniffi::Record, Clone, Debug, PartialEq, Eq)]
+pub struct ExternalNestedRec {
+    pub en: ExternalEnum,
+    pub rec: ExternalRec,
+}
+
+pub struct NestedExternalRec(pub ExternalRec);
+
+uniffi::custom_newtype!(NestedExternalRec, ExternalRec);
+
+pub struct NestedExternalInterface(pub Arc<ExternalInterface>);
+
+uniffi::custom_newtype!(NestedExternalInterface, Arc<ExternalInterface>);
+
+#[derive(uniffi::Error, thiserror::Error, Debug)]
+pub enum ExternalError {
+    #[error("Boom")]
+    Boom,
+}

--- a/bindgen-tests/external-types/uniffi.toml
+++ b/bindgen-tests/external-types/uniffi.toml
@@ -5,3 +5,8 @@ omit_checksums = true
 [bindings.swift]
 omit_checksums = true
 
+[bindings.ruby.custom_types.ExternalUrl]
+type_name = "URI"
+imports = ["uri"]
+lift = "URI.parse({})"
+lower = "{}.to_s"

--- a/bindgen-tests/lib/Cargo.toml
+++ b/bindgen-tests/lib/Cargo.toml
@@ -15,6 +15,7 @@ uniffi = { path = "../../uniffi", features = ["bindgen", "ffi-trace", "cargo-met
 url = "2.5"
 
 uniffi-bindgen-tests-external-types-source = { path = "../external-types" }
+uniffi-bindgen-tests-mid-types = { path = "../mid-types" }
 
 [features]
 default = ["simple_fns", "primitive_types", "records", "enums", "collections", "options", "interfaces",

--- a/bindgen-tests/lib/src/external_types.rs
+++ b/bindgen-tests/lib/src/external_types.rs
@@ -4,8 +4,10 @@
 
 use std::sync::Arc;
 use uniffi_bindgen_tests_external_types_source::{
-    ExternalCustomType, ExternalEnum, ExternalInterface, ExternalRec,
+    ExternalCustomType, ExternalEnum, ExternalError, ExternalInterface, ExternalNestedRec,
+    ExternalRec, ExternalUrl, NestedExternalInterface, NestedExternalRec,
 };
+use uniffi_bindgen_tests_mid_types::MidRec;
 
 #[uniffi::export]
 pub fn roundtrip_ext_record(rec: ExternalRec) -> ExternalRec {
@@ -25,4 +27,61 @@ pub fn roundtrip_ext_interface(interface: Arc<ExternalInterface>) -> Arc<Externa
 #[uniffi::export]
 pub fn roundtrip_ext_custom_type(custom: ExternalCustomType) -> ExternalCustomType {
     custom
+}
+
+#[uniffi::export]
+pub fn roundtrip_ext_url(url: ExternalUrl) -> ExternalUrl {
+    url
+}
+
+#[uniffi::export]
+pub fn roundtrip_ext_nested_rec(rec: ExternalNestedRec) -> ExternalNestedRec {
+    rec
+}
+
+#[uniffi::export]
+pub fn roundtrip_nested_ext_rec(rec: NestedExternalRec) -> NestedExternalRec {
+    rec
+}
+
+#[uniffi::export]
+pub fn roundtrip_nested_ext_interface(
+    interface: NestedExternalInterface,
+) -> NestedExternalInterface {
+    interface
+}
+
+#[uniffi::export]
+pub fn roundtrip_maybe_ext_enum(en: Option<ExternalEnum>) -> Option<ExternalEnum> {
+    en
+}
+
+#[uniffi::export]
+pub fn roundtrip_ext_enums(ens: Vec<ExternalEnum>) -> Vec<ExternalEnum> {
+    ens
+}
+
+#[uniffi::export]
+pub async fn async_roundtrip_ext_enum(en: ExternalEnum) -> ExternalEnum {
+    en
+}
+
+#[uniffi::export]
+pub fn throw_ext_error() -> Result<(), ExternalError> {
+    Err(ExternalError::Boom)
+}
+
+/// Local custom type whose builtin is an imported custom type with a bindings conversion.
+pub struct LocalUrl(pub ExternalUrl);
+
+uniffi::custom_newtype!(LocalUrl, ExternalUrl);
+
+#[uniffi::export]
+pub fn roundtrip_local_url(url: LocalUrl) -> LocalUrl {
+    url
+}
+
+#[uniffi::export]
+pub fn roundtrip_mid_rec(rec: MidRec) -> MidRec {
+    rec
 }

--- a/bindgen-tests/mid-types/Cargo.toml
+++ b/bindgen-tests/mid-types/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "uniffi-bindgen-tests-mid-types"
+version = "0.31.0"
+edition = "2021"
+
+[lib]
+crate-type = ["lib", "cdylib", "staticlib"]
+
+[dependencies]
+uniffi = { path = "../../uniffi", default-features = false }
+uniffi-bindgen-tests-external-types-source = { path = "../external-types" }

--- a/bindgen-tests/mid-types/src/lib.rs
+++ b/bindgen-tests/mid-types/src/lib.rs
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Intermediate crate: its public type embeds types from
+//! `uniffi-bindgen-tests-external-types-source`. A consumer that only names
+//! `MidRec` does not list those nested types in its own interface.
+
+uniffi::setup_scaffolding!("uniffi_bindgen_tests_mid_types");
+
+use uniffi_bindgen_tests_external_types_source::{ExternalEnum, ExternalRec};
+
+#[derive(uniffi::Record)]
+pub struct MidRec {
+    pub inner: ExternalRec,
+    pub maybe_enum: Option<ExternalEnum>,
+}

--- a/bindgen-tests/ruby/src/lib.rs
+++ b/bindgen-tests/ruby/src/lib.rs
@@ -114,6 +114,11 @@ mod test {
         run_tests(test_dir(), "tests/futures.rb");
     }
 
+    #[test]
+    fn test_external_types() {
+        run_tests(test_dir(), "tests/external_types.rb");
+    }
+
     fn test_dir() -> &'static Utf8Path {
         static TEST_TEMPDIR: OnceLock<Utf8PathBuf> = OnceLock::new();
         TEST_TEMPDIR.get_or_init(|| {

--- a/bindgen-tests/ruby/tests/external_types.rb
+++ b/bindgen-tests/ruby/tests/external_types.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'test/unit'
+require 'uri'
+require 'uniffi_bindgen_tests'
+
+class TestExternalTypes < Test::Unit::TestCase
+  Ext = UniffiBindgenTestsExternalTypesSource
+  Mid = UniffiBindgenTestsMidTypes
+
+  def test_ext_record
+    rec = Ext::ExternalRec.new(a: 42)
+    result = UniffiBindgenTests.roundtrip_ext_record(rec)
+    assert_equal 42, result.a
+  end
+
+  def test_ext_enum
+    result = UniffiBindgenTests.roundtrip_ext_enum(Ext::ExternalEnum::TWO)
+    assert_equal Ext::ExternalEnum::TWO, result
+  end
+
+  def test_ext_interface
+    obj = Ext::ExternalInterface.new(123)
+    result = UniffiBindgenTests.roundtrip_ext_interface(obj)
+    assert_equal 123, result.get_value
+  end
+
+  def test_ext_custom_type
+    result = UniffiBindgenTests.roundtrip_ext_custom_type(789)
+    assert_equal 789, result
+  end
+
+  # Identity imported u64 newtypes skip consumer coerce; defining-crate
+  # `uniffi_lower_*` must still run `uniffi_in_range` (including `to_int`).
+  def test_ext_custom_type_rejects_negative_like_local
+    local = assert_raises(RangeError) { UniffiBindgenTests.roundtrip_custom_type1(-1) }
+    imported = assert_raises(RangeError) { UniffiBindgenTests.roundtrip_ext_custom_type(-1) }
+
+    assert_equal local.message, imported.message
+    assert_equal "u64 requires 0 <= value < #{2**64}", imported.message
+  end
+
+  def test_ext_custom_type_rejects_non_integer_like_local
+    local = assert_raises(TypeError) { UniffiBindgenTests.roundtrip_custom_type1('nope') }
+    imported = assert_raises(TypeError) { UniffiBindgenTests.roundtrip_ext_custom_type('nope') }
+
+    assert_equal local.message, imported.message
+    assert_equal 'no implicit conversion of nope into Integer', imported.message
+  end
+
+  # Ruby 4 Float#to_int truncates (1.9 -> 1). Both paths must agree; FFI
+  # `:uint64` without `uniffi_in_range` would not go through `to_int`.
+  def test_ext_custom_type_coerces_float_like_local
+    assert_equal 1, UniffiBindgenTests.roundtrip_custom_type1(1.9)
+    assert_equal 1, UniffiBindgenTests.roundtrip_ext_custom_type(1.9)
+  end
+
+  def test_ext_custom_type_preserves_to_int_coercion
+    int_like = Object.new
+    def int_like.to_int
+      7
+    end
+
+    assert_equal 7, UniffiBindgenTests.roundtrip_custom_type1(int_like)
+    assert_equal 7, UniffiBindgenTests.roundtrip_ext_custom_type(int_like)
+  end
+
+  def test_ext_url_is_uri
+    url = URI.parse('http://example.com/')
+    result = UniffiBindgenTests.roundtrip_ext_url(url)
+
+    assert_kind_of URI, result
+    assert_equal url, result
+  end
+
+  def test_local_url_wrapping_imported_url
+    url = URI.parse('http://example.com/local')
+    result = UniffiBindgenTests.roundtrip_local_url(url)
+
+    assert_kind_of URI, result
+    assert_equal url, result
+  end
+
+  def test_ext_nested_rec
+    rec = Ext::ExternalNestedRec.new(
+      en: Ext::ExternalEnum::ONE,
+      rec: Ext::ExternalRec.new(a: 7)
+    )
+    result = UniffiBindgenTests.roundtrip_ext_nested_rec(rec)
+
+    assert_equal Ext::ExternalEnum::ONE, result.en
+    assert_equal 7, result.rec.a
+  end
+
+  def test_nested_ext_rec_identity_custom
+    inner = Ext::ExternalRec.new(a: 9)
+    result = UniffiBindgenTests.roundtrip_nested_ext_rec(inner)
+
+    assert_instance_of Ext::ExternalRec, result
+    assert_equal 9, result.a
+  end
+
+  def test_nested_ext_interface_identity_custom
+    obj = Ext::ExternalInterface.new(3)
+    result = UniffiBindgenTests.roundtrip_nested_ext_interface(obj)
+
+    assert_instance_of Ext::ExternalInterface, result
+    assert_equal 3, result.get_value
+  end
+
+  def test_optional_and_sequence
+    assert_nil UniffiBindgenTests.roundtrip_maybe_ext_enum(nil)
+    assert_equal Ext::ExternalEnum::TWO,
+                 UniffiBindgenTests.roundtrip_maybe_ext_enum(Ext::ExternalEnum::TWO)
+    assert_equal [Ext::ExternalEnum::ONE, Ext::ExternalEnum::THREE],
+                 UniffiBindgenTests.roundtrip_ext_enums(
+                   [Ext::ExternalEnum::ONE, Ext::ExternalEnum::THREE]
+                 )
+  end
+
+  def test_async_ext_enum
+    result = UniffiBindgenTests.async_roundtrip_ext_enum(Ext::ExternalEnum::TWO)
+    assert_equal Ext::ExternalEnum::TWO, result
+  end
+
+  def test_throw_ext_error
+    assert_raise Ext::ExternalError::Boom do
+      UniffiBindgenTests.throw_ext_error
+    end
+  end
+
+  def test_corrupt_external_enum_raises_defining_crate_internal_error
+    buf = UniffiBindgenTests::RustBuffer.alloc(4)
+    buf.len = 4
+    buf.data.put_bytes(0, [99].pack('l>'))
+    err = assert_raise(Ext::InternalError) do
+      buf.consume_into_TypeExternalEnum
+    end
+
+    assert_match(/Unexpected variant tag/, err.message)
+    assert_not_same UniffiBindgenTests::InternalError, Ext::InternalError
+  end
+
+  def test_mid_rec_roundtrip
+    rec = Mid::MidRec.new(
+      inner: Ext::ExternalRec.new(a: 11),
+      maybe_enum: Ext::ExternalEnum::ONE
+    )
+    result = UniffiBindgenTests.roundtrip_mid_rec(rec)
+
+    assert_equal 11, result.inner.a
+    assert_equal Ext::ExternalEnum::ONE, result.maybe_enum
+  end
+
+  # MidRec's nested External* fields are not in the consumer CI. Mid's generated
+  # file must still require the source crate and name its mixin.
+  def test_mid_generated_requires_source
+    path = $LOADED_FEATURES.find { |f| File.basename(f) == 'uniffi_bindgen_tests_mid_types.rb' }
+    assert_not_nil path, 'uniffi_bindgen_tests_mid_types.rb should be loaded'
+    src = File.read(path)
+
+    assert_match(/require ['"]uniffi_bindgen_tests_external_types_source['"]/, src)
+    assert_match(/UniffiBindgenTestsExternalTypesSource::RustBuffer/, src)
+  end
+end

--- a/docs/manual/src/ruby/configuration.md
+++ b/docs/manual/src/ruby/configuration.md
@@ -8,7 +8,9 @@ The generated Ruby modules can be configured using a `uniffi.toml` configuration
 | ------------------ | -------- | ----------- |
 | `cdylib_name`      | `uniffi_{namespace}`[^1] | The name of the compiled Rust library containing the FFI implementation (not needed when using `generate --library`). |
 | `cdylib_path`      | | An explicit path to the shared library, passed as the `ffi_lib` argument. |
+| `module_name`      | `UpperCamelCase(namespace)` | The Ruby module name emitted as `module …` in that crate's generated bindings. Must be a single constant identifier (e.g. `UniffiOne`), not a nested path (`Foo::Bar`). |
 | `custom_types`     | | A map which controls how custom types are exposed to Ruby. See the [custom types section of the manual](../types/custom_types.md#custom-types-in-the-bindings-code) |
+| `external_packages` | | A map from Rust crate names to Ruby module names for use with [external types](../types/remote_ext_types.md). Keys are crate names, not UniFFI namespaces: the Cargo package name (`my-crate`) and the underscored Rust crate name (`my_crate`) are equivalent (`uniffi_one`, not `uniffi_one_ns`). This controls how generated code *references* external modules (e.g. `OtherCrate::SomeType`). `require` paths still use each crate's UniFFI namespace (the generated `.rb` filename). In library mode (`generate --library`) every peer crate is auto-filled from that crate's `module_name`; a listed value must match. A mismatch is a bindgen error. Omitting a key does not skip the crate or control mixin / `require` membership. |
 | `rename`           | | A map to rename types, functions, methods, and their members in the generated Ruby bindings. See the [renaming section](../renaming.md). |
 | `exclude`          | | A list of crate names to exclude when generating bindings for a library (library mode). |
 
@@ -31,4 +33,34 @@ lift = "URI.parse({})"
 lower = "{}.to_s"
 ```
 
+Module name (defining crate):
+
+```toml
+[bindings.ruby]
+# Default is UpperCamelCase of the UniFFI namespace (e.g. uniffi_one_ns → UniffiOneNs).
+module_name = "UniffiOne"
+```
+
+External Packages (consumer; optional in library mode):
+
+```toml
+[bindings.ruby.external_packages]
+# Map the crate name from [External={name}] / Cargo.toml to its Ruby module name.
+# Hyphens and underscores are equivalent: `rust-crate-name` and `rust_crate_name` are the same key.
+# Library mode already maps every peer crate to that crate's `module_name`; a listed
+# value must match. Keys are crate names, not namespaces.
+rust-crate-name = "ExternalRubyModule"
+```
+
 Refer to [`examples/custom-types/uniffi.toml`](https://github.com/mozilla/uniffi-rs/blob/main/examples/custom-types/uniffi.toml) for a complete example.
+
+## InternalError
+
+Each generated module defines its own `InternalError` class (`StandardError` subclass), for example `Coverall::InternalError`.
+This is the same idea as Python `InternalError` and Kotlin `InternalException`: a public bindings-level error for panics, protocol mismatches, and corrupt buffers — not for declared API errors.
+
+Readers and writers for a type live in that type's crate (Ruby mixins, like Python/Kotlin converters).
+A corrupt buffer while lifting an [external type](../types/remote_ext_types.md) therefore raises **the defining crate's** `InternalError`.
+`rescue ImportedTypesLib::InternalError` will not catch `UniffiOneNs::InternalError`.
+
+Rescue the crate that owns the type, rescue each crate you depend on, or use `rescue StandardError` as a catch-all.

--- a/docs/manual/src/types/remote_ext_types.md
+++ b/docs/manual/src/types/remote_ext_types.md
@@ -85,6 +85,12 @@ This normally means types from other crates in your workspace.
 
 Proc-macros typically use external types automatically, but UDL needs them described.
 
+Bindings-level internal errors (`InternalError` / `InternalException`) are defined by the crate that owns the type — Ruby mixins and Python/Kotlin converters raise that crate's class, not the consumer's.
+
+## Proc-macros
+
+Proc-macro-based code can use external types automatically, without any extra code.
+
 ## UDL
 
 Suppose you depend on the `DemoDict` type from another UniFFIed crate in your workspace.
@@ -165,3 +171,33 @@ rust-crate-name = "kotlin.package.name"
 For Swift, you must compile all generated `.swift` files together in a single
 module since the generate code expects that it can access external types
 without importing them.
+
+### Ruby
+
+For Ruby, external types are supported in library mode
+(`generate --library [path-to-cdylib]`). Single-UDL generation (`generate [udl-path]`)
+is not supported for external types, as the generator cannot resolve types from
+other crates without their compiled scaffolding metadata; bindgen errors rather
+than emitting incomplete bindings. Library mode generates
+all bindings files together and uses `require` to pull in external modules at runtime.
+
+The defining crate's Ruby `module` name defaults to the UniFFI namespace converted
+to UpperCamelCase. Set `[bindings.ruby.module_name]` on that crate to change it.
+Library mode copies each peer's `module_name` into the consumer's
+`[bindings.ruby.external_packages]` map. A consumer-side entry is optional and
+must match; a mismatch is a bindgen error. `require` paths still use the
+namespace / `.rb` filename (references only):
+
+```
+# defining crate
+[bindings.ruby]
+module_name = "RubyModuleName"
+
+# consumer (optional in library mode; must match the defining crate)
+[bindings.ruby.external_packages]
+# Map crate names from [External={name}] / Cargo.toml into Ruby module names.
+# `rust-crate-name` and `rust_crate_name` are the same key.
+rust-crate-name = "RubyModuleName"
+```
+
+See the [Ruby configuration](../ruby/configuration.md) page for more details.

--- a/examples/remote-types/tests/bindings/test_remote_types.rb
+++ b/examples/remote-types/tests/bindings/test_remote_types.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'test/unit'
+require 'remote_types'
+
+class TestRemoteTypes < Test::Unit::TestCase
+  include RemoteTypes
+
+  def test_logger
+    testLogger = LogSink.new 'SomeFile'
+    testLogger.log LogLevel::INFO, 'Hello world'
+  end
+
+  def test_error_handling
+    assert_raises AnyhowError do
+      LogSink.new ''
+      raise RuntimeError, 'Constructor should have thrown'
+    end
+  end
+end

--- a/examples/remote-types/tests/test_generated_bindings.rs
+++ b/examples/remote-types/tests/test_generated_bindings.rs
@@ -2,4 +2,5 @@ uniffi::build_foreign_language_testcases!(
     "tests/bindings/test_remote_types.kts",
     "tests/bindings/test_remote_types.py",
     "tests/bindings/test_remote_types.swift",
+    "tests/bindings/test_remote_types.rb",
 );

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/mod.rs
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use anyhow::Result;
+use anyhow::{anyhow, bail, Result};
 use askama::Template;
 
 use heck::{ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use crate::interface::{Enum, *};
 
@@ -19,19 +19,65 @@ const RESERVED_WORDS: &[&str] = &[
     "until", "when", "while", "yield", "__FILE__", "__LINE__",
 ];
 
+// Info for an external crate, used by `wrapper.rb` to emit `require`.
+// Ruby module names for mixin *calls* are computed by `mixin_owner_module`,
+// not stored here.
+#[derive(Debug)]
+pub struct ExternalMixin {
+    pub require_path: String,
+}
+
 fn is_reserved_word(word: &str) -> bool {
     RESERVED_WORDS.contains(&word)
 }
 
-/// Get the canonical, unique-within-this-component name for a type.
+/// A single Ruby constant identifier: `UniffiOne`, not `foo`, `Foo::Bar`, or `END`.
+fn is_valid_ruby_constant(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_uppercase() => chars.all(|c| c.is_ascii_alphanumeric() || c == '_'),
+        _ => false,
+    }
+}
+
+/// Extract the crate name from a module path (everything before the first `::`).
 ///
-/// When generating helper code for foreign language bindings, it's sometimes useful to be
-/// able to name a particular type in order to e.g. call a helper function that is specific
-/// to that type. We support this by defining a naming convention where each type gets a
-/// unique canonical name, constructed recursively from the names of its component types (if any).
+/// Hyphens are normalized to underscores so UDL `[External="my-crate"]` and
+/// proc-macro `module_path!()` (`my_crate`) resolve to the same key. Matches
+/// [`crate::interface::ComponentInterface::namespace_for_module_path`].
+fn crate_name_from_module_path(module_path: &str) -> String {
+    module_path
+        .split("::")
+        .next()
+        .unwrap_or(module_path)
+        .replace('-', "_")
+}
+
+fn peel_boxes(type_: &Type) -> &Type {
+    match type_ {
+        Type::Box { inner_type } => peel_boxes(inner_type),
+        other => other,
+    }
+}
+
+fn peel_boxes_and_custom(type_: &Type) -> &Type {
+    match peel_boxes(type_) {
+        Type::Custom { builtin, .. } => peel_boxes_and_custom(builtin),
+        other => other,
+    }
+}
+
+fn askama_err(err: impl Into<anyhow::Error>) -> askama::Error {
+    askama::Error::Custom(err.into().into())
+}
+
+/// Unique-within-this-component name used in generated helper identifiers
+/// (`write_TypeFoo`, `alloc_from_string`, …).
+///
+/// Named types share the `Type` prefix so a record named `SequenceRecord` cannot
+/// collide with `sequence<Record>`. Callbacks keep a distinct prefix.
 pub fn canonical_name(t: &Type) -> String {
     match t {
-        // Builtin primitive types, with plain old names.
         Type::Int8 => "i8".into(),
         Type::UInt8 => "u8".into(),
         Type::Int16 => "i16".into(),
@@ -45,23 +91,13 @@ pub fn canonical_name(t: &Type) -> String {
         Type::String => "string".into(),
         Type::Bytes => "bytes".into(),
         Type::Boolean => "bool".into(),
-        // API defined types.
-        // Note that these all get unique names, and the parser ensures that the names do not
-        // conflict with a builtin type. We add a prefix to the name to guard against pathological
-        // cases like a record named `SequenceRecord` interfering with `sequence<Record>`.
-        // However, types that support importing all end up with the same prefix of "Type", so
-        // that the import handling code knows how to find the remote reference.
-        Type::Object { name, .. } => format!("Type{name}"),
-        Type::Enum { name, .. } => format!("Type{name}"),
-        Type::Record { name, .. } => format!("Type{name}"),
-        Type::CallbackInterface { name, .. } => format!("CallbackInterface{name}"),
         Type::Timestamp => "Timestamp".into(),
         Type::Duration => "Duration".into(),
-        // Recursive types.
-        // These add a prefix to the name of the underlying type.
-        // The component API definition cannot give names to recursive types, so as long as the
-        // prefixes we add here are all unique amongst themselves, then we have no chance of
-        // acccidentally generating name collisions.
+        Type::Object { name, .. }
+        | Type::Enum { name, .. }
+        | Type::Record { name, .. }
+        | Type::Custom { name, .. } => format!("Type{name}"),
+        Type::CallbackInterface { name, .. } => format!("CallbackInterface{name}"),
         Type::Optional { inner_type } => format!("Optional{}", canonical_name(inner_type)),
         Type::Sequence { inner_type } => format!("Sequence{}", canonical_name(inner_type)),
         Type::Set { inner_type } => format!("Set{}", canonical_name(inner_type)),
@@ -73,7 +109,6 @@ pub fn canonical_name(t: &Type) -> String {
             canonical_name(key_type).to_upper_camel_case(),
             canonical_name(value_type).to_upper_camel_case()
         ),
-        Type::Custom { name, .. } => format!("Type{name}"),
         Type::Box { inner_type } => canonical_name(inner_type),
     }
 }
@@ -90,24 +125,24 @@ pub struct CustomTypeConfig {
 }
 
 impl CustomTypeConfig {
+    fn conversion<'a>(&'a self, primary: &'a str, fallback: &'a str) -> &'a str {
+        if primary.is_empty() {
+            fallback
+        } else {
+            primary
+        }
+    }
+
     /// Produce a Ruby expression that lifts a raw-builtin value `nm` into the custom type.
     fn lift(&self, name: &str) -> String {
-        let converter = if self.lift.is_empty() {
-            &self.into_custom
-        } else {
-            &self.lift
-        };
-        converter.replace("{}", name)
+        self.conversion(&self.lift, &self.into_custom)
+            .replace("{}", name)
     }
 
     /// Produce a Ruby expression that lowers a value `nm` to its raw builtin.
     fn lower(&self, name: &str) -> String {
-        let converter = if self.lower.is_empty() {
-            &self.from_custom
-        } else {
-            &self.lower
-        };
-        converter.replace("{}", name)
+        self.conversion(&self.lower, &self.from_custom)
+            .replace("{}", name)
     }
 
     /// True if this config actually specifies conversion expressions.
@@ -123,19 +158,24 @@ impl CustomTypeConfig {
 pub struct Config {
     pub(super) cdylib_name: Option<String>,
     cdylib_path: Option<String>,
+    /// Ruby `module` name emitted in generated bindings.
+    ///
+    /// Default (when unset): UpperCamelCase of the UniFFI namespace.
+    #[serde(default)]
+    pub(super) module_name: Option<String>,
     #[serde(default)]
     custom_types: HashMap<String, CustomTypeConfig>,
     #[serde(default)]
     pub(super) exclude: Vec<String>,
     #[serde(default)]
     pub(super) rename: toml::Table,
+    #[serde(default)]
+    pub(super) external_packages: HashMap<String, String>,
 }
 
 impl Config {
     pub fn cdylib_name(&self) -> String {
-        self.cdylib_name
-            .clone()
-            .unwrap_or_else(|| "uniffi".to_string())
+        self.cdylib_name.as_deref().unwrap_or("uniffi").to_owned()
     }
 
     pub fn custom_cdylib_path(&self) -> bool {
@@ -145,6 +185,66 @@ impl Config {
     pub fn cdylib_path(&self) -> String {
         self.cdylib_path.clone().unwrap_or_default()
     }
+
+    /// Ruby module name for this crate: config override or UpperCamelCase(`namespace`).
+    pub fn module_name(&self, namespace: &str) -> String {
+        self.module_name
+            .clone()
+            .unwrap_or_else(|| class_name_rb_inner(namespace))
+    }
+
+    /// Default `module_name` when the TOML omits it: UpperCamelCase of the namespace.
+    pub(super) fn default_module_name(namespace: &str) -> String {
+        class_name_rb_inner(namespace)
+    }
+
+    /// Reject nested paths, reserved words, and non-constant identifiers.
+    pub(super) fn validate_module_name(&self) -> Result<()> {
+        let Some(name) = &self.module_name else {
+            return Ok(());
+        };
+        if !is_valid_ruby_constant(name) || is_reserved_word(name) {
+            bail!(
+                "invalid [bindings.ruby.module_name] `{name}`: must be a single Ruby constant \
+                 (e.g. `UniffiOne`), not nested (`Foo::Bar`) or a reserved word"
+            );
+        }
+        Ok(())
+    }
+
+    pub fn external_package_name(&self, module_path: &str, namespace: Option<&str>) -> String {
+        let crate_name = crate_name_from_module_path(module_path);
+
+        self.external_packages
+            .get(&crate_name)
+            .cloned()
+            .unwrap_or_else(|| class_name_rb_inner(namespace.unwrap_or(module_path)))
+    }
+
+    /// Canonicalize `external_packages` keys to underscored Rust crate names.
+    ///
+    /// Cargo package names and UDL `[External="..."]` values may contain hyphens;
+    /// proc-macro module paths and `ci.crate_name()` never do. Rewrite keys so
+    /// `my-crate` and `my_crate` are the same entry. Conflicting values for the
+    /// same crate are an error.
+    pub(super) fn normalize_external_package_keys(&mut self) -> Result<()> {
+        let mut normalized = HashMap::with_capacity(self.external_packages.len());
+        for (key, value) in &self.external_packages {
+            let canon = crate_name_from_module_path(key);
+            if let Some(existing) = normalized.get(&canon) {
+                if existing != value {
+                    bail!(
+                        "conflicting [bindings.ruby.external_packages] entries for crate `{canon}`: \
+                         `{key}` = `{value}` vs existing `{existing}`"
+                    );
+                }
+            } else {
+                normalized.insert(canon, value.clone());
+            }
+        }
+        self.external_packages = normalized;
+        Ok(())
+    }
 }
 
 #[derive(Template)]
@@ -153,18 +253,334 @@ pub struct RubyWrapper<'a> {
     config: Config,
     ci: &'a ComponentInterface,
 }
+
+/// Owner-module policies (not interchangeable):
+///
+/// - mixin read/write: defining crate for named types, else this crate
+/// - object/callback lift/lower (`ffi_module_prefix`): defining crate, else local
+/// - record/enum/object class names in defaults (`type_class_module`)
+/// - custom `uniffi_{lift,lower}_*` (`custom_owner_module`)
+///
+/// `ffi_module_prefix` is `None` for records/enums so alloc stays on this crate's
+/// `RustBuffer`. Mixin calls are the opposite: bytes interpretation lives in the
+/// defining crate.
 impl<'a> RubyWrapper<'a> {
     pub fn new(config: Config, ci: &'a ComponentInterface) -> Self {
         Self { config, ci }
     }
+
+    pub fn module_name(&self) -> String {
+        self.config.module_name(self.ci.namespace())
+    }
+
+    pub fn external_type_module(&self, module_path: &str) -> String {
+        let namespace = self.ci.namespace_for_module_path(module_path).ok();
+        self.config.external_package_name(module_path, namespace)
+    }
+
+    pub fn is_external_module(&self, module_path: &str) -> bool {
+        crate_name_from_module_path(module_path) != self.ci.crate_name()
+    }
+
+    fn this_module_rooted(&self) -> String {
+        format!("::{}", self.module_name())
+    }
+
+    fn owner_module_for_path(&self, module_path: &str) -> String {
+        if self.is_external_module(module_path) {
+            format!("::{}", self.external_type_module(module_path))
+        } else {
+            self.this_module_rooted()
+        }
+    }
+
+    fn mixin_owner_module(&self, type_: &Type) -> String {
+        match peel_boxes(type_).module_path() {
+            Some(mp) => self.owner_module_for_path(mp),
+            None => self.this_module_rooted(),
+        }
+    }
+
+    fn rust_buffer_op(&self, type_: &Type, mixin: &str, op: &str) -> String {
+        format!(
+            "{}::{mixin}.{op}_{}",
+            self.mixin_owner_module(type_),
+            canonical_name(type_),
+        )
+    }
+
+    /// Callee only, e.g. `::NsA::RustBufferBuilderMixin.write_TypeFoo`.
+    pub fn rust_buffer_write(&self, type_: &Type) -> Result<String, askama::Error> {
+        Ok(self.rust_buffer_op(type_, "RustBufferBuilderMixin", "write"))
+    }
+
+    /// Callee only, e.g. `::NsA::RustBufferStreamMixin.read_TypeFoo`.
+    pub fn rust_buffer_read(&self, type_: &Type) -> Result<String, askama::Error> {
+        Ok(self.rust_buffer_op(type_, "RustBufferStreamMixin", "read"))
+    }
+
+    /// `Method` object for a function's error reader, or `None`.
+    ///
+    /// Unwraps Custom types to find the inner Enum/Object. Named
+    /// `error_reader_method_expr` so it does not collide with the Askama macro
+    /// `error_reader_expr` in `macros.rb`.
+    pub fn error_reader_method_expr(&self, func: &impl Callable) -> Option<String> {
+        let error_type = match func.throws_type() {
+            Some(Type::Custom { builtin, .. }) => builtin.as_ref(),
+            Some(type_) => type_,
+            None => return None,
+        };
+        match error_type {
+            Type::Enum { .. } | Type::Object { .. } => Some(format!(
+                "{}::RustBufferStreamMixin.method(:read_{})",
+                self.mixin_owner_module(error_type),
+                canonical_name(error_type),
+            )),
+            _ => None,
+        }
+    }
+
+    /// Direct external crates to `require`, unique by crate.
+    ///
+    /// Transitive crates are not listed: nested C types are absent from
+    /// `iter_external_types()`, and the intermediate crate's mixin body names C
+    /// lexically (its `wrapper.rb` already `require`s C).
+    pub fn external_mixin_modules(&self) -> Result<Vec<ExternalMixin>, askama::Error> {
+        let mut seen_crates = BTreeSet::new();
+        let mut module_to_crate = HashMap::new();
+        let mut result = Vec::new();
+
+        for typ in self.ci.iter_external_types() {
+            let Some(module_path) = typ.module_path() else {
+                continue;
+            };
+            let crate_name = crate_name_from_module_path(module_path);
+            if !seen_crates.insert(crate_name.clone()) {
+                continue;
+            }
+
+            // Single-UDL generation has no crate→namespace map for dependencies.
+            let require_path = match self.ci.namespace_for_module_path(module_path) {
+                Ok(ns) => ns.to_owned(),
+                Err(_) => {
+                    return Err(askama_err(anyhow!(
+                        "Cannot resolve namespace for external crate `{crate_name}`. \
+                         Single-UDL generation is not supported for external types; generate from a \
+                         compiled library (e.g. `uniffi-bindgen generate path/to/libfoo.dylib --language ruby`) \
+                         so UniFFI can load scaffolding metadata for all crates."
+                    )));
+                }
+            };
+
+            let module_name = self.external_type_module(module_path);
+            if let Some(existing) = module_to_crate.get(&module_name) {
+                return Err(askama_err(anyhow!(
+                    "Ruby module `{module_name}` is used by both crate `{existing}` and crate `{crate_name}`; \
+                     each crate must have a unique Ruby module name"
+                )));
+            }
+            module_to_crate.insert(module_name, crate_name);
+
+            result.push(ExternalMixin { require_path });
+        }
+
+        Ok(result)
+    }
+
+    /// Deduplicated require paths declared by external custom type configs.
+    pub fn external_custom_type_imports(&self) -> Vec<String> {
+        let mut imports = BTreeSet::new();
+        for typ in self.ci.iter_external_types() {
+            let Type::Custom { name, .. } = typ else {
+                continue;
+            };
+            if let Some(extra) = self
+                .config
+                .custom_types
+                .get(name)
+                .and_then(|cfg| cfg.imports.as_ref())
+            {
+                imports.extend(extra.iter().cloned());
+            }
+        }
+        imports.into_iter().collect()
+    }
+
+    /// Prefix for object/callback handle lift/lower. `None` for RustBuffer-backed
+    /// types so alloc/reserve/free stay on this crate's cdylib.
+    fn ffi_module_prefix(&self, type_: &Type) -> Option<String> {
+        match peel_boxes_and_custom(type_) {
+            Type::Object { module_path, .. } | Type::CallbackInterface { module_path, .. }
+                if self.is_external_module(module_path) =>
+            {
+                Some(self.external_type_module(module_path))
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn is_external_custom(&self, type_: &Type) -> bool {
+        matches!(
+            peel_boxes(type_),
+            Type::Custom { module_path, .. } if self.is_external_module(module_path)
+        )
+    }
+
+    pub(crate) fn custom_owner_module(&self, module_path: &str) -> String {
+        self.owner_module_for_path(module_path)
+    }
+
+    pub fn lift_rb(&self, nm: &str, type_: &Type) -> Result<String, askama::Error> {
+        let module = self.ffi_module_prefix(type_);
+        filters::lift_rb_inner_dispatch(nm, type_, module.as_deref(), self)
+    }
+
+    pub fn lower_rb(&self, nm: impl AsRef<str>, type_: &Type) -> Result<String, askama::Error> {
+        let module = self.ffi_module_prefix(type_);
+        filters::lower_rb_inner_dispatch(nm.as_ref(), type_, module.as_deref(), self)
+    }
+
+    pub fn check_lower_rb(
+        &self,
+        nm: impl AsRef<str>,
+        type_: &Type,
+    ) -> Result<String, askama::Error> {
+        let module = self.ffi_module_prefix(type_);
+        filters::check_lower_rb_inner(nm.as_ref(), type_, module.as_deref(), self)
+    }
+
+    pub fn coerce_rb(&self, nm: impl AsRef<str>, type_: &Type) -> Result<String, askama::Error> {
+        let ns = self.module_name();
+        filters::coerce_rb_inner(nm, ns, type_, self)
+    }
+
+    pub fn field_default_rb(&self, field: &Field) -> Result<String, askama::Error> {
+        self.default_rb(field.default_value(), &field.as_type(), "field")
+    }
+
+    pub fn arg_default_rb(&self, arg: &Argument) -> Result<String, askama::Error> {
+        self.default_rb(arg.default_value(), &arg.as_type(), "arg")
+    }
+
+    fn default_rb(
+        &self,
+        default: Option<&DefaultValue>,
+        ty: &Type,
+        what: &str,
+    ) -> Result<String, askama::Error> {
+        match default {
+            Some(default) => filters::default_rb_inner(default, ty, self),
+            None => Err(askama_err(anyhow!(
+                "{what} default requested but none is set"
+            ))),
+        }
+    }
+
+    /// Prefix for constructing a Ruby class (defaults). Unlike `ffi_module_prefix`,
+    /// this includes records and enums.
+    pub(crate) fn type_class_module(&self, type_: &Type) -> Option<String> {
+        match peel_boxes_and_custom(type_) {
+            Type::Record { module_path, .. }
+            | Type::Object { module_path, .. }
+            | Type::Enum { module_path, .. }
+                if self.is_external_module(module_path) =>
+            {
+                Some(self.external_type_module(module_path))
+            }
+            _ => None,
+        }
+    }
 }
 
-fn class_name_rb_inner(nm: &str) -> Result<String, askama::Error> {
-    Ok(nm.to_string().to_upper_camel_case())
+fn class_name_rb_inner(nm: &str) -> String {
+    nm.to_string().to_upper_camel_case()
 }
 
 mod filters {
     use super::*;
+
+    /// Qualify `name` with an optional external module path.
+    ///
+    /// `qualify("Foo", Some("Mod"))` → `"::Mod::Foo"`; `qualify("", Some("Mod"))`
+    /// → `"::Mod::"`; `None` leaves `name` unchanged (local, relative).
+    pub(super) fn qualify(name: &str, module: Option<&str>) -> String {
+        match module {
+            Some(m) => format!("::{m}::{name}"),
+            None => name.to_string(),
+        }
+    }
+
+    /// How a type crosses the FFI after peeling `Type::Box`. Custom is *not*
+    /// peeled: lift/lower wrap with `uniffi_{lift,lower}_*` then recurse.
+    enum FfiShape<'a> {
+        Custom {
+            name: &'a str,
+            builtin: &'a Type,
+            module_path: &'a str,
+        },
+        Int,
+        Float,
+        Boolean,
+        Object {
+            name: &'a str,
+        },
+        Callback {
+            name: &'a str,
+        },
+        RustBuffer,
+    }
+
+    fn ffi_shape(type_: &Type) -> FfiShape<'_> {
+        match peel_boxes(type_) {
+            Type::Custom {
+                name,
+                builtin,
+                module_path,
+                ..
+            } => FfiShape::Custom {
+                name,
+                builtin,
+                module_path,
+            },
+            Type::Int8
+            | Type::UInt8
+            | Type::Int16
+            | Type::UInt16
+            | Type::Int32
+            | Type::UInt32
+            | Type::Int64
+            | Type::UInt64 => FfiShape::Int,
+            Type::Float32 | Type::Float64 => FfiShape::Float,
+            Type::Boolean => FfiShape::Boolean,
+            Type::Object { name, .. } => FfiShape::Object { name },
+            Type::CallbackInterface { name, .. } => FfiShape::Callback { name },
+            Type::Enum { .. }
+            | Type::Record { .. }
+            | Type::Optional { .. }
+            | Type::Sequence { .. }
+            | Type::Set { .. }
+            | Type::Timestamp
+            | Type::String
+            | Type::Bytes
+            | Type::Duration
+            | Type::Map { .. } => FfiShape::RustBuffer,
+            Type::Box { .. } => unreachable!("peeled"),
+        }
+    }
+
+    fn int_coerce_bounds(type_: &Type) -> Option<(&'static str, &'static str, &'static str)> {
+        match type_ {
+            Type::Int8 => Some(("i8", "-2**7", "2**7")),
+            Type::Int16 => Some(("i16", "-2**15", "2**15")),
+            Type::Int32 => Some(("i32", "-2**31", "2**31")),
+            Type::Int64 => Some(("i64", "-2**63", "2**63")),
+            Type::UInt8 => Some(("u8", "0", "2**8")),
+            Type::UInt16 => Some(("u16", "0", "2**16")),
+            Type::UInt32 => Some(("u32", "0", "2**32")),
+            Type::UInt64 => Some(("u64", "0", "2**64")),
+            _ => None,
+        }
+    }
 
     #[askama::filter_fn]
     pub fn type_ffi(type_: &FfiType, _: &dyn askama::Values) -> Result<String, askama::Error> {
@@ -193,40 +609,41 @@ mod filters {
         })
     }
 
-    /// Generate the Ruby FFI::Pointer write method name for writing a lowered return value.
-    /// For RustBuffer returns, return "rustbuffer" as a sentinel - template handles it specially.
+    /// Ruby FFI::Pointer write method for a lowered callback return.
+    /// `rustbuffer` is a sentinel the template handles specially.
     #[askama::filter_fn]
     pub fn ffi_write_return_rb(
         return_type: &Type,
         _: &dyn askama::Values,
     ) -> Result<String, askama::Error> {
         let ffi_type = FfiType::from(return_type);
-
-        Ok(match &ffi_type {
-            FfiType::Int8 => "write_int8".to_string(),
-            FfiType::UInt8 => "write_uint8".to_string(),
-            FfiType::Int16 => "write_int16".to_string(),
-            FfiType::UInt16 => "write_uint16".to_string(),
-            FfiType::Int32 => "write_int32".to_string(),
-            FfiType::UInt32 => "write_uint32".to_string(),
-            FfiType::Int64 => "write_int64".to_string(),
-            FfiType::UInt64 => "write_uint64".to_string(),
-            FfiType::Float32 => "write_float".to_string(),
-            FfiType::Float64 => "write_double".to_string(),
-            FfiType::Handle => "write_uint64".to_string(),
-            FfiType::RustBuffer(_) => "rustbuffer".to_string(),
-            _ => panic!("Unsupported FFI return type for callback: {ffi_type:?}"),
-        })
+        match &ffi_type {
+            FfiType::Int8 => Ok("write_int8".to_string()),
+            FfiType::UInt8 => Ok("write_uint8".to_string()),
+            FfiType::Int16 => Ok("write_int16".to_string()),
+            FfiType::UInt16 => Ok("write_uint16".to_string()),
+            FfiType::Int32 => Ok("write_int32".to_string()),
+            FfiType::UInt32 => Ok("write_uint32".to_string()),
+            FfiType::Int64 => Ok("write_int64".to_string()),
+            FfiType::UInt64 => Ok("write_uint64".to_string()),
+            FfiType::Float32 => Ok("write_float".to_string()),
+            FfiType::Float64 => Ok("write_double".to_string()),
+            FfiType::Handle => Ok("write_uint64".to_string()),
+            FfiType::RustBuffer(_) => Ok("rustbuffer".to_string()),
+            _ => Err(askama_err(anyhow!(
+                "Unsupported FFI return type for callback: {ffi_type:?}"
+            ))),
+        }
     }
 
-    /// Return the Ruby default value for an FFI return type (used in async error callbacks).
+    /// Ruby default value for an FFI return type (async error callbacks).
     #[askama::filter_fn]
     pub fn ffi_default_value_rb(
         return_type: &Type,
         _: &dyn askama::Values,
     ) -> Result<String, askama::Error> {
         let ffi_type = FfiType::from(return_type);
-        Ok(match &ffi_type {
+        match &ffi_type {
             FfiType::Int8
             | FfiType::UInt8
             | FfiType::Int16
@@ -235,14 +652,16 @@ mod filters {
             | FfiType::UInt32
             | FfiType::Int64
             | FfiType::UInt64
-            | FfiType::Handle => "0".to_string(),
-            FfiType::Float32 | FfiType::Float64 => "0.0".to_string(),
-            FfiType::RustBuffer(_) => "RustBuffer.new".to_string(),
-            _ => panic!("Unsupported FFI return type for callback: {ffi_type:?}"),
-        })
+            | FfiType::Handle => Ok("0".to_string()),
+            FfiType::Float32 | FfiType::Float64 => Ok("0.0".to_string()),
+            FfiType::RustBuffer(_) => Ok("RustBuffer.new".to_string()),
+            _ => Err(askama_err(anyhow!(
+                "Unsupported FFI return type for callback: {ffi_type:?}"
+            ))),
+        }
     }
 
-    /// Return the ForeignFutureResult struct name for a method's return type.
+    /// ForeignFutureResult struct name for a method's return type.
     #[askama::filter_fn]
     pub fn foreign_future_result_rb(
         method: &Method,
@@ -251,14 +670,22 @@ mod filters {
         Ok(method.foreign_future_ffi_result_struct().name().to_string())
     }
 
-    fn default_rb_inner(default: &DefaultValue) -> Result<String, askama::Error> {
-        let DefaultValue::Literal(literal) = default else {
-            unimplemented!("not supported.");
-        };
-        literal_rb_inner(literal)
+    pub(super) fn default_rb_inner(
+        default: &DefaultValue,
+        ty: &Type,
+        wrapper: &RubyWrapper<'_>,
+    ) -> Result<String, askama::Error> {
+        match default {
+            DefaultValue::Literal(lit) => literal_rb_inner(lit, ty, wrapper),
+            DefaultValue::Default => type_zero_value_rb(ty, wrapper),
+        }
     }
 
-    fn literal_rb_inner(literal: &Literal) -> Result<String, askama::Error> {
+    fn literal_rb_inner(
+        literal: &Literal,
+        ty: &Type,
+        wrapper: &RubyWrapper<'_>,
+    ) -> Result<String, askama::Error> {
         Ok(match literal {
             Literal::Boolean(v) => {
                 if *v {
@@ -270,15 +697,46 @@ mod filters {
             // use the double-quote form to match with the other languages, and quote escapes.
             Literal::String(s) => format!("\"{s}\""),
             Literal::None => "nil".into(),
-            Literal::Some { inner } => default_rb_inner(inner)?,
+            Literal::Some { inner } => {
+                let inner_ty = match ty {
+                    Type::Optional { inner_type } => inner_type.as_ref(),
+                    // Peel Custom wrappers — the metadata construction already validated
+                    // that the builtin is Optional; match type_zero_value_rb's convention.
+                    Type::Custom { builtin, .. } => match builtin.as_ref() {
+                        Type::Optional { inner_type } => inner_type.as_ref(),
+                        other => {
+                            return Err(askama_err(anyhow!(
+                                "Expected Optional type for Some literal, got {other:?}"
+                            )));
+                        }
+                    },
+                    _ => {
+                        return Err(askama_err(anyhow!(
+                            "Expected Optional type for Some literal, got {ty:?}"
+                        )));
+                    }
+                };
+                default_rb_inner(inner, inner_ty, wrapper)?
+            }
             Literal::EmptySequence => "[]".into(),
             Literal::EmptyMap => "{}".into(),
             Literal::EmptySet => "Set.new".into(),
             Literal::Enum(v, type_) => match type_ {
                 Type::Enum { name, .. } => {
-                    format!("{}::{}", class_name_rb_inner(name)?, enum_name_rb_inner(v)?)
+                    format!(
+                        "{}::{}",
+                        qualify(
+                            &class_name_rb_inner(name),
+                            wrapper.type_class_module(type_).as_deref()
+                        ),
+                        enum_name_rb_inner(v)?
+                    )
                 }
-                _ => panic!("Unexpected type in enum literal: {type_:?}"),
+                _ => {
+                    return Err(askama_err(anyhow!(
+                        "Unexpected type in enum literal: {type_:?}"
+                    )));
+                }
             },
             // https://docs.ruby-lang.org/en/2.0.0/syntax/literals_rdoc.html
             Literal::Int(i, radix, _) => match radix {
@@ -295,8 +753,7 @@ mod filters {
         })
     }
 
-    /// Return the Ruby zero/default value for a type (used for `#[uniffi::default]`).
-    fn type_zero_value_rb(ty: &Type) -> Result<String, askama::Error> {
+    fn type_zero_value_rb(ty: &Type, wrapper: &RubyWrapper<'_>) -> Result<String, askama::Error> {
         Ok(match ty {
             Type::Int8
             | Type::UInt8
@@ -314,53 +771,25 @@ mod filters {
             Type::Bytes => "\"\".b".to_string(),
             Type::Map { .. } => "{}".to_string(),
             Type::Set { .. } => "Set.new".to_string(),
-            // Named types with no-arg constructors
             Type::Record { name, .. } | Type::Object { name, .. } => {
-                format!("{}.new", class_name_rb_inner(name)?)
+                format!(
+                    "{}.new",
+                    qualify(
+                        &class_name_rb_inner(name),
+                        wrapper.type_class_module(ty).as_deref()
+                    )
+                )
             }
-            // Custom types delegate to their underlying builtin
-            Type::Custom { builtin, .. } => type_zero_value_rb(builtin)?,
+            Type::Custom { builtin, .. } => type_zero_value_rb(builtin, wrapper)?,
             _ => {
-                return Err(askama::Error::Custom(
-                    anyhow::anyhow!("No zero value for type {ty:?}").into(),
-                ))
+                return Err(askama_err(anyhow!("No zero value for type {ty:?}")));
             }
         })
     }
 
-    /// Render the Ruby default value for a field, handling both `Default` and `Literal` variants.
-    #[askama::filter_fn]
-    pub fn field_default_rb(
-        field: &Field,
-        _: &dyn askama::Values,
-    ) -> Result<String, askama::Error> {
-        match field.default_value() {
-            Some(DefaultValue::Default) => {
-                let ty = field.as_type();
-                type_zero_value_rb(&ty)
-            }
-            Some(DefaultValue::Literal(lit)) => literal_rb_inner(lit),
-            None => Err(askama::Error::Custom(
-                anyhow::anyhow!("field_default_rb called on field with no default value").into(),
-            )),
-        }
-    }
-
-    /// Render the Ruby default value for a function/method argument.
-    #[askama::filter_fn]
-    pub fn arg_default_rb(arg: &Argument, _: &dyn askama::Values) -> Result<String, askama::Error> {
-        match arg.default_value() {
-            Some(DefaultValue::Default) => type_zero_value_rb(&arg.as_type()),
-            Some(DefaultValue::Literal(lit)) => literal_rb_inner(lit),
-            None => Err(askama::Error::Custom(
-                anyhow::anyhow!("arg_default_rb called on arg with no default value").into(),
-            )),
-        }
-    }
-
     #[askama::filter_fn]
     pub fn class_name_rb(nm: &str, _: &dyn askama::Values) -> Result<String, askama::Error> {
-        class_name_rb_inner(nm)
+        Ok(class_name_rb_inner(nm))
     }
 
     #[askama::filter_fn]
@@ -385,34 +814,26 @@ mod filters {
         Ok(nm.to_string().to_shouty_snake_case())
     }
 
-    #[askama::filter_fn]
-    pub fn coerce_rb<S1: AsRef<str>, S2: AsRef<str>>(
-        nm: S1,
-        _: &dyn askama::Values,
-        ns: S2,
-        type_: &Type,
-        config: &Config,
-    ) -> Result<String, askama::Error> {
-        coerce_rb_inner(nm, ns, type_, &config.custom_types)
-    }
-
     pub fn coerce_rb_inner<S1: AsRef<str>, S2: AsRef<str>>(
         nm: S1,
         ns: S2,
         type_: &Type,
-        custom_types: &HashMap<String, CustomTypeConfig>,
+        wrapper: &RubyWrapper<'_>,
     ) -> Result<String, askama::Error> {
         let nm = nm.as_ref();
         let ns = ns.as_ref();
         Ok(match type_ {
-            Type::Int8 => format!("::{ns}::uniffi_in_range({nm}, \"i8\", -2**7, 2**7)"),
-            Type::Int16 => format!("::{ns}::uniffi_in_range({nm}, \"i16\", -2**15, 2**15)"),
-            Type::Int32 => format!("::{ns}::uniffi_in_range({nm}, \"i32\", -2**31, 2**31)"),
-            Type::Int64 => format!("::{ns}::uniffi_in_range({nm}, \"i64\", -2**63, 2**63)"),
-            Type::UInt8 => format!("::{ns}::uniffi_in_range({nm}, \"u8\", 0, 2**8)"),
-            Type::UInt16 => format!("::{ns}::uniffi_in_range({nm}, \"u16\", 0, 2**16)"),
-            Type::UInt32 => format!("::{ns}::uniffi_in_range({nm}, \"u32\", 0, 2**32)"),
-            Type::UInt64 => format!("::{ns}::uniffi_in_range({nm}, \"u64\", 0, 2**64)"),
+            Type::Int8
+            | Type::Int16
+            | Type::Int32
+            | Type::Int64
+            | Type::UInt8
+            | Type::UInt16
+            | Type::UInt32
+            | Type::UInt64 => {
+                let (ty, lo, hi) = int_coerce_bounds(type_).expect("int type");
+                format!("::{ns}::uniffi_in_range({nm}, \"{ty}\", {lo}, {hi})")
+            }
             Type::Float32
             | Type::Float64
             | Type::Object { .. }
@@ -425,13 +846,10 @@ mod filters {
             Type::String => format!("::{ns}::uniffi_utf8({nm})"),
             Type::Bytes => format!("::{ns}::uniffi_bytes({nm})"),
             Type::Optional { inner_type: t } => {
-                format!(
-                    "({nm} ? {} : nil)",
-                    coerce_rb_inner(nm, ns, t, custom_types)?
-                )
+                format!("({nm} ? {} : nil)", coerce_rb_inner(nm, ns, t, wrapper)?)
             }
             Type::Sequence { inner_type: t } => {
-                let coerce_code = coerce_rb_inner("v", ns, t, custom_types)?;
+                let coerce_code = coerce_rb_inner("v", ns, t, wrapper)?;
                 if coerce_code == "v" {
                     nm.to_string()
                 } else {
@@ -439,7 +857,7 @@ mod filters {
                 }
             }
             Type::Set { inner_type: t } => {
-                let coerce_code = coerce_rb_inner("v", ns, t, custom_types)?;
+                let coerce_code = coerce_rb_inner("v", ns, t, wrapper)?;
                 if coerce_code == "v" {
                     nm.to_string()
                 } else {
@@ -450,8 +868,8 @@ mod filters {
                 key_type: kt,
                 value_type: vt,
             } => {
-                let k_coerce_code = coerce_rb_inner("k", ns, kt, custom_types)?;
-                let v_coerce_code = coerce_rb_inner("v", ns, vt, custom_types)?;
+                let k_coerce_code = coerce_rb_inner("k", ns, kt, wrapper)?;
+                let v_coerce_code = coerce_rb_inner("v", ns, vt, wrapper)?;
 
                 if k_coerce_code == "k" && v_coerce_code == "v" {
                     nm.to_string()
@@ -461,310 +879,197 @@ mod filters {
                     )
                 }
             }
-            Type::Box { inner_type } => coerce_rb_inner(nm, ns, inner_type, custom_types)?,
+            Type::Box { inner_type } => coerce_rb_inner(nm, ns, inner_type, wrapper)?,
             Type::Custom { name, builtin, .. } => {
-                // For config-backed custom types, the user passes a custom-typed values;
-                // skip builtin coercion (the lower expression handles conversion).
-                if custom_types.contains_key(name) {
+                // Config-backed and imported customs skip consumer-side builtin
+                // coerce. Identity newtypes coerce inside the defining crate's
+                // `uniffi_lower_*` so `to_int` / `to_str` still flow to FFI.
+                if wrapper.config.custom_types.contains_key(name)
+                    || wrapper.is_external_custom(type_)
+                {
                     nm.to_string()
                 } else {
-                    coerce_rb_inner(nm, ns, builtin, custom_types)?
+                    coerce_rb_inner(nm, ns, builtin, wrapper)?
                 }
             }
         })
     }
 
-    #[askama::filter_fn]
-    pub fn check_lower_rb<S: AsRef<str>>(
-        nm: S,
-        _: &dyn askama::Values,
-        type_: &Type,
-        config: &Config,
-    ) -> Result<String, askama::Error> {
-        let nm = nm.as_ref();
-        Ok(match type_ {
-            Type::Object { name, .. } => {
-                format!("({}.uniffi_check_lower {nm})", class_name_rb_inner(name)?)
-            }
-            Type::Enum { .. }
-            | Type::Record { .. }
-            | Type::Optional { .. }
-            | Type::Sequence { .. }
-            | Type::Set { .. }
-            | Type::Map { .. } => {
-                format!("RustBuffer.check_lower_{}({})", canonical_name(type_), nm)
-            }
-            Type::Custom { name, .. } => {
-                if let Some(cfg) = config.custom_types.get(name) {
-                    if let Some(type_name) = &cfg.type_name {
-                        // Emit: rause TypeError, "Expected URI, got #{nm.class}" unless nm.is_a?(URI)
-                        format!(
-                            "raise TypeError, \"Expected {type_name}, got {{#{nm}.class}}\" unless {nm}.is_a?({type_name})"
-                        )
-                    } else {
-                        "".to_string()
-                    }
-                } else {
-                    "".to_string()
-                }
-            }
-            _ => "".to_owned(),
-        })
-    }
-
-    pub fn lower_rb_inner(
+    pub(super) fn check_lower_rb_inner(
         nm: &str,
         type_: &Type,
-        custom_types: &HashMap<String, CustomTypeConfig>,
+        module: Option<&str>,
+        wrapper: &RubyWrapper<'_>,
     ) -> Result<String, askama::Error> {
-        let mut type_ = type_;
-        while let Type::Box { inner_type } = type_ {
-            type_ = &**inner_type;
-        }
-        lower_rb_inner_no_box(nm, type_, custom_types)
-    }
-
-    fn lower_rb_inner_no_box(
-        nm: &str,
-        type_: &Type,
-        custom_types: &HashMap<String, CustomTypeConfig>,
-    ) -> Result<String, askama::Error> {
-        Ok(match type_ {
-            Type::Box { inner_type } => lower_rb_inner(nm, inner_type, custom_types)?,
-            Type::Custom { name, builtin, .. } => {
-                if let Some(cfg) = custom_types.get(name) {
-                    // Apply the configured `lower` expression, then lower the resulting builtin.
-                    let lowered_nm = cfg.lower(nm);
-                    lower_rb_inner(&lowered_nm, builtin, custom_types)?
-                } else {
-                    lower_rb_inner(nm, builtin, custom_types)?
-                }
-            }
-            type_ => return lower_rb_inner_dispatch(nm, type_),
-        })
-    }
-
-    pub fn lower_rb_inner_dispatch(nm: &str, type_: &Type) -> Result<String, askama::Error> {
-        Ok(match type_ {
-            Type::Int8
-            | Type::UInt8
-            | Type::Int16
-            | Type::UInt16
-            | Type::Int32
-            | Type::UInt32
-            | Type::Int64
-            | Type::UInt64
-            | Type::Float32
-            | Type::Float64 => nm.to_string(),
-            Type::Boolean => format!("({nm} ? 1 : 0)"),
-            Type::Object { name, .. } => {
-                format!("({}.uniffi_lower {nm})", class_name_rb_inner(name)?)
-            }
-            Type::CallbackInterface { name, .. } => {
+        Ok(match ffi_shape(type_) {
+            FfiShape::Object { name } => {
                 format!(
-                    "(CallbackInterface{}FfiConverter.lower {})",
-                    class_name_rb_inner(name)?,
+                    "({}.uniffi_check_lower {nm})",
+                    qualify(&class_name_rb_inner(name), module)
+                )
+            }
+            FfiShape::RustBuffer => match peel_boxes(type_) {
+                Type::Enum { .. }
+                | Type::Record { .. }
+                | Type::Optional { .. }
+                | Type::Sequence { .. }
+                | Type::Set { .. }
+                | Type::Map { .. } => format!(
+                    "{}RustBuffer.check_lower_{}({nm})",
+                    qualify("", module),
+                    canonical_name(type_)
+                ),
+                _ => String::new(),
+            },
+            FfiShape::Custom {
+                name,
+                builtin,
+                module_path,
+            } => {
+                // External types always use the defining crate's checker
+                // (identity newtypes forward to the builtin there).
+                // Local types with a `type_name` use this crate's checker.
+                // Identity local newtypes recurse so `LocalUrl = Url` still checks `URI`.
+                let has_local_type_name = wrapper
+                    .config
+                    .custom_types
+                    .get(name)
+                    .and_then(|cfg| cfg.type_name.as_ref())
+                    .is_some();
+                if wrapper.is_external_module(module_path) || has_local_type_name {
+                    format!(
+                        "{}.uniffi_check_lower_{}({nm})",
+                        wrapper.custom_owner_module(module_path),
+                        canonical_name(type_),
+                    )
+                } else {
+                    check_lower_rb_inner(nm, builtin, module, wrapper)?
+                }
+            }
+            _ => String::new(),
+        })
+    }
+
+    pub fn lower_rb_inner_dispatch(
+        nm: &str,
+        type_: &Type,
+        module: Option<&str>,
+        wrapper: &RubyWrapper<'_>,
+    ) -> Result<String, askama::Error> {
+        Ok(match ffi_shape(type_) {
+            FfiShape::Custom {
+                builtin,
+                module_path,
+                ..
+            } => {
+                // Convert via the owning module, then lower the builtin.
+                // Forward `module` so Object/CallbackInterface stay qualified.
+                // Consumer `custom_types` live in `uniffi_lower_*` (CustomTypeTemplate.rb).
+                let converted = format!(
+                    "{}.uniffi_lower_{}({nm})",
+                    wrapper.custom_owner_module(module_path),
+                    canonical_name(type_),
+                );
+                lower_rb_inner_dispatch(&converted, builtin, module, wrapper)?
+            }
+            FfiShape::Int | FfiShape::Float => nm.to_string(),
+            FfiShape::Boolean => format!("({nm} ? 1 : 0)"),
+            FfiShape::Object { name } => {
+                format!(
+                    "({}.uniffi_lower {nm})",
+                    qualify(&class_name_rb_inner(name), module)
+                )
+            }
+            FfiShape::Callback { name } => {
+                format!(
+                    "({}CallbackInterface{}FfiConverter.lower {})",
+                    qualify("", module),
+                    class_name_rb_inner(name),
                     nm
                 )
             }
-            Type::Enum { .. }
-            | Type::Record { .. }
-            | Type::Optional { .. }
-            | Type::Sequence { .. }
-            | Type::Set { .. }
-            | Type::Timestamp
-            | Type::String
-            | Type::Bytes
-            | Type::Duration
-            | Type::Map { .. } => {
-                format!("RustBuffer.alloc_from_{}({})", canonical_name(type_), nm)
+            FfiShape::RustBuffer => {
+                format!(
+                    "{}RustBuffer.alloc_from_{}({})",
+                    qualify("", module),
+                    canonical_name(type_),
+                    nm
+                )
             }
-            Type::Box { .. } => unreachable!(),
-            Type::Custom { .. } => unreachable!("Custom types should be handled before dispatch"),
-        })
-    }
-
-    #[askama::filter_fn]
-    pub fn lower_rb(
-        nm: impl AsRef<str>,
-        _: &dyn askama::Values,
-        type_: &Type,
-        config: &Config,
-    ) -> Result<String, askama::Error> {
-        lower_rb_inner(nm.as_ref(), type_, &config.custom_types)
-    }
-
-    fn lift_rb_inner(
-        nm: &str,
-        type_: &Type,
-        custom_types: &HashMap<String, CustomTypeConfig>,
-    ) -> Result<String, askama::Error> {
-        let mut type_ = type_;
-        while let Type::Box { inner_type } = type_ {
-            type_ = &**inner_type;
-        }
-        lift_rb_inner_no_box(nm, type_, custom_types)
-    }
-
-    fn lift_rb_inner_no_box(
-        nm: &str,
-        type_: &Type,
-        custom_types: &HashMap<String, CustomTypeConfig>,
-    ) -> Result<String, askama::Error> {
-        Ok(match type_ {
-            Type::Box { inner_type } => lift_rb_inner(nm, inner_type, custom_types)?,
-            Type::Custom { name, builtin, .. } => {
-                // First lift the raw builtin value, then apply the configured lift expression.
-                let lifted = lift_rb_inner(nm, builtin, custom_types)?;
-                if let Some(cfg) = custom_types.get(name) {
-                    cfg.lift(&lifted)
-                } else {
-                    lifted
-                }
-            }
-            type_ => return lift_rb_inner_dispatch(nm, type_, custom_types),
         })
     }
 
     pub fn lift_rb_inner_dispatch(
         nm: &str,
         type_: &Type,
-        custom_types: &HashMap<String, CustomTypeConfig>,
+        module: Option<&str>,
+        wrapper: &RubyWrapper<'_>,
     ) -> Result<String, askama::Error> {
-        Ok(match type_ {
-            Type::Int8
-            | Type::UInt8
-            | Type::Int16
-            | Type::UInt16
-            | Type::Int32
-            | Type::UInt32
-            | Type::Int64
-            | Type::UInt64 => format!("{nm}.to_i"),
-            Type::Float32 | Type::Float64 => format!("{nm}.to_f"),
-            Type::Boolean => format!("1 == {nm}"),
-            Type::Object { name, .. } => {
-                format!("{}.uniffi_lift({nm})", class_name_rb_inner(name)?)
-            }
-            Type::CallbackInterface { name, .. } => {
+        Ok(match ffi_shape(type_) {
+            FfiShape::Custom {
+                builtin,
+                module_path,
+                ..
+            } => {
+                // Lift the builtin, then convert via the owning module.
+                let lifted = lift_rb_inner_dispatch(nm, builtin, module, wrapper)?;
                 format!(
-                    "(CallbackInterface{}FfiConverter.lift {nm})",
-                    class_name_rb_inner(name)?
+                    "{}.uniffi_lift_{}({lifted})",
+                    wrapper.custom_owner_module(module_path),
+                    canonical_name(type_),
                 )
             }
-            Type::Enum { .. } => {
+            FfiShape::Int => format!("{nm}.to_i"),
+            FfiShape::Float => format!("{nm}.to_f"),
+            FfiShape::Boolean => format!("1 == {nm}"),
+            FfiShape::Object { name } => {
                 format!(
-                    "{nm}.consume_into_{}",
-                    class_name_rb_inner(&canonical_name(type_))?
+                    "{}.uniffi_lift({nm})",
+                    qualify(&class_name_rb_inner(name), module)
                 )
             }
-            Type::Record { .. }
-            | Type::Optional { .. }
-            | Type::Sequence { .. }
-            | Type::Set { .. }
-            | Type::Timestamp
-            | Type::String
-            | Type::Bytes
-            | Type::Duration
-            | Type::Map { .. } => format!("{nm}.consume_into_{}", canonical_name(type_)),
-            Type::Box { .. } => unreachable!(),
-            Type::Custom { name, builtin, .. } => {
-                let lifted = lift_rb_inner(nm, builtin, custom_types)?;
-                if let Some(cfg) = custom_types.get(name) {
-                    cfg.lift(&lifted)
-                } else {
-                    lifted
-                }
+            FfiShape::Callback { name } => {
+                format!(
+                    "({}CallbackInterface{}FfiConverter.lift {nm})",
+                    qualify("", module),
+                    class_name_rb_inner(name)
+                )
+            }
+            FfiShape::RustBuffer => {
+                format!("{nm}.consume_into_{}", canonical_name(type_))
             }
         })
     }
 
-    #[askama::filter_fn]
-    pub fn lift_rb(
-        nm: &str,
-        _: &dyn askama::Values,
-        type_: &Type,
-        config: &Config,
-    ) -> Result<String, askama::Error> {
-        lift_rb_inner(nm, type_, &config.custom_types)
-    }
-
     /// Render the Ruby expression that lowers the `self` value of a trait method.
-    /// For Object types, this is `(ClassName.uniffi_lower self)`.
-    /// For Record/Enum types, this serializes `self` into a RustBuffer.
     #[askama::filter_fn]
     pub fn lower_method_self_rb(
         meth: &Method,
         _: &dyn askama::Values,
-        config: &Config,
+        wrapper: &RubyWrapper<'filter>,
     ) -> Result<String, askama::Error> {
         let self_type = meth
             .self_type()
-            .expect("Trait method must have a self type");
-
-        lower_rb_inner("self", &self_type, &config.custom_types)
+            .ok_or_else(|| askama_err(anyhow!("Trait method must have a self type")))?;
+        wrapper.lower_rb("self", &self_type)
     }
 
-    /// Render a Ruby integer literal for the discriminant of the variant at `index` in enum `e`.
+    /// Ruby integer literal for the discriminant of the variant at `index` in enum `e`.
     #[askama::filter_fn]
     pub fn variant_discr_literal(
         e: &Enum,
         _: &dyn askama::Values,
         index: &usize,
     ) -> Result<String, askama::Error> {
-        let literal = e
-            .variant_discr(*index)
-            .map_err(|err| askama::Error::Custom(err.into()))?;
+        let literal = e.variant_discr(*index).map_err(askama_err)?;
 
         match literal {
             Literal::UInt(v, _, _) => Ok(v.to_string()),
             Literal::Int(v, _, _) => Ok(v.to_string()),
-            _ => Err(askama::Error::Custom(
-                anyhow::anyhow!("Only integer discriminants are supported").into(),
-            )),
+            _ => Err(askama_err(anyhow!(
+                "Only integer discriminants are supported"
+            ))),
         }
-    }
-}
-
-#[cfg(test)]
-mod test_type {
-    use super::*;
-
-    #[test]
-    fn test_canonical_names() {
-        // Non-exhaustive, but gives a bit of a flavour of what we want.
-        assert_eq!(canonical_name(&Type::UInt8), "u8");
-        assert_eq!(canonical_name(&Type::String), "string");
-        assert_eq!(canonical_name(&Type::Bytes), "bytes");
-        assert_eq!(
-            canonical_name(&Type::Optional {
-                inner_type: Box::new(Type::Sequence {
-                    inner_type: Box::new(Type::Object {
-                        module_path: "anything".to_string(),
-                        name: "Example".into(),
-                        imp: ObjectImpl::Struct,
-                    })
-                })
-            }),
-            "OptionalSequenceTypeExample"
-        );
-
-        let map = Type::Map {
-            key_type: Box::new(Type::UInt32),
-            value_type: Box::new(Type::UInt32),
-        };
-        assert_eq!(canonical_name(&map), "MapU32U32");
-        assert_eq!(
-            canonical_name(&Type::Enum {
-                module_path: "foo".to_string(),
-                name: "HTMLError".to_string()
-            }),
-            "TypeHTMLError"
-        );
-    }
-
-    #[test]
-    fn test_class_name() {
-        assert_eq!(class_name_rb_inner("Example").unwrap(), "Example");
     }
 }
 

--- a/uniffi_bindgen/src/bindings/ruby/gen_ruby/tests.rs
+++ b/uniffi_bindgen/src/bindings/ruby/gen_ruby/tests.rs
@@ -1,4 +1,34 @@
-use super::{is_reserved_word, Config};
+use super::{
+    canonical_name, class_name_rb_inner, crate_name_from_module_path, filters, is_reserved_word,
+    Config, RubyWrapper,
+};
+use crate::bindings::ruby::generate_ruby_bindings;
+use crate::interface::{ComponentInterface, ObjectImpl, Type};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use uniffi_meta::NamespaceMetadata;
+
+fn namespace(crate_name: &str, name: &str) -> NamespaceMetadata {
+    NamespaceMetadata {
+        crate_name: crate_name.to_string(),
+        name: name.to_string(),
+    }
+}
+
+fn ci_with_namespaces(
+    udl: &str,
+    crate_name: &str,
+    namespaces: &[(&str, &str)],
+) -> ComponentInterface {
+    let mut ci = ComponentInterface::from_webidl(udl, crate_name).unwrap();
+    let map = namespaces
+        .iter()
+        .map(|(c, n)| (c.to_string(), namespace(c, n)))
+        .collect::<BTreeMap<_, _>>();
+    ci.set_crate_to_namespace_map(map);
+    ci
+}
 
 #[test]
 fn when_reserved_word() {
@@ -38,4 +68,678 @@ fn cdylib_path() {
 
     assert_eq!("/foo/bar", config.cdylib_path());
     assert!(config.custom_cdylib_path());
+}
+
+#[test]
+fn module_name_falls_back_to_namespace_camel_case() {
+    let config = Config::default();
+    assert_eq!(config.module_name("foo_ns"), "FooNs");
+}
+
+#[test]
+fn module_name_config_overrides_namespace() {
+    let config = Config {
+        module_name: Some("CustomFoo".into()),
+        ..Default::default()
+    };
+    assert_eq!(config.module_name("foo_ns"), "CustomFoo");
+}
+
+#[test]
+fn module_name_rejects_invalid_identifiers() {
+    for name in ["foo", "Foo::Bar", "", "END", "1Foo"] {
+        let config = Config {
+            module_name: Some(name.into()),
+            ..Default::default()
+        };
+        let err = config.validate_module_name().unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("module_name"), "name={name:?}: {msg}");
+        assert!(msg.contains(name), "name={name:?}: {msg}");
+    }
+}
+
+#[test]
+fn module_name_accepts_valid_constant() {
+    let config = Config {
+        module_name: Some("UniffiOne".into()),
+        ..Default::default()
+    };
+    config.validate_module_name().unwrap();
+}
+
+#[test]
+fn generate_emits_configured_module_name() {
+    let ci = ComponentInterface::from_webidl(
+        r#"
+        namespace foo_ns {};
+        dictionary Foo { string value; };
+        "#,
+        "test",
+    )
+    .unwrap();
+    let config = Config {
+        module_name: Some("CustomFoo".into()),
+        ..Default::default()
+    };
+    let src = generate_ruby_bindings(&config, &ci).unwrap();
+    assert!(src.contains("module CustomFoo"), "{src}");
+    assert!(src.contains("::CustomFoo."), "{src}");
+    assert!(src.contains("::CustomFoo::RustBufferBuilderMixin"), "{src}");
+    assert!(!src.contains("module FooNs"), "{src}");
+    assert!(!src.contains("::FooNs."), "{src}");
+}
+
+#[test]
+fn generate_rejects_invalid_module_name() {
+    let ci = ComponentInterface::from_webidl("namespace test {};", "test").unwrap();
+    let config = Config {
+        module_name: Some("foo".into()),
+        ..Default::default()
+    };
+    let err = generate_ruby_bindings(&config, &ci).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("module_name"), "{msg}");
+}
+
+#[test]
+fn crate_name_from_module_path_normalizes_hyphens() {
+    assert_eq!(crate_name_from_module_path("my-crate"), "my_crate");
+    assert_eq!(crate_name_from_module_path("my_crate"), "my_crate");
+    assert_eq!(crate_name_from_module_path("my-crate::sub"), "my_crate");
+    assert_eq!(crate_name_from_module_path("my_crate::sub"), "my_crate");
+}
+
+#[test]
+fn hyphenated_config_key_matches_underscored_module_path() {
+    let mut config = Config::default();
+    config
+        .external_packages
+        .insert("my-crate".into(), "Custom".into());
+    config.normalize_external_package_keys().unwrap();
+    assert_eq!(
+        config.external_package_name("my_crate::sub", Some("my_ns")),
+        "Custom"
+    );
+}
+
+#[test]
+fn underscored_config_key_matches_hyphenated_udl_module_path() {
+    let mut config = Config::default();
+    config
+        .external_packages
+        .insert("my_crate".into(), "Custom".into());
+    config.normalize_external_package_keys().unwrap();
+    assert_eq!(
+        config.external_package_name("my-crate", Some("my_ns")),
+        "Custom"
+    );
+}
+
+#[test]
+fn unmapped_crate_falls_back_to_namespace() {
+    let config = Config::default();
+    assert_eq!(
+        config.external_package_name("other_crate", Some("other_ns")),
+        "OtherNs"
+    );
+}
+
+#[test]
+fn normalize_external_package_keys_rejects_conflicting_values() {
+    let mut config = Config::default();
+    config
+        .external_packages
+        .insert("my-crate".into(), "A".into());
+    config
+        .external_packages
+        .insert("my_crate".into(), "B".into());
+    let err = config.normalize_external_package_keys().unwrap_err();
+    assert!(err.to_string().contains("conflicting"));
+}
+
+#[test]
+fn normalize_external_package_keys_allows_duplicate_equivalent_keys() {
+    let mut config = Config::default();
+    config
+        .external_packages
+        .insert("my-crate".into(), "Custom".into());
+    config
+        .external_packages
+        .insert("my_crate".into(), "Custom".into());
+    config.normalize_external_package_keys().unwrap();
+    assert_eq!(config.external_packages.get("my_crate").unwrap(), "Custom");
+    assert!(!config.external_packages.contains_key("my-crate"));
+}
+
+#[test]
+fn is_external_module_treats_hyphenated_name_as_same_crate() {
+    let ci = ComponentInterface::new("foo_bar");
+    let wrapper = RubyWrapper::new(Config::default(), &ci);
+    assert!(!wrapper.is_external_module("foo-bar"));
+    assert!(!wrapper.is_external_module("foo_bar"));
+    assert!(!wrapper.is_external_module("foo-bar::sub"));
+    assert!(wrapper.is_external_module("other_crate"));
+    assert!(wrapper.is_external_module("other-crate"));
+}
+
+const TWO_TYPES_UDL: &str = r#"
+    namespace consumer {
+        TypeA get_a();
+        TypeB get_b();
+    };
+
+    [External="crate_a"]
+    typedef dictionary TypeA;
+
+    [External="crate_b"]
+    typedef dictionary TypeB;
+"#;
+
+#[test]
+fn external_mixin_modules_errors_when_external_crate_namespace_unresolved() {
+    let ci = ComponentInterface::from_webidl(TWO_TYPES_UDL, "consumer").unwrap();
+    let err = RubyWrapper::new(Config::default(), &ci)
+        .external_mixin_modules()
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("crate_a") || msg.contains("crate_b"), "{msg}");
+    assert!(
+        msg.contains("Single-UDL generation is not supported"),
+        "{msg}"
+    );
+
+    let render_err = generate_ruby_bindings(&Config::default(), &ci).unwrap_err();
+    let render_msg = format!("{render_err:#}");
+    assert!(
+        render_msg.contains("Single-UDL generation is not supported"),
+        "{render_msg}"
+    );
+}
+
+#[test]
+fn external_mixin_modules_collapses_two_types_from_same_crate() {
+    let ci = ci_with_namespaces(
+        r#"
+        namespace consumer {
+            TypeA get_a();
+            TypeB get_b();
+        };
+
+        [External="crate_a"]
+        typedef dictionary TypeA;
+
+        [External="crate_a"]
+        typedef dictionary TypeB;
+        "#,
+        "consumer",
+        &[("consumer", "consumer"), ("crate_a", "ns_a")],
+    );
+    let mixins = RubyWrapper::new(Config::default(), &ci)
+        .external_mixin_modules()
+        .unwrap();
+    assert_eq!(mixins.len(), 1);
+    assert_eq!(mixins[0].require_path, "ns_a");
+}
+
+#[test]
+fn external_mixin_modules_lists_each_crate() {
+    let ci = ci_with_namespaces(
+        TWO_TYPES_UDL,
+        "consumer",
+        &[
+            ("consumer", "consumer"),
+            ("crate_a", "ns_a"),
+            ("crate_b", "ns_b"),
+        ],
+    );
+    let mut mixins = RubyWrapper::new(Config::default(), &ci)
+        .external_mixin_modules()
+        .unwrap();
+    mixins.sort_by(|a, b| a.require_path.cmp(&b.require_path));
+    assert_eq!(mixins.len(), 2);
+    assert_eq!(mixins[0].require_path, "ns_a");
+    assert_eq!(mixins[1].require_path, "ns_b");
+}
+
+#[test]
+fn external_mixin_modules_errors_on_camel_case_collision() {
+    let ci = ci_with_namespaces(
+        TWO_TYPES_UDL,
+        "consumer",
+        &[
+            ("consumer", "consumer"),
+            ("crate_a", "foo_bar"),
+            ("crate_b", "fooBar"),
+        ],
+    );
+    let err = RubyWrapper::new(Config::default(), &ci)
+        .external_mixin_modules()
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("FooBar"), "{msg}");
+    assert!(msg.contains("crate_a"), "{msg}");
+    assert!(msg.contains("crate_b"), "{msg}");
+}
+
+#[test]
+fn external_mixin_modules_errors_on_external_packages_collision() {
+    let ci = ci_with_namespaces(
+        TWO_TYPES_UDL,
+        "consumer",
+        &[
+            ("consumer", "consumer"),
+            ("crate_a", "ns_a"),
+            ("crate_b", "ns_b"),
+        ],
+    );
+    let mut config = Config::default();
+    config
+        .external_packages
+        .insert("crate_a".into(), "Shared".into());
+    config
+        .external_packages
+        .insert("crate_b".into(), "Shared".into());
+    let err = RubyWrapper::new(config, &ci)
+        .external_mixin_modules()
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("Shared"), "{msg}");
+    assert!(msg.contains("crate_a"), "{msg}");
+    assert!(msg.contains("crate_b"), "{msg}");
+}
+
+#[test]
+fn external_mixin_modules_ignores_unused_external_packages_entry() {
+    let ci = ci_with_namespaces(
+        r#"
+        namespace consumer {
+            TypeB get_b();
+        };
+
+        [External="crate_b"]
+        typedef dictionary TypeB;
+        "#,
+        "consumer",
+        &[
+            ("consumer", "consumer"),
+            ("crate_b", "ns_b"),
+            ("crate_c", "ns_c"),
+        ],
+    );
+    let mut config = Config::default();
+    config
+        .external_packages
+        .insert("crate_b".into(), "NsB".into());
+    config
+        .external_packages
+        .insert("crate_c".into(), "NsC".into());
+    let mixins = RubyWrapper::new(config, &ci)
+        .external_mixin_modules()
+        .unwrap();
+    assert_eq!(mixins.len(), 1);
+    assert_eq!(mixins[0].require_path, "ns_b");
+}
+
+#[test]
+fn external_mixin_modules_collapses_hyphenated_and_underscored_crate() {
+    let ci = ci_with_namespaces(
+        r#"
+        namespace consumer {
+            TypeA get_a();
+            TypeB get_b();
+        };
+
+        [External="my-crate"]
+        typedef dictionary TypeA;
+
+        [External="my_crate"]
+        typedef dictionary TypeB;
+        "#,
+        "consumer",
+        &[("consumer", "consumer"), ("my_crate", "my_ns")],
+    );
+    let mixins = RubyWrapper::new(Config::default(), &ci)
+        .external_mixin_modules()
+        .unwrap();
+    assert_eq!(mixins.len(), 1);
+    assert_eq!(mixins[0].require_path, "my_ns");
+}
+
+#[test]
+fn identity_custom_lower_coerces_integer_builtin() {
+    let ci = ComponentInterface::from_webidl(
+        r#"
+        namespace test {
+            Handle id(Handle h);
+        };
+
+        [Custom]
+        typedef u64 Handle;
+        "#,
+        "test",
+    )
+    .unwrap();
+    let src = generate_ruby_bindings(&Config::default(), &ci).unwrap();
+    let lower = src
+        .split("def self.uniffi_lower_TypeHandle(v)")
+        .nth(1)
+        .expect("identity lower for Handle");
+    let body = lower.split("def self.").next().unwrap();
+    assert!(
+        body.contains("uniffi_in_range(v, \"u64\""),
+        "identity u64 custom lower must coerce via uniffi_in_range, got:\n{body}"
+    );
+}
+
+#[test]
+fn identity_custom_lower_coerces_string_builtin() {
+    let ci = ComponentInterface::from_webidl(
+        r#"
+        namespace test {
+            Guid id(Guid g);
+        };
+
+        [Custom]
+        typedef string Guid;
+        "#,
+        "test",
+    )
+    .unwrap();
+    let src = generate_ruby_bindings(&Config::default(), &ci).unwrap();
+    let lower = src
+        .split("def self.uniffi_lower_TypeGuid(v)")
+        .nth(1)
+        .expect("identity lower for Guid");
+    let body = lower.split("def self.").next().unwrap();
+    assert!(
+        body.contains("uniffi_utf8(v)"),
+        "identity string custom lower must coerce via uniffi_utf8, got:\n{body}"
+    );
+}
+
+#[test]
+fn mixin_owner_module_roots_external_record() {
+    let ci = ci_with_namespaces(
+        TWO_TYPES_UDL,
+        "consumer",
+        &[
+            ("consumer", "consumer"),
+            ("crate_a", "ns_a"),
+            ("crate_b", "ns_b"),
+        ],
+    );
+    let w = RubyWrapper::new(Config::default(), &ci);
+    let type_a = ci.get_type("TypeA").unwrap();
+    assert_eq!(
+        w.rust_buffer_write(&type_a).unwrap(),
+        "::NsA::RustBufferBuilderMixin.write_TypeTypeA"
+    );
+    assert_eq!(
+        w.rust_buffer_read(&type_a).unwrap(),
+        "::NsA::RustBufferStreamMixin.read_TypeTypeA"
+    );
+
+    let local = Type::Record {
+        module_path: "consumer".into(),
+        name: "Local".into(),
+    };
+    assert_eq!(
+        w.rust_buffer_write(&local).unwrap(),
+        "::Consumer::RustBufferBuilderMixin.write_TypeLocal"
+    );
+
+    let optional_ext = Type::Optional {
+        inner_type: Box::new(type_a.clone()),
+    };
+    assert_eq!(
+        w.rust_buffer_write(&optional_ext).unwrap(),
+        "::Consumer::RustBufferBuilderMixin.write_OptionalTypeTypeA"
+    );
+
+    assert_eq!(
+        w.rust_buffer_write(&Type::String).unwrap(),
+        "::Consumer::RustBufferBuilderMixin.write_string"
+    );
+}
+
+#[test]
+fn rust_buffer_write_qualifies_external_record() {
+    let ci = ci_with_namespaces(
+        TWO_TYPES_UDL,
+        "consumer",
+        &[
+            ("consumer", "consumer"),
+            ("crate_a", "ns_a"),
+            ("crate_b", "ns_b"),
+        ],
+    );
+    let w = RubyWrapper::new(Config::default(), &ci);
+    let type_a = ci.get_type("TypeA").unwrap();
+    let callee = w.rust_buffer_write(&type_a).unwrap();
+    assert_eq!(callee, "::NsA::RustBufferBuilderMixin.write_TypeTypeA");
+    assert!(
+        !callee.contains('('),
+        "callee must not bake argument list: {callee}"
+    );
+}
+
+#[test]
+fn generated_consumer_does_not_include_foreign_mixins() {
+    let ci = ci_with_namespaces(
+        TWO_TYPES_UDL,
+        "consumer",
+        &[
+            ("consumer", "consumer"),
+            ("crate_a", "ns_a"),
+            ("crate_b", "ns_b"),
+        ],
+    );
+    let src = generate_ruby_bindings(&Config::default(), &ci).unwrap();
+    assert!(src.contains("require 'ns_a'"), "{src}");
+    assert!(src.contains("require 'ns_b'"), "{src}");
+    assert!(
+        src.contains("::NsA::RustBufferBuilderMixin.write_TypeTypeA"),
+        "{src}"
+    );
+    assert!(
+        !src.contains("include ::NsA::RustBufferBuilderMixin"),
+        "{src}"
+    );
+    assert!(
+        !src.contains("include ::NsB::RustBufferBuilderMixin"),
+        "{src}"
+    );
+}
+
+#[test]
+fn generated_local_only_uses_module_functions() {
+    let ci = ComponentInterface::from_webidl(
+        r#"
+        namespace test {};
+        dictionary Foo { string value; };
+        "#,
+        "test",
+    )
+    .unwrap();
+    let src = generate_ruby_bindings(&Config::default(), &ci).unwrap();
+    assert!(src.contains("def self.write_TypeFoo(builder, v)"), "{src}");
+    assert!(
+        src.contains("::Test::RustBufferBuilderMixin.write_TypeFoo"),
+        "{src}"
+    );
+    assert!(!src.contains("builder.write_TypeFoo"), "{src}");
+    assert!(!src.contains("include RustBufferBuilderMixin"), "{src}");
+}
+
+#[test]
+fn error_reader_is_method_object() {
+    let ci = ComponentInterface::from_webidl(
+        r#"
+        namespace test {
+            [Throws=Boom]
+            u32 go();
+        };
+        [Error]
+        enum Boom { "Oops" };
+        "#,
+        "test",
+    )
+    .unwrap();
+    let src = generate_ruby_bindings(&Config::default(), &ci).unwrap();
+    assert!(
+        src.contains("rust_call_with_error(::Test::RustBufferStreamMixin.method(:read_TypeBoom)"),
+        "{src}"
+    );
+}
+
+#[test]
+fn templates_have_no_receiver_mixin_calls() {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/bindings/ruby/templates");
+    for entry in fs::read_dir(&dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|s| s.to_str()) != Some("rb") {
+            continue;
+        }
+        let src = fs::read_to_string(&path).unwrap();
+        let name = path.file_name().unwrap().to_string_lossy();
+        for (i, line) in src.lines().enumerate() {
+            let trimmed = line.trim();
+            if trimmed.starts_with('#') {
+                continue;
+            }
+            let loc = format!("{name}:{}", i + 1);
+            if line.contains("self.write_{{") {
+                assert!(
+                    line.contains("def self.write_{{"),
+                    "{loc}: leftover self.write_ {line}"
+                );
+            }
+            if line.contains("self.read_{{") {
+                assert!(
+                    line.contains("def self.read_{{"),
+                    "{loc}: leftover self.read_ {line}"
+                );
+            }
+            assert!(
+                !line.contains("builder.write_{{") && !line.contains("stream.read_{{"),
+                "{loc}: leftover facade {line}"
+            );
+            if line.contains("write_{{") {
+                assert!(
+                    line.contains("def self.write_{{"),
+                    "{loc}: write_{{{{ not a module-function def: {line}"
+                );
+            }
+            if line.contains("read_{{") {
+                assert!(
+                    line.contains("def self.read_{{"),
+                    "{loc}: read_{{{{ not a module-function def: {line}"
+                );
+            }
+        }
+        if name == "RustBufferBuilder.rb" {
+            for (i, line) in src.lines().enumerate() {
+                let trimmed = line.trim();
+                if trimmed.starts_with('#') || trimmed.starts_with("def pack_into") {
+                    continue;
+                }
+                if trimmed.contains("pack_into") {
+                    assert!(
+                        line.contains("builder.pack_into"),
+                        "RustBufferBuilder.rb:{}: pack_into without builder. receiver: {line}",
+                        i + 1
+                    );
+                }
+            }
+        }
+        if name == "RustBufferStream.rb" {
+            for (i, line) in src.lines().enumerate() {
+                let trimmed = line.trim();
+                if trimmed.starts_with('#') || trimmed.starts_with("def unpack_from") {
+                    continue;
+                }
+                if trimmed.contains("unpack_from") {
+                    assert!(
+                        line.contains("stream.unpack_from"),
+                        "RustBufferStream.rb:{}: unpack_from without stream. receiver: {line}",
+                        i + 1
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn qualify_roots_external_module() {
+    assert_eq!(filters::qualify("Foo", Some("Mod")), "::Mod::Foo");
+    assert_eq!(filters::qualify("", Some("Mod")), "::Mod::");
+    assert_eq!(filters::qualify("Foo", None), "Foo");
+}
+
+#[test]
+fn canonical_names() {
+    assert_eq!(canonical_name(&Type::UInt8), "u8");
+    assert_eq!(canonical_name(&Type::String), "string");
+    assert_eq!(canonical_name(&Type::Bytes), "bytes");
+    assert_eq!(
+        canonical_name(&Type::Optional {
+            inner_type: Box::new(Type::Sequence {
+                inner_type: Box::new(Type::Object {
+                    module_path: "anything".to_string(),
+                    name: "Example".into(),
+                    imp: ObjectImpl::Struct,
+                })
+            })
+        }),
+        "OptionalSequenceTypeExample"
+    );
+
+    let map = Type::Map {
+        key_type: Box::new(Type::UInt32),
+        value_type: Box::new(Type::UInt32),
+    };
+    assert_eq!(canonical_name(&map), "MapU32U32");
+    assert_eq!(
+        canonical_name(&Type::Enum {
+            module_path: "foo".to_string(),
+            name: "HTMLError".to_string()
+        }),
+        "TypeHTMLError"
+    );
+}
+
+#[test]
+fn class_name() {
+    assert_eq!(class_name_rb_inner("Example"), "Example");
+}
+
+#[test]
+fn enum_lift_consume_into_matches_method_name() {
+    // heck would turn TypeHTMLError into TypeHtmlError; the generated
+    // consume_into_* method uses canonical_name, so the lift call site must too.
+    let ci = ComponentInterface::from_webidl(
+        r#"
+        namespace test {
+            HTMLError id();
+        };
+        enum HTMLError { "InvalidHTML" };
+        "#,
+        "test",
+    )
+    .unwrap();
+    let src = generate_ruby_bindings(&Config::default(), &ci).unwrap();
+    assert!(
+        src.contains("def consume_into_TypeHTMLError"),
+        "method def:\n{src}"
+    );
+    assert!(
+        src.contains("result.consume_into_TypeHTMLError"),
+        "lift call site must match the method, not heck(canonical_name):\n{src}"
+    );
+    assert!(
+        !src.contains("consume_into_TypeHtmlError"),
+        "heck-rewritten consume_into must not appear:\n{src}"
+    );
 }

--- a/uniffi_bindgen/src/bindings/ruby/mod.rs
+++ b/uniffi_bindgen/src/bindings/ruby/mod.rs
@@ -26,7 +26,7 @@ pub fn generate(loader: &BindgenLoader, options: GenerateOptions) -> Result<()> 
     let cdylib = loader.library_name(&options.source).map(|l| l.to_string());
     let mut components =
         loader.load_components(cis, |ci, toml| parse_config(ci, toml, cdylib.clone()))?;
-    apply_renames(&mut components);
+    apply_renames(&mut components)?;
     for c in components.iter_mut() {
         c.ci.derive_ffi_funcs()?;
     }
@@ -54,6 +54,7 @@ pub fn generate(loader: &BindgenLoader, options: GenerateOptions) -> Result<()> 
 // Generate ruby bindings for the given ComponentInterface, as a string.
 pub fn generate_ruby_bindings(config: &Config, ci: &ComponentInterface) -> Result<String> {
     use askama::Template;
+    config.validate_module_name()?;
     RubyWrapper::new(config.clone(), ci)
         .render()
         .context("failed to render ruby bindings")
@@ -73,10 +74,15 @@ fn parse_config(
             .clone()
             .unwrap_or_else(|| format!("uniffi_{}", ci.namespace()))
     });
+    config
+        .module_name
+        .get_or_insert_with(|| Config::default_module_name(ci.namespace()));
+    config.validate_module_name()?;
+    config.normalize_external_package_keys()?;
     Ok(config)
 }
 
-fn apply_renames(components: &mut Vec<Component<Config>>) {
+fn apply_renames(components: &mut Vec<Component<Config>>) -> Result<()> {
     // Remove excluded items, this happens before renaming
     for c in components.iter_mut() {
         apply_exclusions(&mut c.ci, &c.config.exclude);
@@ -94,5 +100,243 @@ fn apply_renames(components: &mut Vec<Component<Config>>) {
         for c in &mut *components {
             rename(&mut c.ci, &module_renames);
         }
+    }
+
+    populate_external_packages(components);
+    validate_external_package_overrides(components)?;
+    Ok(())
+}
+
+/// Fill each crate's `external_packages` from peer crates.
+///
+/// Default module name is each peer's [`Config::module_name`] (explicit
+/// `[bindings.ruby.module_name]`, or UpperCamelCase of that crate's namespace).
+/// User overrides in `[bindings.ruby.external_packages]` win; keys must already
+/// be normalized (`my-crate` → `my_crate`) via [`Config::normalize_external_package_keys`].
+/// Overrides that do not match the defining crate are rejected by
+/// [`validate_external_package_overrides`].
+///
+/// Library mode inserts **every** other crate in the cdylib, not only crates
+/// this component uses as a direct external. The map is a module-name lookup
+/// (so `external_package_name` does not depend on the namespace fallback).
+/// It is not mixin / `require` membership — that comes from
+/// `ComponentInterface::iter_external_types` via
+/// `RubyWrapper::external_mixin_modules`. Omitting a key therefore does not
+/// mean "do not treat this crate as a direct external".
+fn populate_external_packages(components: &mut [Component<Config>]) {
+    let packages = HashMap::<String, String>::from_iter(components.iter().map(|c| {
+        (
+            c.ci.crate_name().to_string(),
+            c.config.module_name(c.ci.namespace()),
+        )
+    }));
+    for c in components.iter_mut() {
+        for (ext_crate, ext_package) in &packages {
+            if ext_crate != c.ci.crate_name() && !c.config.external_packages.contains_key(ext_crate)
+            {
+                c.config
+                    .external_packages
+                    .insert(ext_crate.to_string(), ext_package.clone());
+            }
+        }
+    }
+}
+
+/// Consumer `external_packages` entries for crates in this library must match
+/// that crate's emitted Ruby module ([`Config::module_name`]).
+///
+/// Keys that are not a peer crate in `components` are ignored (typos for
+/// crates not in this library). A mismatch is a bindgen error: `require` still
+/// loads the defining crate's real module, so a wrong reference name would
+/// NameError at load time.
+fn validate_external_package_overrides(components: &[Component<Config>]) -> Result<()> {
+    let defined: HashMap<String, String> = components
+        .iter()
+        .map(|c| {
+            (
+                c.ci.crate_name().to_string(),
+                c.config.module_name(c.ci.namespace()),
+            )
+        })
+        .collect();
+
+    for consumer in components {
+        let consumer_crate = consumer.ci.crate_name();
+        for (crate_name, referenced) in &consumer.config.external_packages {
+            let Some(actual) = defined.get(crate_name) else {
+                continue;
+            };
+            if referenced != actual {
+                bail!(
+                    "[bindings.ruby.external_packages] maps crate `{crate_name}` to `{referenced}` \
+                     in `{consumer_crate}`, but that crate generates module `{actual}`. \
+                     Set `[bindings.ruby.module_name]` on the defining crate, or remove the override."
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn component(crate_name: &str, config: Config) -> Component<Config> {
+        Component {
+            ci: ComponentInterface::new(crate_name),
+            config,
+        }
+    }
+
+    #[test]
+    fn hyphenated_user_override_is_not_clobbered_by_auto_pop() {
+        let mut consumer_config = Config::default();
+        consumer_config
+            .external_packages
+            .insert("my-crate".into(), "Custom".into());
+        consumer_config.normalize_external_package_keys().unwrap();
+
+        let mut defining_config = Config::default();
+        defining_config.module_name = Some("Custom".into());
+
+        let mut components = vec![
+            component("consumer", consumer_config),
+            component("my_crate", defining_config),
+        ];
+        populate_external_packages(&mut components);
+        validate_external_package_overrides(&components).unwrap();
+        assert_eq!(
+            components[0]
+                .config
+                .external_packages
+                .get("my_crate")
+                .map(String::as_str),
+            Some("Custom")
+        );
+    }
+
+    #[test]
+    fn auto_pop_fills_missing_peer_crate() {
+        let mut components = vec![
+            component("consumer", Config::default()),
+            component("my_crate", Config::default()),
+        ];
+        populate_external_packages(&mut components);
+        assert!(components[0]
+            .config
+            .external_packages
+            .contains_key("my_crate"));
+        assert!(!components[0]
+            .config
+            .external_packages
+            .contains_key("consumer"));
+    }
+
+    #[test]
+    fn auto_pop_uses_peer_module_name() {
+        let mut defining_config = Config::default();
+        defining_config.module_name = Some("CustomMod".into());
+        let mut components = vec![
+            component("consumer", Config::default()),
+            component("my_crate", defining_config),
+        ];
+        populate_external_packages(&mut components);
+        validate_external_package_overrides(&components).unwrap();
+        assert_eq!(
+            components[0]
+                .config
+                .external_packages
+                .get("my_crate")
+                .map(String::as_str),
+            Some("CustomMod")
+        );
+    }
+
+    #[test]
+    fn matching_explicit_override_is_ok() {
+        let mut consumer_config = Config::default();
+        consumer_config
+            .external_packages
+            .insert("my_crate".into(), "CustomMod".into());
+
+        let mut defining_config = Config::default();
+        defining_config.module_name = Some("CustomMod".into());
+
+        let mut components = vec![
+            component("consumer", consumer_config),
+            component("my_crate", defining_config),
+        ];
+        populate_external_packages(&mut components);
+        validate_external_package_overrides(&components).unwrap();
+        assert_eq!(
+            components[0]
+                .config
+                .external_packages
+                .get("my_crate")
+                .map(String::as_str),
+            Some("CustomMod")
+        );
+    }
+
+    #[test]
+    fn mismatch_override_is_bindgen_error() {
+        let mut consumer_config = Config::default();
+        consumer_config
+            .external_packages
+            .insert("my_crate".into(), "Wrong".into());
+
+        let mut defining_config = Config::default();
+        defining_config.module_name = Some("Right".into());
+
+        let mut components = vec![
+            component("consumer", consumer_config),
+            component("my_crate", defining_config),
+        ];
+        populate_external_packages(&mut components);
+        let err = validate_external_package_overrides(&components).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("my_crate"), "{msg}");
+        assert!(msg.contains("Wrong"), "{msg}");
+        assert!(msg.contains("Right"), "{msg}");
+        assert!(msg.contains("module_name"), "{msg}");
+        assert!(msg.contains("consumer"), "{msg}");
+    }
+
+    #[test]
+    fn unused_non_peer_external_packages_entry_is_ignored() {
+        let mut consumer_config = Config::default();
+        consumer_config
+            .external_packages
+            .insert("not_in_library".into(), "Whatever".into());
+        let mut components = vec![
+            component("consumer", consumer_config),
+            component("my_crate", Config::default()),
+        ];
+        populate_external_packages(&mut components);
+        validate_external_package_overrides(&components).unwrap();
+    }
+
+    #[test]
+    fn parse_config_defaults_module_name_from_namespace() {
+        let ci = ComponentInterface::from_webidl("namespace foo_ns {};", "foo").unwrap();
+        let config = parse_config(&ci, toml::Value::Table(Default::default()), None).unwrap();
+        assert_eq!(config.module_name.as_deref(), Some("FooNs"));
+    }
+
+    #[test]
+    fn parse_config_rejects_invalid_module_name() {
+        let ci = ComponentInterface::from_webidl("namespace foo_ns {};", "foo").unwrap();
+        let toml: toml::Value = toml::from_str(
+            r#"
+            [bindings.ruby]
+            module_name = "foo"
+            "#,
+        )
+        .unwrap();
+        let err = parse_config(&ci, toml, None).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("module_name"), "{msg}");
+        assert!(msg.contains("foo"), "{msg}");
     }
 }

--- a/uniffi_bindgen/src/bindings/ruby/templates/Async.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/Async.rb
@@ -37,7 +37,7 @@ end
 # cancel_fn is called in the ensure block when exception interrupts an in-flight poll.
 # This guarantees Rust fires the continuation callback so the handle-map entry is released
 # and the pipe is drained before we free the future.
-def self.uniffi_rust_call_async(rust_future, poll_fn, cancel_fn, complete_fn, free_fn, lift_func, error_ffi_converter)
+def self.uniffi_rust_call_async(rust_future, poll_fn, cancel_fn, complete_fn, free_fn, lift_func, error_reader)
   rd = wr = nil
   handle = nil
   poll_in_flight = false
@@ -61,10 +61,10 @@ def self.uniffi_rust_call_async(rust_future, poll_fn, cancel_fn, complete_fn, fr
       break if poll_code == UNIFFI_RUST_FUTURE_POLL_READY
     end
 
-    result = if error_ffi_converter.nil?
-      ::{{ ci.namespace()|class_name_rb }}.rust_call(complete_fn, rust_future)
+    result = if error_reader.nil?
+      ::{{ self.module_name() }}.rust_call(complete_fn, rust_future)
     else
-      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error(error_ffi_converter, complete_fn, rust_future)
+      ::{{ self.module_name() }}.rust_call_with_error(error_reader, complete_fn, rust_future)
     end
 
     lift_func.call(result)
@@ -133,7 +133,7 @@ end
 # Execute a foreign async callback method in a background thread.
 # Enforces the at-most-once guarantee on handle_success / handle_error: whichever
 # fires first (normal completion or Rust-side drop) suppresses the other.
-def self.uniffi_trait_interface_call_async(make_call, uniffi_out_dropped_callback, handle_success, handle_error, error_type = nil, lower_error = nil)
+def self.uniffi_trait_interface_call_async(make_call, uniffi_out_dropped_callback, handle_success, handle_error, error_class = nil, lower_error = nil)
   once = UniffiOnceFlag.new
 
   thread = Thread.new do
@@ -149,10 +149,10 @@ def self.uniffi_trait_interface_call_async(make_call, uniffi_out_dropped_callbac
       rescue Exception => e # We have to catch all errors to prevent Rust future from hanging forever.
         next unless once.claim!
 
-        if !error_type.nil? && ::{{ ci.namespace()|class_name_rb }}.uniffi_is_error_type?(e, error_type)
+        if !error_class.nil? && ::{{ self.module_name() }}.uniffi_is_error_type?(e, error_class)
           handle_error.call(UNIFFI_CALLBACK_ERROR, lower_error.call(e))
         else
-          handle_error.call(UNIFFI_CALLBACK_UNEXPECTED_ERROR, {{ "e.inspect"|lower_rb(&Type::String, config) }})
+          handle_error.call(UNIFFI_CALLBACK_UNEXPECTED_ERROR, {{ self.lower_rb("e.inspect", &Type::String)? }})
         end
         next
       end
@@ -167,7 +167,7 @@ def self.uniffi_trait_interface_call_async(make_call, uniffi_out_dropped_callbac
       # once was already claimed, so only attempt this if we can still claim (e.g. lowering failed
       # before handle_error was called due to short-circuit evaluation).
       begin
-        handle_error.call(UNIFFI_CALLBACK_UNEXPECTED_ERROR, {{ "e.inspect"|lower_rb(&Type::String, config) }})
+        handle_error.call(UNIFFI_CALLBACK_UNEXPECTED_ERROR, {{ self.lower_rb("e.inspect", &Type::String)? }})
       rescue Exception
         # If even this fails, Rust will hang. Nothing more we can do.
       end

--- a/uniffi_bindgen/src/bindings/ruby/templates/CustomTypeTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/CustomTypeTemplate.rb
@@ -1,7 +1,21 @@
+{%- let canonical_type_name = self::canonical_name(type_) %}
 {%- match config.custom_types.get(name.as_str()) %}
 {%- when None %}
 # Custom type `{{ name }}` - no binding config, backed by builtin `{{ self::canonical_name(builtin) }}`.
-# Values crosss the FFI as the builtin type unchanged.
+# Identity lower coerces the builtin (`uniffi_in_range` / `uniffi_utf8` / …)
+# so imported primitive FFI args still run `to_int` / `to_str` here.
+
+def self.uniffi_lift_{{ canonical_type_name }}(raw)
+  raw
+end
+
+def self.uniffi_lower_{{ canonical_type_name }}(v)
+  {{ self.coerce_rb("v", builtin)? }}
+end
+
+def self.uniffi_check_lower_{{ canonical_type_name }}(v)
+  {{ self.check_lower_rb("v", builtin)? }}
+end
 
 {%- when Some(cfg) %}
 # Custom type `{{ name }}` - binding config supplied, backed by builtin `{{ self::canonical_name(builtin) }}`.
@@ -16,4 +30,33 @@ require '{{ import_name }}'
 {%- endfor %}
 {%- when None %}
 {%- endmatch %}
+
+def self.uniffi_lift_{{ canonical_type_name }}(raw)
+{%- if cfg.has_conversion() %}
+  {{ cfg.lift("raw") }}
+{%- else %}
+  raw
+{%- endif %}
+end
+
+def self.uniffi_lower_{{ canonical_type_name }}(v)
+{%- if cfg.has_conversion() %}
+  {{ cfg.lower("v") }}
+{%- else %}
+{%- match cfg.type_name %}
+{%- when Some(_) %}
+  v
+{%- else %}
+  {{ self.coerce_rb("v", builtin)? }}
+{%- endmatch %}
+{%- endif %}
+end
+
+def self.uniffi_check_lower_{{ canonical_type_name }}(v)
+{%- match cfg.type_name %}
+{%- when Some(type_name) %}
+  raise TypeError, "Expected {{ type_name }}, got #{v.class}" unless v.is_a?({{ type_name }})
+{%- else %}
+{%- endmatch %}
+end
 {%- endmatch %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/EnumTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/EnumTemplate.rb
@@ -30,7 +30,7 @@ class {{ e.name()|class_name_rb }}
     {%- if named_fields %}
     def initialize({% for field in variant.fields() %}{{ field.name()|var_name_rb -}}:
       {%- match field.default_value() %}
-      {%- when Some(default) %} {{ field|field_default_rb }}
+      {%- when Some(default) %} {{ self.field_default_rb(field)? }}
       {%- else %}
       {% endmatch %}
       {%- if loop.last %}{% else %}, {% endif -%}{% endfor %})

--- a/uniffi_bindgen/src/bindings/ruby/templates/ErrorTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/ErrorTemplate.rb
@@ -73,6 +73,12 @@ module {{ e.name()|class_name_rb }}
       {%- endif %}
 
     end
+
+    {% for variant in e.variants() %}
+    def {{ variant.name()|var_name_rb }}?
+      instance_of? {{ e.name()|class_name_rb }}::{{ variant.name()|class_name_rb }}
+    end
+    {% endfor %}
   end
   {%- endfor %}
 {% endif %}
@@ -80,48 +86,26 @@ end
 {% endif %}
 {%- endfor %}
 
-# Map error modules to the RustBuffer method name that reads them
-ERROR_MODULE_TO_READER_METHOD = {
-{% for e in ci.enum_definitions() %}
-{%- if ci.is_name_used_as_error(e.name()) -%}
-  {{ e.name()|class_name_rb }} => :read_{{ self::canonical_name(e.as_type().borrow()) }},
-{% endif %}
-{%- endfor -%}
-{% for obj in ci.object_definitions() %}
-{%- if ci.is_name_used_as_error(obj.name()) -%}
-  '{{ obj.name()|class_name_rb }}' => :read_{{ self::canonical_name(obj.as_type().borrow()) }},
-{% endif %}
-{%- endfor -%}
-}
+private_constant :CALL_SUCCESS, :CALL_ERROR, :CALL_PANIC, :RustCallStatus
 
-private_constant :ERROR_MODULE_TO_READER_METHOD, :CALL_SUCCESS, :CALL_ERROR, :CALL_PANIC,
-                 :RustCallStatus
-
-def self.consume_buffer_into_error(error_module, rust_buffer)
+def self.consume_buffer_into_error(reader, rust_buffer)
   rust_buffer.consumeWithStream do |stream|
-    reader_method = ERROR_MODULE_TO_READER_METHOD[error_module] ||
-                    ERROR_MODULE_TO_READER_METHOD[error_module.name&.split('::')&.last]
-    return stream.send(reader_method)
+    return reader.call(stream)
   end
 end
 
+# This crate's bindings error (panics, protocol mismatches, corrupt buffers).
+# Mixin readers/writers raise this class, so a consumer lifting this crate's types
+# should rescue {{ self.module_name() }}::InternalError — not their own
+# crate's InternalError. Matches Python InternalError / Kotlin InternalException.
 class InternalError < StandardError
 end
 
 def self.rust_call(fn_name, *args)
-  # Call a rust function
   rust_call_with_error(nil, fn_name, *args)
 end
 
-def self.rust_call_with_error(error_module, fn_name, *args)
-  # Call a rust function and handle errors
-  #
-  # Use this when the rust function returns a Result<>.  error_module must be the error_module that corresponds to that Result.
-
-
-  # Note: RustCallStatus.new zeroes out the struct, which is exactly what we
-  # want to pass to Rust (code=0, error_buf=RustBuffer(len=0, capacity=0,
-  # data=NULL))
+def self.rust_call_with_error(error_reader, fn_name, *args)
   status = RustCallStatus.new
   args << status
 
@@ -131,18 +115,14 @@ def self.rust_call_with_error(error_module, fn_name, *args)
   when CALL_SUCCESS
     result
   when CALL_ERROR
-    if error_module.nil?
+    if error_reader.nil?
       status.error_buf.free
-      raise InternalError, "CALL_ERROR with no error_module set"
-    else
-      raise consume_buffer_into_error(error_module, status.error_buf)
+      raise InternalError, "CALL_ERROR with no error_reader set"
     end
+    raise consume_buffer_into_error(error_reader, status.error_buf)
   when CALL_PANIC
-    # When the rust code sees a panic, it tries to construct a RustBuffer
-    # with the message.  But if that code panics, then it just sends back
-    # an empty buffer.
     if status.error_buf.len > 0
-      raise InternalError, {{ "status.error_buf"|lift_rb(&Type::String, config) }}
+      raise InternalError, {{ self.lift_rb("status.error_buf", &Type::String)? }}
     else
       raise InternalError, "Rust panic"
     end

--- a/uniffi_bindgen/src/bindings/ruby/templates/Helpers.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/Helpers.rb
@@ -24,18 +24,18 @@ UNIFFI_CALLBACK_UNEXPECTED_ERROR = 2
 
 # Call a method on a callback interface object, catching and reporting errors
 # to Rust via the call_status.
-# If error_type is provided, known errors of that type are reported as UNIFFI_CALLBACK_ERROR;
+# If error_class is provided, known errors of that type are reported as UNIFFI_CALLBACK_ERROR;
 # all other errors are reported as UNIFFI_CALLBACK_UNEXPECTED_ERROR.
-def self.uniffi_trait_interface_call(call_status, make_call, write_return_value, error_type = nil, lower_error = nil)
+def self.uniffi_trait_interface_call(call_status, make_call, write_return_value, error_class = nil, lower_error = nil)
   begin
     write_return_value.call make_call.call
   rescue StandardError => e
-    buf = if !error_type.nil? && uniffi_is_error_type?(e, error_type)
+    buf = if !error_class.nil? && uniffi_is_error_type?(e, error_class)
       call_status[:code] = UNIFFI_CALLBACK_ERROR
       lower_error.call e
     else
       call_status[:code] = UNIFFI_CALLBACK_UNEXPECTED_ERROR
-      {{ "e.inspect"|lower_rb(&Type::String, config) }}
+      {{ self.lower_rb("e.inspect", &Type::String)? }}
     end
 
     error_buf = call_status[:error_buf]
@@ -48,15 +48,17 @@ end
 # Check if an exception is a variant of the given error type.
 # Error types in Ruby are either modules (non-flat enums) or classes (flat enums),
 # with variant classes as constant within them.
-def self.uniffi_is_error_type?(e, error_type)
-  # Object-as-error: error_type is a class itself (e.g. MyError < StandardError)
-  if error_type.is_a?(Class) && e.is_a?(error_type)
+# error_class should be the Ruby Class or Module constant (e.g. MyError
+# for local errors, ::OtherModule::SomeError for external errors).
+def self.uniffi_is_error_type?(e, error_class)
+  # Object-as-error: error_class is a class itself (e.g. MyError < StandardError)
+  if error_class.is_a?(Class) && e.is_a?(error_class)
     return true
   end
 
-  # Enum error: error_type is a module with class constants for each variant
-  error_type.constants.any? do |c|
-    klass = error_type.const_get c
+  # Enum error: error_class is a module with class constants for each variant
+  error_class.constants.any? do |c|
+    klass = error_class.const_get c
     klass.is_a?(Class) && e.is_a?(klass)
   end
 end

--- a/uniffi_bindgen/src/bindings/ruby/templates/MethodImpls.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/MethodImpls.rb
@@ -9,14 +9,14 @@
 {%- match meth.return_type() -%}
 
 {%- when Some with (return_type) -%}
-def {{ meth.name()|fn_name_rb }}{% call rb::arg_list_decl(meth) %}{% endcall %}
+def {{ meth.name()|fn_name_rb }}({% call rb::arg_list_decl(meth) %}{% endcall %})
   {%- call rb::setup_args_extra_indent(meth) %}{% endcall %}
   result = {% call rb::to_ffi_call_with_lower_self(meth) %}{% endcall %}
-  return {{ "result"|lift_rb(return_type, config) }}
+  return {{ self.lift_rb("result", return_type)? }}
 end
 
 {%- when None %}
-def {{ meth.name()|fn_name_rb }}{% call rb::arg_list_decl(meth) %}{% endcall %}
+def {{ meth.name()|fn_name_rb }}({% call rb::arg_list_decl(meth) %}{% endcall %})
   {%- call rb::setup_args_extra_indent(meth) %}{% endcall %}
   result = {% call rb::to_ffi_call_with_lower_self(meth) %}{% endcall %}
 end

--- a/uniffi_bindgen/src/bindings/ruby/templates/ObjectTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/ObjectTemplate.rb
@@ -14,7 +14,7 @@ class {{ obj.name()|class_name_rb }}{% if ci.is_name_used_as_error(obj.name()) %
   # to the actual instance, only its underlying handle.
   def self.uniffi_define_finalizer_by_handle(handle, object_id)
     Proc.new do |_id|
-      ::{{ ci.namespace()|class_name_rb }}.rust_call(
+      ::{{ self.module_name() }}.rust_call(
         :{{ obj.ffi_object_free().name() }},
         handle
       )
@@ -40,7 +40,7 @@ class {{ obj.name()|class_name_rb }}{% if ci.is_name_used_as_error(obj.name()) %
   end
 
   def uniffi_clone_handle
-    return ::{{ci.namespace()|class_name_rb }}.rust_call(
+    return ::{{ self.module_name() }}.rust_call(
       :{{ obj.ffi_object_clone().name() }},
       @handle
     )
@@ -75,7 +75,7 @@ class {{ obj.name()|class_name_rb }}{% if ci.is_name_used_as_error(obj.name()) %
   end
 
   def uniffi_clone_handle()
-    return ::{{ ci.namespace()|class_name_rb }}.rust_call(
+    return ::{{ self.module_name() }}.rust_call(
       :{{ obj.ffi_object_clone().name() }},
       @handle
     )
@@ -141,7 +141,7 @@ class {{ obj.name()|class_name_rb }}{% if ci.is_name_used_as_error(obj.name()) %
   def {{ meth.name()|fn_name_rb }}({% call rb::arg_list_decl(meth) %}{% endcall %})
     {%- call rb::setup_args_extra_indent(meth) %}{% endcall %}
     result = {% call rb::to_ffi_call_with_prefix("uniffi_clone_handle()", meth) %}{% endcall %}
-    return {{ "result"|lift_rb(return_type, config) }}
+    return {{ self.lift_rb("result", return_type)? }}
   end
 
   {%- when None -%}

--- a/uniffi_bindgen/src/bindings/ruby/templates/RecordTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RecordTemplate.rb
@@ -4,7 +4,7 @@ class {{ rec.name()|class_name_rb }}
 
   def initialize({% for field in rec.fields() %}{{ field.name()|var_name_rb -}}:
         {%- match field.default_value() %}
-        {%- when Some(_) %} {{ field|field_default_rb }}
+        {%- when Some(_) %} {{ self.field_default_rb(field)? }}
         {%- else %}
         {%- endmatch %}
   {%- if loop.last %}{% else %}, {% endif -%}{% endfor %})

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferBuilder.rb
@@ -1,3 +1,300 @@
+# Mixin containing type-specific write methods as module functions.
+# Call sites name this module explicitly (e.g.
+# `::ThisNs::RustBufferBuilderMixin.write_TypeFoo(builder, v)`) so two crates
+# that both define `Foo` do not flatten `write_TypeFoo` onto one receiver.
+# The `builder` argument is always the *local* crate's RustBufferBuilder so
+# pack_into / reserve / write route through that crate's allocator.
+#
+# Nested types from further crates are reached by lexical calls in this
+# mixin's generated bodies, not by `include`. Do not use `module_function`
+# (it would reintroduce private instance methods).
+# InternalError in these methods is this crate's class.
+module RustBufferBuilderMixin
+  {% for typ in ci.iter_local_types() -%}
+  {%- let canonical_type_name = self::canonical_name(typ) -%}
+  {%- match typ -%}
+
+  {% when Type::Int8 -%}
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    v = ::{{ self.module_name() }}::uniffi_in_range(v, "i8", -2**7, 2**7)
+    builder.pack_into(1, 'c', v)
+  end
+
+  {% when Type::UInt8 -%}
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    v = ::{{ self.module_name() }}::uniffi_in_range(v, "u8", 0, 2**8)
+    builder.pack_into(1, 'c', v)
+  end
+
+  {% when Type::Int16 -%}
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    v = ::{{ self.module_name() }}::uniffi_in_range(v, "i16", -2**15, 2**15)
+    builder.pack_into(2, 's>', v)
+  end
+
+  {% when Type::UInt16 -%}
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    v = ::{{ self.module_name() }}::uniffi_in_range(v, "u16", 0, 2**16)
+    builder.pack_into(2, 'S>', v)
+  end
+
+  {% when Type::Int32 -%}
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    v = ::{{ self.module_name() }}::uniffi_in_range(v, "i32", -2**31, 2**31)
+    builder.pack_into(4, 'l>', v)
+  end
+
+  {% when Type::UInt32 -%}
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    v = ::{{ self.module_name() }}::uniffi_in_range(v, "u32", 0, 2**32)
+    builder.pack_into(4, 'L>', v)
+  end
+
+  {% when Type::Int64 -%}
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    v = ::{{ self.module_name() }}::uniffi_in_range(v, "i64", -2**63, 2**63)
+    builder.pack_into(8, 'q>', v)
+  end
+
+  {% when Type::UInt64 -%}
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    v = ::{{ self.module_name() }}::uniffi_in_range(v, "u64", 0, 2**64)
+    builder.pack_into(8, 'Q>', v)
+  end
+
+  {% when Type::Float32 -%}
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    builder.pack_into(4, 'g', v)
+  end
+
+  {% when Type::Float64 -%}
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    builder.pack_into(8, 'G', v)
+  end
+
+  {% when Type::Boolean -%}
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    builder.pack_into(1, 'c', v ? 1 : 0)
+  end
+
+  {% when Type::String -%}
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    v = ::{{ self.module_name() }}::uniffi_utf8(v)
+    builder.pack_into 4, 'l>', v.bytes.size
+    builder.write v
+  end
+
+  {% when Type::Bytes -%}
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    v = ::{{ self.module_name() }}::uniffi_bytes(v)
+    builder.pack_into 4, 'l>', v.bytes.size
+    builder.write v
+  end
+
+  {% when Type::Timestamp -%}
+  # The Timestamp type.
+  ONE_SECOND_IN_NANOSECONDS = 10**9
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    seconds = v.tv_sec
+    nanoseconds = v.tv_nsec
+
+    # UniFFi conventions assume that nanoseconds part has to represent nanoseconds portion of
+    # duration between epoch and the timestamp moment. Ruby `Time#tv_nsec` returns the number of
+    # nanoseconds for the subsecond part, which is sort of opposite to "duration" meaning.
+    # Hence we need to convert value returned by `Time#tv_nsec` back and forth with the following
+    # logic:
+    if seconds < 0 && nanoseconds != 0
+      # In order to get duration nsec we shift by 1 second:
+      nanoseconds = ONE_SECOND_IN_NANOSECONDS - nanoseconds
+
+      # Then we compensate 1 second shift:
+      seconds += 1
+    end
+
+    builder.pack_into 8, 'q>', seconds
+    builder.pack_into 4, 'L>', nanoseconds
+  end
+
+  {% when Type::Duration -%}
+  # The Duration type.
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    seconds = v.tv_sec
+    nanoseconds = v.tv_nsec
+
+    raise ArgumentError, 'Invalid duration, must be non-negative' if seconds < 0
+
+    builder.pack_into 8, 'Q>', seconds
+    builder.pack_into 4, 'L>', nanoseconds
+  end
+
+  {% when Type::Object with { name: object_name, .. } -%}
+  # The Object type {{ object_name }}.
+
+  def self.write_{{ canonical_type_name }}(builder, obj)
+    handle = {{ object_name|class_name_rb}}.uniffi_lower obj
+    builder.pack_into(8, 'Q>', handle)
+  end
+
+  {% when Type::Enum { name: enum_name, .. } -%}
+  {% if !ci.is_name_used_as_error(enum_name) %}
+  {%- let e = ci.get_enum_definition(enum_name).unwrap() -%}
+  # The Enum type {{ enum_name }}.
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    {%- if e.is_flat() %}
+    {%- for variant in e.variants() %}
+    if v == {{ enum_name|class_name_rb }}::{{ variant.name()|enum_name_rb }}
+      builder.pack_into(4, 'l>', {{ loop.index }})
+    end
+    {%- endfor %}
+    {%- else -%}
+    {%- for variant in e.variants() %}
+    if v.{{ variant.name()|var_name_rb }}?
+      builder.pack_into(4, 'l>', {{ loop.index }})
+      {%- for field in variant.fields() %}
+        {{ self.rust_buffer_write(field.as_type().borrow())? }}(builder, v.{% call rb::field_name(field, loop.index) %}{% endcall %})
+      {%- endfor %}
+    end
+    {%- endfor %}
+    {%- endif %}
+ end
+  {% else %}
+  {%- let e = ci.get_enum_definition(enum_name).unwrap() -%}
+  # The Error type {{ enum_name }} - write for callback error returns.
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    {%- if e.is_flat() %}
+    {%- for variant in e.variants() %}
+    if v.is_a?({{ enum_name|class_name_rb }}::{{ variant.name()|class_name_rb }})
+      builder.pack_into 4, 'l>', {{ loop.index }}
+      return
+    end
+    {%- endfor %}
+    {%- else -%}
+    {%- for variant in e.variants() %}
+    if v.is_a?({{ enum_name|class_name_rb }}::{{ variant.name()|class_name_rb }})
+      builder.pack_into 4, 'l>', {{ loop.index }}
+      {%- for field in variant.fields() %}
+        {%- if field.name().is_empty() %}
+        {{ self.rust_buffer_write(field.as_type().borrow())? }}(builder, v[{{ loop.index0 }}])
+        {%- else %}
+        {{ self.rust_buffer_write(field.as_type().borrow())? }}(builder, v.{{ field.name()|var_name_rb }})
+        {%- endif %}
+      {%- endfor %}
+      return
+    end
+    {%- endfor %}
+    {%- endif %}
+  end
+  {% endif %}
+
+  {% when Type::Record { name: record_name, .. } -%}
+  {%- let rec = ci.get_record_definition(record_name).unwrap() -%}
+  # The Record type {{ record_name }}.
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    {%- for field in rec.fields() %}
+    {{ self.rust_buffer_write(field.as_type().borrow())? }}(builder, v.{{ field.name()|var_name_rb }})
+    {%- endfor %}
+  end
+
+  {% when Type::Optional { inner_type } -%}
+  # The Optional<T> type for {{ self::canonical_name(inner_type) }}.
+
+  def self.write_{{ canonical_type_name }}(builder, v)
+    if v.nil?
+      builder.pack_into(1, 'c', 0)
+    else
+      builder.pack_into(1, 'c', 1)
+      {{ self.rust_buffer_write(inner_type)? }}(builder, v)
+    end
+  end
+
+  {% when Type::Sequence { inner_type } -%}
+  # The Sequence<T> type for {{ self::canonical_name(inner_type) }}.
+
+  def self.write_{{ canonical_type_name }}(builder, items)
+    builder.pack_into(4, 'l>', items.size)
+
+    items.each do |item|
+      {{ self.rust_buffer_write(inner_type)? }}(builder, item)
+    end
+  end
+
+  {% when Type::Set { inner_type } -%}
+  # The Set<T> type for {{ self::canonical_name(inner_type) }}.
+
+  def self.write_{{ canonical_type_name }}(builder, items)
+    builder.pack_into(4, 'l>', items.size)
+
+    items.each do |item|
+      {{ self.rust_buffer_write(inner_type)? }}(builder, item)
+    end
+  end
+
+  {% when Type::Map { key_type: k, value_type: v } -%}
+  # The Map<T> type for {{ canonical_type_name }}.
+
+  def self.write_{{ canonical_type_name }}(builder, items)
+    builder.pack_into(4, 'l>', items.size)
+
+    items.each do |k, v|
+      {{ self.rust_buffer_write(k)? }}(builder, k)
+      {{ self.rust_buffer_write(v)? }}(builder, v)
+    end
+  end
+
+  {% when Type::Custom { name, builtin, .. } -%}
+  {%- match config.custom_types.get(name.as_str()) %}
+  {%- when Some(cfg) %}{%- if cfg.has_conversion() %}
+  # Custom type {{ name }}: applies lower, then writes builtin `{{ self::canonical_name(builtin) }}`
+  def self.write_{{ canonical_type_name }}(builder, v)
+    {{ self.rust_buffer_write(builtin)? }}(builder, {{ cfg.lower("v") }})
+  end
+  {%- else %}
+  # The Custom type {{ name }} delegates serialization to its builtin type.
+  def self.write_{{ canonical_type_name }}(builder, v)
+    {{ self.rust_buffer_write(builtin)? }}(builder, v)
+  end
+  {%- endif %}
+  {%- when None %}
+  # The Custom type {{ name }} delegates serialization to its builtin type.
+  def self.write_{{ canonical_type_name }}(builder, v)
+    {{ self.rust_buffer_write(builtin)? }}(builder, v)
+  end
+  {%- endmatch %}
+
+  {% when Type::CallbackInterface { name, .. } -%}
+  # The CallbackInterface type {{ name }}: write a uint64 handle.
+  def self.write_{{ canonical_type_name }}(builder, v)
+    handle = {{ self::canonical_name(typ) }}FfiConverter.lower(v)
+    builder.pack_into 8, 'Q>', handle
+  end
+
+  {%- else -%}
+  # This type is not yet supported in the Ruby backend.
+  def self.write_{{ canonical_type_name }}(builder, v)
+    raise InternalError('RustBufferStream.write() not implemented yet for {{ canonical_type_name }}')
+  end
+
+  {%- endmatch -%}
+  {%- endfor %}
+end
 
 # Helper for structured writing of values into a RustBuffer.
 class RustBufferBuilder
@@ -27,290 +324,14 @@ class RustBufferBuilder
     end
   end
 
-  {% for typ in ci.iter_local_types() -%}
-  {%- let canonical_type_name = self::canonical_name(typ) -%}
-  {%- match typ -%}
-
-  {% when Type::Int8 -%}
-
-  def write_{{ canonical_type_name }}(v)
-    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i8", -2**7, 2**7)
-    pack_into(1, 'c', v)
-  end
-
-  {% when Type::UInt8 -%}
-
-  def write_{{ canonical_type_name }}(v)
-    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u8", 0, 2**8)
-    pack_into(1, 'c', v)
-  end
-
-  {% when Type::Int16 -%}
-
-  def write_{{ canonical_type_name }}(v)
-    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i16", -2**15, 2**15)
-    pack_into(2, 's>', v)
-  end
-
-  {% when Type::UInt16 -%}
-
-  def write_{{ canonical_type_name }}(v)
-    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u16", 0, 2**16)
-    pack_into(2, 'S>', v)
-  end
-
-  {% when Type::Int32 -%}
-
-  def write_{{ canonical_type_name }}(v)
-    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i32", -2**31, 2**31)
-    pack_into(4, 'l>', v)
-  end
-
-  {% when Type::UInt32 -%}
-
-  def write_{{ canonical_type_name }}(v)
-    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u32", 0, 2**32)
-    pack_into(4, 'L>', v)
-  end
-
-  {% when Type::Int64 -%}
-
-  def write_{{ canonical_type_name }}(v)
-    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "i64", -2**63, 2**63)
-    pack_into(8, 'q>', v)
-  end
-
-  {% when Type::UInt64 -%}
-
-  def write_{{ canonical_type_name }}(v)
-    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_in_range(v, "u64", 0, 2**64)
-    pack_into(8, 'Q>', v)
-  end
-
-  {% when Type::Float32 -%}
-
-  def write_{{ canonical_type_name }}(v)
-    pack_into(4, 'g', v)
-  end
-
-  {% when Type::Float64 -%}
-
-  def write_{{ canonical_type_name }}(v)
-    pack_into(8, 'G', v)
-  end
-
-  {% when Type::Boolean -%}
-
-  def write_{{ canonical_type_name }}(v)
-    pack_into(1, 'c', v ? 1 : 0)
-  end
-
-  {% when Type::String -%}
-
-  def write_{{ canonical_type_name }}(v)
-    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_utf8(v)
-    pack_into 4, 'l>', v.bytes.size
-    write v
-  end
-
-  {% when Type::Bytes -%}
-
-  def write_{{ canonical_type_name }}(v)
-    v = ::{{ ci.namespace()|class_name_rb }}::uniffi_bytes(v)
-    pack_into 4, 'l>', v.bytes.size
-    write v
-  end
-
-  {% when Type::Timestamp -%}
-  # The Timestamp type.
-  ONE_SECOND_IN_NANOSECONDS = 10**9
-
-  def write_{{ canonical_type_name }}(v)
-    seconds = v.tv_sec
-    nanoseconds = v.tv_nsec
-
-    # UniFFi conventions assume that nanoseconds part has to represent nanoseconds portion of
-    # duration between epoch and the timestamp moment. Ruby `Time#tv_nsec` returns the number of
-    # nanoseconds for the subsecond part, which is sort of opposite to "duration" meaning.
-    # Hence we need to convert value returned by `Time#tv_nsec` back and forth with the following
-    # logic:
-    if seconds < 0 && nanoseconds != 0
-      # In order to get duration nsec we shift by 1 second:
-      nanoseconds = ONE_SECOND_IN_NANOSECONDS - nanoseconds
-
-      # Then we compensate 1 second shift:
-      seconds += 1
-    end
-
-    pack_into 8, 'q>', seconds
-    pack_into 4, 'L>', nanoseconds
-  end
-
-  {% when Type::Duration -%}
-  # The Duration type.
-
-  def write_{{ canonical_type_name }}(v)
-    seconds = v.tv_sec
-    nanoseconds = v.tv_nsec
-
-    raise ArgumentError, 'Invalid duration, must be non-negative' if seconds < 0
-
-    pack_into 8, 'Q>', seconds
-    pack_into 4, 'L>', nanoseconds
-  end
-
-  {% when Type::Object with { name: object_name, .. } -%}
-  # The Object type {{ object_name }}.
-
-  def write_{{ canonical_type_name }}(obj)
-    handle = {{ object_name|class_name_rb}}.uniffi_lower obj
-    pack_into(8, 'Q>', handle)
-  end
-
-  {% when Type::Enum { name: enum_name, .. } -%}
-  {% if !ci.is_name_used_as_error(enum_name) %}
-  {%- let e = ci.get_enum_definition(enum_name).unwrap() -%}
-  # The Enum type {{ enum_name }}.
-
-  def write_{{ canonical_type_name }}(v)
-    {%- if e.is_flat() %}
-    {%- for variant in e.variants() %}
-    if v == {{ enum_name|class_name_rb }}::{{ variant.name()|enum_name_rb }}
-      pack_into(4, 'l>', {{ loop.index }})
-    end
-    {%- endfor %}
-    {%- else -%}
-    {%- for variant in e.variants() %}
-    if v.{{ variant.name()|var_name_rb }}?
-      pack_into(4, 'l>', {{ loop.index }})
-      {%- for field in variant.fields() %}
-        self.write_{{ self::canonical_name(field.as_type().borrow()) }}(v.{% call rb::field_name(field, loop.index) %}{% endcall %})
-      {%- endfor %}
-    end
-    {%- endfor %}
-    {%- endif %}
- end
-  {% else %}
-  {%- let e = ci.get_enum_definition(enum_name).unwrap() -%}
-  # The Error type {{ enum_name }} - write for callback error returns.
-
-  def write_{{ canonical_type_name }}(v)
-    {%- if e.is_flat() %}
-    {%- for variant in e.variants() %}
-    if v.is_a?({{ enum_name|class_name_rb }}::{{ variant.name()|class_name_rb }})
-      pack_into 4, 'l>', {{ loop.index }}
-      return
-    end
-    {%- endfor %}
-    {%- else -%}
-    {%- for variant in e.variants() %}
-    if v.is_a?({{ enum_name|class_name_rb }}::{{ variant.name()|class_name_rb }})
-      pack_into 4, 'l>', {{ loop.index }}
-      {%- for field in variant.fields() %}
-        {%- if field.name().is_empty() %}
-        self.write_{{ self::canonical_name(field.as_type().borrow()) }}(v[{{ loop.index0 }}])
-        {%- else %}
-        self.write_{{ self::canonical_name(field.as_type().borrow()) }}(v.{{ field.name()|var_name_rb }})
-        {%- endif %}
-      {%- endfor %}
-      return
-    end
-    {%- endfor %}
-    {%- endif %}
-  end
-  {% endif %}
-
-  {% when Type::Record { name: record_name, .. } -%}
-  {%- let rec = ci.get_record_definition(record_name).unwrap() -%}
-  # The Record type {{ record_name }}.
-
-  def write_{{ canonical_type_name }}(v)
-    {%- for field in rec.fields() %}
-    self.write_{{ self::canonical_name(field.as_type().borrow()) }}(v.{{ field.name()|var_name_rb }})
-    {%- endfor %}
-  end
-
-  {% when Type::Optional { inner_type } -%}
-  # The Optional<T> type for {{ self::canonical_name(inner_type) }}.
-
-  def write_{{ canonical_type_name }}(v)
-    if v.nil?
-      pack_into(1, 'c', 0)
-    else
-      pack_into(1, 'c', 1)
-      self.write_{{ self::canonical_name(inner_type) }}(v)
+  # Public so RustBufferBuilderMixin module functions can pack without
+  # `include` flattening instance methods onto this class.
+  # The class itself is private_constant. `reserve` stays private.
+  def pack_into(size, format, value)
+    reserve(size) do
+      @rust_buf.data.put_array_of_char @rust_buf.len, [value].pack(format).bytes
     end
   end
-
-  {% when Type::Sequence { inner_type } -%}
-  # The Sequence<T> type for {{ self::canonical_name(inner_type) }}.
-
-  def write_{{ canonical_type_name }}(items)
-    pack_into(4, 'l>', items.size)
-
-    items.each do |item|
-      self.write_{{ self::canonical_name(inner_type) }}(item)
-    end
-  end
-
-  {% when Type::Set { inner_type } -%}
-  # The Set<T> type for {{ self::canonical_name(inner_type) }}.
-
-  def write_{{ canonical_type_name }}(items)
-    pack_into(4, 'l>', items.size)
-
-    items.each do |item|
-      self.write_{{ self::canonical_name(inner_type) }}(item)
-    end
-  end
-
-  {% when Type::Map { key_type: k, value_type: v } -%}
-  # The Map<T> type for {{ canonical_type_name }}.
-
-  def write_{{ canonical_type_name }}(items)
-    pack_into(4, 'l>', items.size)
-
-    items.each do |k, v|
-      self.write_{{ self::canonical_name(k) }}(k)
-      self.write_{{ self::canonical_name(v) }}(v)
-    end
-  end
-
-  {% when Type::Custom { name, builtin, .. } -%}
-  {%- match config.custom_types.get(name.as_str()) %}
-  {%- when Some(cfg) %}{%- if cfg.has_conversion() %}
-  # Custom type {{ name }}: applies lower, then writes builtin `{{ self::canonical_name(builtin) }}`
-  def write_{{ canonical_type_name }}(v)
-    write_{{ self::canonical_name(builtin) }}({{ cfg.lower("v") }})
-  end
-  {%- else %}
-  # The Custom type {{ name }} delegates serialization to its builtin type.
-  def write_{{ canonical_type_name }}(v)
-    write_{{ self::canonical_name(builtin) }}(v)
-  end
-  {%- endif %}
-  {%- when None %}
-  # The Custom type {{ name }} delegates serialization to its builtin type.
-  def write_{{ canonical_type_name }}(v)
-    write_{{ self::canonical_name(builtin) }}(v)
-  end
-  {%- endmatch %}
-
-  {% when Type::CallbackInterface { name, .. } -%}
-  # The CallbackInterface type {{ name }}: write a uint64 handle.
-  def write_{{ canonical_type_name }}(v)
-    handle = {{ self::canonical_name(typ) }}FfiConverter.lower(v)
-    pack_into 8, 'Q>', handle
-  end
-
-  {%- else -%}
-  # This type is not yet supported in the Ruby backend.
-  def write_{{ canonical_type_name }}(v)
-    raise InternalError('RustBufferStream.write() not implemented yet for {{ canonical_type_name }}')
-  end
-
-  {%- endmatch -%}
-  {%- endfor %}
 
   private
 
@@ -322,12 +343,6 @@ class RustBufferBuilder
     yield
 
     @rust_buf.len += num_bytes
-  end
-
-  def pack_into(size, format, value)
-    reserve(size) do
-      @rust_buf.data.put_array_of_char @rust_buf.len, [value].pack(format).bytes
-    end
   end
 end
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferStream.rb
@@ -1,94 +1,82 @@
-
-# Helper for structured reading of values from a RustBuffer.
-class RustBufferStream
-
-  def initialize(rbuf)
-    @rbuf = rbuf
-    @offset = 0
-  end
-
-  def remaining
-    @rbuf.len - @offset
-  end
-
-  def read(size)
-    raise InternalError, 'read past end of rust buffer' if @offset + size > @rbuf.len
-
-    data = @rbuf.data.get_bytes @offset, size
-
-    @offset += size
-
-    data
-  end
-
+# Mixin containing type-specific read methods as module functions.
+# Call sites name this module explicitly (e.g.
+# `::ThisNs::RustBufferStreamMixin.read_TypeFoo(stream)`) so two crates
+# that both define `Foo` do not flatten `read_TypeFoo` onto one receiver.
+# The `stream` argument is always the *local* crate's RustBufferStream so
+# unpack_from / read route through that crate's buffer.
+#
+# Nested types from further crates are reached by lexical calls in this
+# mixin's generated bodies, not by `include`. Do not use `module_function`.
+# InternalError in these methods is this crate's class.
+module RustBufferStreamMixin
   {% for typ in ci.iter_local_types() -%}
   {%- let canonical_type_name = self::canonical_name(typ) -%}
   {%- match typ -%}
 
   {% when Type::Int8 -%}
 
-  def read_{{ self::canonical_name(typ) }}
-    unpack_from 1, 'c'
+  def self.read_{{ self::canonical_name(typ) }}(stream)
+    stream.unpack_from 1, 'c'
   end
 
   {% when Type::UInt8 -%}
 
-  def read_{{ self::canonical_name(typ) }}
-    unpack_from 1, 'c'
+  def self.read_{{ self::canonical_name(typ) }}(stream)
+    stream.unpack_from 1, 'c'
   end
 
   {% when Type::Int16 -%}
 
-  def read_{{ self::canonical_name(typ) }}
-    unpack_from 2, 's>'
+  def self.read_{{ self::canonical_name(typ) }}(stream)
+    stream.unpack_from 2, 's>'
   end
 
   {% when Type::UInt16 -%}
 
-  def read_{{ self::canonical_name(typ) }}
-    unpack_from 2, 'S>'
+  def self.read_{{ self::canonical_name(typ) }}(stream)
+    stream.unpack_from 2, 'S>'
   end
 
   {% when Type::Int32 -%}
 
-  def read_{{ self::canonical_name(typ) }}
-    unpack_from 4, 'l>'
+  def self.read_{{ self::canonical_name(typ) }}(stream)
+    stream.unpack_from 4, 'l>'
   end
 
   {% when Type::UInt32 -%}
 
-  def read_{{ self::canonical_name(typ) }}
-    unpack_from 4, 'L>'
+  def self.read_{{ self::canonical_name(typ) }}(stream)
+    stream.unpack_from 4, 'L>'
   end
 
   {% when Type::Int64 -%}
 
-  def read_{{ self::canonical_name(typ) }}
-    unpack_from 8, 'q>'
+  def self.read_{{ self::canonical_name(typ) }}(stream)
+    stream.unpack_from 8, 'q>'
   end
 
   {% when Type::UInt64 -%}
 
-  def read_{{ self::canonical_name(typ) }}
-    unpack_from 8, 'Q>'
+  def self.read_{{ self::canonical_name(typ) }}(stream)
+    stream.unpack_from 8, 'Q>'
   end
 
   {% when Type::Float32 -%}
 
-  def read_{{ self::canonical_name(typ) }}
-    unpack_from 4, 'g'
+  def self.read_{{ self::canonical_name(typ) }}(stream)
+    stream.unpack_from 4, 'g'
   end
 
   {% when Type::Float64 -%}
 
-  def read_{{ self::canonical_name(typ) }}
-    unpack_from 8, 'G'
+  def self.read_{{ self::canonical_name(typ) }}(stream)
+    stream.unpack_from 8, 'G'
   end
 
   {% when Type::Boolean -%}
 
-  def read_{{ self::canonical_name(typ) }}
-    v = unpack_from 1, 'c'
+  def self.read_{{ self::canonical_name(typ) }}(stream)
+    v = stream.unpack_from 1, 'c'
 
     return false if v == 0
     return true if v == 1
@@ -98,31 +86,31 @@ class RustBufferStream
 
   {% when Type::String -%}
 
-  def read_{{ self::canonical_name(typ) }}
-    size = unpack_from 4, 'l>'
+  def self.read_{{ self::canonical_name(typ) }}(stream)
+    size = stream.unpack_from 4, 'l>'
 
     raise InternalError, 'Unexpected negative string length' if size.negative?
 
-    read(size).force_encoding(Encoding::UTF_8)
+    stream.read(size).force_encoding(Encoding::UTF_8)
   end
 
   {% when Type::Bytes -%}
 
-  def read_{{ self::canonical_name(typ) }}
-    size = unpack_from 4, 'l>'
+  def self.read_{{ self::canonical_name(typ) }}(stream)
+    size = stream.unpack_from 4, 'l>'
 
     raise InternalError, 'Unexpected negative byte string length' if size.negative?
 
-    read(size).force_encoding(Encoding::BINARY)
+    stream.read(size).force_encoding(Encoding::BINARY)
   end
 
   {% when Type::Timestamp -%}
   # The Timestamp type.
   ONE_SECOND_IN_NANOSECONDS = 10**9
 
-  def read_{{ canonical_type_name }}
-    seconds = unpack_from 8, 'q>'
-    nanoseconds = unpack_from 4, 'L>'
+  def self.read_{{ canonical_type_name }}(stream)
+    seconds = stream.unpack_from 8, 'q>'
+    nanoseconds = stream.unpack_from 4, 'L>'
 
     # UniFFi conventions assume that nanoseconds part has to represent nanoseconds portion of
     # duration between epoch and the timestamp moment. Ruby `Time#tv_nsec` returns the number of
@@ -143,9 +131,9 @@ class RustBufferStream
   {% when Type::Duration -%}
   # The Duration type.
 
-  def read_{{ canonical_type_name }}
-    seconds = unpack_from 8, 'q>'
-    nanoseconds = unpack_from 4, 'L>'
+  def self.read_{{ canonical_type_name }}(stream)
+    seconds = stream.unpack_from 8, 'q>'
+    nanoseconds = stream.unpack_from 4, 'L>'
 
     Time.at(seconds, nanoseconds, :nanosecond, in: '+00:00').utc
   end
@@ -153,8 +141,8 @@ class RustBufferStream
   {% when Type::Object with { name: object_name, .. } -%}
   # The Object type {{ object_name }}.
 
-  def read_{{ canonical_type_name }}
-    handle = unpack_from 8, 'Q>'
+  def self.read_{{ canonical_type_name }}(stream)
+    handle = stream.unpack_from 8, 'Q>'
     return {{ object_name|class_name_rb }}.uniffi_lift(handle)
   end
 
@@ -164,8 +152,8 @@ class RustBufferStream
   {% let enum_name = name %}
   # The Enum type {{ enum_name }}.
 
-  def read_{{ canonical_type_name }}
-    variant = unpack_from 4, 'l>'
+  def self.read_{{ canonical_type_name }}(stream)
+    variant = stream.unpack_from 4, 'l>'
     {% if e.is_flat() -%}
     {%- for variant in e.variants() %}
     if variant == {{ loop.index }}
@@ -181,7 +169,7 @@ class RustBufferStream
         {%- let named_fields = !variant.fields()[0].name().is_empty() %}
         return {{ enum_name|class_name_rb }}::{{ variant.name()|enum_name_rb }}.new(
             {%- for field in variant.fields() %}
-            {% if named_fields %}{{ field.name()|var_name_rb }}: {% endif %}self.read_{{ self::canonical_name(field.as_type().borrow()) }}(){% if loop.last %}{% else %},{% endif %}
+            {% if named_fields %}{{ field.name()|var_name_rb }}: {% endif %}{{ self.rust_buffer_read(field.as_type().borrow())? }}(stream){% if loop.last %}{% else %},{% endif %}
             {%- endfor %}
         )
         {%- else %}
@@ -199,13 +187,13 @@ class RustBufferStream
 
   # The Error type {{ error_name }}
 
-  def read_{{ canonical_type_name }}
-    variant = unpack_from 4, 'l>'
+  def self.read_{{ canonical_type_name }}(stream)
+    variant = stream.unpack_from 4, 'l>'
     {% if e.is_flat() -%}
     {%- for variant in e.variants() %}
     if variant == {{ loop.index }}
       return {{ error_name|class_name_rb }}::{{ variant.name()|class_name_rb }}.new(
-        read_{{ self::canonical_name(&Type::String) }}()
+        {{ self.rust_buffer_read(&Type::String)? }}(stream)
       )
     end
     {%- endfor %}
@@ -218,7 +206,7 @@ class RustBufferStream
         {%- let named_fields = !variant.fields()[0].name().is_empty() %}
         return {{ error_name|class_name_rb }}::{{ variant.name()|class_name_rb }}.new(
             {%- for field in variant.fields() %}
-            {% if named_fields %}{{ field.name()|var_name_rb }}: {% endif %}read_{{ self::canonical_name(&field.as_type()) }}(){% if loop.last %}{% else %},{% endif %}
+            {% if named_fields %}{{ field.name()|var_name_rb }}: {% endif %}{{ self.rust_buffer_read(field.as_type().borrow())? }}(stream){% if loop.last %}{% else %},{% endif %}
             {%- endfor %}
         )
         {%- else %}
@@ -236,10 +224,10 @@ class RustBufferStream
   {%- let rec = ci.get_record_definition(record_name).unwrap() -%}
   # The Record type {{ record_name }}.
 
-  def read_{{ canonical_type_name }}
+  def self.read_{{ canonical_type_name }}(stream)
     {{ rec.name()|class_name_rb }}.new(
       {%- for field in rec.fields() %}
-      {{ field.name()|var_name_rb }}: read_{{ self::canonical_name(field.as_type().borrow()) }}{% if loop.last %}{% else %},{% endif %}
+      {{ field.name()|var_name_rb }}: {{ self.rust_buffer_read(field.as_type().borrow())? }}(stream){% if loop.last %}{% else %},{% endif %}
       {%- endfor %}
     )
   end
@@ -247,13 +235,13 @@ class RustBufferStream
   {% when Type::Optional { inner_type } %}
   # The Optional<T> type for {{ self::canonical_name(inner_type) }}.
 
-  def read_{{ canonical_type_name }}
-    flag = unpack_from 1, 'c'
+  def self.read_{{ canonical_type_name }}(stream)
+    flag = stream.unpack_from 1, 'c'
 
     if flag == 0
       return nil
     elsif flag == 1
-      return read_{{ self::canonical_name(inner_type) }}
+      return {{ self.rust_buffer_read(inner_type)? }}(stream)
     else
       raise InternalError, 'Unexpected flag byte for {{ canonical_type_name }}'
     end
@@ -262,15 +250,15 @@ class RustBufferStream
   {% when Type::Sequence { inner_type } -%}
   # The Sequence<T> type for {{ self::canonical_name(inner_type) }}.
 
-  def read_{{ canonical_type_name }}
-    count = unpack_from 4, 'l>'
+  def self.read_{{ canonical_type_name }}(stream)
+    count = stream.unpack_from 4, 'l>'
 
     raise InternalError, 'Unexpected negative sequence length' if count.negative?
 
     items = []
 
     count.times do
-      items.append read_{{ self::canonical_name(inner_type) }}
+      items.append {{ self.rust_buffer_read(inner_type)? }}(stream)
     end
 
     items
@@ -279,15 +267,15 @@ class RustBufferStream
   {% when Type::Set { inner_type } -%}
   # The Set<T> type for {{ self::canonical_name(inner_type) }}.
 
-  def read_{{ canonical_type_name }}
-    count = unpack_from 4, 'l>'
+  def self.read_{{ canonical_type_name }}(stream)
+    count = stream.unpack_from 4, 'l>'
 
     raise InternalError, 'Unexpected negative set size' if count.negative?
 
     items = Set.new
 
     count.times do
-      items.add read_{{ self::canonical_name(inner_type) }}
+      items.add {{ self.rust_buffer_read(inner_type)? }}(stream)
     end
 
     items
@@ -296,14 +284,14 @@ class RustBufferStream
   {% when Type::Map { key_type: k, value_type: v } -%}
   # The Map<T> type for {{ canonical_type_name }}.
 
-  def read_{{ canonical_type_name }}
-    count = unpack_from 4, 'l>'
+  def self.read_{{ canonical_type_name }}(stream)
+    count = stream.unpack_from 4, 'l>'
     raise InternalError, 'Unexpected negative map size' if count.negative?
 
     items = {}
     count.times do
-      key = read_{{ self::canonical_name(k) }}
-      items[key] = read_{{ self::canonical_name(v) }}
+      key = {{ self.rust_buffer_read(k)? }}(stream)
+      items[key] = {{ self.rust_buffer_read(v)? }}(stream)
     end
 
     items
@@ -313,39 +301,61 @@ class RustBufferStream
   {%- match config.custom_types.get(name.as_str()) %}
   {%- when Some(cfg) %}{%- if cfg.has_conversion() %}
   # Custom type {{ name }}: reads builtin `{{ self::canonical_name(builtin) }}`, then applies lift.
-  def read_{{ canonical_type_name }}
-    raw = read_{{ self::canonical_name(builtin) }}
+  def self.read_{{ canonical_type_name }}(stream)
+    raw = {{ self.rust_buffer_read(builtin)? }}(stream)
     {{ cfg.lift("raw") }}
   end
   {%- else %}
   # The Custom type {{ name }} delegates deserialization to its builtin type.
-  def read_{{ canonical_type_name }}
-    read_{{ self::canonical_name(builtin) }}
+  def self.read_{{ canonical_type_name }}(stream)
+    {{ self.rust_buffer_read(builtin)? }}(stream)
   end
   {%- endif %}
   {%- when None %}
   # The Custom type {{ name }} delegates deserialization to its builtin type.
-  def read_{{ canonical_type_name }}
-    read_{{ self::canonical_name(builtin) }}
+  def self.read_{{ canonical_type_name }}(stream)
+    {{ self.rust_buffer_read(builtin)? }}(stream)
   end
   {%- endmatch %}
 
   {% when Type::CallbackInterface { name, .. } -%}
 
   # The CallbackInterface type {{ name }}: read a uint64 handle.
-  def read_{{ canonical_type_name }}
-    handle = unpack_from 8, 'Q>'
+  def self.read_{{ canonical_type_name }}(stream)
+    handle = stream.unpack_from 8, 'Q>'
     {{ self::canonical_name(typ) }}FfiConverter.lift handle
   end
 
   {%- else -%}
   # This type is not yet supported in the Ruby backend.
-  def read_{{ canonical_type_name }}
+  def self.read_{{ canonical_type_name }}(stream)
     raise InternalError, 'RustBufferStream.read not implemented yet for {{ canonical_type_name }}'
   end
 
   {%- endmatch -%}
   {%- endfor %}
+end
+
+# Helper for structured reading of values from a RustBuffer.
+class RustBufferStream
+  def initialize(rbuf)
+    @rbuf = rbuf
+    @offset = 0
+  end
+
+  def remaining
+    @rbuf.len - @offset
+  end
+
+  def read(size)
+    raise InternalError, 'read past end of rust buffer' if @offset + size > @rbuf.len
+
+    data = @rbuf.data.get_bytes @offset, size
+
+    @offset += size
+
+    data
+  end
 
   def unpack_from(size, format)
     raise InternalError, 'read past end of rust buffer' if @offset + size > @rbuf.len

--- a/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RustBufferTemplate.rb
@@ -4,15 +4,15 @@ class RustBuffer < FFI::Struct
          :data,     :pointer
 
   def self.alloc(size)
-    return ::{{ ci.namespace()|class_name_rb }}.rust_call(:{{ ci.ffi_rustbuffer_alloc().name() }}, size)
+    return ::{{ self.module_name() }}.rust_call(:{{ ci.ffi_rustbuffer_alloc().name() }}, size)
   end
 
   def self.reserve(rbuf, additional)
-    return ::{{ ci.namespace()|class_name_rb }}.rust_call(:{{ ci.ffi_rustbuffer_reserve().name() }}, rbuf, additional)
+    return ::{{ self.module_name() }}.rust_call(:{{ ci.ffi_rustbuffer_reserve().name() }}, rbuf, additional)
   end
 
   def free
-    ::{{ ci.namespace()|class_name_rb }}.rust_call(:{{ ci.ffi_rustbuffer_free().name() }}, self)
+    ::{{ self.module_name() }}.rust_call(:{{ ci.ffi_rustbuffer_free().name() }}, self)
   end
 
   def capacity
@@ -85,42 +85,42 @@ class RustBuffer < FFI::Struct
 
   def self.alloc_from_{{ canonical_type_name }}(value)
     RustBuffer.allocWithBuilder do |builder|
-      builder.write_{{ canonical_type_name }}(value)
+      {{ self.rust_buffer_write(typ)? }}(builder, value)
       return builder.finalize
     end
   end
 
   def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read_{{ canonical_type_name }}
+      return {{ self.rust_buffer_read(typ)? }}(stream)
     end
   end
 
   {% when Type::Timestamp -%}
   def self.alloc_from_{{ canonical_type_name }}(v)
     RustBuffer.allocWithBuilder do |builder|
-      builder.write_{{ canonical_type_name }}(v)
+      {{ self.rust_buffer_write(typ)? }}(builder, v)
       return builder.finalize
     end
   end
 
   def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read_{{ canonical_type_name }}
+      return {{ self.rust_buffer_read(typ)? }}(stream)
     end
   end
 
   {% when Type::Duration -%}
   def self.alloc_from_{{ canonical_type_name }}(v)
     RustBuffer.allocWithBuilder do |builder|
-      builder.write_{{ canonical_type_name }}(v)
+      {{ self.rust_buffer_write(typ)? }}(builder, v)
       return builder.finalize
     end
   end
 
   def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read_{{ canonical_type_name }}
+      return {{ self.rust_buffer_read(typ)? }}(stream)
     end
   end
 
@@ -130,25 +130,24 @@ class RustBuffer < FFI::Struct
 
   def self.check_lower_{{ canonical_type_name }}(v)
     {%- for field in rec.fields() %}
-    {{ "v.{}"|format(field.name()|var_name_rb)|check_lower_rb(field.as_type().borrow(), config) }}
+    {{ self.check_lower_rb("v.{}"|format(field.name()|var_name_rb), field.as_type().borrow())? }}
     {%- endfor %}
   end
 
   def self.alloc_from_{{ canonical_type_name }}(v)
     RustBuffer.allocWithBuilder do |builder|
-      builder.write_{{ canonical_type_name }}(v)
+      {{ self.rust_buffer_write(typ)? }}(builder, v)
       return builder.finalize
     end
   end
 
   def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read_{{ canonical_type_name }}
+      return {{ self.rust_buffer_read(typ)? }}(stream)
     end
   end
 
   {% when Type::Enum { name: enum_name, .. }  -%}
-  {% if !ci.is_name_used_as_error(enum_name) %}
   {%- let e = ci.get_enum_definition(enum_name).unwrap() -%}
   # The Enum type {{ enum_name }}.
 
@@ -158,9 +157,9 @@ class RustBuffer < FFI::Struct
     if v.{{ variant.name()|var_name_rb }}?
       {%- for field in variant.fields() %}
       {%- if field.name().is_empty() %}
-        {{ "v.values[{}]"|format(loop.index0)|check_lower_rb(field.as_type().borrow(), config) }}
+        {{ self.check_lower_rb("v.values[{}]"|format(loop.index0), field.as_type().borrow())? }}
       {%- else %}
-        {{ "v.{}"|format(field.name())|check_lower_rb(field.as_type().borrow(), config) }}
+        {{ self.check_lower_rb("v.{}"|format(field.name()|var_name_rb), field.as_type().borrow())? }}
       {%- endif %}
       {%- endfor %}
       return
@@ -171,53 +170,36 @@ class RustBuffer < FFI::Struct
 
   def self.alloc_from_{{ canonical_type_name }}(v)
     RustBuffer.allocWithBuilder do |builder|
-      builder.write_{{ canonical_type_name }}(v)
+      {{ self.rust_buffer_write(typ)? }}(builder, v)
       return builder.finalize
     end
   end
 
   def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read_{{ canonical_type_name }}
+      return {{ self.rust_buffer_read(typ)? }}(stream)
     end
   end
-  {% else %}
-  {%- let e = ci.get_enum_definition(enum_name).unwrap() -%}
-  # Error enum - generate alloc_from for callback error serialization
-  def self.alloc_from_{{ canonical_type_name }}(v)
-    RustBuffer.allocWithBuilder do |builder|
-      builder.write_{{ canonical_type_name }}(v)
-      return builder.finalize
-    end
-  end
-
-  # Enum used as error - generate consume_into_ for use as a return value
-  def consume_into_{{ canonical_type_name }}
-    consumeWithStream do |stream|
-      return stream.read_{{ canonical_type_name }}
-    end
-  end
-  {% endif %}
 
   {% when Type::Optional { inner_type } -%}
   # The Optional<T> type for {{ self::canonical_name(inner_type) }}.
 
   def self.check_lower_{{ canonical_type_name }}(v)
     if !v.nil?
-      {{ "v"|check_lower_rb(inner_type.borrow(), config) }}
+      {{ self.check_lower_rb("v", inner_type.borrow())? }}
     end
   end
 
   def self.alloc_from_{{ canonical_type_name }}(v)
     RustBuffer.allocWithBuilder do |builder|
-      builder.write_{{ canonical_type_name }}(v)
+      {{ self.rust_buffer_write(typ)? }}(builder, v)
       return builder.finalize()
     end
   end
 
   def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read_{{ canonical_type_name }}
+      return {{ self.rust_buffer_read(typ)? }}(stream)
     end
   end
 
@@ -226,20 +208,20 @@ class RustBuffer < FFI::Struct
 
   def self.check_lower_{{ canonical_type_name }}(v)
     v.each do |item|
-      {{ "item"|check_lower_rb(inner_type.borrow(), config) }}
+      {{ self.check_lower_rb("item", inner_type.borrow())? }}
     end
   end
 
   def self.alloc_from_{{ canonical_type_name }}(v)
     RustBuffer.allocWithBuilder do |builder|
-      builder.write_{{ canonical_type_name }}(v)
+      {{ self.rust_buffer_write(typ)? }}(builder, v)
       return builder.finalize()
     end
   end
 
   def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read_{{ canonical_type_name }}
+      return {{ self.rust_buffer_read(typ)? }}(stream)
     end
   end
 
@@ -248,20 +230,20 @@ class RustBuffer < FFI::Struct
 
   def self.check_lower_{{ canonical_type_name }}(v)
     v.each do |item|
-      {{ "item"|check_lower_rb(inner_type.borrow(), config) }}
+      {{ self.check_lower_rb("item", inner_type.borrow())? }}
     end
   end
 
   def self.alloc_from_{{ canonical_type_name }}(v)
     RustBuffer.allocWithBuilder do |builder|
-      builder.write_{{ canonical_type_name }}(v)
+      {{ self.rust_buffer_write(typ)? }}(builder, v)
       return builder.finalize()
     end
   end
 
   def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read_{{ canonical_type_name }}
+      return {{ self.rust_buffer_read(typ)? }}(stream)
     end
   end
 
@@ -270,27 +252,58 @@ class RustBuffer < FFI::Struct
 
   def self.check_lower_{{ canonical_type_name }}(v)
     v.each do |k, v|
-      {{ "k"|check_lower_rb(k.borrow(), config) }}
-      {{ "v"|check_lower_rb(v.borrow(), config) }}
+      {{ self.check_lower_rb("k", k.borrow())? }}
+      {{ self.check_lower_rb("v", v.borrow())? }}
     end
   end
 
   def self.alloc_from_{{ canonical_type_name }}(v)
     RustBuffer.allocWithBuilder do |builder|
-      builder.write_{{ canonical_type_name }}(v)
+      {{ self.rust_buffer_write(typ)? }}(builder, v)
       return builder.finalize
     end
   end
 
   def consume_into_{{ canonical_type_name }}
     consumeWithStream do |stream|
-      return stream.read_{{ canonical_type_name }}
+      return {{ self.rust_buffer_read(typ)? }}(stream)
     end
   end
 
   {%- else -%}
   {#- No code emitted for types that don't lower into a RustBuffer -#}
   {%- endmatch -%}
+  {%- endfor %}
+
+  {%- for typ in ci.iter_external_types() -%}
+  {%- let canonical_type_name = self::canonical_name(typ) -%}
+  {%- match typ %}
+  {%- when Type::Record { .. } | Type::Enum { .. } %}
+  # External type bridge: allocates locally, delegates write through the
+  # bridge that routes reserve through this shared library's allocator.
+  def self.alloc_from_{{ canonical_type_name }}(v)
+    RustBuffer.allocWithBuilder do |builder|
+      {{ self.rust_buffer_write(typ)? }}(builder, v)
+      return builder.finalize()
+    end
+  end
+
+  # External type bridge: frees locally, delegates read to external stream.
+  def consume_into_{{ canonical_type_name }}
+    consumeWithStream do |stream|
+      return {{ self.rust_buffer_read(typ)? }}(stream)
+    end
+  end
+
+  # External type bridge: check_lower only validates the Ruby value; it never
+  # allocs, reserves, or frees a RustBuffer. Delegating to the defining crate
+  # is safe and does not break the local-allocator invariant of the bridges
+  # above.
+  def self.check_lower_{{ canonical_type_name }}(v)
+    ::{{ self.external_type_module(typ.module_path().unwrap()) }}::RustBuffer.check_lower_{{ canonical_type_name }}(v)
+  end
+  {%- else %}
+  {%- endmatch %}
   {%- endfor %}
 end
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/TopLevelFunctionTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/TopLevelFunctionTemplate.rb
@@ -12,7 +12,7 @@ end
 def self.{{ func.name()|fn_name_rb }}({%- call rb::arg_list_decl(func) %}{% endcall -%})
   {%- call rb::setup_args(func) %}{% endcall %}
   result = {% call rb::to_ffi_call(func) %}{% endcall %}
-  return {{ "result"|lift_rb(return_type, config) }}
+  return {{ self.lift_rb("result", return_type)? }}
 end
 
 {% when None %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/UniffiTraitImpls.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/UniffiTraitImpls.rb
@@ -6,22 +6,22 @@
 {%- if let Some(display_fmt) = trait_methods.display_fmt %}
 # The Rust `Display::fmt` implementation.
 def to_s
-  result = ::{{ ci.namespace()|class_name_rb }}.rust_call(
+  result = ::{{ self.module_name() }}.rust_call(
     :{{ display_fmt.ffi_func().name() }},
-    {{ display_fmt|lower_method_self_rb(config) }}
+    {{ display_fmt|lower_method_self_rb(self) }}
   )
-  {{ "result"|lift_rb(display_fmt.return_type().unwrap(), config) }}
+  {{ self.lift_rb("result", display_fmt.return_type().unwrap())? }}
 end
 {%- endif %}
 
 {%- if let Some(debug_fmt) = trait_methods.debug_fmt %}
 # The Rust `Debug::fmt` implementation.
 def inspect
-  result = ::{{ ci.namespace()|class_name_rb }}.rust_call(
+  result = ::{{ self.module_name() }}.rust_call(
     :{{ debug_fmt.ffi_func().name() }},
-    {{ debug_fmt|lower_method_self_rb(config) }}
+    {{ debug_fmt|lower_method_self_rb(self) }}
   )
-  {{ "result"|lift_rb(debug_fmt.return_type().unwrap(), config) }}
+  {{ self.lift_rb("result", debug_fmt.return_type().unwrap())? }}
 end
 {%- endif %}
 
@@ -29,23 +29,23 @@ end
 # The Rust `Eq::eq` implementation.
 def ==(other)
   return false unless other.is_a?(self.class)
-  result = ::{{ ci.namespace()|class_name_rb }}.rust_call(
+  result = ::{{ self.module_name() }}.rust_call(
     :{{ eq.ffi_func().name() }},
-    {{ eq|lower_method_self_rb(config) }},
-    {{ "other"|lower_rb(eq.arguments()[0].as_type().borrow(), config) }}
+    {{ eq|lower_method_self_rb(self) }},
+    {{ self.lower_rb("other", eq.arguments()[0].as_type().borrow())? }}
   )
-  {{ "result"|lift_rb(eq.return_type().unwrap(), config) }}
+  {{ self.lift_rb("result", eq.return_type().unwrap())? }}
 end
 {%- endif %}
 
 {%- if let Some(hash) = trait_methods.hash_hash %}
 # The Rust `Hash::hash` implementation.
 def hash
-  result = ::{{ ci.namespace()|class_name_rb }}.rust_call(
+  result = ::{{ self.module_name() }}.rust_call(
     :{{ hash.ffi_func().name() }},
-    {{ hash|lower_method_self_rb(config) }}
+    {{ hash|lower_method_self_rb(self) }}
   )
-  {{ "result"|lift_rb(hash.return_type().unwrap(), config) }}
+  {{ self.lift_rb("result", hash.return_type().unwrap())? }}
 end
 
 def eql?(other)
@@ -60,12 +60,12 @@ include Comparable
 def <=>(other)
   # do we need this?
   # return nil unless other.is_a?(self.class)
-  result = ::{{ ci.namespace()|class_name_rb }}.rust_call(
+  result = ::{{ self.module_name() }}.rust_call(
     :{{ cmp.ffi_func().name() }},
-    {{ cmp|lower_method_self_rb(config) }},
-    {{ "other"|lower_rb(cmp.arguments()[0].as_type().borrow(), config) }}
+    {{ cmp|lower_method_self_rb(self) }},
+    {{ self.lower_rb("other", cmp.arguments()[0].as_type().borrow())? }}
   )
-  {{ "result"|lift_rb(cmp.return_type().unwrap(), config) }}
+  {{ self.lift_rb("result", cmp.return_type().unwrap())? }}
 rescue
   nil
 end

--- a/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/macros.rb
@@ -17,21 +17,24 @@ values[{{- field_num - 1 -}}]
 {%- endif -%}
 {%- endmacro -%}
 
-{#- Helper: emit the opening of a rust_call or rust_call_with_error call. -#}
+{#- Helper: emit the opening of a rust_call or rust_call_with_error call.
+    The reader is a Method object from error_reader_method_expr.
+-#}
 {%- macro rust_call_head(func) -%}
-    {%- match func.throws_type() -%}
-    {%- when Some(Type::Custom { builtin, .. }) -%}
-      {%- match builtin.borrow() -%}
-      {%- when Type::Enum { name, .. } | Type::Object { name, .. } -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
-      {%- else -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call
-      {%- endmatch -%}
-    {%- when Some(Type::Enum { name, .. }) | Some(Type::Object { name, .. }) -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call_with_error({{ name|class_name_rb }},
-    {%- else -%}
-      ::{{ ci.namespace()|class_name_rb }}.rust_call(
+    {%- match self.error_reader_method_expr(func) %}
+    {%- when Some with (reader) %}
+    ::{{ self.module_name() }}.rust_call_with_error({{ reader }},
+    {%- when None %}
+    ::{{ self.module_name() }}.rust_call(
     {%- endmatch -%}
+{%- endmacro -%}
+
+{#- Emit the error-reader argument for async FFI calls: Method object or Ruby `nil`. -#}
+{%- macro error_reader_expr(func) -%}
+    {%- match self.error_reader_method_expr(func) %}
+    {%- when Some with (reader) %}{{ reader }}
+    {%- when None %}nil
+    {%- endmatch %}
 {%- endmacro -%}
   
 {%- macro to_ffi_call(func) -%}
@@ -52,14 +55,14 @@ values[{{- field_num - 1 -}}]
 {%- macro to_ffi_call_with_lower_self(func) -%}
     {%- call rust_call_head(func) %}{% endcall -%}
     :{{ func.ffi_func().name() }},
-    {{ func|lower_method_self_rb(config) }},
+    {{ func|lower_method_self_rb(self) }},
     {%- call _arg_list_ffi_call(func) %}{% endcall -%}
 )
 {%- endmacro -%}
 
 {%- macro _arg_list_ffi_call(func) %}
     {%- for arg in func.arguments() %}
-        {{- arg.name()|var_name_rb|lower_rb(arg.as_type().borrow(), config) }}
+        {{- self.lower_rb(arg.name()|var_name_rb, arg.as_type().borrow())? }}
         {%- if !loop.last %},{% endif %}
     {%- endfor %}
 {%- endmacro -%}
@@ -73,7 +76,7 @@ values[{{- field_num - 1 -}}]
     {%- for arg in func.arguments() -%}
         {{ arg.name()|var_name_rb }}
         {%- match arg.default_value() %}
-        {%- when Some(_) %} = {{ arg|arg_default_rb }}
+        {%- when Some(_) %} = {{ self.arg_default_rb(arg)? }}
         {%- else %}
         {%- endmatch %}
         {%- if !loop.last %}, {% endif -%}
@@ -89,25 +92,8 @@ values[{{- field_num - 1 -}}]
     {%- if func.has_rust_call_status_arg() -%}RustCallStatus.by_ref{% endif -%}]
 {%- endmacro -%}
 
-{#- Helper: emit the error class name or nil for async rust calls. -#}
-{%- macro throws_error_class_expr(func) %}
-    {%- match func.throws_type() %}
-    {%- when Some(Type::Custom { builtin, .. }) %}
-      {%- match builtin.borrow() %}
-      {%- when Type::Enum { name, .. } | Type::Object { name, .. } %}
-    {{ name|class_name_rb }}
-      {%- else %}
-    nil
-      {%- endmatch %}
-    {%- when Some(Type::Enum { name, .. }) | Some(Type::Object { name, .. }) %}
-    {{ name|class_name_rb }}
-    {%- else %}
-    nil
-    {%- endmatch %}
-{%- endmacro %}
-
 {%- macro to_ffi_call_async(func, prefix = "") -%}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_rust_call_async(
+    ::{{ self.module_name() }}.uniffi_rust_call_async(
       UniFFILib.{{ func.ffi_func().name() }}(
         {%- if !prefix.is_empty() %}{{- prefix }},{% endif %}
         {%- call _arg_list_ffi_call(func) %}{% endcall -%}
@@ -118,17 +104,16 @@ values[{{- field_num - 1 -}}]
       :{{ func.ffi_rust_future_free(ci) }},
       {%- match func.return_type() %}
       {%- when Some with (return_type) %}
-      Proc.new { |v| {{ "v"|lift_rb(return_type, config) }} },
+      Proc.new { |v| {{ self.lift_rb("v", return_type)? }} },
       {%- when None %}
       Proc.new { |v| nil },
       {%- endmatch %}
-      {%- call throws_error_class_expr(func) %}{% endcall %}
+      {%- call error_reader_expr(func) %}{% endcall %}
     )
 {%- endmacro %}
 
-{#- Async constructor variant: uses identity lift to return raw handle for uniffi_allocate -#}
 {%- macro to_ffi_call_async_constructor(func) %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_rust_call_async(
+    ::{{ self.module_name() }}.uniffi_rust_call_async(
       UniFFILib.{{ func.ffi_func().name() }}(
         {%- call _arg_list_ffi_call(func) %}{% endcall -%}
       ),
@@ -137,7 +122,7 @@ values[{{- field_num - 1 -}}]
       :{{ func.ffi_rust_future_complete(ci) }},
       :{{ func.ffi_rust_future_free(ci) }},
       Proc.new { |v| v },
-      {%- call throws_error_class_expr(func) %}{% endcall %}
+      {%- call error_reader_expr(func) %}{% endcall %}
     )
 {%- endmacro %}
 
@@ -148,15 +133,15 @@ values[{{- field_num - 1 -}}]
 
 {%- macro setup_args(func) %}
     {%- for arg in func.arguments() %}
-    {{ arg.name()|var_name_rb }} = {{ arg.name()|var_name_rb|coerce_rb(ci.namespace()|class_name_rb, arg.as_type().borrow(), config) }}
-    {{ arg.name()|var_name_rb|check_lower_rb(arg.as_type().borrow(), config) }}
+    {{ arg.name()|var_name_rb }} = {{ self.coerce_rb(arg.name()|var_name_rb, arg.as_type().borrow())? }}
+    {{ self.check_lower_rb(arg.name()|var_name_rb, arg.as_type().borrow())? }}
     {% endfor -%}
 {%- endmacro -%}
 
 {%- macro setup_args_extra_indent(meth) %}
         {%- for arg in meth.arguments() %}
-        {{ arg.name()|var_name_rb }} = {{ arg.name()|var_name_rb|coerce_rb(ci.namespace()|class_name_rb, arg.as_type().borrow(), config) }}
-        {{ arg.name()|var_name_rb|check_lower_rb(arg.as_type().borrow(), config) }}
+        {{ arg.name()|var_name_rb }} = {{ self.coerce_rb(arg.name()|var_name_rb, arg.as_type().borrow())? }}
+        {{ self.check_lower_rb(arg.name()|var_name_rb, arg.as_type().borrow())? }}
         {%- endfor %}
 {%- endmacro -%}
 
@@ -168,7 +153,7 @@ values[{{- field_num - 1 -}}]
     make_call = Proc.new do
       uniffi_obj.{{ method.name()|fn_name_rb }}(
         {%- for arg in method.arguments() %}
-        {{ arg.name()|lift_rb(arg.as_type().borrow(), config) }}{% if !loop.last %},{% endif %}
+        {{ self.lift_rb(arg.name(), arg.as_type().borrow())? }}{% if !loop.last %},{% endif %}
         {%- endfor %}
       )
     end
@@ -183,7 +168,7 @@ values[{{- field_num - 1 -}}]
       result_struct = UniFFILib::{{ method|foreign_future_result_rb }}.new
       {%- match method.return_type() %}
       {%- when Some with (return_type) %}
-      result_struct[:return_value] = {{ "return_value"|lower_rb(return_type, config) }}
+      result_struct[:return_value] = {{ self.lower_rb("return_value", return_type)? }}
       result_struct[:call_status] = RustCallStatus.new
       {%- when None %}
       result_struct[:call_status] = RustCallStatus.new
@@ -224,7 +209,7 @@ values[{{- field_num - 1 -}}]
     {%- match method.return_type() %}
     {%- when Some with (return_type) %}
     write_return_value = Proc.new do |v|
-      lowered = {{ "v"|lower_rb(return_type, config) }}
+      lowered = {{ self.lower_rb("v", return_type)? }}
       {%- let ffi_type_name = return_type|ffi_write_return_rb %}
       {%- if ffi_type_name == "rustbuffer" %}
       # Write a RustBuffer struct into the out pointer
@@ -242,6 +227,20 @@ values[{{- field_num - 1 -}}]
     {%- endmatch %}
 {%- endmacro %}
 
+{#- Emit the error-specific trailing arguments (error class, lower-proc)
+    for a sync/async trait-interface call.
+    `lower_type` is the Type to use in the lower expression
+    (error_type itself for direct errors, builtin for Custom-wrapped errors).
+-#}
+{%- macro trait_call_error_args(name, module_path, lower_type) %}
+      {%- if self.is_external_module(module_path) %}
+      ::{{ self.external_type_module(module_path) }}::{{ name|class_name_rb }},
+      {%- else %}
+      {{ name|class_name_rb }},
+      {%- endif %}
+      Proc.new { |e| {{ self.lower_rb("e", lower_type)? }} }
+{%- endmacro %}
+
 {#-
 // Dispatch the throws type for a sync callback/trait-interface method.
 // Caller must have in scope: uniffi_call_status, make_call, write_return_value.
@@ -249,36 +248,34 @@ values[{{- field_num - 1 -}}]
 {%- macro sync_throws_dispatch(method) %}
     {%- match method.throws_type() %}
     {%- when None %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call(
+    ::{{ self.module_name() }}.uniffi_trait_interface_call(
       uniffi_call_status,
       make_call,
       write_return_value,
     )
     {%- when Some with (error_type) %}
     {%- match error_type %}
-    {%- when Type::Enum { name, .. } | Type::Object { name, .. } %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call(
+    {%- when Type::Enum { name, module_path, .. } | Type::Object { name, module_path, .. } %}
+    ::{{ self.module_name() }}.uniffi_trait_interface_call(
       uniffi_call_status,
       make_call,
       write_return_value,
-      {{ name|class_name_rb }},
-      Proc.new { |e| {{ "e"|lower_rb(error_type, config) }} }
+      {%- call trait_call_error_args(name, module_path, error_type) %}{% endcall %}
     )
     {%- when Type::Custom { builtin, .. } %}
     {%- match builtin.borrow() %}
-    {%- when Type::Enum { name, .. } | Type::Object { name, .. } %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call(
+    {%- when Type::Enum { name, module_path, .. } | Type::Object { name, module_path, .. } %}
+    ::{{ self.module_name() }}.uniffi_trait_interface_call(
       uniffi_call_status,
       make_call,
       write_return_value,
-      {{ name|class_name_rb }},
-      Proc.new { |e| {{ "e"|lower_rb(builtin, config) }} }
+      {%- call trait_call_error_args(name, module_path, builtin) %}{% endcall %}
     )
     {%- else %}
     raise RuntimeError, "Unsupported custom error type"
     {%- endmatch %}
     {%- else %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call(
+    ::{{ self.module_name() }}.uniffi_trait_interface_call(
       uniffi_call_status,
       make_call,
       write_return_value
@@ -294,7 +291,7 @@ values[{{- field_num - 1 -}}]
 {%- macro async_throws_dispatch(method) %}
     {%- match method.throws_type() %}
     {%- when None %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_async(
+    ::{{ self.module_name() }}.uniffi_trait_interface_call_async(
       make_call,
       uniffi_out_dropped_callback,
       handle_success,
@@ -302,28 +299,26 @@ values[{{- field_num - 1 -}}]
     )
     {%- when Some with (error_type) %}
     {%- match error_type %}
-    {%- when Type::Enum { name, .. } | Type::Object { name, .. } %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_async(
+    {%- when Type::Enum { name, module_path, .. } | Type::Object { name, module_path, .. } %}
+    ::{{ self.module_name() }}.uniffi_trait_interface_call_async(
       make_call,
       uniffi_out_dropped_callback,
       handle_success,
       handle_error,
-      {{ name|class_name_rb }},
-      Proc.new { |e| {{ "e"|lower_rb(error_type, config) }} }
+      {%- call trait_call_error_args(name, module_path, error_type) %}{% endcall %}
     )
     {%- when Type::Custom { builtin, .. } %}
     {%- match builtin.borrow() %}
-    {%- when Type::Enum { name, .. } | Type::Object { name, .. } %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_async(
+    {%- when Type::Enum { name, module_path, .. } | Type::Object { name, module_path, .. } %}
+    ::{{ self.module_name() }}.uniffi_trait_interface_call_async(
       make_call,
       uniffi_out_dropped_callback,
       handle_success,
       handle_error,
-      {{ name|class_name_rb }},
-      Proc.new { |e| {{ "e"|lower_rb(builtin, config) }} }
+      {%- call trait_call_error_args(name, module_path, builtin) %}{% endcall %}
     )
     {%- else %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_async(
+    ::{{ self.module_name() }}.uniffi_trait_interface_call_async(
       make_call,
       uniffi_out_dropped_callback,
       handle_success,
@@ -331,7 +326,7 @@ values[{{- field_num - 1 -}}]
     )
     {%- endmatch %}
     {%- else %}
-    ::{{ ci.namespace()|class_name_rb }}.uniffi_trait_interface_call_async(
+    ::{{ self.module_name() }}.uniffi_trait_interface_call_async(
       make_call,
       uniffi_out_dropped_callback,
       handle_success,

--- a/uniffi_bindgen/src/bindings/ruby/templates/wrapper.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/wrapper.rb
@@ -20,7 +20,15 @@ require 'set'
 require 'monitor'
 {%- endif %}
 
-module {{ ci.namespace()|class_name_rb }}
+{%- for ext in self.external_mixin_modules()? %}
+require '{{ ext.require_path }}'
+{%- endfor %}
+
+{%- for import_name in self.external_custom_type_imports() %}
+require '{{ import_name }}'
+{%- endfor %}
+
+module {{ self.module_name() }}
   {% include "Helpers.rb" %}
 
   {%- if ci.has_callback_definitions() %}
@@ -49,22 +57,7 @@ module {{ ci.namespace()|class_name_rb }}
   {%- for type_ in ci.iter_local_types() -%}
   {%- match type_ -%}
   {%- when Type::Custom { name, builtin, .. } -%}
-  {%- if !ci.is_external(type_) %}
   {% include "CustomTypeTemplate.rb" %}
-  {%- else -%}
-  {%- match config.custom_types.get(name.as_str()) %}
-  {%- when Some(cfg) %}
-  {%- match cfg.imports %}
-  {%- when Some(imports) %}
-  # External custom type `{{ name }}`: importing configured dependencies.
-  {%- for import_name in imports %}
-  require '{{ import_name }}'
-  {%- endfor %}
-  {%- when None %}
-  {%- endmatch %}
-  {%- when None %}
-  {%- endmatch %}
-  {%- endif %}
   {%- else -%}
   {%- endmatch %}
   {%- endfor %}
@@ -93,6 +86,7 @@ module {{ ci.namespace()|class_name_rb }}
   {%- let name = cbi.name() %}
   {% include "CallbackInterfaceTemplate.rb" %}
   {% endfor %}
+
 end
 
 {% import "macros.rb" as rb %}


### PR DESCRIPTION
Library-mode only (`generate --library`). Single-UDL with an external type is a bindgen error -- we don't have the other crates' metadata, so the generated require would be nonsense.

Python/Kotlin already have this implementation, and it's small there because they prefix an existing `FfiConverter`. Ruby didn't have such infra. Nested `read/write` were methods on one builder (`write_TypeFoo`), mixed in with include, so two crates that both export `Foo` clobber each other and we couldn't even point at the defining crate. `lift/lower` were `Askama` filters with no crate context. That's why this PR looks like a huge rewrite.

What we generate now:
- `require` the other crate's .rb
- `RustBuffer.alloc/free` stay on the consumer cdylib
- `read_*`/`write_*` are module functions on the defining crate
- custom types call that crate's `uniffi_lift_*` / `uniffi_lower_*` (`Url` → `URI`, identity newtypes still go through `uniffi_in_range`)
- errors: uses method object for the defining crate's reader, so a corrupt buffer raises their `InternalError`

`[bindings.ruby.module_name]` sets the generated module name. Library mode fills `[bindings.ruby.external_packages]` from each peer's module_name; a mismatch is a bindgen error. Keys are crate names (`uniffi_one`, not `uniffi_one_ns`); hyphens and underscores are the same. `require` still uses the namespace / filename.

Most of the template churn (`ObjectTemplate`, `Async`, `Helpers`, etc) is just `self.lift_rb` / `self.module_name` after those moved onto `RubyWrapper`. The actual serialization change is `RustBuffer*.rb` + `wrapper.rb` + `CustomTypeTemplate.rb` + `macros.rb`. `gen_ruby/mod.rs` has the owner-policy comment if the four different "which crate?" helpers are confusing.

`fixtures/ext-types/lib` is the happy path. `transitive-lib` is the one that matters for mixin dispatch: it only depends on sub-lib, so it can't accidentally `require` `uniffi-one`. `bindgen-tests/ruby/tests/external_types.rb` checks imported identity customs still `range-check`. `gen_ruby/tests.rs` is mostly “did we include a foreign mixin again.”