### PR TITLE
Make the fallback Tokio runtime multi-threaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   UniFFI. Use `#[uniffi::export(remote)]` or `[Trait, Remote]` in UDL. Foreign implementations are not supported, see the docs for more.
 
 ### What's Fixed
+- The runtime `#[uniffi::export(async_runtime = "tokio")]` falls back to when no Tokio runtime is
+  ambient is now multi-threaded. It was current-thread, which made `tokio::task::block_in_place`
+  abort the process in any task spawned from an exported async fn - reachable through any dependency
+  that offloads blocking work that way. Requires `async-compat` 0.2.6.
 - Kotlin: Fixed messages for error classes that inherit `Throwable`, but not `Exception`.
 - Fix UDL remote enums, now allowing `[Enum, Remote] interface { ... }`
   (via [#2823](https://github.com/mozilla/uniffi-rs/issues/2823)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "async-compat"
-version = "0.2.1"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b48b4ff0c2026db683dea961cd8ea874737f56cffca86fa84415eaddc51c00d"
+checksum = "4c97d7ff3c25d6c10d64170c12acaf5d4245e76dece3779c1d92b153a64f11df"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -1734,6 +1734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68722da18b0fc4a05fdc1120b302b82051265792a1e1b399086e9b204b10ad3d"
 dependencies = [
  "backtrace",
+ "num_cpus",
  "pin-project-lite",
 ]
 

--- a/docs/manual/src/futures.md
+++ b/docs/manual/src/futures.md
@@ -48,6 +48,27 @@ In Rust `Future` terminology this means the foreign bindings supply the "executo
 
 There are [some great API docs](https://docs.rs/uniffi_core/latest/uniffi_core/ffi/rustfuture/index.html) on the implementation that are well worth a read.
 
+## Using Tokio
+
+The foreign bindings supply the executor, so an exported `async fn` is not polled by a Tokio runtime
+and code needing a Tokio context will panic. Enable the `tokio` feature and annotate the export:
+
+```Rust
+#[uniffi::export(async_runtime = "tokio")]
+pub async fn fetch(url: String) -> String { ... }
+```
+
+Each poll then happens inside a Tokio context: the ambient runtime if the polling thread has one,
+otherwise a process-wide fallback.
+
+Note that this gives the future a Tokio *context*, not Tokio worker threads - it is still polled by
+the foreign executor. The difference shows up in anything you `spawn`, which does run on the
+runtime. The fallback is multi-threaded so that [`tokio::task::block_in_place`] works there; the
+cost is a worker pool sized to the available parallelism, and it is only built when no runtime is
+ambient.
+
+[`tokio::task::block_in_place`]: https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html
+
 ## Exporting async trait methods
 
 UniFFI is compatible with the [async-trait](https://crates.io/crates/async-trait) crate and this can

--- a/uniffi_core/Cargo.toml
+++ b/uniffi_core/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 [dependencies]
 # Re-exported dependencies used in generated Rust scaffolding files.
 anyhow = "1"
-async-compat = { version = "0.2.1", optional = true }
+async-compat = { version = "0.2.6", optional = true }
 async-trait = "0.1"
 bytes = "1.11"
 once_cell = "1.10.0"
@@ -27,7 +27,7 @@ ffi-trace = []
 
 # Enable support for Tokio's futures.
 # This must still be opted into on a per-function basis using `#[uniffi::export(async_runtime = "tokio")]`.
-tokio = ["dep:async-compat"]
+tokio = ["dep:async-compat", "async-compat/multi-thread"]
 
 # Enable support for the ffi buffer scaffolding functions
 scaffolding-ffi-buffer-fns = []


### PR DESCRIPTION
`#[uniffi::export(async_runtime = "tokio")]` currently aborts the process if anything spawned from the exported future calls `tokio::task::block_in_place`. One line fixes it.

## The bug

`Compat` enters a process-wide fallback runtime when none is ambient on the polling thread — the normal case for a call arriving from foreign code, where the poll happens on a Kotlin dispatcher thread or a Swift `Task`.

That fallback is current-thread. The exported future's own poll is fine: `Compat::poll` only enters the context, and `block_in_place` passes through harmlessly when no runtime is *entered*. But a task **spawned** from inside that future runs *on* the fallback, and there:

```
thread 'async-compat/tokio-1' panicked:
can call blocking only when running on the multi-threaded runtime
```

It aborts rather than returning an error, on a thread the caller never created, with a message that names neither UniFFI nor `async-compat`.

## This isn't about parallelism

Worth separating up front, because [a comment on #1726](https://github.com/mozilla/uniffi-rs/issues/1726#issuecomment-1699375375) reads the other way:

> I *think* the main thing we need from tokio is the blocking thread pool and timers, and we don't care that much about async tasks actually running in parallel.

That matches my case too: I'm not after throughput. Timers, the blocking pool and `spawn_blocking` all work on the current-thread fallback. `block_in_place` is the one call that doesn't, and the reason is structural — tokio implements it by taking the current worker's core and handing it to a blocking-pool thread, so the tasks queued behind the blocking call keep running. A current-thread scheduler has no core to hand over, so the call aborts rather than degrading.

Which means what's actually required here is the multi-threaded *flavour*, not a big pool: `block_in_place` hands off to the blocking pool, so it works even with a single worker thread. The `available_parallelism()` worker count is just `Builder::new_multi_thread()`'s default, incidental to the fix — see below if that's the part you'd want changed.

## The fix

`async-compat` 0.2.6 added an opt-in `multi-thread` feature for exactly this (smol-rs/async-compat#50). Turning it on:

```toml
tokio = ["dep:async-compat", "async-compat/multi-thread"]
```

The docs change is larger than the code change only because `async_runtime` wasn't covered in the manual at all.

## What it costs

- pulls in `tokio/rt-multi-thread`
- the fallback starts a worker pool sized to available parallelism, where it previously started one thread

If the worker count is the sticking point, it is separable from the fix: only the flavour is load-bearing, so a smaller default (or an exposed `worker_threads`) would do just as well, and I'm happy to take that up with `async-compat` rather than have it block this.

Both are bounded by the fallback being built **only when no runtime is ambient**. A caller that already has its own Tokio runtime keeps using it and pays nothing — which is what upstream's `fallback_runtime_is_created_if_and_only_if_outside_tokio_context` test pins down.

The flavour was also already non-deterministic: a caller polling under an ambient multi-threaded runtime has always had multi-threaded spawns. So this makes behaviour consistent rather than removing a guarantee anyone could have relied on, which is why I filed it under "What's Fixed".

**If you'd rather not change the default, say the word and I'll push it as an opt-in feature instead.** It was a separate `tokio-multi-thread` flag in my first draft; collapsing it into `tokio` was a judgement call, not a requirement.

## Not the #1726 design question

This deliberately doesn't touch it. Configuring the runtime — worker count, thread names, sharing one with the rest of the application — stays unsupported, and every design sketched in #1726 remains equally available afterwards. It does answer half of the original objection there, that `async-compat` gives you no say over the runtime, by making the flavour right without foreclosing the rest.