### PR TITLE
kotlin-jni: support Bytes fields inside FFI buffers

### DIFF
--- a/uniffi-bindgen-kotlin-jni/src/bindings/templates/shared/FfiBuffer.kt
+++ b/uniffi-bindgen-kotlin-jni/src/bindings/templates/shared/FfiBuffer.kt
@@ -45,6 +45,14 @@ fun writeString(buf: java.nio.ByteBuffer, offset: kotlin.Int, value: kotlin.Stri
     Scaffolding.ffiBufferWriteString(buf, offset, value)
 }
 
+fun readBytes(buf: java.nio.ByteBuffer, offset: kotlin.Int): kotlin.ByteArray {
+    return Scaffolding.ffiBufferReadBytes(buf, offset)
+}
+
+fun writeBytes(buf: java.nio.ByteBuffer, offset: kotlin.Int, value: kotlin.ByteArray) {
+    Scaffolding.ffiBufferWriteBytes(buf, offset, value)
+}
+
 fun readBuffer(buf: java.nio.ByteBuffer, offset: kotlin.Int): java.nio.ByteBuffer {
     return Scaffolding.ffiBufferReadBuffer(buf, offset).order(java.nio.ByteOrder.nativeOrder())
 }

--- a/uniffi-bindgen-kotlin-jni/src/bindings/templates/shared/Scaffolding.kt
+++ b/uniffi-bindgen-kotlin-jni/src/bindings/templates/shared/Scaffolding.kt
@@ -4,6 +4,8 @@ object Scaffolding {
     @JvmStatic external fun ffiBufferFree(buf: java.nio.ByteBuffer)
     @JvmStatic external fun ffiBufferReadString(buf: java.nio.ByteBuffer, offset: kotlin.Int): kotlin.String
     @JvmStatic external fun ffiBufferWriteString(buf: java.nio.ByteBuffer, offset: kotlin.Int, value: kotlin.String)
+    @JvmStatic external fun ffiBufferReadBytes(buf: java.nio.ByteBuffer, offset: kotlin.Int): kotlin.ByteArray
+    @JvmStatic external fun ffiBufferWriteBytes(buf: java.nio.ByteBuffer, offset: kotlin.Int, value: kotlin.ByteArray)
     @JvmStatic external fun ffiBufferReadBuffer(buf: java.nio.ByteBuffer, offset: kotlin.Int): java.nio.ByteBuffer
     @JvmStatic external fun ffiBufferWriteBuffer(buf: java.nio.ByteBuffer, offset: kotlin.Int, value: java.nio.ByteBuffer)
 

--- a/uniffi-bindgen-kotlin-jni/src/pipeline/ffi_buffer.rs
+++ b/uniffi-bindgen-kotlin-jni/src/pipeline/ffi_buffer.rs
@@ -63,6 +63,9 @@ impl FfiBufferLayoutOracle {
             Type::UInt64 | Type::Int64 | Type::Float64 => Layout::from_size_align(8, 8)?,
             // One 8-byte handle
             Type::Interface { .. } => Layout::from_size_align(8, 8)?,
+            // 8-byte seconds at offset 0, 4-byte nanoseconds at offset 8
+            // (see the timestamp/duration scaffolding templates)
+            Type::Timestamp | Type::Duration => Layout::from_size_align(12, 8)?,
             // (data, length, capacity) fields
             Type::String | Type::Bytes => Layout::from_size_align(24, 8)?,
             // (data, size) fields

--- a/uniffi-bindgen-kotlin-jni/src/pipeline/ffi_buffer.rs
+++ b/uniffi-bindgen-kotlin-jni/src/pipeline/ffi_buffer.rs
@@ -64,7 +64,7 @@ impl FfiBufferLayoutOracle {
             // One 8-byte handle
             Type::Interface { .. } => Layout::from_size_align(8, 8)?,
             // (data, length, capacity) fields
-            Type::String => Layout::from_size_align(24, 8)?,
+            Type::String | Type::Bytes => Layout::from_size_align(24, 8)?,
             // (data, size) fields
             Type::Sequence { .. } | Type::Map { .. } | Type::Set { .. } => {
                 Layout::from_size_align(16, 8)?

--- a/uniffi-bindgen-kotlin-jni/src/pipeline/types.rs
+++ b/uniffi-bindgen-kotlin-jni/src/pipeline/types.rs
@@ -267,6 +267,7 @@ impl TypeNode {
             Type::Float64 => "uniffi::ffibuffer::write_f64".into(),
             Type::Boolean => "uniffi::ffibuffer::write_bool".into(),
             Type::String => "uniffi::ffibuffer::write_string".into(),
+            Type::Bytes => "uniffi::ffibuffer::write_vec_u8".into(),
             _ => format!("write_type_{id}"),
         }
     }
@@ -287,6 +288,7 @@ impl TypeNode {
             Type::Float64 => "uniffi::ffibuffer::read_f64".into(),
             Type::Boolean => "uniffi::ffibuffer::read_bool".into(),
             Type::String => "uniffi::ffibuffer::read_string".into(),
+            Type::Bytes => "uniffi::ffibuffer::read_vec_u8".into(),
             _ => format!("read_type_{id}"),
         }
     }
@@ -407,6 +409,7 @@ impl TypeNode {
             Type::Float64 => "writeDouble".into(),
             Type::Boolean => "writeBoolean".into(),
             Type::String => "writeString".into(),
+            Type::Bytes => "writeBytes".into(),
             _ => format!("writeType{id}"),
         }
     }
@@ -427,6 +430,7 @@ impl TypeNode {
             Type::Float64 => "readDouble".into(),
             Type::Boolean => "readBoolean".into(),
             Type::String => "readString".into(),
+            Type::Bytes => "readBytes".into(),
             _ => format!("readType{id}"),
         }
     }

--- a/uniffi-bindgen-kotlin-jni/src/scaffolding/templates/ffi_buffer.rs
+++ b/uniffi-bindgen-kotlin-jni/src/scaffolding/templates/ffi_buffer.rs
@@ -79,6 +79,42 @@ unsafe extern "system" fn Java_uniffi_Scaffolding_ffiBufferWriteString(
 }
 
 #[unsafe(no_mangle)]
+unsafe extern "system" fn Java_uniffi_Scaffolding_ffiBufferReadBytes(
+    env: *mut uniffi_jni::JNIEnv,
+    _: *mut uniffi_jni::jclass,
+    buf: uniffi_jni::jobject,
+    offset: ::std::primitive::i32,
+) -> uniffi_jni::jbyteArray {
+    unsafe {
+        uniffi_jni::rust_call_with_env(env, |env| {
+            let (ptr, capacity) = uniffi_jni::lift_buffer(env, buf)?;
+            let ptr = ptr.add(offset as ::std::primitive::usize);
+            let v = uniffi::ffibuffer::read_vec_u8(ptr)?;
+            uniffi_jni::lower_vec_u8(env, v)
+        })
+    }
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "system" fn Java_uniffi_Scaffolding_ffiBufferWriteBytes(
+    env: *mut uniffi_jni::JNIEnv,
+    _: *mut uniffi_jni::jclass,
+    buf: uniffi_jni::jobject,
+    offset: ::std::primitive::i32,
+    value: uniffi_jni::jbyteArray,
+) {
+    unsafe {
+        uniffi_jni::rust_call_with_env(env, |env| {
+            let v = uniffi_jni::lift_vec_u8(env, value)?;
+            let (ptr, _) = uniffi_jni::lift_buffer(env, buf)?;
+            let ptr = ptr.add(offset as ::std::primitive::usize);
+            uniffi::ffibuffer::write_vec_u8(ptr, v)?;
+            uniffi::Result::Ok(())
+        })
+    }
+}
+
+#[unsafe(no_mangle)]
 unsafe extern "system" fn Java_uniffi_Scaffolding_ffiBufferReadBuffer(
     env: *mut uniffi_jni::JNIEnv,
     _: *mut uniffi_jni::jclass,

--- a/uniffi_core/src/ffi/ffibuffer.rs
+++ b/uniffi_core/src/ffi/ffibuffer.rs
@@ -190,6 +190,65 @@ pub unsafe fn write_string(ptr: *mut u8, mut value: String) -> Result<()> {
     }
 }
 
+/// Read a byte vector value
+///
+/// Like strings, byte vectors are deconstructed into their raw parts (data, length, and
+/// capacity), the raw parts are casted to `u64` values, then written to the buffer,
+/// so the total size is 24 bytes and the alignment is 8.
+///
+/// # Safety
+///
+/// * There must be at least 24 bytes of capacity remaining in the pointer.
+/// * The position must be aligned to 8 bytes
+/// * The other side of the FFI must have written a byte vector to the current address
+pub unsafe fn read_vec_u8(ptr: *mut u8) -> Result<Vec<u8>> {
+    // Safety:
+    //
+    // * ptr is properly aligned and has enough space left
+    // * We assume the foreign side wrote the correct value to the buffer
+    Ok(unsafe {
+        let ptr = ptr.cast::<u64>();
+        let data: u64 = ptr.read();
+        let length: u64 = ptr.add(1).read();
+        let capacity: u64 = ptr.add(2).read();
+        trace!("ffibuffer::read_vec_u8 ({ptr:?} -> {data:x}, {length}, {capacity})");
+        Vec::from_raw_parts(
+            ptr::with_exposed_provenance_mut(data as usize),
+            length as usize,
+            capacity as usize,
+        )
+    })
+}
+
+/// Write a byte vector value
+///
+/// Like strings, byte vectors are deconstructed into their raw parts (data, length, and
+/// capacity), the raw parts are casted to `u64` values, then written to the buffer,
+/// so the total size is 24 bytes and the alignment is 8.
+///
+/// # Safety
+///
+/// * There must be at least 24 bytes of capacity remaining in the pointer.
+/// * The position must be aligned to 8 bytes
+pub unsafe fn write_vec_u8(ptr: *mut u8, mut value: Vec<u8>) -> Result<()> {
+    // Safety:
+    //
+    // * ptr is properly aligned and has enough space left
+    unsafe {
+        let data = value.as_mut_ptr().expose_provenance() as u64;
+        let length = value.len() as u64;
+        let capacity = value.capacity() as u64;
+        trace!("ffibuffer::write_vec_u8  ({ptr:?} -> {data:x}, {length}, {capacity})");
+        // Leak the vec, then write the components to the buffer.
+        mem::forget(value);
+        let ptr = ptr.cast::<u64>();
+        ptr.write(data);
+        ptr.add(1).write(length);
+        ptr.add(2).write(capacity);
+        Ok(())
+    }
+}
+
 /// Read a nested FFI buffer
 ///
 /// Like strings, these are deconstructed into their raw parts, casted to `u64` values,


### PR DESCRIPTION
fixes `No FFI buffer Layout for Bytes` and also for `Duration`/`Timestamp`.

parts of #2972 