### PR TITLE
Add a regression test for rust_future_free releasing its handle

### DIFF
--- a/uniffi_core/src/ffi/rustfuture/tests.rs
+++ b/uniffi_core/src/ffi/rustfuture/tests.rs
@@ -222,6 +222,23 @@ fn test_release_future() {
     assert!(channel_weak.upgrade().is_none());
 }
 
+// `rust_future_new` moves ownership of the `Arc` into the handle, so `rust_future_free` has to take
+// that reference back to drop it. Nothing else in this file goes through the handle functions the
+// foreign bindings actually call, so a `rust_future_free` that borrowed the handle leaked every
+// future while every test here still passed.
+#[test]
+fn test_free_drops_the_handles_reference() {
+    let (_sender, rust_future) = channel();
+    let weak = Arc::downgrade(&rust_future);
+    let handle = Handle::from_arc(rust_future);
+    assert_eq!(weak.strong_count(), 1);
+
+    unsafe { rust_future_free::<RustBuffer>(handle) };
+
+    assert_eq!(weak.strong_count(), 0);
+    assert!(weak.upgrade().is_none());
+}
+
 // If `free` is called with a continuation still stored, we should call it them then.
 //
 // This shouldn't happen in practice, but it seems like good defensive programming


### PR DESCRIPTION
`rust_future_free` is the only handle function that consumes its handle, and 99414c16 fixed it to use `Handle::into_arc` instead of `Handle::into_arc_borrowed`. That fix landed without a test.

Nothing in `rustfuture/tests.rs` goes through the handle functions the foreign bindings call: every test operates on an `Arc<RustFuture>` directly. Restoring `into_arc_borrowed` today leaves the whole suite green, because `RustFuture::free` was never the broken part.

This adds a test that takes the `rust_future_new` path, frees the handle, and asserts the future is dropped.

Verified: passes on `main`; fails on the second assertion with `into_arc_borrowed` restored.