### PR TITLE
uniffi_parse_rs: use the trait's own path for trait object references

### DIFF
--- a/uniffi_parse_rs/src/types.rs
+++ b/uniffi_parse_rs/src/types.rs
@@ -516,11 +516,17 @@ impl<'ir> RPath<'ir> {
                 }
                 let trait_path = self.resolve(ir, cache, trait_bounds[0], Namespace::Type)?;
                 match trait_path.item()? {
-                    Item::Trait(tr) => Ok(Type::Trait {
-                        module_path: self.path_string(),
-                        name: tr.ident.unraw().to_string(),
-                        export_ty: tr.attrs.export_ty,
-                    }),
+                    Item::Trait(tr) => {
+                        // Use the trait's own public path, not the referencing module's —
+                        // the reference must match the metadata generated for the trait's
+                        // definition, which may live in another module or crate.
+                        let names = trait_path.public_path_to_item(ir, cache)?;
+                        Ok(Type::Trait {
+                            module_path: names.module_path,
+                            name: names.name,
+                            export_ty: tr.attrs.export_ty,
+                        })
+                    }
                     Item::Udl(uniffi_meta::Type::Object {
                         module_path,
                         name,
@@ -1128,6 +1134,14 @@ pub mod tests {
             })
         );
         assert_eq!(
+            run_resolve_type(&ir, &mut cache, "types", "dyn mod1::TraitInterface"),
+            Ok(Type::Trait {
+                module_path: "types::mod1".into(),
+                name: "TraitInterface".into(),
+                export_ty: TraitExportType::TraitInterface(TraitKind::RustOnly),
+            })
+        );
+        assert_eq!(
             run_resolve_type(
                 &ir,
                 &mut cache,
@@ -1594,7 +1608,7 @@ pub mod tests {
                 None
             ),
             Ok(uniffi_meta::Type::Object {
-                module_path: "types".into(),
+                module_path: "types::mod1".into(),
                 name: "TraitInterface".into(),
                 imp: ObjectImpl::Trait(TraitKind::RustOnly),
             }),
@@ -1650,7 +1664,7 @@ pub mod tests {
             run_resolve_arg(&ir, &mut cache, "types", "&dyn mod1::TraitInterface", None),
             Ok(ArgType {
                 ty: uniffi_meta::Type::Object {
-                    module_path: "types".into(),
+                    module_path: "types::mod1".into(),
                     name: "TraitInterface".into(),
                     imp: ObjectImpl::Trait(TraitKind::RustOnly),
                 },


### PR DESCRIPTION
A `dyn Trait` reference resolved to a `Type::Trait` carrying the *referencing* module's path, while the metadata generated for the trait's definition carries the trait's own public path.  A reference from another module or crate (e.g. `Arc<dyn some_crate::module::Callback>` in a downstream binding crate) produced a type that matched no definition, failing downstream with "type module path not found".

Use `public_path_to_item` on the resolved trait, the same way the Record/Enum/Object arms already do.

part of #2972 