### PR TITLE
uniffi_parse_rs: resolve custom types by the type they cover

### DIFF
--- a/uniffi_parse_rs/src/ir.rs
+++ b/uniffi_parse_rs/src/ir.rs
@@ -151,7 +151,7 @@ impl Ir {
     }
 
     pub fn into_metadata_group_map(self) -> Result<MetadataGroupMap> {
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&self);
         self.crate_roots_and_paths()
             .map(|(mut module_path, module)| {
                 let mut group = MetadataGroup {
@@ -182,7 +182,9 @@ impl Ir {
 
         // Resolve the items
         let mut resolved_map = HashMap::new();
-        let mut cache = LookupCache::default();
+        // `LookupCache::empty()`, not `new()`: the type mapping registry can only be
+        // built once the items it maps are resolved, which is what's happening here.
+        let mut cache = LookupCache::empty();
         for crate_root in self.crate_roots.values() {
             crate_root.try_visit_modules_and_paths(|module, rpath| {
                 let Some(unresolved) = unresolved_map.remove(&module.id) else {

--- a/uniffi_parse_rs/src/paths.rs
+++ b/uniffi_parse_rs/src/paths.rs
@@ -13,8 +13,8 @@ use proc_macro2::Span;
 use syn::{ext::IdentExt, spanned::Spanned, Ident, Path};
 
 use crate::{
-    files::FileId, BuiltinItem, Error, ErrorKind::*, Ir, Item, ItemNames, Module, Result, UseGlob,
-    UseItem,
+    files::FileId, BuiltinItem, CustomType, Error, ErrorKind::*, Ir, Item, ItemNames, Module,
+    Result, UseGlob, UseItem,
 };
 
 // For tests only, print tracing info.
@@ -256,6 +256,14 @@ impl<'ir> RPath<'ir> {
                     Ok(RPath::new(item))
                 }
                 None => {
+                    // The path points into an unparsed crate.  A `custom_type!` may still
+                    // cover it, if its underlying type aliases the same path.
+                    if namespace == Namespace::Type {
+                        if let Some(mapped) = cache.external_type_mapping(path) {
+                            trace!("  resolved to type mapping: {mapped}");
+                            return Ok(mapped);
+                        }
+                    }
                     trace!("  not found");
                     Err(Error::new(self.file_id(), path.span(), NotFound))
                 }
@@ -660,7 +668,6 @@ impl fmt::Display for RPath<'_> {
 }
 
 /// Cache for path lookups
-#[derive(Default)]
 pub struct LookupCache<'ir> {
     // Cached results for `RPath::child`
     // This maps module id / ident / namespaces to lookup results
@@ -670,6 +677,259 @@ pub struct LookupCache<'ir> {
     // Cached results for `RPath::public_path_to_item()`
     // This maps path strings to lookup results
     pub public_paths: HashMap<String, Result<ItemNames>>,
+    // Type mappings indexed by the type they cover
+    type_mappings: TypeMappingRegistry<'ir>,
+}
+
+impl<'ir> LookupCache<'ir> {
+    /// Create a lookup cache for a fully-resolved IR
+    ///
+    /// [LookupCache::empty] leaves the type mapping registry empty.  That's the right
+    /// choice while the IR is still being resolved (the `custom_type!` items don't exist
+    /// yet); anything resolving types afterwards should use this constructor.
+    pub fn new(ir: &'ir Ir) -> Self {
+        Self {
+            type_mappings: TypeMappingRegistry::new(ir),
+            ..Self::empty()
+        }
+    }
+
+    /// A cache with an empty type mapping registry: lookups resolve as if no mappings
+    /// were registered
+    ///
+    /// This is correct in exactly two places — while the IR is still being resolved (the
+    /// items the registry maps don't exist yet), and for the registry build itself.
+    /// Everything else should use [LookupCache::new].
+    pub(crate) fn empty() -> Self {
+        Self {
+            children: HashMap::new(),
+            children_resolving: HashSet::new(),
+            public_paths: HashMap::new(),
+            type_mappings: TypeMappingRegistry::default(),
+        }
+    }
+
+    /// Look up the type mapping registered for the item at `item_path`
+    ///
+    /// `uniffi::custom_type!` is type-keyed in the macro flow: the generated FFI impls apply
+    /// wherever the type is named, no matter where the macro was invoked.  When parsing sources
+    /// we resolve names lexically, so a path can reach the underlying type (a type alias or a
+    /// non-UniFFI type) without ever passing through the module that invoked `custom_type!`.
+    /// This maps such items back to their custom type.
+    pub fn registered_type_mapping(&self, item_path: &RPath<'ir>) -> Option<RPath<'ir>> {
+        // Don't map custom types to themselves
+        if matches!(item_path.item(), Ok(Item::CustomType(_))) {
+            return None;
+        }
+        self.type_mappings
+            .by_item
+            .get(&item_path.path_string())
+            .cloned()
+    }
+
+    /// Look up the type mapping registered for a path into an unparsed crate
+    ///
+    /// This handles custom types whose underlying type comes from a non-UniFFI crate,
+    /// e.g. `type Decimal = rust_decimal::Decimal;` + `uniffi::custom_type!(Decimal, String)`.
+    /// Other modules can name the type as `use rust_decimal::Decimal`, which never resolves
+    /// to an item since `rust_decimal` isn't parsed.
+    pub fn external_type_mapping(&self, path: &Path) -> Option<RPath<'ir>> {
+        let key = external_path_key(path)?;
+        self.type_mappings.by_external_path.get(&key).cloned()
+    }
+}
+
+/// Type mappings indexed by the Rust type they cover
+///
+/// A mapping's value is the item to resolve the covered type to — today always a
+/// `custom_type!` item.
+#[derive(Default)]
+struct TypeMappingRegistry<'ir> {
+    /// Canonical item path (`RPath::path_string`) of the underlying item -> mapped item
+    by_item: HashMap<String, RPath<'ir>>,
+    /// Normalized textual path into an unparsed crate -> mapped item
+    by_external_path: HashMap<String, RPath<'ir>>,
+}
+
+impl<'ir> TypeMappingRegistry<'ir> {
+    fn new(ir: &'ir Ir) -> Self {
+        // Building the registry resolves paths itself.  Use a scratch cache — its
+        // registry is empty, so those resolutions see "nothing registered" — and discard
+        // it afterwards, so nothing memoized under that assumption survives into the
+        // caller's cache.
+        let cache = &mut LookupCache::empty();
+        let mut registry = Self::default();
+        for (root_path, root_module) in ir.crate_roots_and_paths() {
+            let mut stack = vec![(root_path, root_module)];
+            while let Some((module_path, module)) = stack.pop() {
+                for item in module.items.iter() {
+                    match item {
+                        Item::Module(m) => stack.push((module_path.append_child(item), m)),
+                        Item::CustomType(custom_type) => registry.register_custom_type(
+                            ir,
+                            cache,
+                            &module_path,
+                            module,
+                            item,
+                            custom_type,
+                        ),
+                        _ => (),
+                    }
+                }
+            }
+        }
+        registry
+    }
+
+    fn register_custom_type(
+        &mut self,
+        ir: &'ir Ir,
+        cache: &mut LookupCache<'ir>,
+        module_path: &RPath<'ir>,
+        module: &'ir Module,
+        custom_type_item: &'ir Item,
+        custom_type: &CustomType,
+    ) {
+        let custom_type_path = module_path.append_child(custom_type_item);
+        // Find the Rust item the custom type ident names, ignoring special items
+        // (the custom type itself shadows the name in its own module).
+        let mut underlying =
+            match module_path.underlying_item(ir, cache, module, &custom_type.ident.unraw()) {
+                Some(Underlying::Item(path)) => path,
+                Some(Underlying::External(path)) => {
+                    if let Some(key) = external_path_key(&path) {
+                        self.by_external_path.entry(key).or_insert(custom_type_path);
+                    }
+                    return;
+                }
+                // The custom type ident doesn't name anything else, so there's nothing to map
+                // (name resolution finds the custom type directly in this case).
+                None => return,
+            };
+
+        // Register the underlying item, following type alias chains so that references to
+        // any point of the chain resolve to the custom type.
+        let mut seen = HashSet::new();
+        loop {
+            let alias_target = match underlying.item() {
+                // A generic alias can't correspond to a (non-generic) custom type
+                Ok(Item::Type(alias)) if alias.generics.params.is_empty() => Some(&alias.ty),
+                Ok(Item::NonUniffi(..)) => None,
+                _ => return,
+            };
+            let key = underlying.path_string();
+            if !seen.insert(key.clone()) {
+                return; // alias cycle
+            }
+            self.by_item
+                .entry(key)
+                .or_insert_with(|| custom_type_path.clone());
+
+            // Follow the alias target if it's a plain, non-generic path
+            let Some(syn::Type::Path(target)) = alias_target.map(Box::as_ref) else {
+                return;
+            };
+            if target.qself.is_some()
+                || target
+                    .path
+                    .segments
+                    .iter()
+                    .any(|seg| !seg.arguments.is_none())
+            {
+                return;
+            }
+            let Ok(parent) = underlying.parent() else {
+                return;
+            };
+            match parent.resolve_type_or_non_uniffi(ir, cache, &target.path) {
+                Ok(next) => underlying = next,
+                Err(e) if e.is_not_found() => {
+                    if let Some(key) = external_path_key(&target.path) {
+                        self.by_external_path.entry(key).or_insert(custom_type_path);
+                    }
+                    return;
+                }
+                Err(_) => return,
+            }
+        }
+    }
+}
+
+enum Underlying<'ir> {
+    /// The custom type covers an item we parsed
+    Item(RPath<'ir>),
+    /// The custom type covers a path into an unparsed crate
+    External(Path),
+}
+
+/// Resolution helpers for building the type mapping registry
+impl<'ir> RPath<'ir> {
+    /// Find the non-special item a custom type's ident names in this module
+    fn underlying_item(
+        &self,
+        ir: &'ir Ir,
+        cache: &mut LookupCache<'ir>,
+        module: &'ir Module,
+        ident: &Ident,
+    ) -> Option<Underlying<'ir>> {
+        let mut use_globs = vec![];
+        for item in module.items.iter() {
+            if item.is_special() {
+                continue;
+            }
+            match item {
+                Item::Type(_) | Item::NonUniffi(..) if item.ident().as_ref() == Some(ident) => {
+                    return Some(Underlying::Item(self.append_child(item)));
+                }
+                Item::UseItem(use_item) if use_item.ident == *ident => {
+                    return match self.resolve_type_or_non_uniffi(ir, cache, &use_item.path) {
+                        Ok(path) => Some(Underlying::Item(path)),
+                        Err(e) if e.is_not_found() => {
+                            Some(Underlying::External(use_item.path.clone()))
+                        }
+                        Err(_) => None,
+                    };
+                }
+                Item::UseGlob(use_glob) => use_globs.push(use_glob),
+                _ => (),
+            }
+        }
+        for namespace in [Namespace::Type, Namespace::NonUniffiType] {
+            if let Ok(Some(child)) =
+                self.child_glob_use(ir, cache, ident, use_globs.clone(), namespace)
+            {
+                return Some(Underlying::Item(child.path));
+            }
+        }
+        None
+    }
+
+    /// Resolve a path in the type namespace, falling back to non-UniFFI types
+    fn resolve_type_or_non_uniffi(
+        &self,
+        ir: &'ir Ir,
+        cache: &mut LookupCache<'ir>,
+        path: &Path,
+    ) -> Result<RPath<'ir>> {
+        match self.resolve(ir, cache, path, Namespace::Type) {
+            Err(e) if e.is_not_found() => self.resolve(ir, cache, path, Namespace::NonUniffiType),
+            result => result,
+        }
+    }
+}
+
+/// Normalized key for a path that should point into an unparsed crate
+fn external_path_key(path: &Path) -> Option<String> {
+    if path.segments.len() < 2 || path.segments.iter().any(|seg| !seg.arguments.is_none()) {
+        return None;
+    }
+    Some(
+        path.segments
+            .iter()
+            .map(|seg| seg.ident.unraw().to_string())
+            .collect::<Vec<_>>()
+            .join("::"),
+    )
 }
 
 fn get_builtin_item(path: &Path) -> Option<&'static Item> {
@@ -816,7 +1076,7 @@ pub mod tests {
     #[test]
     fn test_resolve_item() {
         let ir = Ir::new_for_test(&["paths"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "paths::mod1", "Mod1Record"),
@@ -835,7 +1095,7 @@ pub mod tests {
     #[test]
     fn test_resolve_item_with_super_keyword() {
         let ir = Ir::new_for_test(&["paths"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(
@@ -874,7 +1134,7 @@ pub mod tests {
     #[test]
     fn test_resolve_item_with_self_keyword() {
         let ir = Ir::new_for_test(&["paths"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "paths", "mod3::Mod3Record"),
@@ -920,7 +1180,7 @@ pub mod tests {
     #[test]
     fn test_resolve_item_with_crate_keyword() {
         let ir = Ir::new_for_test(&["paths"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(
@@ -945,7 +1205,7 @@ pub mod tests {
     #[test]
     fn test_resolve_item_with_rust_keyword() {
         let ir = Ir::new_for_test(&["paths"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "paths", "r#break"),
@@ -961,7 +1221,7 @@ pub mod tests {
     #[test]
     fn test_use_remote_type() {
         let ir = Ir::new_for_test(&["paths", "paths2", "paths3"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "paths", "RemoteRecord"),
@@ -977,7 +1237,7 @@ pub mod tests {
     #[test]
     fn test_resolve_item_with_implicate_crate_lookup() {
         let ir = Ir::new_for_test(&["paths", "paths2"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             // `paths2` doesn't exist in `mod3`, so this should lookup a top-level crate
@@ -1004,7 +1264,7 @@ pub mod tests {
     #[test]
     fn test_resolve_item_with_use() {
         let ir = Ir::new_for_test(&["paths", "paths2"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "paths2", "TestRecord"),
@@ -1036,7 +1296,7 @@ pub mod tests {
     #[test]
     fn test_name_conflicts() {
         let ir = Ir::new_for_test(&["name_conflicts"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "name_conflicts", "Record"),
@@ -1086,7 +1346,6 @@ pub mod tests {
     fn test_raw_ident() {
         // Test that we "unraw" idents before matching them by removing the `r#` prefix
         let mut ir = Ir::new_for_test(&["raw_idents"]);
-        let mut cache = LookupCache::default();
 
         ir.add_udl_metadata(
             "raw_idents",
@@ -1101,6 +1360,7 @@ pub mod tests {
             .into()],
         )
         .unwrap();
+        let mut cache = LookupCache::new(&ir);
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "raw_idents", "r#Record"),
             Ok("raw_idents::Record".to_string()),
@@ -1114,7 +1374,7 @@ pub mod tests {
     #[test]
     fn test_same_item_imported_different_ways() {
         let ir = Ir::new_for_test(&["paths"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_item(&ir, &mut cache, "paths", "Mod2Record"),

--- a/uniffi_parse_rs/src/public_paths.rs
+++ b/uniffi_parse_rs/src/public_paths.rs
@@ -228,7 +228,7 @@ mod test {
     use super::*;
 
     pub fn run_public_path_to_item(ir: &Ir, item_path: &str) -> ItemNames {
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(ir);
         let crate_path = path_for_module(ir, item_path.split("::").next().unwrap());
         let item = crate_path
             .resolve(

--- a/uniffi_parse_rs/src/test_src/custom_type_paths.rs
+++ b/uniffi_parse_rs/src/test_src/custom_type_paths.rs
@@ -1,0 +1,52 @@
+// Custom types resolved by the type they cover, not the module the macro was invoked in.
+//
+// The `custom_type!` invocations live in `registrations`; other modules name the
+// underlying types directly (through aliases, non-UniFFI structs, or paths into
+// unparsed crates) and must still resolve to the custom type.
+
+mod types {
+    // A non-UniFFI type covered by a custom type registered in another module
+    pub struct Concrete { }
+
+    // An alias to a type from an unparsed crate, covered by a custom type in another module
+    pub type ExternalAlias = external_crate::ExternalType;
+}
+
+mod registrations {
+    use crate::types::{Concrete, ExternalAlias};
+
+    uniffi::custom_type!(Concrete, String, {
+        remote,
+        into: |obj| obj.to_string(),
+        try_from: |s| s.parse(),
+    });
+
+    uniffi::custom_type!(ExternalAlias, String, {
+        remote,
+        into: |obj| obj.to_string(),
+        try_from: |s| s.parse(),
+    });
+
+    // A custom type over a local alias to an unparsed crate.  Other modules import the
+    // external type directly (`use external_crate2::Direct`) and never see this alias.
+    type Direct = external_crate2::Direct;
+
+    uniffi::custom_type!(Direct, String, {
+        remote,
+        into: |obj| obj.to_string(),
+        try_from: |s| s.parse(),
+    });
+}
+
+mod usage {
+    use external_crate2::Direct;
+
+    use crate::types::{Concrete, ExternalAlias};
+
+    #[derive(uniffi::Record)]
+    pub struct UsesCustomTypes {
+        pub concrete: Concrete,
+        pub aliased: ExternalAlias,
+        pub direct: Direct,
+    }
+}

--- a/uniffi_parse_rs/src/test_src/custom_type_paths2.rs
+++ b/uniffi_parse_rs/src/test_src/custom_type_paths2.rs
@@ -1,0 +1,12 @@
+// Mirrors a binding crate that reuses custom types implemented by `custom_type_paths`:
+// it names the underlying type straight from the unparsed crate, and that must resolve
+// to the custom type registered over in `custom_type_paths`.
+
+mod usage2 {
+    use external_crate2::Direct;
+
+    #[derive(uniffi::Record)]
+    pub struct BindingRecord {
+        pub direct: Direct,
+    }
+}

--- a/uniffi_parse_rs/src/types.rs
+++ b/uniffi_parse_rs/src/types.rs
@@ -380,7 +380,22 @@ impl<'ir> RPath<'ir> {
                 if ty_path.path.is_ident("Self") {
                     return Ok(Type::SelfTy);
                 }
-                let path_to_type = self.resolve(ir, cache, &ty_path.path, Namespace::Type)?;
+                let path_to_type = match self.resolve(ir, cache, &ty_path.path, Namespace::Type) {
+                    Ok(path) => path,
+                    Err(e) if e.is_not_found() => {
+                        // The path doesn't name a UniFFI item, but it may name a non-UniFFI
+                        // type that a `uniffi::custom_type!` elsewhere covers.
+                        match self
+                            .resolve(ir, cache, &ty_path.path, Namespace::NonUniffiType)
+                            .ok()
+                            .and_then(|path| cache.registered_type_mapping(&path))
+                        {
+                            Some(custom_type_path) => custom_type_path,
+                            None => return Err(e),
+                        }
+                    }
+                    Err(e) => return Err(e),
+                };
                 // We can use `mem::take` to remove the generic_params and use them for this lookup.
                 // If we need to recurse another level, we want a new set of generic params anyways.
                 let generics = GenericArgs::new_with_context_params(
@@ -822,7 +837,7 @@ pub mod tests {
     #[test]
     fn test_resolve_builtin_types() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_type(&ir, &mut cache, "types", "()"),
@@ -911,7 +926,7 @@ pub mod tests {
     #[test]
     fn test_resolve_user_types() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_type(&ir, &mut cache, "types::mod1", "String"),
@@ -966,7 +981,7 @@ pub mod tests {
     #[test]
     fn test_resolve_custom_types() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_type(&ir, &mut cache, "types", "JsonObject"),
@@ -1015,7 +1030,7 @@ pub mod tests {
     #[test]
     fn test_resolve_custom_types_by_target_path() {
         let ir = Ir::new_for_test(&["custom_type_paths"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         let custom = |name: &str| {
             Ok(Type::Custom {
@@ -1078,7 +1093,7 @@ pub mod tests {
         // `custom_type_paths2` mirrors a binding crate: it names a type whose custom
         // type is implemented by `custom_type_paths`.
         let ir = Ir::new_for_test(&["custom_type_paths", "custom_type_paths2"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         let custom = Ok(Type::Custom {
             module_path: "custom_type_paths::registrations".into(),
@@ -1096,7 +1111,7 @@ pub mod tests {
     #[test]
     fn test_resolve_compound_types() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_type(&ir, &mut cache, "types", "Vec<String>"),
@@ -1204,7 +1219,7 @@ pub mod tests {
     #[test]
     fn test_resolve_type_trait_objects() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_type(&ir, &mut cache, "types::mod1", "dyn TraitInterface"),
@@ -1276,7 +1291,7 @@ pub mod tests {
     #[test]
     fn test_resolve_type_with_type_aliases() {
         let ir = Ir::new_for_test(&["type_aliases"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_type(&ir, &mut cache, "type_aliases", "RecordAlias"),
@@ -1420,7 +1435,7 @@ pub mod tests {
     #[test]
     fn test_resolve_box_types() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         // Right now we just ignore the box since it doesn't make a difference in the generated
         // bindings.  If we want to use this to generate scaffolding, then we'll need something
@@ -1447,7 +1462,7 @@ pub mod tests {
     #[test]
     fn test_resolve_type_references() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_type(&ir, &mut cache, "types::mod1", "&std::primitive::u32"),
@@ -1478,7 +1493,7 @@ pub mod tests {
     #[test]
     fn test_remote_types() {
         let ir = Ir::new_for_test(&["remote_types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_uniffi_meta_type(&ir, &mut cache, "remote_types", "AnyhowError", None),
@@ -1500,7 +1515,6 @@ pub mod tests {
     #[test]
     fn test_udl_types() {
         let mut ir = Ir::new_for_test(&["udl_types", "udl_types_crate2"]);
-        let mut cache = LookupCache::default();
         ir.add_udl_metadata(
             "udl_types",
             vec![
@@ -1540,6 +1554,7 @@ pub mod tests {
             ],
         )
         .unwrap();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_uniffi_meta_type(&ir, &mut cache, "udl_types::mod1", "UdlRecord", None),
@@ -1655,7 +1670,7 @@ pub mod tests {
     #[test]
     fn test_result_uniffi_meta() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_uniffi_meta_type(&ir, &mut cache, "types", "TestRecord", None),
@@ -1719,7 +1734,7 @@ pub mod tests {
     #[test]
     fn test_result_arg() {
         let ir = Ir::new_for_test(&["types"]);
-        let mut cache = LookupCache::default();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_arg(&ir, &mut cache, "types", "TestRecord", None),
@@ -1799,7 +1814,6 @@ pub mod tests {
     #[test]
     fn test_raw_ident() {
         let mut ir = Ir::new_for_test(&["raw_idents"]);
-        let mut cache = LookupCache::default();
         ir.add_udl_metadata(
             "raw_idents",
             vec![uniffi_meta::RecordMetadata {
@@ -1813,6 +1827,7 @@ pub mod tests {
             .into()],
         )
         .unwrap();
+        let mut cache = LookupCache::new(&ir);
 
         assert_eq!(
             run_resolve_uniffi_meta_type(&ir, &mut cache, "raw_idents", "RecordWrapper", None),

--- a/uniffi_parse_rs/src/types.rs
+++ b/uniffi_parse_rs/src/types.rs
@@ -1013,6 +1013,87 @@ pub mod tests {
     }
 
     #[test]
+    fn test_resolve_custom_types_by_target_path() {
+        let ir = Ir::new_for_test(&["custom_type_paths"]);
+        let mut cache = LookupCache::default();
+
+        let custom = |name: &str| {
+            Ok(Type::Custom {
+                module_path: "custom_type_paths::registrations".into(),
+                name: name.into(),
+                builtin: Box::new(Type::String),
+            })
+        };
+
+        // A non-UniFFI type covered by a custom type registered in another module
+        assert_eq!(
+            run_resolve_type(&ir, &mut cache, "custom_type_paths::usage", "Concrete"),
+            custom("Concrete"),
+        );
+        // A type alias covered by a custom type registered in another module
+        assert_eq!(
+            run_resolve_type(&ir, &mut cache, "custom_type_paths::usage", "ExternalAlias"),
+            custom("ExternalAlias"),
+        );
+        // A type imported directly from an unparsed crate, covered by a custom type
+        // over a local alias to the same path
+        assert_eq!(
+            run_resolve_type(&ir, &mut cache, "custom_type_paths::usage", "Direct"),
+            custom("Direct"),
+        );
+
+        // The same types, named by path instead of through use statements
+        assert_eq!(
+            run_resolve_type(&ir, &mut cache, "custom_type_paths", "types::Concrete"),
+            custom("Concrete"),
+        );
+        assert_eq!(
+            run_resolve_type(&ir, &mut cache, "custom_type_paths", "types::ExternalAlias"),
+            custom("ExternalAlias"),
+        );
+        assert_eq!(
+            run_resolve_type(
+                &ir,
+                &mut cache,
+                "custom_type_paths",
+                "external_crate2::Direct"
+            ),
+            custom("Direct"),
+        );
+
+        // Paths into unparsed crates without a covering custom type still fail
+        assert_eq!(
+            run_resolve_type(
+                &ir,
+                &mut cache,
+                "custom_type_paths",
+                "external_crate2::Other"
+            ),
+            Err(ErrorKind::NotFound),
+        );
+    }
+
+    #[test]
+    fn test_resolve_custom_types_from_another_crate() {
+        // `custom_type_paths2` mirrors a binding crate: it names a type whose custom
+        // type is implemented by `custom_type_paths`.
+        let ir = Ir::new_for_test(&["custom_type_paths", "custom_type_paths2"]);
+        let mut cache = LookupCache::default();
+
+        let custom = Ok(Type::Custom {
+            module_path: "custom_type_paths::registrations".into(),
+            name: "Direct".into(),
+            builtin: Box::new(Type::String),
+        });
+
+        // Through a direct import from the unparsed crate
+        assert_eq!(
+            run_resolve_type(&ir, &mut cache, "custom_type_paths2::usage2", "Direct"),
+            custom,
+        );
+    }
+
+    #[test]
     fn test_resolve_compound_types() {
         let ir = Ir::new_for_test(&["types"]);
         let mut cache = LookupCache::default();


### PR DESCRIPTION
Make the routes from the previous commit resolve, by keying custom types
on the type they cover rather than on the module that named them.

Build a crate-graph-wide registry mapping each custom type's underlying
type to the custom type item. For every `custom_type!`, the ident's
non-special binding in its module is resolved (following non-generic type
alias chains) and each step is registered by canonical item path; if the
chain ends in an unparsed crate, the final path is registered textually.

It's called `TypeMappingRegistry` rather than naming custom types: what a
mapping holds is the item that resolving the covered type should reach,
and nothing about the lookup is specific to custom types — a hand-written
`TypeId` impl declares the same kind of mapping, onto a builtin container.
Custom types are the only kind here.

Resolution consults the registry in two places: a type path that only
resolves in the (previously unused) NonUniffiType namespace is accepted
when a custom type covers it, and a global path into an unparsed crate
falls back to the textual registry before erroring. Between them these
cover every route, since the registry holds each step of the alias chain:
a local endpoint resolves through the first, an external one through the
second.

The registry is built eagerly by `LookupCache::new`, which replaces the
derived `Default` — the cache now needs the IR. `Ir::resolve_items` uses
`LookupCache::empty()` instead: the registry can only be built once the
items it maps are resolved, which is what that pass is doing. Building it
resolves paths itself, against a scratch cache whose registry is empty, so
those lookups see no registered custom types and nothing they memoize
survives into the caller's cache.

part of #2972 