### PR TITLE
uniffi_macros: add #[uniffi(skip)] for enum and error variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
   See [#2911](https://github.com/mozilla/uniffi-rs/pull/2911).
 - Added support for remote trait interfaces - ie, traits defined in a crate which doesn't use
   UniFFI. Use `#[uniffi::export(remote)]` or `[Trait, Remote]` in UDL. Foreign implementations are not supported, see the docs for more.
+- Added `#[uniffi(skip)]` for enum and error variants. The variant is left out
+  of the generated bindings entirely, so its fields can hold Rust types that
+  can't cross the FFI.
 
 ### What's Fixed
 - Kotlin: Fixed messages for error classes that inherit `Throwable`, but not `Exception`.

--- a/docs/manual/src/proc_macro/enumerations.md
+++ b/docs/manual/src/proc_macro/enumerations.md
@@ -109,3 +109,28 @@ pub enum MyEnum {
 ```
 
 See [Renaming](./renaming.md) for more details on renaming functionality.
+
+## Skipping variants
+
+Mark a variant with `#[uniffi(skip)]` to keep it out of the foreign bindings
+entirely. The variant still works from Rust, but it disappears from the
+generated enum and no foreign code can construct, receive, or match on it.
+Because the variant never has to be represented on the other side of the FFI,
+its fields can hold any Rust type, including ones that don't implement the FFI
+traits:
+
+```rust
+#[derive(uniffi::Enum)]
+pub enum MyEnum {
+    Foo,
+    Bar(u8),
+    #[uniffi(skip)]
+    RustOnly(std::sync::mpsc::Receiver<()>),
+}
+```
+
+If Rust code ever tries to send a `RustOnly` value across the FFI, for example
+by returning it from a `#[uniffi::export]`ed function, it panics at runtime.
+
+At least one variant must stay visible. Skipping every variant leaves nothing
+for the foreign bindings to generate, which is a compile error.

--- a/docs/manual/src/proc_macro/errors.md
+++ b/docs/manual/src/proc_macro/errors.md
@@ -48,3 +48,10 @@ fn do_http_request() -> Result<(), MyApiError> {
     // ...
 }
 ```
+
+An error variant can also be marked with `#[uniffi(skip)]`, the same as on a
+plain `Enum`; see [Skipping variants](./enumerations.md#skipping-variants). One
+extra rule applies here: a type used as the `E` in `Result<T, E>` must be
+`Send + Sync + 'static` as a whole, and that requirement is structural over
+every field, including skipped ones. So a skipped error variant's payload still
+needs to satisfy it, even though it never has to implement any FFI trait.

--- a/fixtures/enum-types/src/lib.rs
+++ b/fixtures/enum-types/src/lib.rs
@@ -142,16 +142,46 @@ fn roundtrip_boxed_record(boxed: Box<BoxedContent>) -> Box<BoxedContent> {
     boxed
 }
 
+// A variant marked #[uniffi(skip)] is invisible to bindgen, so its
+// payload can hold a type that can't cross the FFI boundary.
+#[derive(uniffi::Enum)]
+pub enum EnumWithSkippedVariant {
+    Visible,
+    #[uniffi(skip)]
+    Hidden(std::sync::mpsc::Receiver<()>),
+}
+
+#[uniffi::export]
+fn get_visible_enum_value() -> EnumWithSkippedVariant {
+    EnumWithSkippedVariant::Visible
+}
+
 uniffi::include_scaffolding!("enum_types");
 
 #[cfg(test)]
 mod test {
-    use crate::AnimalSignedInt;
+    use crate::{AnimalSignedInt, EnumWithSkippedVariant};
 
     #[test]
     fn check_signed() {
         assert_eq!(AnimalSignedInt::Koala as i8, -1);
         assert_eq!(AnimalSignedInt::Wallaby as i8, 0);
         assert_eq!(AnimalSignedInt::Wombat as i8, 1);
+    }
+
+    #[test]
+    fn skipped_variant_is_constructible_in_rust() {
+        let (_tx, rx) = std::sync::mpsc::channel::<()>();
+        let value = EnumWithSkippedVariant::Hidden(rx);
+        assert!(matches!(value, EnumWithSkippedVariant::Hidden(_)));
+    }
+
+    #[test]
+    #[should_panic(expected = "#[uniffi(skip)]")]
+    fn skipped_variant_cannot_cross_the_ffi() {
+        let (_tx, rx) = std::sync::mpsc::channel::<()>();
+        let _ = <EnumWithSkippedVariant as uniffi::Lower<crate::UniFfiTag>>::lower(
+            EnumWithSkippedVariant::Hidden(rx),
+        );
     }
 }

--- a/fixtures/enum-types/tests/bindings/test_enum_types.kts
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.kts
@@ -35,3 +35,5 @@ assert(NamedEnumWithDefaults.I().d == 0U.toUByte())
 assert(NamedEnumWithDefaults.I().e == 1U.toUByte())
 assert(NamedEnumWithDefaults.I(e=2U).d == 0U.toUByte())
 assert(NamedEnumWithDefaults.I(e=2U).e == 2U.toUByte())
+
+assert(getVisibleEnumValue() == EnumWithSkippedVariant.VISIBLE)

--- a/fixtures/enum-types/tests/bindings/test_enum_types.py
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.py
@@ -60,5 +60,9 @@ class TestErrorTypes(unittest.TestCase):
         result = roundtrip_boxed_record(content)
         self.assertEqual(result.value, "world")
 
+    def test_skipped_variant(self):
+        self.assertEqual(get_visible_enum_value(), EnumWithSkippedVariant.VISIBLE)
+        self.assertFalse(hasattr(EnumWithSkippedVariant, "HIDDEN"))
+
 if __name__=='__main__':
     unittest.main()

--- a/fixtures/enum-types/tests/bindings/test_enum_types.rb
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.rb
@@ -81,4 +81,9 @@ class TestEnumTypes < Test::Unit::TestCase
     result = EnumTypes.roundtrip_boxed_record(content)
     assert_equal 'world', result.value
   end
+
+  def test_skipped_variant
+    # The skipped variant is invisible, so `Visible` is the only value left.
+    assert_equal EnumTypes::EnumWithSkippedVariant::VISIBLE, EnumTypes.get_visible_enum_value
+  end
 end

--- a/fixtures/enum-types/tests/bindings/test_enum_types.swift
+++ b/fixtures/enum-types/tests/bindings/test_enum_types.swift
@@ -44,3 +44,9 @@ switch NamedEnumWithDefaults.i(d: 2) {
         assert(d == 2)
         assert(e == 1)
 }
+
+// The skipped variant is invisible, so `.visible` is the only case left.
+switch getVisibleEnumValue() {
+    case .visible:
+        break
+}

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -323,6 +323,12 @@ impl BasicError {
 pub enum SimpleError {
     A,
     B,
+    // An error type used in `Result<T, E>` must itself be `Send + Sync +
+    // 'static`, which is structural over every field including skipped
+    // ones, so the payload here can't be `Receiver<()>` like the plain-enum
+    // examples use.
+    #[uniffi(skip)]
+    Hidden(std::sync::atomic::AtomicPtr<()>),
 }
 
 impl From<uniffi::UnexpectedUniFFICallbackError> for BasicError {
@@ -346,6 +352,14 @@ pub enum FlatError {
     // Inner types that aren't FFI-convertible are allowed for flat errors
     #[error("OS error: {0}")]
     OsError(std::io::Error),
+
+    // Flat errors already allow arbitrary field types without #[uniffi(skip)],
+    // but skip must still work here: it hides the variant entirely. The
+    // payload must stay Send + Sync + 'static since that's a Result<T, E>
+    // requirement on the whole error type, unrelated to skip.
+    #[error("Hidden")]
+    #[uniffi(skip)]
+    Hidden(std::sync::atomic::AtomicPtr<()>),
 }
 
 #[uniffi::export]
@@ -533,3 +547,29 @@ impl ObjectWithDefaults {
 }
 
 uniffi::include_scaffolding!("proc-macro");
+
+#[cfg(test)]
+mod skip_variant_tests {
+    use super::{FlatError, SimpleError};
+    use std::sync::atomic::AtomicPtr;
+
+    #[test]
+    fn skipped_variant_is_constructible_in_rust() {
+        let value = SimpleError::Hidden(AtomicPtr::new(std::ptr::null_mut()));
+        assert!(matches!(value, SimpleError::Hidden(_)));
+    }
+
+    #[test]
+    #[should_panic(expected = "#[uniffi(skip)]")]
+    fn skipped_rich_error_variant_cannot_cross_the_ffi() {
+        let value = SimpleError::Hidden(AtomicPtr::new(std::ptr::null_mut()));
+        let _ = <SimpleError as uniffi::Lower<crate::UniFfiTag>>::lower(value);
+    }
+
+    #[test]
+    #[should_panic(expected = "#[uniffi(skip)]")]
+    fn skipped_flat_error_variant_cannot_cross_the_ffi() {
+        let value = FlatError::Hidden(AtomicPtr::new(std::ptr::null_mut()));
+        let _ = <FlatError as uniffi::Lower<crate::UniFfiTag>>::lower(value);
+    }
+}

--- a/fixtures/uitests/tests/ui/enum_all_variants_skipped.rs
+++ b/fixtures/uitests/tests/ui/enum_all_variants_skipped.rs
@@ -1,0 +1,9 @@
+fn main() {} /* empty main required by `trybuild` */
+
+#[derive(uniffi::Enum)]
+pub enum AllSkipped {
+    #[uniffi(skip)]
+    Hidden(std::sync::mpsc::Receiver<()>),
+}
+
+uniffi_macros::setup_scaffolding!();

--- a/fixtures/uitests/tests/ui/enum_all_variants_skipped.stderr
+++ b/fixtures/uitests/tests/ui/enum_all_variants_skipped.stderr
@@ -1,0 +1,7 @@
+error: #[uniffi(skip)] on every variant leaves no variant for bindgen to generate
+ --> tests/ui/enum_all_variants_skipped.rs:3:10
+  |
+3 | #[derive(uniffi::Enum)]
+  |          ^^^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `uniffi::Enum` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/fixtures/uitests/tests/ui/export_attrs.stderr
+++ b/fixtures/uitests/tests/ui/export_attrs.stderr
@@ -36,7 +36,7 @@ error: expected `default` or `name`
 27 |     #[uniffi(flat_error)]
    |              ^^^^^^^^^^
 
-error: expected `name`
+error: expected `name` or `skip`
   --> tests/ui/export_attrs.rs:34:14
    |
 34 |     #[uniffi(flat_error)]

--- a/uniffi_macros/src/enum_.rs
+++ b/uniffi_macros/src/enum_.rs
@@ -93,6 +93,23 @@ impl EnumItem {
         Ok(())
     }
 
+    /// Bindgen needs at least one variant to generate a foreign type for. Without this check,
+    /// skipping every variant would only fail downstream, in a per-language template.
+    pub fn check_not_all_variants_skipped(&self) -> syn::Result<()> {
+        for v in self.enum_.variants.iter() {
+            if variant_attrs(v)?.skip.is_none() {
+                return Ok(());
+            }
+        }
+        if self.enum_.variants.is_empty() {
+            return Ok(());
+        }
+        Err(syn::Error::new(
+            Span::call_site(),
+            "#[uniffi(skip)] on every variant leaves no variant for bindgen to generate",
+        ))
+    }
+
     pub fn ident(&self) -> &Ident {
         &self.ident
     }
@@ -136,7 +153,8 @@ impl EnumItem {
 pub fn expand_enum(input: DeriveInput, options: DeriveOptions) -> syn::Result<TokenStream> {
     let item = EnumItem::new(input)?;
     item.check_attributes_valid_for_enum()?;
-    let ffi_converter_impl = enum_ffi_converter_impl(&item, &options);
+    item.check_not_all_variants_skipped()?;
+    let ffi_converter_impl = enum_ffi_converter_impl(&item, &options)?;
 
     let meta_static_var = options
         .generate_metadata
@@ -148,7 +166,10 @@ pub fn expand_enum(input: DeriveInput, options: DeriveOptions) -> syn::Result<To
     })
 }
 
-pub(crate) fn enum_ffi_converter_impl(item: &EnumItem, options: &DeriveOptions) -> TokenStream {
+pub(crate) fn enum_ffi_converter_impl(
+    item: &EnumItem,
+    options: &DeriveOptions,
+) -> syn::Result<TokenStream> {
     enum_or_error_ffi_converter_impl(
         item,
         options,
@@ -159,7 +180,7 @@ pub(crate) fn enum_ffi_converter_impl(item: &EnumItem, options: &DeriveOptions) 
 pub(crate) fn rich_error_ffi_converter_impl(
     item: &EnumItem,
     options: &DeriveOptions,
-) -> TokenStream {
+) -> syn::Result<TokenStream> {
     enum_or_error_ffi_converter_impl(
         item,
         options,
@@ -171,14 +192,23 @@ fn enum_or_error_ffi_converter_impl(
     item: &EnumItem,
     options: &DeriveOptions,
     metadata_type_code: TokenStream,
-) -> TokenStream {
+) -> syn::Result<TokenStream> {
     let name = &item.foreign_name();
     let ident = item.ident();
     let impl_spec = options.ffi_impl_header("FfiConverter", ident);
     let derive_ffi_traits = options.derive_all_ffi_traits(ident);
-    let mut write_match_arms: Vec<_> = item
-        .enum_()
-        .variants
+
+    let mut kept = Vec::new();
+    let mut skipped = Vec::new();
+    for v in item.enum_().variants.iter() {
+        if variant_attrs(v)?.skip.is_some() {
+            skipped.push(v);
+        } else {
+            kept.push(v);
+        }
+    }
+
+    let mut write_match_arms: Vec<_> = kept
         .iter()
         .enumerate()
         .map(|(i, v)| {
@@ -214,6 +244,14 @@ fn enum_or_error_ffi_converter_impl(
             }
         })
         .collect();
+    write_match_arms.extend(skipped.iter().map(|v| {
+        let v_ident = &v.ident;
+        quote! {
+            Self::#v_ident { .. } => ::std::panic!(
+                "Attempted to lower a #[uniffi(skip)] enum variant across the FFI"
+            ),
+        }
+    }));
     if item.is_non_exhaustive() {
         write_match_arms.push(quote! {
             _ => ::std::panic!("Unexpected variant in non-exhaustive enum"),
@@ -223,7 +261,7 @@ fn enum_or_error_ffi_converter_impl(
         match obj { #(#write_match_arms)* }
     };
 
-    let try_read_match_arms = item.enum_().variants.iter().enumerate().map(|(i, v)| {
+    let try_read_match_arms = kept.iter().enumerate().map(|(i, v)| {
         let idx = Index::from(i + 1);
         let v_ident = &v.ident;
         let is_tuple = v.fields.iter().any(|f| f.ident.is_none());
@@ -249,7 +287,7 @@ fn enum_or_error_ffi_converter_impl(
         })
     };
 
-    quote! {
+    Ok(quote! {
         #[automatically_derived]
         unsafe #impl_spec {
             ::uniffi::ffi_converter_rust_buffer_lift_and_lower!(crate::UniFfiTag);
@@ -268,7 +306,7 @@ fn enum_or_error_ffi_converter_impl(
         }
 
         #derive_ffi_traits
-    }
+    })
 }
 
 pub(crate) fn enum_meta_static_var(item: &EnumItem) -> syn::Result<TokenStream> {
@@ -351,11 +389,17 @@ fn variant_value(v: &Variant) -> syn::Result<TokenStream> {
 }
 
 pub fn variant_metadata(item: &EnumItem) -> syn::Result<Vec<TokenStream>> {
-    let enum_ = item.enum_();
+    let mut kept_variants = Vec::new();
+    for v in item.enum_().variants.iter() {
+        let attrs = variant_attrs(v)?;
+        if attrs.skip.is_none() {
+            kept_variants.push((v, attrs));
+        }
+    }
     let variants_len =
-        try_metadata_value_from_usize(enum_.variants.len(), "UniFFI limits enums to 256 variants")?;
+        try_metadata_value_from_usize(kept_variants.len(), "UniFFI limits enums to 256 variants")?;
     std::iter::once(Ok(quote! { .concat_value(#variants_len) }))
-        .chain(enum_.variants.iter().map(|v| {
+        .chain(kept_variants.into_iter().map(|(v, attrs)| {
             let fields_len = try_metadata_value_from_usize(
                 v.fields.len(),
                 "UniFFI limits enum variants to 256 fields",
@@ -390,8 +434,6 @@ pub fn variant_metadata(item: &EnumItem) -> syn::Result<Vec<TokenStream>> {
                     })
                 })
                 .collect::<syn::Result<Vec<_>>>()?;
-
-            let attrs = v.attrs.parse_uniffi_attr_args::<VariantAttr>()?;
 
             let variant_orig_name = orig_name_metadata(attrs.name.is_some(), &v.ident);
             let name = attrs.name.unwrap_or(ident_to_string(&v.ident));
@@ -463,6 +505,7 @@ impl UniffiAttributeArgs for EnumAttr {
 #[derive(Clone, Default)]
 pub struct VariantAttr {
     pub name: Option<String>,
+    pub skip: Option<kw::skip>,
 }
 
 impl UniffiAttributeArgs for VariantAttr {
@@ -472,7 +515,15 @@ impl UniffiAttributeArgs for VariantAttr {
             let _: kw::name = input.parse()?;
             let _: Token![=] = input.parse()?;
             let name = Some(input.parse::<LitStr>()?.value());
-            Ok(Self { name })
+            Ok(Self {
+                name,
+                ..Self::default()
+            })
+        } else if lookahead.peek(kw::skip) {
+            Ok(Self {
+                skip: input.parse()?,
+                ..Self::default()
+            })
         } else {
             Err(lookahead.error())
         }
@@ -481,6 +532,11 @@ impl UniffiAttributeArgs for VariantAttr {
     fn merge(self, other: Self) -> syn::Result<Self> {
         Ok(Self {
             name: either_attribute_arg(self.name, other.name)?,
+            skip: either_attribute_arg(self.skip, other.skip)?,
         })
     }
+}
+
+pub(crate) fn variant_attrs(v: &Variant) -> syn::Result<VariantAttr> {
+    v.attrs.parse_uniffi_attr_args::<VariantAttr>()
 }

--- a/uniffi_macros/src/error.rs
+++ b/uniffi_macros/src/error.rs
@@ -4,7 +4,7 @@ use syn::{DeriveInput, Index};
 use uniffi_meta::EnumShape;
 
 use crate::{
-    enum_::{rich_error_ffi_converter_impl, variant_metadata, EnumItem, VariantAttr},
+    enum_::{rich_error_ffi_converter_impl, variant_attrs, variant_metadata, EnumItem},
     ffiops,
     util::{
         create_metadata_items, extract_docstring, ident_to_string, orig_name_metadata,
@@ -15,6 +15,7 @@ use crate::{
 
 pub fn expand_error(input: DeriveInput, options: DeriveOptions) -> syn::Result<TokenStream> {
     let enum_item = EnumItem::new(input)?;
+    enum_item.check_not_all_variants_skipped()?;
     let ffi_converter_impl = error_ffi_converter_impl(&enum_item, &options)?;
     let meta_static_var = options
         .generate_metadata
@@ -41,18 +42,21 @@ pub fn expand_error(input: DeriveInput, options: DeriveOptions) -> syn::Result<T
 }
 
 fn error_ffi_converter_impl(item: &EnumItem, options: &DeriveOptions) -> syn::Result<TokenStream> {
-    Ok(if item.is_flat_error() {
+    if item.is_flat_error() {
         flat_error_ffi_converter_impl(item, options)
     } else {
         rich_error_ffi_converter_impl(item, options)
-    })
+    }
 }
 
 // FfiConverters for "flat errors"
 //
 // These are errors where we only lower the to_string() value, rather than any associated data.
 // We lower the to_string() value unconditionally, whether the enum has associated data or not.
-fn flat_error_ffi_converter_impl(item: &EnumItem, options: &DeriveOptions) -> TokenStream {
+fn flat_error_ffi_converter_impl(
+    item: &EnumItem,
+    options: &DeriveOptions,
+) -> syn::Result<TokenStream> {
     let name = &item.foreign_name();
     let ident = item.ident();
     let lower_impl_spec = options.ffi_impl_header("Lower", ident);
@@ -60,10 +64,18 @@ fn flat_error_ffi_converter_impl(item: &EnumItem, options: &DeriveOptions) -> To
     let type_id_impl_spec = options.ffi_impl_header("TypeId", ident);
     let derive_ffi_traits = options.derive_ffi_traits(ident, &["LowerError", "ConvertError"]);
 
+    let mut kept = Vec::new();
+    let mut skipped = Vec::new();
+    for v in item.enum_().variants.iter() {
+        if variant_attrs(v)?.skip.is_some() {
+            skipped.push(v);
+        } else {
+            kept.push(v);
+        }
+    }
+
     let lower_impl = {
-        let mut match_arms: Vec<_> = item
-            .enum_()
-            .variants
+        let mut match_arms: Vec<_> = kept
             .iter()
             .enumerate()
             .map(|(i, v)| {
@@ -79,6 +91,14 @@ fn flat_error_ffi_converter_impl(item: &EnumItem, options: &DeriveOptions) -> To
                 }
             })
             .collect();
+        match_arms.extend(skipped.iter().map(|v| {
+            let v_ident = &v.ident;
+            quote! {
+                Self::#v_ident { .. } => ::std::panic!(
+                    "Attempted to lower a #[uniffi(skip)] enum variant across the FFI"
+                ),
+            }
+        }));
         if item.is_non_exhaustive() {
             match_arms.push(quote! {
                 _ => ::std::panic!("Unexpected variant in non-exhaustive enum"),
@@ -105,7 +125,7 @@ fn flat_error_ffi_converter_impl(item: &EnumItem, options: &DeriveOptions) -> To
     };
 
     let lift_impl = if item.generate_error_try_read() {
-        let match_arms = item.enum_().variants.iter().enumerate().map(|(i, v)| {
+        let match_arms = kept.iter().enumerate().map(|(i, v)| {
             let v_ident = &v.ident;
             let idx = Index::from(i + 1);
 
@@ -155,7 +175,7 @@ fn flat_error_ffi_converter_impl(item: &EnumItem, options: &DeriveOptions) -> To
         }
     };
 
-    quote! {
+    Ok(quote! {
         #lower_impl
         #lift_impl
 
@@ -167,7 +187,7 @@ fn flat_error_ffi_converter_impl(item: &EnumItem, options: &DeriveOptions) -> To
         }
 
         #derive_ffi_traits
-    }
+    })
 }
 
 pub(crate) fn error_meta_static_var(item: &EnumItem) -> syn::Result<TokenStream> {
@@ -198,12 +218,17 @@ pub(crate) fn error_meta_static_var(item: &EnumItem) -> syn::Result<TokenStream>
 }
 
 pub fn flat_error_variant_metadata(item: &EnumItem) -> syn::Result<Vec<TokenStream>> {
-    let enum_ = item.enum_();
+    let mut kept_variants = Vec::new();
+    for v in item.enum_().variants.iter() {
+        let attrs = variant_attrs(v)?;
+        if attrs.skip.is_none() {
+            kept_variants.push((v, attrs));
+        }
+    }
     let variants_len =
-        try_metadata_value_from_usize(enum_.variants.len(), "UniFFI limits enums to 256 variants")?;
+        try_metadata_value_from_usize(kept_variants.len(), "UniFFI limits enums to 256 variants")?;
     std::iter::once(Ok(quote! { .concat_value(#variants_len) }))
-        .chain(enum_.variants.iter().map(|v| {
-            let attrs = v.attrs.parse_uniffi_attr_args::<VariantAttr>()?;
+        .chain(kept_variants.into_iter().map(|(v, attrs)| {
             let orig_name = orig_name_metadata(attrs.name.is_some(), &v.ident);
             let name = attrs.name.unwrap_or(ident_to_string(&v.ident));
 

--- a/uniffi_macros/src/util.rs
+++ b/uniffi_macros/src/util.rs
@@ -269,6 +269,7 @@ pub mod kw {
     syn::custom_keyword!(Some);
     syn::custom_keyword!(with_try_read);
     syn::custom_keyword!(name);
+    syn::custom_keyword!(skip);
     syn::custom_keyword!(non_exhaustive);
     syn::custom_keyword!(lower);
     syn::custom_keyword!(try_lift);

--- a/uniffi_parse_rs/src/attrs/enums.rs
+++ b/uniffi_parse_rs/src/attrs/enums.rs
@@ -135,6 +135,7 @@ impl VariantAttributes {
         let Some(metas) = env.parse_attrs(attrs)? else {
             return Ok(None);
         };
+        let mut skip = false;
         for meta in metas {
             if meta.path().is_ident("uniffi") {
                 if let Meta::List(list) = meta {
@@ -144,6 +145,9 @@ impl VariantAttributes {
                             let name: LitStr = meta.input.parse()?;
                             parsed.name = Some(name.value());
                             Ok(())
+                        } else if meta.path.is_ident("skip") {
+                            skip = true;
+                            Ok(())
                         } else {
                             Err(meta.error("Invalid attribute"))
                         }
@@ -152,6 +156,12 @@ impl VariantAttributes {
             } else if meta.path().is_ident("doc") {
                 extract_docstring(&mut parsed.docstring, &meta);
             }
+        }
+        // A skipped variant is dropped the same way a `#[cfg(...)]`-excluded
+        // one is above, so its fields are never parsed and can hold types
+        // that don't cross the FFI boundary.
+        if skip {
+            return Ok(None);
         }
         Ok(Some(parsed))
     }

--- a/uniffi_parse_rs/src/test_src/full_interface.rs
+++ b/uniffi_parse_rs/src/test_src/full_interface.rs
@@ -31,6 +31,10 @@ mod submod {
         /// Variant2 docstring
         #[uniffi(name="TwoRenamed")]
         Two(i8, u8),
+        // Skipped variants are dropped before their fields are parsed, so
+        // they may hold types that can't cross the FFI boundary.
+        #[uniffi(skip)]
+        Hidden(std::sync::mpsc::Receiver<()>),
     }
 }
 


### PR DESCRIPTION
Exported enums sometimes need an internal variant that only Rust code will construct, carrying data that cannot pass the FFI boundary.

This adds a new `#[uniffi(skip)]` attribute which can be added to enum and error variants. It drops the variant from both the macro-generated metadata and the `uniffi_parse_rs` source-level extractor, so its fields never need to satisfy any FFI trait.

Lowering a skipped variant across the FFI panics, since no wire tag is ever reserved for it. Skipping every variant is a compile-time error.

This feature is related to #2404, but not the same: that issue is about skipping _fields_ in a record – this is about skipping _variants_ in an enum. Because the foreign code cannot create the skipped variants, the question of what to do with "missing" data does not come up.

---

The code here was written with Claude Code and I'm not very familiar with it. The ask to Claude was:

> Please add a new feature: I would like a `#[uniffi(skip)]` attribute for enum variants (not struct (record) fields). It should:
>
> - not generate foreign code for the variant
> - allow arbitrary payloads for this variant (types that cannot cross the FFI boundary)
>
> Please add this, write tests for it (follow the project conventions), and update user facing documentation.

I later explained Claude that these variants are used for

> We have Web, Android, and iOS apps that send events to a Rust core. They only ever constructs a subset of variants, while some variants are Rust-internal. Since the internal events are never sent to foreign code, we will never run into the runtime panics when trying to lower these types.

I asked it about other cases in UniFFI where runtime panics are accepted, and it said

> Existing precedent for "compiles fine, panics on the wrong operation":
>
> - `#[non_exhaustive]` remote enums panic if an upstream crate adds a variant your bindings don't know about
> - `#[uniffi(flat_error)]` without `with_try_read` where lifting always panics, by design.